### PR TITLE
fix(card-modal): backdrop-close + watchers dropdown (card-view UX polish)

### DIFF
--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -181,18 +181,82 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<span class="card-modal__done-label">{{ isDone ? t('kanso', 'Done') : t('kanso', 'Mark done') }}</span>
 						</button>
 
-						<button
-							class="card-modal__watch-btn"
-							:class="{ 'card-modal__watch-btn--active': isWatching }"
-							:aria-pressed="isWatching"
-							:disabled="toggleSubscription.isPending.value"
-							:title="isWatching ? t('kanso', 'Stop watching this card') : t('kanso', 'Watch this card')"
-							@click="handleWatchToggle">
-							<EyeOffOutlineIcon v-if="isWatching" :size="18" />
-							<EyeOutlineIcon v-else :size="18" />
-							<span v-if="watcherCount > 0" class="card-modal__watch-count">{{ watcherCount }}</span>
-							<span v-else class="card-modal__watch-label">{{ t('kanso', 'Watch') }}</span>
-						</button>
+						<span class="card-modal__watch-wrap">
+							<button
+								class="card-modal__watch-btn"
+								:class="{ 'card-modal__watch-btn--active': isWatching }"
+								:aria-pressed="isWatching"
+								:disabled="toggleSubscription.isPending.value"
+								:title="isWatching ? t('kanso', 'Stop watching this card') : t('kanso', 'Watch this card')"
+								@click="handleWatchToggle">
+								<EyeOffOutlineIcon v-if="isWatching" :size="18" />
+								<EyeOutlineIcon v-else :size="18" />
+								<span v-if="watcherCount > 0" class="card-modal__watch-count">{{ watcherCount }}</span>
+								<span v-else class="card-modal__watch-label">{{ t('kanso', 'Watch') }}</span>
+							</button>
+							<button
+								class="card-modal__watch-caret"
+								:class="{ 'card-modal__watch-caret--active': isWatching }"
+								:aria-expanded="openPicker === 'watchers'"
+								:aria-label="t('kanso', 'Show watchers')"
+								:title="t('kanso', 'Show watchers')"
+								@click="togglePicker('watchers')">
+								<ChevronDownIcon :size="16" />
+							</button>
+							<div
+								v-if="openPicker === 'watchers'"
+								class="card-modal__popover card-modal__popover--right card-modal__watch-panel"
+								role="dialog"
+								:aria-label="t('kanso', 'Watchers')">
+								<span class="card-modal__watch-panel-title">
+									{{ n('kanso', '%n watcher', '%n watchers', watcherCount) }}
+								</span>
+								<span
+									v-for="uid in displayedWatcherIds"
+									:key="'watch-panel-' + uid"
+									class="card-modal__watch-row">
+									<NcAvatar
+										:user="uid"
+										:display-name="participantName(uid)"
+										:size="24"
+										:show-user-status="false"
+										:disable-tooltip="true" />
+									<span class="card-modal__watch-row-name">{{ participantName(uid) }}</span>
+									<button
+										v-if="canEdit"
+										class="card-modal__pill-x"
+										:title="t('kanso', 'Remove watcher')"
+										:disabled="toggleOtherSubscription.isPending.value"
+										@click="handleToggleWatcher(uid, false)">
+										<CloseIcon :size="12" />
+									</button>
+								</span>
+								<span
+									v-if="displayedWatcherIds.length === 0 && !isWatching"
+									class="card-modal__watch-panel-empty">
+									{{ t('kanso', 'No one is watching this card yet.') }}
+								</span>
+								<template v-if="canEdit && unwatchedParticipants.length > 0">
+									<span class="card-modal__watch-panel-divider" />
+									<span class="card-modal__watch-panel-subtitle">{{ t('kanso', 'Add watcher') }}</span>
+									<button
+										v-for="p in unwatchedParticipants"
+										:key="'watch-add-' + p.uid"
+										class="card-modal__assign-option"
+										:disabled="toggleOtherSubscription.isPending.value"
+										@click="handleToggleWatcher(p.uid, true)">
+										<NcAvatar
+											:user="p.uid"
+											:display-name="p.displayName"
+											:size="24"
+											:show-user-status="false"
+											:disable-tooltip="true" />
+										<span>{{ p.displayName }}</span>
+									</button>
+								</template>
+								<span v-if="watcherError" class="card-modal__save-error">{{ watcherError }}</span>
+							</div>
+						</span>
 
 						<NcActions class="card-modal__actions-menu" :force-menu="true">
 							<NcActionButton
@@ -574,56 +638,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</div>
 							<span v-if="contactError" class="card-modal__save-error">{{ contactError }}</span>
 						</template>
-
-						<span class="card-modal__attr-divider" />
-
-						<!-- Watchers -->
-						<span
-							v-for="uid in displayedWatcherIds"
-							:key="'watch-' + uid"
-							class="card-modal__assignee-pill">
-							<NcAvatar
-								:user="uid"
-								:display-name="participantName(uid)"
-								:size="22"
-								:show-user-status="false"
-								:disable-tooltip="false" />
-							<span class="card-modal__assignee-name">{{ participantName(uid) }}</span>
-							<button
-								v-if="canEdit"
-								class="card-modal__pill-x"
-								:title="t('kanso', 'Remove watcher')"
-								:disabled="toggleOtherSubscription.isPending.value"
-								@click="handleToggleWatcher(uid, false)">
-								<CloseIcon :size="12" />
-							</button>
-						</span>
-						<div v-if="canEdit && unwatchedParticipants.length > 0" class="card-modal__attr">
-							<button
-								class="card-modal__pill card-modal__pill--dashed"
-								:aria-expanded="openPicker === 'watch'"
-								@click="togglePicker('watch')">
-								<EyeOutlineIcon :size="14" />
-								{{ t('kanso', 'Add watcher') }}
-							</button>
-							<div v-if="openPicker === 'watch'" class="card-modal__popover">
-								<button
-									v-for="p in unwatchedParticipants"
-									:key="p.uid"
-									class="card-modal__assign-option"
-									:disabled="toggleOtherSubscription.isPending.value"
-									@click="handleToggleWatcher(p.uid, true)">
-									<NcAvatar
-										:user="p.uid"
-										:display-name="p.displayName"
-										:size="24"
-										:show-user-status="false"
-										:disable-tooltip="true" />
-									<span>{{ p.displayName }}</span>
-								</button>
-							</div>
-						</div>
-						<span v-if="watcherError" class="card-modal__save-error">{{ watcherError }}</span>
 
 					<span class="card-modal__attr-divider" />
 
@@ -4046,6 +4060,76 @@ async function handleToggleProject(projectId) {
 	border-color: var(--color-primary-element);
 	background: var(--color-primary-light);
 	color: var(--color-primary-element);
+}
+.card-modal__watch-wrap {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+}
+.card-modal__watch-caret {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 36px;
+	border: 1px solid var(--color-border);
+	border-radius: 100px;
+	background: var(--color-main-background);
+	color: var(--color-text-maxcontrast);
+	cursor: pointer;
+}
+.card-modal__watch-caret:hover {
+	border-color: var(--color-primary-element);
+	color: var(--color-primary-element);
+}
+.card-modal__watch-caret--active {
+	border-color: var(--color-primary-element);
+	background: var(--color-primary-light);
+	color: var(--color-primary-element);
+}
+.card-modal__watch-panel {
+	min-width: 240px;
+	gap: 4px;
+}
+.card-modal__watch-panel-title {
+	padding: 4px 8px 2px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+.card-modal__watch-panel-subtitle {
+	padding: 2px 8px;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	color: var(--color-text-maxcontrast);
+}
+.card-modal__watch-panel-empty {
+	padding: 4px 8px 6px;
+	font-size: 0.8125rem;
+	color: var(--color-text-maxcontrast);
+}
+.card-modal__watch-panel-divider {
+	height: 1px;
+	margin: 4px 0;
+	background: var(--color-border);
+}
+.card-modal__watch-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 32px;
+	padding: 2px 8px;
+}
+.card-modal__watch-row-name {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.8125rem;
 }
 .card-modal__icon-btn {
 	display: flex;

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		:name="cardTitle"
 		size="large"
 		class="card-modal-modal"
-		@close="closeModal">
+		@close="onModalClose">
 		<div
 			class="card-modal"
 			:class="`card-modal--tab-${viewMode}`"
@@ -1626,7 +1626,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, nextTick, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
 import { useRouter, useRoute } from 'vue-router'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -2989,6 +2989,44 @@ function closeModal() {
 // it, not the whole card (which would discard an in-progress edit). Inline edits
 // (title/description/comment) stop propagation themselves, so they never reach here.
 function onModalEscape() {
+	if (openPicker.value !== null) {
+		openPicker.value = null
+		return
+	}
+	closeModal()
+}
+
+// Close the card when the dark backdrop is clicked (not just the X). NcModal's own
+// close-on-click-outside prop is unreliable in @nextcloud/vue 9, and its teleported
+// wrapper mounts a tick later than this component, so a direct listener attach races
+// the transition. Instead we listen on `document` (capture) and act only when the
+// mousedown TARGET is our modal's own .modal-wrapper (the dark backdrop). The
+// target-is-wrapper check is the drag guard: a text-selection drag that STARTS on
+// inner content has target inside .modal-container, so releasing on the backdrop
+// never closes the card. The handler funnels through onModalClose so it obeys the
+// same picker-first precedence as Escape.
+function onDocumentMousedown(event) {
+	const target = event.target
+	if (!(target instanceof Element) || !target.classList.contains('modal-wrapper')) {
+		return
+	}
+	// Scope to THIS card's modal (guard against other stacked NcModals on the page).
+	if (!target.closest('.card-modal-modal')) {
+		return
+	}
+	onModalClose()
+}
+onMounted(() => {
+	document.addEventListener('mousedown', onDocumentMousedown, true)
+})
+onBeforeUnmount(() => {
+	document.removeEventListener('mousedown', onDocumentMousedown, true)
+})
+
+// NcModal emits `close` from the X button; the backdrop handler above funnels here
+// too. Mirror onModalEscape's precedence: if an attribute popover is open, dismiss
+// it first rather than closing the whole card (which would drop the picker context).
+function onModalClose() {
 	if (openPicker.value !== null) {
 		openPicker.value = null
 		return

--- a/tests/e2e/card-modal-layout.spec.js
+++ b/tests/e2e/card-modal-layout.spec.js
@@ -251,4 +251,84 @@ test.describe('Card modal two-column layout', () => {
 		await page.locator('.card-modal').press('Escape')
 		await expect(page).not.toHaveURL(new RegExp(`/card/${state.cardId}`), { timeout: 8_000 })
 	})
+
+	// The dark backdrop is the strip of the .modal-wrapper to the LEFT of the centred
+	// .modal-container. The wrapper's own top band is covered by NcModal's .modal-header,
+	// so the corner is NOT backdrop — compute a point midway between the wrapper's left
+	// edge and the container's left edge, at the container's vertical centre. That point
+	// resolves to the .modal-wrapper itself (the element our close-on-backdrop handler
+	// keys off), which is what a user clicking "outside the card" actually hits.
+	async function backdropPoint(page) {
+		return page.evaluate(() => {
+			const wrapper = document.querySelector('.modal-wrapper')
+			const container = document.querySelector('.modal-container')
+			const wb = wrapper.getBoundingClientRect()
+			const cb = container.getBoundingClientRect()
+			return { x: (wb.x + cb.x) / 2, y: cb.y + cb.height / 2 }
+		})
+	}
+
+	test('clicking the backdrop closes the card modal (#3656)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+		await expect(page).toHaveURL(new RegExp(`/card/${state.cardId}`))
+
+		// A genuine backdrop press closes the card, same effect as the X.
+		const pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+
+		await expect(page).not.toHaveURL(new RegExp(`/card/${state.cardId}`), { timeout: 8_000 })
+	})
+
+	test('with a popover open, a backdrop click closes only the popover, not the modal (#3656)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		// Open an attribute popover (the due-date pill).
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		await expect(page.locator('.card-modal__popover').first()).toBeVisible({ timeout: 5_000 })
+
+		// A backdrop press while a popover is open dismisses the popover first,
+		// mirroring the Escape precedence — the modal must stay open.
+		let pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0)
+		await expect(page.locator('.card-modal')).toBeVisible()
+		await expect(page).toHaveURL(new RegExp(`/card/${state.cardId}`))
+
+		// A second backdrop press (no popover open) now closes the modal.
+		pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+		await expect(page).not.toHaveURL(new RegExp(`/card/${state.cardId}`), { timeout: 8_000 })
+	})
+
+	test('a text-selection drag that ends on the backdrop does NOT close the modal (#3656)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal__content', { timeout: 15_000 })
+		await expect(page).toHaveURL(new RegExp(`/card/${state.cardId}`))
+
+		// Press down INSIDE the modal content (on the title), drag out to the
+		// backdrop, and release there — as when selecting text. The close-on-backdrop
+		// handler keys off the mousedown TARGET being the wrapper, so a press that
+		// STARTED inside the content never triggers a close.
+		const titleBox = await page.locator('.card-modal__title').boundingBox()
+		expect(titleBox).not.toBeNull()
+		const pt = await backdropPoint(page)
+
+		await page.mouse.move(titleBox.x + 4, titleBox.y + titleBox.height / 2)
+		await page.mouse.down()
+		await page.mouse.move(pt.x, pt.y, { steps: 12 })
+		await page.mouse.up()
+
+		// The modal must still be open — the drag started inside, not on the backdrop.
+		await expect(page.locator('.card-modal')).toBeVisible()
+		await expect(page).toHaveURL(new RegExp(`/card/${state.cardId}`))
+	})
 })

--- a/tests/e2e/subscription.spec.js
+++ b/tests/e2e/subscription.spec.js
@@ -244,6 +244,97 @@ test.describe('Card Subscriptions / Watchers', () => {
 	})
 })
 
+test.describe('Watchers dropdown UI (caret panel)', () => {
+	// #3654: watchers are managed from a dropdown under the top-right Watch button
+	// (no standalone body section). Drive the panel through the UI.
+	const BOB = 'kanso_watch_ui_bob'
+	const BOB_PASS = 'SubUiWatcher#2026'
+	const state = { boardId: 0, stackId: 0, cardId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		await provisionUser(BOB, BOB_PASS)
+		for (const b of await apiGet('/boards')) {
+			if (b.title === 'Watchers UI E2E Board') await apiDelete(`/boards/${b.id}`)
+		}
+		const board = await apiPost('/boards', { title: 'Watchers UI E2E Board' })
+		state.boardId = board.id
+		await shareBoardWith(board.id, BOB, 3) // READ | EDIT — becomes a board participant
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'To Do' })
+		state.stackId = stack.id
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'Dropdown Watchers' })
+		state.cardId = card.id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+		await deleteUser(BOB)
+	})
+
+	test('no standalone watchers section remains in the modal body', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// The old "Add watcher" pill lived in the attribute bar; it must be gone.
+		await expect(page.locator('.card-modal__attrbar')).not.toContainText('Add watcher', { timeout: 3000 })
+		// The dropdown panel is closed until the caret is clicked.
+		await expect(page.locator('.card-modal__watch-panel')).toHaveCount(0)
+	})
+
+	test('caret opens the panel; add + remove a watcher from it', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const caret = page.locator('.card-modal__watch-caret')
+		await expect(caret).toBeVisible({ timeout: 5000 })
+		await expect(caret).toHaveAttribute('aria-expanded', 'false', { timeout: 3000 })
+
+		// Open the dropdown.
+		await caret.click()
+		const panel = page.locator('.card-modal__watch-panel')
+		await expect(panel).toBeVisible({ timeout: 4000 })
+		await expect(caret).toHaveAttribute('aria-expanded', 'true', { timeout: 3000 })
+
+		// Add BOB via the "Add watcher" picker inside the panel.
+		const addOption = panel.locator('.card-modal__assign-option', { hasText: BOB })
+		await expect(addOption).toBeVisible({ timeout: 4000 })
+		await addOption.click()
+
+		// Reopen (adding closes the popover) and verify BOB is now a listed watcher.
+		await caret.click()
+		await expect(panel).toBeVisible({ timeout: 4000 })
+		const bobRow = panel.locator('.card-modal__watch-row', { hasText: BOB })
+		await expect(bobRow).toBeVisible({ timeout: 4000 })
+
+		// Count badge should now reflect at least one watcher.
+		await expect(page.locator('.card-modal__watch-count')).toBeVisible({ timeout: 4000 })
+
+		// Remove BOB via the × on his row.
+		await bobRow.locator('.card-modal__pill-x').click()
+		await expect(panel.locator('.card-modal__watch-row', { hasText: BOB })).toHaveCount(0, { timeout: 4000 })
+	})
+
+	test('Escape closes the dropdown before the modal', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const caret = page.locator('.card-modal__watch-caret')
+		await caret.click()
+		await expect(page.locator('.card-modal__watch-panel')).toBeVisible({ timeout: 4000 })
+
+		// First Escape dismisses the panel but keeps the card open.
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.card-modal__watch-panel')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal')).toBeVisible({ timeout: 3000 })
+	})
+})
+
 test.describe('Watcher management — add / remove OTHER users', () => {
 	const BOB = 'kanso_watch_bob'
 	const BOB_PASS = 'Sub2Watcher#2026'


### PR DESCRIPTION
Two user-reported card-modal UX fixes, bundled into one PR (both touch `CardModal.vue`).

## #3656 — close the card view on backdrop click
The card modal only closed via the X (and Escape). Clicking the dark overlay outside the modal now closes it too.
- `@nextcloud/vue` 9.9.0's built-in `:close-on-click-outside` doesn't fire, so this uses a document-level **capture-phase `mousedown`** handler that acts only when the mousedown **target** is this modal's own `.modal-wrapper`.
- That target check doubles as the **drag guard**: a text-selection drag that starts inside the content and releases on the backdrop does **not** close.
- Routes through a new `onModalClose()` that mirrors `onModalEscape` — **picker-first precedence**: if an inner popover is open, the outside click closes the popover first, not the whole modal.

## #3654 — move watchers into a dropdown under the Watch button
The standalone Watchers section in the modal body took too much vertical space.
- Removed that section; the top-right **Watch** control gains a caret that opens a compact dropdown listing watchers (avatar + name + remove ×) with an "Add watcher" picker.
- Reuses the existing `handleToggleWatcher` / participant picker / subscription flow — **no new endpoints, no migration**.
- Registered in the shared `openPicker` state machine (`openPicker === 'watchers'`) so Escape and backdrop-click both close the dropdown before the modal (composes with #3656).

## #3653 — (no change) comment-reaction row layout
Investigated as part of this batch: the reaction row is **already** correct on `main` (`.card-modal__reactions` is `flex/wrap/center/gap`, add-wrap is `inline-flex`, picker is `position:absolute`) and verified inline live in the NC34 dev stack. No diff needed — closed as already-satisfied.

## Tests
- `card-modal-layout.spec.js` +3 (backdrop closes; picker-first; drag-select doesn't close) → 10/10.
- `subscription.spec.js` +3 (no body section; caret open + add/remove; Escape closes panel first) → 12/12.
- `npm run build` clean. Frontend-only; no PHP, no migration, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)