### PR TITLE
ci: drop the redundant post-merge run on main (PR-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@
 name: CI
 
 on:
-  # Feature branches are covered by pull_request; scoping push to main (+ release
-  # tags) stops every PR commit triggering two full runs (push AND pull_request).
+  # Every change lands via a PR, and the pull_request run is the merge gate — so we
+  # deliberately do NOT re-run CI on main after a merge. That post-merge run would
+  # just repeat the ~1.5h suite the PR already passed, on the slow serial runners.
+  # Push only builds release tags; feature branches are covered by pull_request.
   push:
-    branches: [main]
     tags: ['v*']
   pull_request:
 


### PR DESCRIPTION
Follow-up to the trigger dedup in #8. Every change lands via a PR whose `pull_request` run is the required-checks **merge gate**, so re-running the full CI suite on the post-merge `main` commit just repeats the ~1.5h run that already passed — pure redundancy on the slow serial self-hosted runners.

**Change:** drop `push.branches: [main]` from the CI triggers. Keep:
- `pull_request` — the merge gate (all 6 required checks still run on every PR, unchanged).
- `push.tags: ['v*']` — release tags still build.

**Effect:** merging a PR no longer kicks off a `main` run. The only thing lost is a post-merge full-suite run on `main` itself; branch protection is unaffected (required checks are evaluated on the PR), and for a solo, always-PR-gated repo the merged squash result is what the PR just tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)