### PR TITLE
Card-view depth + UX/perf polish (time tracking, custom fields, review-stage gating, +)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.25</version>
+	<version>0.9.26</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.26</version>
+	<version>0.9.27</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -41,6 +41,9 @@ links and webhook, and one-click Import from Deck.
 	<dependencies>
 		<nextcloud min-version="30" max-version="34"/>
 	</dependencies>
+	<commands>
+		<command>OCA\Kanso\Command\Rebalance</command>
+	</commands>
 	<background-jobs>
 		<job>OCA\Kanso\Cron\PruneChanges</job>
 		<job>OCA\Kanso\Cron\ArchiveDoneCards</job>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,6 +52,14 @@ links and webhook, and one-click Import from Deck.
 		<admin>OCA\Kanso\Settings\BackupAdmin</admin>
 		<admin-section>OCA\Kanso\Settings\AdminSection</admin-section>
 	</settings>
+	<activity>
+		<settings>
+			<setting>OCA\Kanso\Activity\Setting</setting>
+		</settings>
+		<providers>
+			<provider>OCA\Kanso\Activity\Provider</provider>
+		</providers>
+	</activity>
 	<navigations>
 		<navigation>
 			<name>Kanso</name>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.27</version>
+	<version>0.9.28</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.28</version>
+	<version>0.9.29</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -247,6 +247,17 @@ return [
 		['name' => 'reviewType#update', 'url' => '/api/review-types/{id}', 'verb' => 'PATCH'],
 		['name' => 'reviewType#destroy', 'url' => '/api/review-types/{id}', 'verb' => 'DELETE'],
 
+		// Per-board custom-field DEFINITIONS (#3537). MANAGE-gated CRUD; the board
+		// payload carries the definition list, so there is no index endpoint
+		// (mirrors review-types). VALUES are set per card below.
+		['name' => 'cardField#create', 'url' => '/api/card-fields', 'verb' => 'POST'],
+		['name' => 'cardField#update', 'url' => '/api/card-fields/{id}', 'verb' => 'PATCH'],
+		['name' => 'cardField#destroy', 'url' => '/api/card-fields/{id}', 'verb' => 'DELETE'],
+		// Per-card custom-field VALUES (#3537). EDIT-gated; a set is an upsert
+		// (one value per card/field). Set = PUT, clear = DELETE.
+		['name' => 'cardFieldValue#set', 'url' => '/api/cards/{cardId}/fields/{fieldId}', 'verb' => 'PUT'],
+		['name' => 'cardFieldValue#clear', 'url' => '/api/cards/{cardId}/fields/{fieldId}', 'verb' => 'DELETE'],
+
 		['name' => 'archiveRule#index', 'url' => '/api/boards/{id}/archive-rules', 'verb' => 'GET'],
 		['name' => 'archiveRule#create', 'url' => '/api/boards/{id}/archive-rules', 'verb' => 'POST'],
 		['name' => 'archiveRule#update', 'url' => '/api/archive-rules/{id}', 'verb' => 'PATCH'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -199,6 +199,13 @@ return [
 		['name' => 'cardAttachment#inline', 'url' => '/api/cards/{cardId}/attachments/{attachmentId}/inline', 'verb' => 'GET'],
 		['name' => 'cardAttachment#destroy', 'url' => '/api/cards/{cardId}/attachments/{attachmentId}', 'verb' => 'DELETE'],
 
+		// Manual time tracking on a card (#3536): list (READ), add a manual entry
+		// (EDIT) and delete an entry (EDIT). Seconds + optional note; the per-card
+		// total lives only in the card detail payload (never the summaries).
+		['name' => 'cardTimeEntry#index', 'url' => '/api/cards/{cardId}/time-entries', 'verb' => 'GET'],
+		['name' => 'cardTimeEntry#create', 'url' => '/api/cards/{cardId}/time-entries', 'verb' => 'POST'],
+		['name' => 'cardTimeEntry#destroy', 'url' => '/api/cards/{cardId}/time-entries/{entryId}', 'verb' => 'DELETE'],
+
 		['name' => 'cardRelation#index', 'url' => '/api/cards/{cardId}/relations', 'verb' => 'GET'],
 		['name' => 'cardRelation#create', 'url' => '/api/cards/{cardId}/relations', 'verb' => 'POST'],
 		['name' => 'cardRelation#destroy', 'url' => '/api/cards/{cardId}/relations/{relationId}', 'verb' => 'DELETE'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -69,6 +69,11 @@ return [
 		// Trello board JSON import → a fresh Kanso board owned by the importer.
 		// A distinct literal POST path, alongside boardPortability#import above.
 		['name' => 'trelloImport#import', 'url' => '/api/trello-import', 'verb' => 'POST'],
+		// Delta-sync read (#3675): board changes since the client's cursor, so a
+		// single edit patches the client cache instead of a whole-board refetch.
+		// Declared BEFORE board#show so the router never captures "changes" as a
+		// board id (same ordering rule as card#templates / card#resolveRef above).
+		['name' => 'board#changes', 'url' => '/api/boards/{id}/changes', 'verb' => 'GET'],
 		['name' => 'board#show', 'url' => '/api/boards/{id}', 'verb' => 'GET'],
 		['name' => 'boardStats#show', 'url' => '/api/boards/{id}/stats', 'verb' => 'GET'],
 		['name' => 'board#participants', 'url' => '/api/boards/{id}/participants', 'verb' => 'GET'],

--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Activity;
+
+use OCP\Activity\Exceptions\UnknownActivityException;
+use OCP\Activity\IEvent;
+use OCP\Activity\IProvider;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+
+/**
+ * Renders Kanso's Nextcloud Activity-stream events. Registered via the app's
+ * info.xml `<activity>` block. Events are produced at the service layer by
+ * {@see \OCA\Kanso\Service\ActivityPublisher} (driven from the same
+ * {@see \OCA\Kanso\Service\ChangeNotifier} choke point that writes the change
+ * log), each carrying a subject key + parameters; parse() resolves them into a
+ * localized, linked, rich message at display time - mirroring how
+ * {@see \OCA\Kanso\Notification\Notifier} handles bell notifications.
+ *
+ * Only four coarse, user-facing milestones are surfaced: a card created, moved
+ * or marked done, and a board shared. Everything else stays out of the stream.
+ */
+class Provider implements IProvider {
+	/** The single Activity type Kanso registers - kept small on purpose. */
+	public const TYPE_KANSO = 'kanso';
+
+	public const SUBJECT_CARD_CREATED = 'card_created';
+	public const SUBJECT_CARD_MOVED = 'card_moved';
+	public const SUBJECT_CARD_DONE = 'card_done';
+	public const SUBJECT_BOARD_SHARED = 'board_shared';
+
+	public const OBJECT_CARD = 'card';
+	public const OBJECT_BOARD = 'board';
+
+	public function __construct(
+		private IFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+	) {
+	}
+
+	/**
+	 * @param string $language
+	 * @param IEvent $event
+	 * @param IEvent|null $previousEvent
+	 * @return IEvent
+	 * @throws UnknownActivityException if the event is not Kanso's or is an
+	 *                                  unknown subject. UnknownActivityException
+	 *                                  extends \InvalidArgumentException, so the
+	 *                                  short-circuit is the NC 30+ preferred form
+	 *                                  and still an \InvalidArgumentException.
+	 */
+	#[\Override]
+	public function parse($language, IEvent $event, ?IEvent $previousEvent = null): IEvent {
+		if ($event->getApp() !== 'kanso') {
+			// Not our activity - the manager will try the next provider.
+			throw new UnknownActivityException();
+		}
+
+		$l = $this->l10nFactory->get('kanso', $language);
+		$params = $event->getSubjectParameters();
+		$actorUid = (string)($params['actor'] ?? '');
+		$name = (string)($params['name'] ?? '');
+
+		$actor = $this->userManager->get($actorUid);
+		$actorName = $actor !== null ? $actor->getDisplayName() : $actorUid;
+
+		[$plain, $rich] = match ($event->getSubject()) {
+			self::SUBJECT_CARD_CREATED
+				=> [$l->t('%1$s created %2$s', [$actorName, $name]), $l->t('{actor} created {object}')],
+			self::SUBJECT_CARD_MOVED
+				=> [$l->t('%1$s moved %2$s', [$actorName, $name]), $l->t('{actor} moved {object}')],
+			self::SUBJECT_CARD_DONE
+				=> [$l->t('%1$s marked %2$s as done', [$actorName, $name]), $l->t('{actor} marked {object} as done')],
+			self::SUBJECT_BOARD_SHARED
+				=> [$l->t('%1$s shared %2$s with you', [$actorName, $name]), $l->t('{actor} shared {object} with you')],
+			// Any other subject is not one of ours - decline it.
+			default => throw new UnknownActivityException(),
+		};
+
+		$event
+			->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('kanso', 'app.svg')))
+			->setParsedSubject($plain)
+			->setRichSubject(
+				$rich,
+				[
+					'actor' => [
+						'type' => 'user',
+						'id' => $actorUid,
+						'name' => $actorName,
+					],
+					'object' => [
+						'type' => 'highlight',
+						'id' => (string)$event->getObjectId(),
+						'name' => $name,
+					],
+				]
+			);
+
+		// The absolute deep link set by the publisher (ActivityPublisher) is left
+		// as-is - it already points at the card/board inside the SPA.
+
+		return $event;
+	}
+}

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Activity;
+
+use OCP\Activity\ISetting;
+use OCP\L10N\IFactory;
+
+/**
+ * The single Activity-app setting that lists Kanso in the user's Activity
+ * preferences, so each user can opt this app's stream/mail in or out. Registered
+ * via the app's info.xml `<activity><settings>` block. Its identifier matches the
+ * event type produced by {@see Provider::TYPE_KANSO} so the toggle governs every
+ * Kanso event.
+ */
+class Setting implements ISetting {
+	public function __construct(
+		private IFactory $l10nFactory,
+	) {
+	}
+
+	#[\Override]
+	public function getIdentifier(): string {
+		return Provider::TYPE_KANSO;
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10nFactory->get('kanso')->t('A card was created, moved or completed, or a board was shared with you');
+	}
+
+	#[\Override]
+	public function getPriority(): int {
+		return 51;
+	}
+
+	#[\Override]
+	public function canChangeStream(): bool {
+		return true;
+	}
+
+	#[\Override]
+	public function isDefaultEnabledStream(): bool {
+		return true;
+	}
+
+	#[\Override]
+	public function canChangeMail(): bool {
+		return true;
+	}
+
+	#[\Override]
+	public function isDefaultEnabledMail(): bool {
+		return false;
+	}
+}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -9,6 +9,8 @@ namespace OCA\Kanso\AppInfo;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Kanso\Notification\Notifier;
+use OCA\Kanso\Service\ActivityPublisher;
+use OCP\Activity\IManager as IActivityManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -16,8 +18,10 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\IAppData;
+use OCP\IURLGenerator;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * @implements IEventListener<LoadAdditionalScriptsEvent>
@@ -38,6 +42,24 @@ class Application extends App implements IBootstrap, IEventListener {
 		// Kanso's app-data, never in a user's personal Files.
 		$context->registerService(IAppData::class, static function (ContainerInterface $c): IAppData {
 			return $c->get(IAppDataFactory::class)->get(self::APP_ID);
+		});
+
+		// Activity-stream bridge (#3439): construct the publisher with a nullable
+		// Activity IManager - the Activity app is optional, so feature-detect it
+		// here and hand the publisher null when it is absent (it then no-ops). The
+		// container cannot auto-wire an optional dependency, hence the factory.
+		$context->registerService(ActivityPublisher::class, static function (ContainerInterface $c): ActivityPublisher {
+			$manager = null;
+			try {
+				$manager = $c->get(IActivityManager::class);
+			} catch (\Throwable) {
+				// Activity app not installed - publisher runs as a no-op.
+			}
+			return new ActivityPublisher(
+				$manager,
+				$c->get(IURLGenerator::class),
+				$c->get(LoggerInterface::class),
+			);
 		});
 
 		// "Share from Files" (#3645): inject Kanso's Files-integration bundle into

--- a/lib/Command/Rebalance.php
+++ b/lib/Command/Rebalance.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Command;
+
+use OCA\Kanso\Service\CardService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * `occ kanso:rebalance` - recovery for a stack whose fractional sort keys have
+ * grown past {@see \OCA\Kanso\Service\SortKeyService::MAX_KEY_LENGTH} (the move
+ * endpoint reports this as 409 `rebalance_required`). It rewrites the target
+ * stack's card sort keys to short, evenly-spaced values with the display order
+ * preserved, restoring room for future inserts.
+ *
+ * Usage:
+ *   occ kanso:rebalance <stackId>         rebalance one stack
+ *   occ kanso:rebalance --board <boardId> rebalance every stack on a board
+ */
+class Rebalance extends Command {
+	public function __construct(
+		private CardService $cardService,
+	) {
+		parent::__construct();
+	}
+
+	#[\Override]
+	protected function configure(): void {
+		$this
+			->setName('kanso:rebalance')
+			->setDescription('Rewrite card sort keys to short, evenly-spaced values (recovers from sort-key overflow)')
+			->addArgument(
+				'stackId',
+				InputArgument::OPTIONAL,
+				'ID of the stack to rebalance',
+			)
+			->addOption(
+				'board',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Rebalance every stack on this board ID instead of a single stack',
+			);
+	}
+
+	#[\Override]
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$stackArg = $input->getArgument('stackId');
+		$boardArg = $input->getOption('board');
+
+		if ($boardArg !== null && $stackArg !== null) {
+			$output->writeln('<error>Pass either a stackId argument or --board, not both.</error>');
+			return 1;
+		}
+		if ($boardArg === null && $stackArg === null) {
+			$output->writeln('<error>Pass a stackId argument or --board <boardId>.</error>');
+			return 1;
+		}
+
+		if ($boardArg !== null) {
+			$boardId = (int)$boardArg;
+			try {
+				return $this->rebalanceBoard($boardId, $output);
+			} catch (DoesNotExistException) {
+				$output->writeln(sprintf('<error>Board %d does not exist.</error>', $boardId));
+				return 1;
+			}
+		}
+
+		$stackId = (int)$stackArg;
+		try {
+			return $this->rebalanceStack($stackId, $output);
+		} catch (DoesNotExistException) {
+			$output->writeln(sprintf('<error>Stack %d does not exist.</error>', $stackId));
+			return 1;
+		}
+	}
+
+	private function rebalanceStack(int $stackId, OutputInterface $output): int {
+		$count = $this->cardService->rebalanceStack($stackId);
+		$output->writeln(sprintf('Rebalanced stack %d: %d card(s) rewritten.', $stackId, $count));
+		return 0;
+	}
+
+	private function rebalanceBoard(int $boardId, OutputInterface $output): int {
+		$results = $this->cardService->rebalanceBoard($boardId);
+		$total = array_sum($results);
+		foreach ($results as $stackId => $count) {
+			$output->writeln(sprintf('  stack %d: %d card(s) rewritten.', $stackId, $count));
+		}
+		$output->writeln(sprintf('Rebalanced board %d: %d stack(s), %d card(s) total.', $boardId, count($results), $total));
+		return 0;
+	}
+}

--- a/lib/Controller/BoardController.php
+++ b/lib/Controller/BoardController.php
@@ -11,6 +11,7 @@ use OCA\Kanso\Db\AclMapper;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardContactMapper;
+use OCA\Kanso\Db\CardFieldMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardRelationMapper;
@@ -53,6 +54,7 @@ class BoardController extends Controller {
 		private CardContactMapper $cardContactMapper,
 		private CardReviewMapper $cardReviewMapper,
 		private ReviewTypeMapper $reviewTypeMapper,
+		private CardFieldMapper $cardFieldMapper,
 		private ChecklistItemMapper $checklistItemMapper,
 		private CommentMapper $commentMapper,
 		private AclMapper $aclMapper,
@@ -126,6 +128,9 @@ class BoardController extends Controller {
 				),
 				'labels' => $this->labelMapper->findByBoard($id),
 				'reviewTypes' => $this->reviewTypeMapper->findByBoard($id),
+				// Custom-field DEFINITIONS ride the board payload (#3537); their
+				// per-card VALUES live only in the card detail payload.
+				'cardFields' => $this->cardFieldMapper->findByBoard($id),
 				'acl' => $this->aclMapper->findByBoard($id),
 				// The requester's own bits, so the frontend can gate the
 				// share/manage UI without re-deriving ACL semantics.

--- a/lib/Controller/BoardController.php
+++ b/lib/Controller/BoardController.php
@@ -16,6 +16,7 @@ use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardRelationMapper;
 use OCA\Kanso\Db\CardReviewMapper;
+use OCA\Kanso\Db\Change;
 use OCA\Kanso\Db\ChangeMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
@@ -102,30 +103,10 @@ class BoardController extends Controller {
 				return $response;
 			}
 
-			$labelIdsByCard = $this->cardLabelMapper->findLabelIdsByBoard($id);
-			$assigneesByCard = $this->cardAssigneeMapper->findUserIdsByBoard($id);
-			$contactsByCard = $this->cardContactMapper->findContactsByBoard($id);
-			$checklistByCard = $this->checklistItemMapper->progressByBoard($id);
-			$childProgressByCard = $this->cardMapper->childProgressByBoard($id);
-			$commentCountByCard = $this->commentMapper->countsByBoard($id);
-			$reviewStateByCard = $this->cardReviewMapper->reviewStatesByBoard($id);
-			// Card ids blocked by a not-done card - drives the tile "blocked" badge.
-			$blockedIds = array_flip($this->cardRelationMapper->blockedCardIdsByBoard($id));
 			$response = new JSONResponse([
 				'board' => $board,
 				'stacks' => $this->stackMapper->findByBoard($id),
-				'cards' => array_map(
-					static fn (Card $card): array => $card->jsonSerializeSummary()
-						+ ['labelIds' => $labelIdsByCard[$card->getId()] ?? []]
-						+ ['assigneeIds' => $assigneesByCard[$card->getId()] ?? []]
-						+ ['contacts' => $contactsByCard[$card->getId()] ?? []]
-						+ ['checklist' => $checklistByCard[$card->getId()] ?? ['total' => 0, 'done' => 0]]
-						+ ['childProgress' => $childProgressByCard[$card->getId()] ?? ['total' => 0, 'done' => 0]]
-						+ ['commentCount' => $commentCountByCard[$card->getId()] ?? 0]
-						+ ['reviewState' => $reviewStateByCard[$card->getId()] ?? null]
-						+ ['blocked' => isset($blockedIds[$card->getId()])],
-					$this->cardMapper->findSummariesByBoard($id)
-				),
+				'cards' => $this->serializeCardSummaries($id, $this->cardMapper->findSummariesByBoard($id)),
 				'labels' => $this->labelMapper->findByBoard($id),
 				'reviewTypes' => $this->reviewTypeMapper->findByBoard($id),
 				// Custom-field DEFINITIONS ride the board payload (#3537); their
@@ -137,10 +118,160 @@ class BoardController extends Controller {
 				'permissions' => $this->permissionService->getPermissions($board, $uid),
 				// The requester's board-watch state {subscribed, subscribers, count}.
 				'subscription' => $this->subscriptionService->buildBoardSubscription($id, $uid),
+				// The board's latest change id - the same value as the ETag. Seeds
+				// the client's delta-sync cursor from the body so it can poll
+				// `?since=<cursor>` without parsing the ETag header.
+				'cursor' => (int)$etag,
 			]);
 			$response->setETag($etag);
 			return $response;
 		});
+	}
+
+	/**
+	 * Delta-sync read (#3675): the board changes since the client's cursor, so a
+	 * single edit patches the client cache instead of forcing a whole-board
+	 * refetch. Same ACL gate as {@see self::show()} (via BoardService::find). The
+	 * response advances the client's cursor and carries per-entity upserts/removes:
+	 *
+	 *   {cursor, resync, cards:{upsert:[...], remove:[ids]}, stacks:{upsert:[...], remove:[ids]}}
+	 *
+	 * `resync:true` (a 200 with the flag, never an error status) tells the client
+	 * to drop its cursor and do a full {@see self::show()} refetch. It fires when:
+	 *   - the cursor is unusable (`since <= 0`, or below the board's retained tail
+	 *     after pruning), so a delta would be incomplete;
+	 *   - the window is saturated (client too far behind - more than the row cap);
+	 *   - the window touched an entity kind this delta path does not (yet) model
+	 *     (labels / acl / review-types / custom-fields / board itself). Those are
+	 *     rare relative to card/stack edits, and a full refetch on one is an
+	 *     acceptable MVP cut that avoids replicating the board-wide array
+	 *     enrichment (labels list, acl, permissions, subscription) here.
+	 *
+	 * The cursor is ALWAYS the board's latest change id (even on an empty delta or
+	 * a resync), so the client advances and a subsequent poll starts from there.
+	 * No ETag: the request is already conditional via `since`.
+	 */
+	#[NoAdminRequired]
+	public function changes(int $id, int $since = 0): JSONResponse {
+		return $this->respond(function () use ($id, $since): JSONResponse {
+			$uid = $this->currentUserId();
+			// Same ACL gate show() trusts: throws NotPermitted (→403) / DoesNotExist
+			// (→404), which ApiErrorTrait maps exactly as it does for show().
+			$this->boardService->find($id, $uid);
+
+			$latest = $this->changeMapper->getLatestChangeId($id);
+
+			// Unusable cursor → resync. `since <= 0` is a client with no cursor yet;
+			// a cursor below the board's oldest RETAINED change (minus one, so the
+			// exact oldest row is still deliverable) has fallen off the pruned tail
+			// and a delta from it would be incomplete.
+			if ($since <= 0 || $since < $this->changeMapper->getOldestChangeId($id) - 1) {
+				return new JSONResponse(['cursor' => $latest, 'resync' => true]);
+			}
+
+			$limit = 500;
+			$rows = $this->changeMapper->findSince($id, $since, $limit);
+			// Saturated window: the client is more than one page behind, so the
+			// delta may be truncated - force a full refetch instead of a partial.
+			if (count($rows) === $limit) {
+				return new JSONResponse(['cursor' => $latest, 'resync' => true]);
+			}
+
+			// Collapse to the latest intent per (entity_type, entity_id): a card
+			// created then moved then edited in the window is one upsert; a card
+			// deleted last is a remove. We only need which cards / stacks to
+			// re-serialize (or drop), and whether any out-of-scope kind appeared.
+			$cardAction = [];
+			$stackAction = [];
+			foreach ($rows as $row) {
+				switch ($row->getEntityType()) {
+					case Change::ENTITY_CARD:
+						$cardAction[$row->getEntityId()] = $row->getAction();
+						break;
+					case Change::ENTITY_STACK:
+						$stackAction[$row->getEntityId()] = $row->getAction();
+						break;
+					default:
+						// A label / acl / review-type / custom-field / board change
+						// rode the window - the MVP scope cut: resync rather than
+						// replicate board-wide array enrichment here.
+						return new JSONResponse(['cursor' => $latest, 'resync' => true]);
+				}
+			}
+
+			// Cards: re-serialize the ones still live (byte-identical to show()),
+			// and remove those the summary query no longer returns - either the
+			// last action was DELETE, or the row was deleted / turned into a
+			// template between the cursor and now.
+			$cardIds = array_keys($cardAction);
+			$liveCards = $this->serializeCardSummaries($id, $this->cardMapper->findSummariesByIds($id, $cardIds));
+			$presentCardIds = array_flip(array_map(static fn (array $c): int => $c['id'], $liveCards));
+			$removedCardIds = array_values(array_filter(
+				$cardIds,
+				static fn (int $cid): bool => !isset($presentCardIds[$cid])
+			));
+
+			// Stacks: same shape as show() (raw entity JSON), remove the absent ones.
+			$liveStacks = $this->stackMapper->findByIds($id, array_keys($stackAction));
+			$presentStackIds = array_flip(array_map(static fn ($s): int => $s->getId(), $liveStacks));
+			$removedStackIds = array_values(array_filter(
+				array_keys($stackAction),
+				static fn (int $sid): bool => !isset($presentStackIds[$sid])
+			));
+
+			return new JSONResponse([
+				'cursor' => $latest,
+				'resync' => false,
+				'cards' => [
+					'upsert' => $liveCards,
+					'remove' => $removedCardIds,
+				],
+				'stacks' => [
+					'upsert' => $liveStacks,
+					'remove' => $removedStackIds,
+				],
+			]);
+		});
+	}
+
+	/**
+	 * Enriches card summaries with the same per-card signal the board payload
+	 * carries (labelIds / assigneeIds / contacts / checklist / childProgress /
+	 * commentCount / reviewState / blocked). Extracted from {@see self::show()} so
+	 * {@see self::changes()} produces a BYTE-IDENTICAL card shape - the delta-sync
+	 * upsert must be indistinguishable from a full-board card, or a patched cache
+	 * entry would drift from a freshly fetched one. The enrichment maps are board-
+	 * wide (one query each, no N+1); the per-card lookups just index into them, so
+	 * passing a subset of the board's cards is safe and cheap.
+	 *
+	 * @param Card[] $cards
+	 * @return list<array<string, mixed>>
+	 */
+	private function serializeCardSummaries(int $boardId, array $cards): array {
+		$labelIdsByCard = $this->cardLabelMapper->findLabelIdsByBoard($boardId);
+		$assigneesByCard = $this->cardAssigneeMapper->findUserIdsByBoard($boardId);
+		$contactsByCard = $this->cardContactMapper->findContactsByBoard($boardId);
+		$checklistByCard = $this->checklistItemMapper->progressByBoard($boardId);
+		$childProgressByCard = $this->cardMapper->childProgressByBoard($boardId);
+		$commentCountByCard = $this->commentMapper->countsByBoard($boardId);
+		$reviewStateByCard = $this->cardReviewMapper->reviewStatesByBoard($boardId);
+		// Card ids blocked by a not-done card - drives the tile "blocked" badge.
+		$blockedIds = array_flip($this->cardRelationMapper->blockedCardIdsByBoard($boardId));
+
+		// array_values so the result is a genuine list (Card[] may be keyed by the
+		// mapper); the delta-sync consumer serializes it as a JSON array.
+		return array_values(array_map(
+			static fn (Card $card): array => $card->jsonSerializeSummary()
+				+ ['labelIds' => $labelIdsByCard[$card->getId()] ?? []]
+				+ ['assigneeIds' => $assigneesByCard[$card->getId()] ?? []]
+				+ ['contacts' => $contactsByCard[$card->getId()] ?? []]
+				+ ['checklist' => $checklistByCard[$card->getId()] ?? ['total' => 0, 'done' => 0]]
+				+ ['childProgress' => $childProgressByCard[$card->getId()] ?? ['total' => 0, 'done' => 0]]
+				+ ['commentCount' => $commentCountByCard[$card->getId()] ?? 0]
+				+ ['reviewState' => $reviewStateByCard[$card->getId()] ?? null]
+				+ ['blocked' => isset($blockedIds[$card->getId()])],
+			$cards
+		));
 	}
 
 	/**

--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -13,6 +13,7 @@ use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardContactMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\CardTimeEntryMapper;
 use OCA\Kanso\Db\ChecklistItem;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
@@ -59,6 +60,7 @@ class CardController extends Controller {
 		private CardRelationService $relationService,
 		private ProjectCardMapper $projectCardMapper,
 		private CardAttachmentMapper $cardAttachmentMapper,
+		private CardTimeEntryMapper $cardTimeEntryMapper,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -146,6 +148,7 @@ class CardController extends Controller {
 			+ ['children' => $children]
 			+ ['commentCount' => $this->commentMapper->countByCard($id)]
 			+ ['attachmentCount' => $this->cardAttachmentMapper->countByCard($id)]
+			+ ['timeSpent' => $this->cardTimeEntryMapper->sumSecondsByCard($id)]
 			+ ['subscription' => $this->subscriptionService->buildCardSubscription($id, $uid)]
 			+ ['relations' => $this->relationService->groupedForCard($id)]
 			+ ['projectIds' => $this->projectCardMapper->findProjectIdsByCard($id)];

--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -13,7 +13,6 @@ use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardContactMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
-use OCA\Kanso\Db\CardReviewMapper;
 use OCA\Kanso\Db\ChecklistItem;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
@@ -24,6 +23,7 @@ use OCA\Kanso\Service\CardService;
 use OCA\Kanso\Service\ContactService;
 use OCA\Kanso\Service\LabelService;
 use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\ReviewService;
 use OCA\Kanso\Service\SubscriptionService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -51,7 +51,7 @@ class CardController extends Controller {
 		private CardLabelMapper $cardLabelMapper,
 		private CardAssigneeMapper $cardAssigneeMapper,
 		private CardContactMapper $cardContactMapper,
-		private CardReviewMapper $cardReviewMapper,
+		private ReviewService $reviewService,
 		private ChecklistItemMapper $checklistItemMapper,
 		private CardMapper $cardMapper,
 		private CommentMapper $commentMapper,
@@ -139,7 +139,7 @@ class CardController extends Controller {
 			+ ['labelIds' => $this->cardLabelMapper->findLabelIdsByCard($id)]
 			+ ['assigneeIds' => $this->cardAssigneeMapper->findUserIdsByCard($id)]
 			+ ['contacts' => $this->cardContactMapper->findContactsByCard($id)]
-			+ ['reviews' => $this->cardReviewMapper->findByCard($id)]
+			+ ['reviews' => $this->reviewService->serializeReviewsForCard($id)]
 			+ ['checklistItems' => $checklistItems]
 			+ ['checklist' => ['total' => count($checklistItems), 'done' => $checklistDone]]
 			+ ['parent' => $parent]

--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -11,6 +11,8 @@ use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardContactMapper;
+use OCA\Kanso\Db\CardFieldValue;
+use OCA\Kanso\Db\CardFieldValueMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardTimeEntryMapper;
@@ -61,6 +63,7 @@ class CardController extends Controller {
 		private ProjectCardMapper $projectCardMapper,
 		private CardAttachmentMapper $cardAttachmentMapper,
 		private CardTimeEntryMapper $cardTimeEntryMapper,
+		private CardFieldValueMapper $cardFieldValueMapper,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -151,7 +154,13 @@ class CardController extends Controller {
 			+ ['timeSpent' => $this->cardTimeEntryMapper->sumSecondsByCard($id)]
 			+ ['subscription' => $this->subscriptionService->buildCardSubscription($id, $uid)]
 			+ ['relations' => $this->relationService->groupedForCard($id)]
-			+ ['projectIds' => $this->projectCardMapper->findProjectIdsByCard($id)];
+			+ ['projectIds' => $this->projectCardMapper->findProjectIdsByCard($id)]
+			// Custom-field VALUES (#3537): [{fieldId, value}] - detail-only, never
+			// in the board summary (the definitions ride the board payload).
+			+ ['fieldValues' => array_map(
+				static fn (CardFieldValue $v): array => $v->jsonSerialize(),
+				$this->cardFieldValueMapper->findByCard($id)
+			)];
 	}
 
 	/**

--- a/lib/Controller/CardFieldController.php
+++ b/lib/Controller/CardFieldController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Controller;
+
+use OCA\Kanso\Service\CardFieldService;
+use OCA\Kanso\Service\NotPermittedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Per-board custom-field DEFINITION CRUD (#3537). Managing the definition list
+ * needs MANAGE (gated in the service). Mirrors ReviewTypeController: the board
+ * payload carries the definition list, so there is no index endpoint.
+ */
+class CardFieldController extends Controller {
+	use ApiErrorTrait;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private CardFieldService $cardFieldService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @param string[]|null $options
+	 */
+	#[NoAdminRequired]
+	public function create(int $boardId = 0, string $name = '', string $type = '', ?array $options = null): JSONResponse {
+		return $this->respond(function () use ($boardId, $name, $type, $options): JSONResponse {
+			return new JSONResponse(
+				$this->cardFieldService->create($boardId, $name, $type, $options, $this->currentUserId())
+			);
+		});
+	}
+
+	/**
+	 * @param string[]|null $options
+	 */
+	#[NoAdminRequired]
+	public function update(int $id, ?string $name = null, ?array $options = null, ?string $sortKey = null): JSONResponse {
+		return $this->respond(function () use ($id, $name, $options, $sortKey): JSONResponse {
+			return new JSONResponse(
+				$this->cardFieldService->update($id, $name, $options, $sortKey, $this->currentUserId())
+			);
+		});
+	}
+
+	#[NoAdminRequired]
+	public function destroy(int $id): JSONResponse {
+		return $this->respond(function () use ($id): JSONResponse {
+			$this->cardFieldService->delete($id, $this->currentUserId());
+			return new JSONResponse([]);
+		});
+	}
+
+	/**
+	 * @throws NotPermittedException if there is no user session
+	 */
+	private function currentUserId(): string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No authenticated user');
+		}
+		return $user->getUID();
+	}
+}

--- a/lib/Controller/CardFieldValueController.php
+++ b/lib/Controller/CardFieldValueController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Controller;
+
+use OCA\Kanso\Service\CardFieldValueService;
+use OCA\Kanso\Service\NotPermittedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Per-card custom-field VALUE writes (#3537). Setting/clearing a value is a
+ * plain card edit, EDIT-gated in the service. A set is an upsert (one value per
+ * card/field); the value rides the card DETAIL payload, not the summary.
+ */
+class CardFieldValueController extends Controller {
+	use ApiErrorTrait;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private CardFieldValueService $cardFieldValueService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	#[NoAdminRequired]
+	public function set(int $cardId, int $fieldId, ?string $value = null): JSONResponse {
+		return $this->respond(function () use ($cardId, $fieldId, $value): JSONResponse {
+			return new JSONResponse(
+				$this->cardFieldValueService->set($cardId, $fieldId, $value, $this->currentUserId())
+			);
+		});
+	}
+
+	#[NoAdminRequired]
+	public function clear(int $cardId, int $fieldId): JSONResponse {
+		return $this->respond(function () use ($cardId, $fieldId): JSONResponse {
+			$this->cardFieldValueService->clear($cardId, $fieldId, $this->currentUserId());
+			return new JSONResponse([]);
+		});
+	}
+
+	/**
+	 * @throws NotPermittedException if there is no user session
+	 */
+	private function currentUserId(): string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No authenticated user');
+		}
+		return $user->getUID();
+	}
+}

--- a/lib/Controller/CardTimeEntryController.php
+++ b/lib/Controller/CardTimeEntryController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Controller;
+
+use OCA\Kanso\Service\CardTimeEntryService;
+use OCA\Kanso\Service\NotPermittedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Card time-tracking endpoints (#3536): list (READ), add a manual entry (EDIT)
+ * and delete an entry (EDIT). Manual entries only - no running-timer state.
+ */
+class CardTimeEntryController extends Controller {
+	use ApiErrorTrait;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private CardTimeEntryService $timeEntryService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	#[NoAdminRequired]
+	public function index(int $cardId): JSONResponse {
+		return $this->respond(function () use ($cardId): JSONResponse {
+			return new JSONResponse(
+				$this->timeEntryService->listForCard($cardId, $this->currentUserId())
+			);
+		});
+	}
+
+	#[NoAdminRequired]
+	public function create(int $cardId, int $seconds = 0, ?string $note = null): JSONResponse {
+		return $this->respond(function () use ($cardId, $seconds, $note): JSONResponse {
+			return new JSONResponse(
+				$this->timeEntryService->add($cardId, $seconds, $note, $this->currentUserId())
+			);
+		});
+	}
+
+	#[NoAdminRequired]
+	public function destroy(int $cardId, int $entryId): JSONResponse {
+		return $this->respond(function () use ($cardId, $entryId): JSONResponse {
+			$this->timeEntryService->delete($cardId, $entryId, $this->currentUserId());
+			return new JSONResponse([]);
+		});
+	}
+
+	/**
+	 * @throws NotPermittedException if there is no user session
+	 */
+	private function currentUserId(): string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No authenticated user');
+		}
+		return $user->getUID();
+	}
+}

--- a/lib/Controller/ReviewTypeController.php
+++ b/lib/Controller/ReviewTypeController.php
@@ -33,19 +33,19 @@ class ReviewTypeController extends Controller {
 	}
 
 	#[NoAdminRequired]
-	public function create(int $boardId = 0, string $title = '', ?string $color = null): JSONResponse {
-		return $this->respond(function () use ($boardId, $title, $color): JSONResponse {
+	public function create(int $boardId = 0, string $title = '', ?string $color = null, ?int $stage = null): JSONResponse {
+		return $this->respond(function () use ($boardId, $title, $color, $stage): JSONResponse {
 			return new JSONResponse(
-				$this->reviewTypeService->create($boardId, $title, $color, $this->currentUserId())
+				$this->reviewTypeService->create($boardId, $title, $color, $this->currentUserId(), $stage)
 			);
 		});
 	}
 
 	#[NoAdminRequired]
-	public function update(int $id, ?string $title = null, ?string $color = null): JSONResponse {
-		return $this->respond(function () use ($id, $title, $color): JSONResponse {
+	public function update(int $id, ?string $title = null, ?string $color = null, ?int $stage = null): JSONResponse {
+		return $this->respond(function () use ($id, $title, $color, $stage): JSONResponse {
 			return new JSONResponse(
-				$this->reviewTypeService->update($id, $title, $color, $this->currentUserId())
+				$this->reviewTypeService->update($id, $title, $color, $this->currentUserId(), $stage)
 			);
 		});
 	}

--- a/lib/Db/CardField.php
+++ b/lib/Db/CardField.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * A board-scoped custom-field definition (table `kanso_card_fields`) - one of a
+ * small FIXED set of typed fields a board defines, whose values are set per
+ * card (see {@see CardFieldValue}). Modelled exactly on {@see ReviewType}: a
+ * per-board typed definition, MANAGE-gated, riding the board payload with no
+ * index endpoint. Ordered by a fractional `sortKey` (never by id) so a reorder
+ * stays a single-row UPDATE.
+ *
+ * The `type` is an app-level enum ({@see CardField::TYPES}) stored as a plain
+ * string and validated in the service, NOT a DB enum. `options` is a JSON array
+ * of choices, only meaningful for type `select`.
+ *
+ * @method int getBoardId()
+ * @method void setBoardId(int $boardId)
+ * @method string getName()
+ * @method void setName(string $name)
+ * @method string getType()
+ * @method void setType(string $type)
+ * @method string|null getOptions()
+ * @method void setOptions(?string $options)
+ * @method string getSortKey()
+ * @method void setSortKey(string $sortKey)
+ */
+class CardField extends Entity implements \JsonSerializable {
+	public const TYPE_TEXT = 'text';
+	public const TYPE_NUMBER = 'number';
+	public const TYPE_DATE = 'date';
+	public const TYPE_SELECT = 'select';
+
+	/** The fixed set of supported field types (app-validated, not a DB enum). */
+	public const TYPES = [
+		self::TYPE_TEXT,
+		self::TYPE_NUMBER,
+		self::TYPE_DATE,
+		self::TYPE_SELECT,
+	];
+
+	// Properties default to null (not to the column defaults): Entity::setter()
+	// skips values equal to the current one, so a non-null default would keep
+	// explicit sets of that same value out of INSERT statements.
+	protected ?int $boardId = null;
+	protected ?string $name = null;
+	protected ?string $type = null;
+	protected ?string $options = null;
+	protected ?string $sortKey = null;
+
+	public function __construct() {
+		$this->addType('boardId', Types::INTEGER);
+		$this->addType('name', Types::STRING);
+		$this->addType('type', Types::STRING);
+		$this->addType('options', Types::TEXT);
+		$this->addType('sortKey', Types::STRING);
+	}
+
+	/**
+	 * The choices for a `select` field as a plain array (empty for other types
+	 * or an unset/invalid options blob).
+	 *
+	 * @return list<string>
+	 */
+	public function getOptionsArray(): array {
+		if ($this->options === null || $this->options === '') {
+			return [];
+		}
+		$decoded = json_decode($this->options, true);
+		if (!is_array($decoded)) {
+			return [];
+		}
+		return array_values(array_map('strval', $decoded));
+	}
+
+	/**
+	 * @return array{id: int, boardId: ?int, name: ?string, type: ?string, options: list<string>, sortKey: ?string}
+	 */
+	#[\Override]
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->getId(),
+			'boardId' => $this->boardId,
+			'name' => $this->name,
+			'type' => $this->type,
+			'options' => $this->getOptionsArray(),
+			'sortKey' => $this->sortKey,
+		];
+	}
+}

--- a/lib/Db/CardFieldMapper.php
+++ b/lib/Db/CardFieldMapper.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `kanso_card_fields`, the per-board custom-field definitions.
+ *
+ * @template-extends QBMapper<CardField>
+ */
+class CardFieldMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'kanso_card_fields', CardField::class);
+	}
+
+	/**
+	 * @throws DoesNotExistException if the field does not exist
+	 * @throws MultipleObjectsReturnedException
+	 * @throws Exception
+	 */
+	public function find(int $id): CardField {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * All field definitions of a board, in their fractional sort-key order (NOT
+	 * by id - reordering is a single-row sort_key UPDATE, the #1 perf bet).
+	 *
+	 * @return CardField[]
+	 * @throws Exception
+	 */
+	public function findByBoard(int $boardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->orderBy('sort_key', 'ASC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * The highest (last) sort key currently used on the board, or null when the
+	 * board has no fields yet - the anchor a new field is appended after.
+	 *
+	 * @throws Exception
+	 */
+	public function lastSortKey(int $boardId): ?string {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('sort_key')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->orderBy('sort_key', 'DESC')
+			->setMaxResults(1);
+
+		$result = $qb->executeQuery();
+		$key = $result->fetchOne();
+		$result->closeCursor();
+
+		return $key === false ? null : (string)$key;
+	}
+}

--- a/lib/Db/CardFieldValue.php
+++ b/lib/Db/CardFieldValue.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * The value a card carries for a board custom-field definition (table
+ * `kanso_card_field_values`). One value per (card_id, field_id) - a unique
+ * index enforces it, so a set is an upsert. The value is a single stringified
+ * column: an ISO date, a number as a string, raw text, or the selected option.
+ * Per-type coercion/validation is the service's job, not the schema's.
+ *
+ * @method int getCardId()
+ * @method void setCardId(int $cardId)
+ * @method int getFieldId()
+ * @method void setFieldId(int $fieldId)
+ * @method string|null getValue()
+ * @method void setValue(?string $value)
+ */
+class CardFieldValue extends Entity implements \JsonSerializable {
+	// Properties default to null (not to the column defaults): Entity::setter()
+	// skips values equal to the current one, so a non-null default would keep
+	// explicit sets of that same value out of INSERT statements.
+	protected ?int $cardId = null;
+	protected ?int $fieldId = null;
+	protected ?string $value = null;
+
+	public function __construct() {
+		$this->addType('cardId', Types::INTEGER);
+		$this->addType('fieldId', Types::INTEGER);
+		$this->addType('value', Types::TEXT);
+	}
+
+	/**
+	 * @return array{fieldId: ?int, value: ?string}
+	 */
+	#[\Override]
+	public function jsonSerialize(): array {
+		return [
+			'fieldId' => $this->fieldId,
+			'value' => $this->value,
+		];
+	}
+}

--- a/lib/Db/CardFieldValueMapper.php
+++ b/lib/Db/CardFieldValueMapper.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `kanso_card_field_values`, the per-card custom-field values. One
+ * row per (card_id, field_id) - a unique index enforces it, so a write is an
+ * upsert.
+ *
+ * @template-extends QBMapper<CardFieldValue>
+ */
+class CardFieldValueMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'kanso_card_field_values', CardFieldValue::class);
+	}
+
+	/**
+	 * Every field value of a card.
+	 *
+	 * @return CardFieldValue[]
+	 * @throws Exception
+	 */
+	public function findByCard(int $cardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * The card's value for one field, or null when it has none.
+	 *
+	 * @throws Exception
+	 */
+	public function findByCardAndField(int $cardId, int $fieldId): ?CardFieldValue {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('field_id', $qb->createNamedParameter($fieldId, IQueryBuilder::PARAM_INT)))
+			->setMaxResults(1);
+
+		$rows = $this->findEntities($qb);
+		return $rows[0] ?? null;
+	}
+
+	/**
+	 * Removes a single (card, field) value - the "clear a value" path.
+	 *
+	 * @return int number of deleted rows (0 when there was no value)
+	 * @throws Exception
+	 */
+	public function deleteByCardAndField(int $cardId, int $fieldId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('field_id', $qb->createNamedParameter($fieldId, IQueryBuilder::PARAM_INT)));
+
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Removes every value referencing a field - the cascade when a field
+	 * definition is deleted.
+	 *
+	 * @return int number of deleted rows
+	 * @throws Exception
+	 */
+	public function deleteByField(int $fieldId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('field_id', $qb->createNamedParameter($fieldId, IQueryBuilder::PARAM_INT)));
+
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Removes every field value of a card - the cascade for a card purge.
+	 *
+	 * @return int number of deleted rows
+	 * @throws Exception
+	 */
+	public function deleteByCard(int $cardId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));
+
+		return $qb->executeStatement();
+	}
+}

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -146,6 +146,36 @@ class CardMapper extends QBMapper {
 	}
 
 	/**
+	 * Summaries (no description) of the given non-deleted, NON-TEMPLATE cards of a
+	 * board - the delta-sync counterpart of {@see self::findSummariesByBoard()},
+	 * restricted to an explicit id set (the cards a `?since=` window touched). Same
+	 * summary shape and same live-card filters (not deleted, not a template) so a
+	 * card that was deleted or turned into a template between the client's cursor
+	 * and now is simply absent from the result - the controller then emits it as a
+	 * `cards.remove`. Board-scoped like every board query. An empty id set
+	 * short-circuits (never emit `IN ()`, which is invalid SQL).
+	 *
+	 * @param int[] $ids
+	 * @return Card[]
+	 * @throws Exception
+	 */
+	public function findSummariesByIds(int $boardId, array $ids): array {
+		if ($ids === []) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(self::SUMMARY_COLUMNS)
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->in('id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('is_template', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)));
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * Summaries (no description) of the non-deleted TEMPLATE cards of a board -
 	 * the per-board template picker source (#3409). The exact complement of
 	 * {@see self::findSummariesByBoard()}'s template exclusion. Ordered by title

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -268,6 +268,46 @@ class CardMapper extends QBMapper {
 	}
 
 	/**
+	 * Live cards of a stack in display order, taking a row-level write lock
+	 * (SELECT ... FOR UPDATE) on each returned row - the read half of a
+	 * {@see \OCA\Kanso\Service\CardService::rebalanceStack()} inside a
+	 * transaction. Locking the stack's rows serialises the rebalance against a
+	 * concurrent move deriving a key from the same neighbours, without a new
+	 * global lock: it matches the app's READ-COMMITTED move posture, just
+	 * pessimistically for the (rare) rebalance path.
+	 *
+	 * @return Card[]
+	 * @throws Exception
+	 */
+	public function findByStackForUpdate(int $stackId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(self::SUMMARY_COLUMNS)
+			->from($this->getTableName())
+			->where($qb->expr()->eq('stack_id', $qb->createNamedParameter($stackId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->orderBy('sort_key', 'ASC')
+			->forUpdate();
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Rewrites a single card's `sort_key` in place - the write half of a
+	 * rebalance. A targeted UPDATE (not a full-entity update) so it touches
+	 * only the reordering column and never clobbers fields absent from the
+	 * summary payload.
+	 *
+	 * @throws Exception
+	 */
+	public function updateSortKeyById(int $cardId, string $sortKey): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			->set('sort_key', $qb->createNamedParameter($sortKey))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+
+	/**
 	 * Summary (no description) of the non-deleted card directly after the
 	 * given sort key in a stack - the lower neighbour of a move target
 	 * position. Null when the position is at the end of the stack.

--- a/lib/Db/CardReview.php
+++ b/lib/Db/CardReview.php
@@ -14,9 +14,13 @@ use OCP\DB\Types;
  * One review request on a card (table `kanso_card_reviews`).
  *
  * A FLAT row - (card_id, reviewer) is unique. `state` is the reviewer's
- * verdict: pending until they act, then approved or changes_requested. There
- * is deliberately no round/stage column (multi-stage review chains are a
- * non-goal). `requested_by` records who asked, for display and notifications.
+ * verdict: pending until they act, then approved or changes_requested. The row
+ * itself carries no stage: multi-stage gating is DERIVED at read time from the
+ * review type's `stage` (see {@see ReviewType} and {@see ReviewService}), never
+ * stored as a fourth state. `requested_by` records who asked; `notified_at` is
+ * the unix time the reviewer was pinged, or null while the request is deferred
+ * (gated behind a lower-stage review) - stamped once so a re-approval upstream
+ * never re-notifies.
  *
  * @method int getCardId()
  * @method void setCardId(int $cardId)
@@ -30,6 +34,8 @@ use OCP\DB\Types;
  * @method void setCreatedAt(int $createdAt)
  * @method int|null getReviewTypeId()
  * @method void setReviewTypeId(?int $reviewTypeId)
+ * @method int|null getNotifiedAt()
+ * @method void setNotifiedAt(?int $notifiedAt)
  */
 class CardReview extends Entity implements \JsonSerializable {
 	public const STATE_PENDING = 'pending';
@@ -45,6 +51,7 @@ class CardReview extends Entity implements \JsonSerializable {
 	protected ?string $requestedBy = null;
 	protected ?int $createdAt = null;
 	protected ?int $reviewTypeId = null;
+	protected ?int $notifiedAt = null;
 
 	public function __construct() {
 		$this->addType('cardId', Types::INTEGER);
@@ -53,10 +60,11 @@ class CardReview extends Entity implements \JsonSerializable {
 		$this->addType('requestedBy', Types::STRING);
 		$this->addType('createdAt', Types::INTEGER);
 		$this->addType('reviewTypeId', Types::INTEGER);
+		$this->addType('notifiedAt', Types::INTEGER);
 	}
 
 	/**
-	 * @return array{id: int, cardId: int, reviewer: string, state: string, requestedBy: string, createdAt: int, reviewTypeId: ?int}
+	 * @return array{id: int, cardId: int, reviewer: string, state: string, requestedBy: string, createdAt: int, reviewTypeId: ?int, notifiedAt: ?int}
 	 */
 	#[\Override]
 	public function jsonSerialize(): array {
@@ -68,6 +76,7 @@ class CardReview extends Entity implements \JsonSerializable {
 			'requestedBy' => (string)$this->getRequestedBy(),
 			'createdAt' => (int)$this->getCreatedAt(),
 			'reviewTypeId' => $this->getReviewTypeId() !== null ? (int)$this->getReviewTypeId() : null,
+			'notifiedAt' => $this->getNotifiedAt() !== null ? (int)$this->getNotifiedAt() : null,
 		];
 	}
 

--- a/lib/Db/CardReview.php
+++ b/lib/Db/CardReview.php
@@ -32,8 +32,8 @@ use OCP\DB\Types;
  * @method void setRequestedBy(string $requestedBy)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
- * @method int|null getReviewTypeId()
- * @method void setReviewTypeId(?int $reviewTypeId)
+ * @method int getReviewTypeId()
+ * @method void setReviewTypeId(int $reviewTypeId)
  * @method int|null getNotifiedAt()
  * @method void setNotifiedAt(?int $notifiedAt)
  */
@@ -44,7 +44,10 @@ class CardReview extends Entity implements \JsonSerializable {
 
 	// Properties default to null (not to the column defaults): Entity::setter()
 	// skips values equal to the current one, so a non-null default would keep
-	// explicit sets of that same value out of INSERT statements.
+	// explicit sets of that same value out of INSERT statements. Note this is
+	// only an INSERT-mechanics default: `review_type_id` is NOT NULL in the
+	// schema (Version001600, 0 = the implicit single-stage review), so a loaded
+	// row always carries a non-null reviewTypeId - hence the non-null getter.
 	protected ?int $cardId = null;
 	protected ?string $reviewer = null;
 	protected ?string $state = null;
@@ -64,7 +67,7 @@ class CardReview extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{id: int, cardId: int, reviewer: string, state: string, requestedBy: string, createdAt: int, reviewTypeId: ?int, notifiedAt: ?int}
+	 * @return array{id: int, cardId: int, reviewer: string, state: string, requestedBy: string, createdAt: int, reviewTypeId: int, notifiedAt: ?int}
 	 */
 	#[\Override]
 	public function jsonSerialize(): array {
@@ -75,7 +78,7 @@ class CardReview extends Entity implements \JsonSerializable {
 			'state' => (string)$this->getState(),
 			'requestedBy' => (string)$this->getRequestedBy(),
 			'createdAt' => (int)$this->getCreatedAt(),
-			'reviewTypeId' => $this->getReviewTypeId() !== null ? (int)$this->getReviewTypeId() : null,
+			'reviewTypeId' => (int)$this->getReviewTypeId(),
 			'notifiedAt' => $this->getNotifiedAt() !== null ? (int)$this->getNotifiedAt() : null,
 		];
 	}

--- a/lib/Db/CardTimeEntry.php
+++ b/lib/Db/CardTimeEntry.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * A manual time entry on a card (table `kanso_card_time_entries`, #3536). Each
+ * row records a duration (in SECONDS) the actor logged against the card, with
+ * an optional free-text note; the per-card total is the SUM of these rows.
+ *
+ * This is MANUAL logging only - there is deliberately NO running-timer state
+ * (no started_at/stopped_at/is_running): a stopwatch in the client just POSTs a
+ * finished duration. `boardId` is denormalized from the card at insert time
+ * (set server-side, never client-supplied) so board-permission gating and the
+ * purge cascade don't need a card join.
+ *
+ * All props default to null: {@see Entity::setter()} skips a set() whose value
+ * equals the current property value, so a non-null default (e.g. 0) would
+ * silently drop that column from the INSERT and violate NOT NULL.
+ *
+ * @method int getCardId()
+ * @method void setCardId(int $cardId)
+ * @method int getBoardId()
+ * @method void setBoardId(int $boardId)
+ * @method int getSeconds()
+ * @method void setSeconds(int $seconds)
+ * @method string|null getNote()
+ * @method void setNote(?string $note)
+ * @method string getCreatedBy()
+ * @method void setCreatedBy(string $createdBy)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ */
+class CardTimeEntry extends Entity implements \JsonSerializable {
+	protected ?int $cardId = null;
+	protected ?int $boardId = null;
+	protected ?int $seconds = null;
+	protected ?string $note = null;
+	protected ?string $createdBy = null;
+	protected ?int $createdAt = null;
+
+	public function __construct() {
+		$this->addType('cardId', Types::INTEGER);
+		$this->addType('boardId', Types::INTEGER);
+		$this->addType('seconds', Types::INTEGER);
+		$this->addType('note', Types::STRING);
+		$this->addType('createdBy', Types::STRING);
+		$this->addType('createdAt', Types::INTEGER);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	#[\Override]
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->getId(),
+			'cardId' => $this->getCardId(),
+			'seconds' => $this->getSeconds(),
+			'note' => $this->getNote(),
+			'createdBy' => $this->getCreatedBy(),
+			'createdAt' => $this->getCreatedAt(),
+		];
+	}
+}

--- a/lib/Db/CardTimeEntryMapper.php
+++ b/lib/Db/CardTimeEntryMapper.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `kanso_card_time_entries`.
+ *
+ * @template-extends QBMapper<CardTimeEntry>
+ */
+class CardTimeEntryMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'kanso_card_time_entries', CardTimeEntry::class);
+	}
+
+	/**
+	 * A single time entry by id.
+	 *
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException if it does not exist
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 * @throws Exception
+	 */
+	public function find(int $id): CardTimeEntry {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * A card's time entries, newest first.
+	 *
+	 * @return CardTimeEntry[]
+	 * @throws Exception
+	 */
+	public function findByCard(int $cardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
+			->orderBy('id', 'DESC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Removes every time-entry ROW of a card - the cascade when a card is
+	 * permanently purged.
+	 *
+	 * @return int number of deleted rows
+	 * @throws Exception
+	 */
+	public function deleteByCard(int $cardId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));
+
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Total seconds logged on a card - powers the card-detail `timeSpent` total
+	 * without loading the rows. A card with no entries sums to 0.
+	 *
+	 * @throws Exception
+	 */
+	public function sumSecondsByCard(int $cardId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->selectAlias($qb->func()->sum('seconds'), 'total')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));
+
+		$result = $qb->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+		return (int)($row['total'] ?? 0);
+	}
+}

--- a/lib/Db/Change.php
+++ b/lib/Db/Change.php
@@ -38,6 +38,7 @@ class Change extends Entity {
 	public const ENTITY_LABEL = 3;
 	public const ENTITY_ACL = 4;
 	public const ENTITY_REVIEW_TYPE = 5;
+	public const ENTITY_CARD_FIELD = 6;
 
 	public const ACTION_CREATE = 0;
 	public const ACTION_UPDATE = 1;

--- a/lib/Db/ChangeMapper.php
+++ b/lib/Db/ChangeMapper.php
@@ -152,6 +152,51 @@ class ChangeMapper extends QBMapper {
 	}
 
 	/**
+	 * Lowest change id of a board - the oldest RETAINED change, the floor of the
+	 * delta window. A client whose cursor is below this floor has fallen off the
+	 * pruned tail and must resync (full refetch) rather than receive an
+	 * incomplete delta. 0 for boards without any change rows (which regular flows
+	 * never produce - see {@see self::getLatestChangeId()}).
+	 *
+	 * @throws Exception
+	 */
+	public function getOldestChangeId(int $boardId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->min('id'))
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)));
+
+		$result = $qb->executeQuery();
+		$min = $result->fetchOne();
+		$result->closeCursor();
+
+		return is_numeric($min) ? (int)$min : 0;
+	}
+
+	/**
+	 * The board's change rows newer than $since (id > $since), oldest first,
+	 * capped at $limit - the delta-sync read behind `GET /api/boards/{id}/changes`.
+	 * Uses the (board_id, id) index (WHERE board_id = ? AND id > ? ORDER BY id).
+	 * When the returned count equals $limit the window is saturated: the caller
+	 * treats that as "client too far behind" and forces a resync rather than
+	 * shipping a partial delta.
+	 *
+	 * @return Change[]
+	 * @throws Exception
+	 */
+	public function findSince(int $boardId, int $since, int $limit = 500): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->gt('id', $qb->createNamedParameter($since, IQueryBuilder::PARAM_INT)))
+			->orderBy('id', 'ASC')
+			->setMaxResults($limit);
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * Ids of change rows eligible for pruning: older than $olderThan, but
 	 * NEVER a board's newest row - deleting that would regress
 	 * getLatestChangeId() to 0 for idle boards, flipping their ETag to "0"

--- a/lib/Db/ReviewType.php
+++ b/lib/Db/ReviewType.php
@@ -13,8 +13,11 @@ use OCP\DB\Types;
 /**
  * A board-scoped review type (table `kanso_review_types`) - a customizable
  * category (QA / Code / Legal / …) a review request can carry. Modelled on
- * {@see Label}: a named, optionally coloured, board-owned tag. It is JUST a
- * tag - no per-type workflow or gate.
+ * {@see Label}: a named, optionally coloured, board-owned tag, plus a `stage`
+ * ordering it in the board's review chain. Lower stages gate higher ones: a
+ * review is "gated" (its reviewer not yet notified) while the card carries any
+ * OTHER unapproved review of a lower stage - see {@see ReviewService}. Untyped
+ * reviews are implicitly stage 0.
  *
  * @method int getBoardId()
  * @method void setBoardId(int $boardId)
@@ -22,6 +25,8 @@ use OCP\DB\Types;
  * @method void setTitle(string $title)
  * @method string|null getColor()
  * @method void setColor(?string $color)
+ * @method int getStage()
+ * @method void setStage(int $stage)
  */
 class ReviewType extends Entity implements \JsonSerializable {
 	// Properties default to null (not to the column defaults): Entity::setter()
@@ -30,15 +35,17 @@ class ReviewType extends Entity implements \JsonSerializable {
 	protected ?int $boardId = null;
 	protected ?string $title = null;
 	protected ?string $color = null;
+	protected ?int $stage = null;
 
 	public function __construct() {
 		$this->addType('boardId', Types::INTEGER);
 		$this->addType('title', Types::STRING);
 		$this->addType('color', Types::STRING);
+		$this->addType('stage', Types::INTEGER);
 	}
 
 	/**
-	 * @return array{id: int, boardId: ?int, title: ?string, color: ?string}
+	 * @return array{id: int, boardId: ?int, title: ?string, color: ?string, stage: int}
 	 */
 	#[\Override]
 	public function jsonSerialize(): array {
@@ -47,6 +54,7 @@ class ReviewType extends Entity implements \JsonSerializable {
 			'boardId' => $this->boardId,
 			'title' => $this->title,
 			'color' => $this->color,
+			'stage' => $this->stage ?? 0,
 		];
 	}
 }

--- a/lib/Db/ReviewTypeMapper.php
+++ b/lib/Db/ReviewTypeMapper.php
@@ -53,4 +53,29 @@ class ReviewTypeMapper extends QBMapper {
 
 		return $this->findEntities($qb);
 	}
+
+	/**
+	 * Review-type id => stage map for a board, in ONE query - the lookup the
+	 * gating fold needs (see {@see \OCA\Kanso\Service\ReviewService}). Untyped
+	 * reviews (review_type_id = 0) are implicitly stage 0 and are NOT keyed here;
+	 * callers must default a missing id to stage 0.
+	 *
+	 * @return array<int, int> map of reviewTypeId => stage
+	 * @throws Exception
+	 */
+	public function stageMapForBoard(int $boardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'stage')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)));
+
+		$result = $qb->executeQuery();
+		$map = [];
+		while (($row = $result->fetch()) !== false) {
+			$map[(int)$row['id']] = (int)$row['stage'];
+		}
+		$result->closeCursor();
+
+		return $map;
+	}
 }

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -56,6 +56,33 @@ class StackMapper extends QBMapper {
 	}
 
 	/**
+	 * The given non-deleted stacks of a board - the delta-sync counterpart of
+	 * {@see self::findByBoard()}, restricted to an explicit id set (the stacks a
+	 * `?since=` window touched). Board-scoped and non-deleted like the full-board
+	 * read, so a stack deleted between the client's cursor and now is simply
+	 * absent from the result - the controller then emits it as a `stacks.remove`.
+	 * An empty id set short-circuits (never emit `IN ()`, which is invalid SQL).
+	 *
+	 * @param int[] $ids
+	 * @return Stack[]
+	 * @throws Exception
+	 */
+	public function findByIds(int $boardId, array $ids): array {
+		if ($ids === []) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->in('id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * The first non-deleted stack of a board carrying the given workflow role
 	 * (in display order), or null. Used to resolve auto-move targets (e.g. the
 	 * "In review" or "Done" column) without a separate config surface.

--- a/lib/Migration/Version001100Date20260730000000.php
+++ b/lib/Migration/Version001100Date20260730000000.php
@@ -16,10 +16,13 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Card review requests (`kanso_card_reviews`): a FLAT approval model - one row
  * per (card, reviewer). A reviewer is asked to sign off; their `state` moves
- * pending → approved | changes_requested. Deliberately flat: NO review round /
- * stage columns (multi-stage review chains are an explicit non-goal). The
- * optional done-gate reads these rows to block a REVIEW-role → DONE-role move
- * until every requested review is approved.
+ * pending → approved | changes_requested. The row stays flat: multi-stage
+ * gating (#3588) is layered on later without a per-review stage column - a
+ * review's stage comes from its review type (`kanso_review_types.stage`) and
+ * "gated" is DERIVED at read time, never stored as a fourth state. The optional
+ * done-gate reads these rows to block a REVIEW-role → DONE-role move until every
+ * requested review is approved (a gated review is unapproved, so it still
+ * blocks).
  *
  * Review mutations append a card-targeted row to `kanso_changes` (via
  * {@see \OCA\Kanso\Service\ReviewService}) so the tile chip updates over the

--- a/lib/Migration/Version001200Date20260731000000.php
+++ b/lib/Migration/Version001200Date20260731000000.php
@@ -20,9 +20,11 @@ use OCP\Migration\SimpleMigrationStep;
  * nullable `review_type_id` on `kanso_card_reviews` (an untyped review keeps
  * the plain "Review" meaning). Ordered by id, like labels.
  *
- * A review type is deliberately just a tag: it carries NO per-type workflow,
- * gate, or approver rule. The done-gate stays "all requested reviews approved"
- * regardless of type.
+ * A review type started as just a tag; #3588 later adds a `stage` column
+ * ordering types into a review chain (lower stages gate higher ones - a gated
+ * review defers its reviewer notification until the blocking reviews approve).
+ * The done-gate itself stays "all requested reviews approved" regardless of
+ * type - a gated review is simply unapproved, so it still blocks Done.
  *
  * Both changes are guarded (hasTable / hasColumn) so the step is idempotent.
  */

--- a/lib/Migration/Version004300Date20260831000000.php
+++ b/lib/Migration/Version004300Date20260831000000.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Review-type stage gating (#3588): review types gain an ordering `stage` and
+ * card reviews gain a `notified_at` stamp so downstream reviews can defer their
+ * reviewer notification until the blocking lower-stage reviews approve.
+ *
+ * - `kanso_review_types.stage` (INTEGER, default 0, notnull): the review type's
+ *   order in the review chain. Lower stages gate higher ones; a review is
+ *   "gated" while the card carries any OTHER unapproved review of a lower stage.
+ *   Untyped reviews (review_type_id = 0) are implicitly stage 0. Gating is
+ *   DERIVED at read time from these stages - it is never stored on the review.
+ * - `kanso_card_reviews.notified_at` (BIGINT, nullable): the unix time the
+ *   reviewer was notified, or null when the request is still deferred (gated).
+ *   Stamped once when the review un-gates so a re-approval never re-notifies.
+ *
+ * Both changes are guarded by hasColumn so the step is idempotent.
+ */
+class Version004300Date20260831000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::getTable() is
+	 *  docblocked as Doctrine\DBAL\Schema\Table, which is not part of the OCP
+	 *  stubs (Deck suppresses the same class in its psalm config).
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('kanso_review_types')) {
+			$types = $schema->getTable('kanso_review_types');
+			if (!$types->hasColumn('stage')) {
+				$types->addColumn('stage', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+				]);
+			}
+		}
+
+		if ($schema->hasTable('kanso_card_reviews')) {
+			$reviews = $schema->getTable('kanso_card_reviews');
+			if (!$reviews->hasColumn('notified_at')) {
+				$reviews->addColumn('notified_at', Types::BIGINT, [
+					'notnull' => false,
+					'length' => 8,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version004400Date20260901000000.php
+++ b/lib/Migration/Version004400Date20260901000000.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Manual time tracking on cards (`kanso_card_time_entries`, #3536). A row logs
+ * a duration (in SECONDS) an actor spent on a card, with an optional note; the
+ * per-card total is the SUM of these rows (surfaced only in the card DETAIL
+ * payload, never the board/summary listings).
+ *
+ * MANUAL entries only - there is deliberately NO running-timer state (no
+ * started_at/stopped_at/is_running). `board_id` is denormalized from the card
+ * at insert time (set server-side) purely so board-permission gating and the
+ * purge cascade don't need a card join; `card_id` remains the scoping key.
+ *
+ * Index/constraint names are globally unique (kanso_ctime_*) so this step is
+ * safe on a fresh install. Guarded by hasTable so the step is idempotent.
+ */
+class Version004400Date20260901000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::createTable() is
+	 *  docblocked as Doctrine\DBAL\Schema\Table, which is not part of the OCP
+	 *  stubs (Deck suppresses the same class in its psalm config).
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('kanso_card_time_entries')) {
+			return null;
+		}
+
+		$table = $schema->createTable('kanso_card_time_entries');
+		$table->addColumn('id', Types::BIGINT, [
+			'autoincrement' => true,
+			'notnull' => true,
+			'length' => 8,
+		]);
+		$table->addColumn('card_id', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 8,
+		]);
+		// Denormalized from the card at insert time (set server-side) for gating
+		// and the purge cascade without a card join.
+		$table->addColumn('board_id', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 8,
+		]);
+		// The logged duration, stored in SECONDS (not minutes).
+		$table->addColumn('seconds', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 8,
+			'default' => 0,
+		]);
+		// Optional free-text note describing the logged time.
+		$table->addColumn('note', Types::STRING, [
+			'notnull' => false,
+			'length' => 255,
+		]);
+		$table->addColumn('created_by', Types::STRING, [
+			'notnull' => true,
+			'length' => 64,
+		]);
+		$table->addColumn('created_at', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 8,
+			'default' => 0,
+		]);
+		$table->setPrimaryKey(['id'], 'kanso_ctime_pk');
+		// A card's entries (list + total) - the hot path.
+		$table->addIndex(['card_id'], 'kanso_ctime_card');
+		// Board-scoped queries / cascade on board delete.
+		$table->addIndex(['board_id'], 'kanso_ctime_board');
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version004500Date20260902000000.php
+++ b/lib/Migration/Version004500Date20260902000000.php
@@ -66,7 +66,10 @@ class Version004500Date20260902000000 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$table->setPrimaryKey(['id']);
+			// Named short defensively: oc_kanso_card_fields (20 chars) sits at the
+			// edge of the default primary-key name length limit enforced on NC
+			// 30-32; an explicit short name keeps install safe across versions.
+			$table->setPrimaryKey(['id'], 'kanso_cfield_pk');
 			$table->addIndex(['board_id'], 'kanso_card_fields_board');
 		}
 
@@ -88,7 +91,11 @@ class Version004500Date20260902000000 extends SimpleMigrationStep {
 			$table->addColumn('value', Types::TEXT, [
 				'notnull' => false,
 			]);
-			$table->setPrimaryKey(['id']);
+			// Named short: oc_kanso_card_field_values (26 chars) overflows the
+			// default primary-key name length check, failing install on NC 30-32
+			// (the install matrix surfaced: 'Primary index name on
+			// "oc_kanso_card_field_values" is too long.').
+			$table->setPrimaryKey(['id'], 'kanso_cfieldval_pk');
 			// One value per field per card - a set is an upsert.
 			$table->addUniqueIndex(['card_id', 'field_id'], 'kanso_card_field_val_uniq');
 			$table->addIndex(['field_id'], 'kanso_card_field_val_field');

--- a/lib/Migration/Version004500Date20260902000000.php
+++ b/lib/Migration/Version004500Date20260902000000.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Custom fields on cards (#3537). Two tables, modelled on `kanso_review_types`:
+ *
+ * - `kanso_card_fields`: per-board custom-field DEFINITIONS. A small fixed set
+ *   of typed fields (text / number / date / select) defined per board. `type`
+ *   is an app-level enum stored as a plain string (validated in the service,
+ *   NOT a DB enum); `options` is a JSON array only meaningful for `select`.
+ *   Ordered by a FRACTIONAL `sort_key` (reorder is a single-row UPDATE), never
+ *   by id.
+ * - `kanso_card_field_values`: the per-card VALUES. One value per
+ *   (card_id, field_id) - a unique index enforces it, so a set is an upsert.
+ *   The value is a single stringified column (per-type coercion is the
+ *   service's job, not a column-per-type).
+ *
+ * Both tables are hasTable-guarded so the step is idempotent; index / unique
+ * names are globally unique.
+ */
+class Version004500Date20260902000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::createTable()
+	 *  is docblocked as Doctrine\DBAL\Schema\Table, not part of the OCP stubs.
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('kanso_card_fields')) {
+			$table = $schema->createTable('kanso_card_fields');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('board_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('name', Types::STRING, [
+				'notnull' => true,
+				'length' => 100,
+			]);
+			$table->addColumn('type', Types::STRING, [
+				'notnull' => true,
+				'length' => 16,
+			]);
+			$table->addColumn('options', Types::TEXT, [
+				'notnull' => false,
+			]);
+			$table->addColumn('sort_key', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['board_id'], 'kanso_card_fields_board');
+		}
+
+		if (!$schema->hasTable('kanso_card_field_values')) {
+			$table = $schema->createTable('kanso_card_field_values');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('card_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('field_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('value', Types::TEXT, [
+				'notnull' => false,
+			]);
+			$table->setPrimaryKey(['id']);
+			// One value per field per card - a set is an upsert.
+			$table->addUniqueIndex(['card_id', 'field_id'], 'kanso_card_field_val_uniq');
+			$table->addIndex(['field_id'], 'kanso_card_field_val_field');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/AclService.php
+++ b/lib/Service/AclService.php
@@ -104,6 +104,10 @@ class AclService {
 			$actorUid
 		);
 
+		// Surface the new share in the Nextcloud Activity stream (best-effort). Only
+		// a fresh share is an activity - a permission-mask update or a revoke is not.
+		$this->changeNotifier->publishBoardShared($boardId, (string)$board->getTitle(), $actorUid);
+
 		return $acl;
 	}
 

--- a/lib/Service/ActivityPublisher.php
+++ b/lib/Service/ActivityPublisher.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Activity\Provider;
+use OCP\Activity\IManager;
+use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Best-effort bridge from Kanso's service-layer mutations to the Nextcloud
+ * Activity stream. A deliberately small counterpart to {@see NotificationService}
+ * (targeted bell) and {@see ChangeNotifier} (realtime push): it publishes ONE
+ * board-scoped Activity event per recipient for the four coarse, user-facing
+ * milestones - card created / moved / done, and board shared - and stays silent
+ * on everything else (field edits, system/cron sweeps).
+ *
+ * Publishing is strictly best-effort and never throws into the mutation that
+ * already committed: the Activity app may not be installed (its IManager is then
+ * absent from the container - the constructor takes a nullable manager), and any
+ * publish() error is swallowed and logged, exactly like the notify_push emit in
+ * {@see ChangeNotifier::pushBoardChanged()}. Users opt in/out entirely through
+ * the Activity app's own settings (see {@see \OCA\Kanso\Activity\Setting}); this
+ * class builds no preference UI of its own.
+ */
+class ActivityPublisher {
+	public function __construct(
+		private ?IManager $activityManager,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Publishes a "card created" event to everyone with access to the board.
+	 *
+	 * @param list<string> $recipients uids with board access (from ChangeNotifier)
+	 */
+	public function cardCreated(int $boardId, int $cardId, string $cardTitle, string $actor, array $recipients): void {
+		$this->publish(Provider::SUBJECT_CARD_CREATED, $boardId, $cardId, $cardTitle, $actor, $recipients);
+	}
+
+	/**
+	 * Publishes a "card moved" event to everyone with access to the board.
+	 *
+	 * @param list<string> $recipients uids with board access (from ChangeNotifier)
+	 */
+	public function cardMoved(int $boardId, int $cardId, string $cardTitle, string $actor, array $recipients): void {
+		$this->publish(Provider::SUBJECT_CARD_MOVED, $boardId, $cardId, $cardTitle, $actor, $recipients);
+	}
+
+	/**
+	 * Publishes a "card done" event to everyone with access to the board.
+	 *
+	 * @param list<string> $recipients uids with board access (from ChangeNotifier)
+	 */
+	public function cardDone(int $boardId, int $cardId, string $cardTitle, string $actor, array $recipients): void {
+		$this->publish(Provider::SUBJECT_CARD_DONE, $boardId, $cardId, $cardTitle, $actor, $recipients);
+	}
+
+	/**
+	 * Publishes a "board shared" event to everyone with access to the board.
+	 * The object is the board itself (there is no single card involved).
+	 *
+	 * @param list<string> $recipients uids with board access (from ChangeNotifier)
+	 */
+	public function boardShared(int $boardId, string $boardTitle, string $actor, array $recipients): void {
+		$this->publish(Provider::SUBJECT_BOARD_SHARED, $boardId, $boardId, $boardTitle, $actor, $recipients, true);
+	}
+
+	/**
+	 * Builds and fans out one Activity event per recipient. Never throws - the
+	 * mutation that triggered this has already committed.
+	 *
+	 * @param list<string> $recipients
+	 */
+	private function publish(string $subject, int $boardId, int $objectId, string $objectName, string $actor, array $recipients, bool $boardObject = false): void {
+		if ($this->activityManager === null || $recipients === []) {
+			// Activity app not installed, or nobody to notify - a silent no-op.
+			return;
+		}
+
+		try {
+			$objectType = $boardObject ? Provider::OBJECT_BOARD : Provider::OBJECT_CARD;
+			$cardId = $boardObject ? 0 : $objectId;
+			$link = $boardObject
+				? $this->boardLink($boardId)
+				: $this->cardLink($boardId, $objectId);
+
+			foreach ($recipients as $uid) {
+				$event = $this->activityManager->generateEvent();
+				$event->setApp('kanso')
+					->setType(Provider::TYPE_KANSO)
+					->setAuthor($actor)
+					->setAffectedUser($uid)
+					->setTimestamp(time())
+					->setObject($objectType, $objectId, $objectName)
+					->setSubject($subject, [
+						'actor' => $actor,
+						'boardId' => $boardId,
+						'cardId' => $cardId,
+						'name' => $objectName,
+					])
+					->setLink($link);
+				$this->activityManager->publish($event);
+			}
+		} catch (\Throwable $e) {
+			// Activity is a non-critical side effect - never break the mutation.
+			// \Throwable also covers the Activity API's IncompleteActivityException.
+			$this->logger->debug(
+				'kanso: failed to publish activity for board ' . $boardId,
+				['exception' => $e]
+			);
+		}
+	}
+
+	private function cardLink(int $boardId, int $cardId): string {
+		return $this->urlGenerator->linkToRouteAbsolute('kanso.page.index')
+			. '#/board/' . $boardId . '/card/' . $cardId;
+	}
+
+	private function boardLink(int $boardId): string {
+		return $this->urlGenerator->linkToRouteAbsolute('kanso.page.index')
+			. '#/board/' . $boardId;
+	}
+}

--- a/lib/Service/ArchiveService.php
+++ b/lib/Service/ArchiveService.php
@@ -18,6 +18,7 @@ use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
 
 /**
  * Auto-archive rules: board-hygiene automation that archives done cards once
@@ -48,6 +49,7 @@ class ArchiveService {
 		private ChangeNotifier $changeNotifier,
 		private PermissionService $permissionService,
 		private ITimeFactory $time,
+		private IDBConnection $db,
 	) {
 	}
 
@@ -199,27 +201,56 @@ class ArchiveService {
 
 	/**
 	 * Archives every eligible card in the rule's scope (capped at
-	 * MAX_PER_SWEEP) and emits a per-card change so open clients refetch.
+	 * MAX_PER_SWEEP), recording a per-card change row so open clients refetch.
 	 * Idempotent: cards already archived are excluded by the eligibility
 	 * query, so re-running the sweep is a no-op for them.
+	 *
+	 * Realtime pushes are COALESCED (#3418): each card's UPDATE + its change row
+	 * is written per-item, but the notify_push fan-out (per-recipient, board-wide)
+	 * fires ONCE for the board at the end of the batch instead of once per card.
+	 * The push body is only {boardId}, so a single push is enough - clients delta/
+	 * refetch and collapse the N change rows regardless. A 100-card sweep with M
+	 * recipients thus emits M pushes, not 100xM.
+	 *
+	 * Each card's archive write and its change row are committed atomically (#3579):
+	 * a failed change-row write rolls that card's archive flag back, so no card is
+	 * left archived without a delta-sync row (and no delta row points at a write
+	 * that never landed). A single card that throws aborts this rule's sweep but is
+	 * isolated by {@see self::runEnabledRules()} so the other rules still run; the
+	 * sweep is idempotent, so a retry picks up whatever committed.
 	 *
 	 * @return int number of cards archived
 	 */
 	public function sweep(ArchiveRule $rule): int {
 		$count = 0;
 		foreach ($this->findEligibleCards($rule) as $card) {
-			$card->setArchived(true);
-			$this->cardMapper->update($card);
-			// System actor (null) - the sweep is not attributed to a user.
-			$this->changeNotifier->notify(
-				$rule->getBoardId(),
-				Change::ENTITY_CARD,
-				$card->getId(),
-				Change::ACTION_UPDATE,
-				null,
-			);
+			$this->db->beginTransaction();
+			try {
+				$card->setArchived(true);
+				$this->cardMapper->update($card);
+				// System actor (null) - the sweep is not attributed to a user.
+				// Record the row only; the coalesced push fires once after the loop.
+				$this->changeNotifier->recordChange(
+					$rule->getBoardId(),
+					Change::ENTITY_CARD,
+					$card->getId(),
+					Change::ACTION_UPDATE,
+					null,
+				);
+				$this->db->commit();
+			} catch (\Throwable $e) {
+				$this->db->rollBack();
+				throw $e;
+			}
 			$count++;
 		}
+
+		// One coalesced realtime push for the whole batch (#3418): only broadcast
+		// when at least one card actually changed, so an empty sweep stays a no-op.
+		if ($count > 0) {
+			$this->changeNotifier->pushBoardChanged($rule->getBoardId());
+		}
+
 		return $count;
 	}
 

--- a/lib/Service/AutomationService.php
+++ b/lib/Service/AutomationService.php
@@ -17,6 +17,7 @@ use OCA\Kanso\Db\Change;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
 
 /**
  * Per-board automation: a deliberately small, FIXED trigger→action menu (no
@@ -41,6 +42,7 @@ class AutomationService {
 		private LabelMapper $labelMapper,
 		private CardLabelMapper $cardLabelMapper,
 		private ChangeNotifier $changeNotifier,
+		private IDBConnection $db,
 	) {
 	}
 
@@ -154,14 +156,23 @@ class AutomationService {
 		if ($action === AutomationRule::ACTION_ADD_LABEL) {
 			$labelId = (int)($params['label'] ?? 0);
 			if ($labelId > 0 && !$this->cardLabelMapper->exists($card->getId(), $labelId)) {
-				$this->cardLabelMapper->insertAssignment($card->getId(), $labelId);
-				$this->changeNotifier->notify(
-					$card->getBoardId(),
-					Change::ENTITY_CARD,
-					$card->getId(),
-					Change::ACTION_UPDATE,
-					$actorUid
-				);
+				// Atomic label-assignment + change-row (#3579); push after commit.
+				$this->db->beginTransaction();
+				try {
+					$this->cardLabelMapper->insertAssignment($card->getId(), $labelId);
+					$this->changeNotifier->recordChange(
+						$card->getBoardId(),
+						Change::ENTITY_CARD,
+						$card->getId(),
+						Change::ACTION_UPDATE,
+						$actorUid,
+					);
+					$this->db->commit();
+				} catch (\Throwable $e) {
+					$this->db->rollBack();
+					throw $e;
+				}
+				$this->changeNotifier->pushBoardChanged($card->getBoardId());
 			}
 		}
 	}

--- a/lib/Service/CardFieldService.php
+++ b/lib/Service/CardFieldService.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\CardField;
+use OCA\Kanso\Db\CardFieldMapper;
+use OCA\Kanso\Db\CardFieldValueMapper;
+use OCA\Kanso\Db\Change;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+
+/**
+ * Custom-field DEFINITION CRUD (#3537) - per-board, a small FIXED set of typed
+ * fields (text / number / date / select). Mirrors {@see ReviewTypeService}:
+ * managing the definition list is a board-structure concern (MANAGE), and every
+ * mutation appends a `kanso_changes` row (ENTITY_CARD_FIELD) so the board ETag
+ * bumps and clients refetch the definitions. Deleting a field cascades its
+ * values in one transaction.
+ *
+ * `type` is validated against {@see CardField::TYPES} (an app-level enum, not a
+ * DB enum). `options` is only allowed / parsed for type `select`.
+ */
+class CardFieldService {
+	private const MAX_NAME_LENGTH = 100;
+	private const MAX_OPTIONS = 50;
+	private const MAX_OPTION_LENGTH = 100;
+
+	public function __construct(
+		private CardFieldMapper $cardFieldMapper,
+		private CardFieldValueMapper $cardFieldValueMapper,
+		private BoardMapper $boardMapper,
+		private ChangeNotifier $changeNotifier,
+		private PermissionService $permissionService,
+		private SortKeyService $sortKeyService,
+		private IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param string[]|null $options choices, only meaningful (and only allowed) for type `select`
+	 *
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws NotPermittedException if the user may not manage the board
+	 * @throws InvalidInputException on invalid name / type / options
+	 */
+	public function create(int $boardId, string $name, string $type, ?array $options, string $uid): CardField {
+		$board = $this->loadBoard($boardId);
+		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
+
+		$type = $this->validateType($type);
+
+		$field = new CardField();
+		$field->setBoardId($boardId);
+		$field->setName($this->validateName($name));
+		$field->setType($type);
+		$field->setOptions($this->encodeOptions($type, $options));
+		$field->setSortKey($this->nextSortKey($boardId));
+		$field = $this->cardFieldMapper->insert($field);
+
+		$this->changeNotifier->notify(
+			$boardId,
+			Change::ENTITY_CARD_FIELD,
+			$field->getId(),
+			Change::ACTION_CREATE,
+			$uid
+		);
+
+		return $field;
+	}
+
+	/**
+	 * Updates a field definition. `type` is immutable once set (changing it
+	 * would strand existing values in an incompatible representation) - name,
+	 * options and sort key are the editable surface.
+	 *
+	 * @param string[]|null $options new choices (only for a `select` field)
+	 *
+	 * @throws DoesNotExistException if the field or its board does not exist or is deleted
+	 * @throws NotPermittedException if the user may not manage the board
+	 * @throws InvalidInputException on invalid name / options / sort key
+	 */
+	public function update(int $id, ?string $name, ?array $options, ?string $sortKey, string $uid): CardField {
+		$field = $this->cardFieldMapper->find($id);
+		$board = $this->loadBoard($field->getBoardId());
+		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
+
+		if ($name !== null) {
+			$field->setName($this->validateName($name));
+		}
+		if ($options !== null) {
+			// Options only mean anything for a select field; reject on others.
+			$field->setOptions($this->encodeOptions($field->getType(), $options));
+		}
+		if ($sortKey !== null) {
+			$field->setSortKey($this->validateSortKey($sortKey));
+		}
+
+		$field = $this->cardFieldMapper->update($field);
+
+		$this->changeNotifier->notify(
+			$field->getBoardId(),
+			Change::ENTITY_CARD_FIELD,
+			$id,
+			Change::ACTION_UPDATE,
+			$uid
+		);
+
+		return $field;
+	}
+
+	/**
+	 * Deletes the field definition and every value that referenced it. The
+	 * cascade + delete + change row are ONE transaction (mirror
+	 * ReviewTypeService::delete): rolled back on any throw so a half-applied
+	 * delete can never leave orphaned values.
+	 *
+	 * @throws DoesNotExistException if the field or its board does not exist or is deleted
+	 * @throws NotPermittedException if the user may not manage the board
+	 */
+	public function delete(int $id, string $uid): void {
+		$field = $this->cardFieldMapper->find($id);
+		$board = $this->loadBoard($field->getBoardId());
+		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
+
+		$this->db->beginTransaction();
+		try {
+			$this->cardFieldValueMapper->deleteByField($id);
+			$this->cardFieldMapper->delete($field);
+			$this->changeNotifier->notify(
+				$field->getBoardId(),
+				Change::ENTITY_CARD_FIELD,
+				$id,
+				Change::ACTION_DELETE,
+				$uid
+			);
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+	}
+
+	/**
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 */
+	private function loadBoard(int $boardId): Board {
+		$board = $this->boardMapper->find($boardId);
+		if ($board->getDeletedAt() > 0) {
+			throw new DoesNotExistException('Board ' . $boardId . ' is deleted');
+		}
+		return $board;
+	}
+
+	/**
+	 * A fractional sort key appended after the board's current last field, or
+	 * the initial key when the board has no fields yet.
+	 */
+	private function nextSortKey(int $boardId): string {
+		$last = $this->cardFieldMapper->lastSortKey($boardId);
+		return $last === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($last);
+	}
+
+	/**
+	 * @throws InvalidInputException
+	 */
+	private function validateName(string $name): string {
+		$name = trim($name);
+		if ($name === '') {
+			throw new InvalidInputException('Name must not be empty');
+		}
+		if (mb_strlen($name) > self::MAX_NAME_LENGTH) {
+			throw new InvalidInputException(
+				'Name must not exceed ' . self::MAX_NAME_LENGTH . ' characters'
+			);
+		}
+		return $name;
+	}
+
+	/**
+	 * @throws InvalidInputException on an unknown field type
+	 */
+	private function validateType(string $type): string {
+		if (!in_array($type, CardField::TYPES, true)) {
+			throw new InvalidInputException(
+				'Unknown field type "' . $type . '"; must be one of: ' . implode(', ', CardField::TYPES)
+			);
+		}
+		return $type;
+	}
+
+	/**
+	 * @throws InvalidInputException
+	 */
+	private function validateSortKey(string $sortKey): string {
+		$sortKey = trim($sortKey);
+		if ($sortKey === '' || preg_match('/^[0-9A-Z]+$/', $sortKey) !== 1) {
+			throw new InvalidInputException('Invalid sort key "' . $sortKey . '"');
+		}
+		return $sortKey;
+	}
+
+	/**
+	 * Validates + JSON-encodes the option list for storage. Options are ONLY
+	 * meaningful for a `select` field: any options passed for another type are
+	 * rejected. For a select field an empty/absent list stores null. Option
+	 * count and per-option length are bounded.
+	 *
+	 * @param string[]|null $options
+	 *
+	 * @throws InvalidInputException on options for a non-select field, too many
+	 *                               options, or an over-long / empty option
+	 */
+	private function encodeOptions(string $type, ?array $options): ?string {
+		if ($type !== CardField::TYPE_SELECT) {
+			if ($options !== null && $options !== []) {
+				throw new InvalidInputException('Options are only allowed for a select field');
+			}
+			return null;
+		}
+
+		if ($options === null || $options === []) {
+			return null;
+		}
+
+		if (count($options) > self::MAX_OPTIONS) {
+			throw new InvalidInputException(
+				'A select field may have at most ' . self::MAX_OPTIONS . ' options'
+			);
+		}
+
+		$clean = [];
+		foreach ($options as $option) {
+			$option = trim((string)$option);
+			if ($option === '') {
+				throw new InvalidInputException('Options must not be empty');
+			}
+			if (mb_strlen($option) > self::MAX_OPTION_LENGTH) {
+				throw new InvalidInputException(
+					'An option must not exceed ' . self::MAX_OPTION_LENGTH . ' characters'
+				);
+			}
+			$clean[] = $option;
+		}
+
+		return json_encode($clean, JSON_THROW_ON_ERROR);
+	}
+}

--- a/lib/Service/CardFieldValueService.php
+++ b/lib/Service/CardFieldValueService.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardField;
+use OCA\Kanso\Db\CardFieldMapper;
+use OCA\Kanso\Db\CardFieldValue;
+use OCA\Kanso\Db\CardFieldValueMapper;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Change;
+use OCP\AppFramework\Db\DoesNotExistException;
+
+/**
+ * Custom-field VALUE writes (#3537): set or clear the value a card carries for
+ * one board field definition. Setting/clearing a value is a plain card edit, so
+ * it is EDIT-gated (NOT MANAGE - defining the field is the MANAGE concern) and
+ * stamps the ordinary card-change path (ENTITY_CARD / ACTION_UPDATE with
+ * VERB_UPDATED) so the card's ETag and activity feed update like any other card
+ * edit.
+ *
+ * One value per (card, field) - the unique index makes a set an upsert. The
+ * value lives in ONE stringified column; per-type coercion/validation
+ * (parseable number, ISO date, option-membership for select) is done here, not
+ * by a typed column-per-type.
+ */
+class CardFieldValueService {
+	private const MAX_VALUE_LENGTH = 2000;
+
+	public function __construct(
+		private CardFieldValueMapper $cardFieldValueMapper,
+		private CardFieldMapper $cardFieldMapper,
+		private CardMapper $cardMapper,
+		private BoardMapper $boardMapper,
+		private ChangeNotifier $changeNotifier,
+		private PermissionService $permissionService,
+	) {
+	}
+
+	/**
+	 * Sets (upserts) the card's value for a field. A null / empty value clears
+	 * it (see {@see self::clear()}). The value is coerced + validated against
+	 * the field's type before storage.
+	 *
+	 * @throws DoesNotExistException if the card, its board, or the field does not exist
+	 * @throws NotPermittedException if the user may not edit the board
+	 * @throws InvalidInputException if the field is not on the card's board or the value is invalid for its type
+	 */
+	public function set(int $cardId, int $fieldId, ?string $value, string $uid): CardFieldValue {
+		$card = $this->cardMapper->find($cardId);
+		$board = $this->loadBoard($card->getBoardId());
+		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_EDIT);
+
+		$field = $this->loadFieldForCard($fieldId, $card);
+
+		$coerced = $this->coerce($field, $value);
+		if ($coerced === null) {
+			// Empty write == clear (no value row for an empty value).
+			return $this->clearInternal($cardId, $fieldId, $card, $board, $uid);
+		}
+
+		$existing = $this->cardFieldValueMapper->findByCardAndField($cardId, $fieldId);
+		if ($existing !== null) {
+			$existing->setValue($coerced);
+			$saved = $this->cardFieldValueMapper->update($existing);
+		} else {
+			$entity = new CardFieldValue();
+			$entity->setCardId($cardId);
+			$entity->setFieldId($fieldId);
+			$entity->setValue($coerced);
+			$saved = $this->cardFieldValueMapper->insert($entity);
+		}
+
+		$this->notifyCardChanged($board->getId(), $cardId, $uid);
+
+		return $saved;
+	}
+
+	/**
+	 * Clears the card's value for a field (idempotent - clearing a field with no
+	 * value is a no-op that still bumps the card).
+	 *
+	 * @throws DoesNotExistException if the card, its board, or the field does not exist
+	 * @throws NotPermittedException if the user may not edit the board
+	 * @throws InvalidInputException if the field is not on the card's board
+	 */
+	public function clear(int $cardId, int $fieldId, string $uid): void {
+		$card = $this->cardMapper->find($cardId);
+		$board = $this->loadBoard($card->getBoardId());
+		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_EDIT);
+
+		$this->loadFieldForCard($fieldId, $card);
+		$this->clearInternal($cardId, $fieldId, $card, $board, $uid);
+	}
+
+	private function clearInternal(int $cardId, int $fieldId, Card $card, Board $board, string $uid): CardFieldValue {
+		$this->cardFieldValueMapper->deleteByCardAndField($cardId, $fieldId);
+		$this->notifyCardChanged($board->getId(), $cardId, $uid);
+
+		// A cleared field has no persisted row; return a transient "empty" value
+		// so callers get a uniform shape.
+		$empty = new CardFieldValue();
+		$empty->setCardId($cardId);
+		$empty->setFieldId($fieldId);
+		$empty->setValue(null);
+		return $empty;
+	}
+
+	private function notifyCardChanged(int $boardId, int $cardId, string $uid): void {
+		$this->changeNotifier->notify(
+			$boardId,
+			Change::ENTITY_CARD,
+			$cardId,
+			Change::ACTION_UPDATE,
+			$uid,
+			verb: Change::VERB_UPDATED,
+		);
+	}
+
+	/**
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 */
+	private function loadBoard(int $boardId): Board {
+		$board = $this->boardMapper->find($boardId);
+		if ($board->getDeletedAt() > 0) {
+			throw new DoesNotExistException('Board ' . $boardId . ' is deleted');
+		}
+		return $board;
+	}
+
+	/**
+	 * Loads a field definition and asserts it belongs to the card's board (a
+	 * value can only be set for a field defined on the same board).
+	 *
+	 * @throws DoesNotExistException if the field does not exist
+	 * @throws InvalidInputException if the field is not on the card's board
+	 */
+	private function loadFieldForCard(int $fieldId, Card $card): CardField {
+		$field = $this->cardFieldMapper->find($fieldId);
+		if ($field->getBoardId() !== $card->getBoardId()) {
+			throw new InvalidInputException('Field ' . $fieldId . ' is not defined on this card\'s board');
+		}
+		return $field;
+	}
+
+	/**
+	 * Coerces + validates a raw input string against the field's type. Returns
+	 * the canonical stored string, or null when the input is empty (a clear).
+	 *
+	 * @throws InvalidInputException if the value is invalid for the field type
+	 */
+	private function coerce(CardField $field, ?string $value): ?string {
+		if ($value === null) {
+			return null;
+		}
+		$value = trim($value);
+		if ($value === '') {
+			return null;
+		}
+		if (mb_strlen($value) > self::MAX_VALUE_LENGTH) {
+			throw new InvalidInputException(
+				'Value must not exceed ' . self::MAX_VALUE_LENGTH . ' characters'
+			);
+		}
+
+		switch ($field->getType()) {
+			case CardField::TYPE_TEXT:
+				return $value;
+			case CardField::TYPE_NUMBER:
+				if (!is_numeric($value)) {
+					throw new InvalidInputException('Value "' . $value . '" is not a valid number');
+				}
+				// Store the numeric string as-is (canonicalised to trimmed form).
+				return $value;
+			case CardField::TYPE_DATE:
+				return $this->normalizeDate($value);
+			case CardField::TYPE_SELECT:
+				if (!in_array($value, $field->getOptionsArray(), true)) {
+					throw new InvalidInputException('Value "' . $value . '" is not one of the field\'s options');
+				}
+				return $value;
+			default:
+				// Unreachable: the type was validated on definition create.
+				throw new InvalidInputException('Unsupported field type "' . (string)$field->getType() . '"');
+		}
+	}
+
+	/**
+	 * Accepts an ISO date (YYYY-MM-DD) or an ISO datetime and stores the
+	 * date part in canonical YYYY-MM-DD form.
+	 *
+	 * @throws InvalidInputException on an unparseable date
+	 */
+	private function normalizeDate(string $value): string {
+		$date = \DateTimeImmutable::createFromFormat('!Y-m-d', substr($value, 0, 10));
+		$errors = \DateTimeImmutable::getLastErrors();
+		if ($date === false || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))) {
+			throw new InvalidInputException('Value "' . $value . '" is not a valid ISO date (YYYY-MM-DD)');
+		}
+		return $date->format('Y-m-d');
+	}
+}

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -236,7 +236,30 @@ class CardService {
 					Change::VERB_CREATED,
 				);
 				$this->db->commit();
-				break;
+
+				// Commit succeeded - now it is safe to broadcast the create.
+				$this->changeNotifier->pushBoardChanged($stack->getBoardId());
+
+				// Surface the create in the Nextcloud Activity stream (best-effort,
+				// never fatal to the create). User-initiated only - $uid is the actor.
+				$this->changeNotifier->publishCardActivity(
+					$stack->getBoardId(),
+					'card_created',
+					$card->getId(),
+					(string)$card->getTitle(),
+					$uid,
+				);
+
+				// Fan a "new card on a board you watch" notification out to board
+				// watchers. Best-effort - a notification hiccup must never fail the
+				// create (the card + its change row are already committed).
+				try {
+					$this->subscriptionService->notifyBoardCardCreated($stack->getBoardId(), $card->getId(), $uid);
+				} catch (\Throwable) {
+					// Ignore - board-activity fan-out is a non-critical side effect.
+				}
+
+				return $card;
 			} catch (\OCP\DB\Exception $e) {
 				$this->db->rollBack();
 				if ($e->getReason() !== \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
@@ -258,20 +281,6 @@ class CardService {
 				throw $e;
 			}
 		}
-
-		// Commit succeeded - now it is safe to broadcast the create.
-		$this->changeNotifier->pushBoardChanged($stack->getBoardId());
-
-		// Fan a "new card on a board you watch" notification out to board
-		// watchers. Best-effort - a notification hiccup must never fail the
-		// create (the card + its change row are already committed).
-		try {
-			$this->subscriptionService->notifyBoardCardCreated($stack->getBoardId(), $card->getId(), $uid);
-		} catch (\Throwable) {
-			// Ignore - board-activity fan-out is a non-critical side effect.
-		}
-
-		return $card;
 	}
 
 	/**
@@ -778,10 +787,15 @@ class CardService {
 			$sortKey = $this->deriveMoveKey($targetStackId, $afterCard);
 
 			$now = time();
+			// Whether THIS move flips the card into the done state (was open before,
+			// lands in a done-role column). Drives the "marked done" Activity subject
+			// below - a plain reshuffle or a move between open columns is "moved".
+			$wasDone = ($card->getDoneAt() ?? 0) > 0;
 			$card->setStackId($targetStackId);
 			$card->setSortKey($sortKey);
 			$card->setLastModified($now);
 			$this->applyDoneAutomation($card, $sourceStack, $targetStack, $now);
+			$becameDone = !$wasDone && ($card->getDoneAt() ?? 0) > 0;
 			$card = $this->cardMapper->update($card);
 
 			// Write the change row inside the transaction (delta-sync source of
@@ -805,6 +819,16 @@ class CardService {
 
 		// Commit succeeded - now it is safe to broadcast the move.
 		$this->changeNotifier->pushBoardChanged($card->getBoardId());
+
+		// Surface the move in the Nextcloud Activity stream (best-effort). A move
+		// that completes the card reads as "marked done", any other move as "moved".
+		$this->changeNotifier->publishCardActivity(
+			$card->getBoardId(),
+			$becameDone ? 'card_done' : 'card_moved',
+			$card->getId(),
+			(string)$card->getTitle(),
+			$uid,
+		);
 
 		return $card;
 	}

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -1075,6 +1075,145 @@ class CardService {
 	}
 
 	/**
+	 * Rewrites every live card in $stackId to a fresh, short, evenly-spaced
+	 * `sort_key`, preserving the current display order (#3379). This is the
+	 * recovery for the pathological case the move endpoint reports as 409
+	 * `rebalance_required`: repeated bisection between the same neighbours grows
+	 * a fractional key past {@see SortKeyService::MAX_KEY_LENGTH}, at which point
+	 * no new key fits between them. A rebalance resets the whole stack to
+	 * two-character keys, restoring generous gaps so subsequent between()/after()
+	 * inserts no longer overflow.
+	 *
+	 * Concurrency: the stack's rows are read with SELECT ... FOR UPDATE inside a
+	 * single transaction (no new global lock - it matches the app's
+	 * READ-COMMITTED move posture used by {@see self::persistMove()}, just
+	 * pessimistically for this rare maintenance path), so a concurrent move
+	 * blocks on the same rows until the rebalance commits.
+	 *
+	 * The (stack_id, sort_key, deleted_at) unique index forbids two live rows in
+	 * a stack sharing a key even transiently, so the rewrite runs in two passes:
+	 * pass 1 parks every row at a distinct three-character temporary key that is
+	 * disjoint from all current keys (and, by length, from the two-character
+	 * finals), pass 2 writes the final evenly-spaced keys. A single stack-level
+	 * MOVE change row (delta-sync) is recorded inside the transaction and the
+	 * board push emitted after commit, mirroring persistMove().
+	 *
+	 * @return int the number of cards rewritten (0 if the stack was empty)
+	 * @throws DoesNotExistException if the stack does not exist or is deleted
+	 * @throws \OCP\DB\Exception on a DB error
+	 * @throws \RuntimeException if the stack is too large for the temporary
+	 *                           three-character key grid (pathological only)
+	 */
+	public function rebalanceStack(int $stackId): int {
+		$stack = $this->loadStack($stackId);
+		$boardId = $stack->getBoardId();
+
+		$this->db->beginTransaction();
+		try {
+			$cards = $this->cardMapper->findByStackForUpdate($stackId);
+			$count = count($cards);
+			if ($count === 0) {
+				$this->db->commit();
+				return 0;
+			}
+
+			$freshKeys = $this->sortKeyService->evenlySpaced($count);
+			$currentKeys = [];
+			foreach ($cards as $card) {
+				$currentKeys[$card->getSortKey()] = true;
+			}
+			$tempKeys = $this->temporaryKeys($currentKeys, $count);
+
+			// Pass 1: park each row at a distinct temporary key that is disjoint
+			// from every current key, so no UPDATE collides with a
+			// not-yet-rewritten row.
+			foreach ($cards as $index => $card) {
+				$this->cardMapper->updateSortKeyById($card->getId(), $tempKeys[$index]);
+			}
+			// Pass 2: write the final evenly-spaced keys, order preserved. The
+			// finals are the short two-character grid and the temp band the
+			// three-character grid, so the two are disjoint and this pass never
+			// collides either.
+			foreach ($cards as $index => $card) {
+				$this->cardMapper->updateSortKeyById($card->getId(), $freshKeys[$index]);
+			}
+
+			// One stack-level MOVE change row is enough for delta-sync clients to
+			// know the stack reordered and refetch it - cheaper than one row per
+			// card.
+			$this->changeNotifier->recordChange(
+				$boardId,
+				Change::ENTITY_STACK,
+				$stackId,
+				Change::ACTION_MOVE,
+				null,
+				Change::VERB_MOVED,
+			);
+
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+
+		// Commit succeeded - now it is safe to broadcast the reordering.
+		$this->changeNotifier->pushBoardChanged($boardId);
+
+		return $count;
+	}
+
+	/**
+	 * Rebalances every stack on $boardId (the `occ kanso:rebalance --board`
+	 * path). Each stack is rebalanced in its own transaction, so one empty or
+	 * failing stack does not roll back the others.
+	 *
+	 * @return array<int,int> map of stack id => number of cards rewritten
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws \OCP\DB\Exception on a DB error
+	 */
+	public function rebalanceBoard(int $boardId): array {
+		$board = $this->loadBoard($boardId);
+		$result = [];
+		foreach ($this->stackMapper->findByBoard($board->getId()) as $stack) {
+			$result[$stack->getId()] = $this->rebalanceStack($stack->getId());
+		}
+		return $result;
+	}
+
+	/**
+	 * $count distinct temporary sort keys for a rebalance's pass 1, drawn from
+	 * the three-character base-36 grid and disjoint from every key currently in
+	 * the stack. Three-character keys are always length-safe (well under
+	 * MAX_KEY_LENGTH) and, by length alone, disjoint from the two-character final
+	 * keys - so parking here never collides with a not-yet-rewritten row and the
+	 * final pass never collides with the parking band. Any grid slot already used
+	 * by a current key is skipped; with 36^3 = 46656 slots this always yields
+	 * enough keys for a realistic stack.
+	 *
+	 * @param array<string,true> $currentKeys the stack's current keys as a set
+	 * @return list<string>
+	 * @throws \RuntimeException if the three-character grid cannot supply $count
+	 *                           free keys (only for a pathologically huge stack)
+	 */
+	private function temporaryKeys(array $currentKeys, int $count): array {
+		$alphabet = SortKeyService::ALPHABET;
+		$base = SortKeyService::BASE;
+		$keys = [];
+		for ($slot = 0; $slot < $base * $base * $base && count($keys) < $count; $slot++) {
+			$key = $alphabet[intdiv($slot, $base * $base) % $base]
+				. $alphabet[intdiv($slot, $base) % $base]
+				. $alphabet[$slot % $base];
+			if (!isset($currentKeys[$key])) {
+				$keys[] = $key;
+			}
+		}
+		if (count($keys) < $count) {
+			throw new \RuntimeException('Stack too large to rebalance: exhausted the temporary sort-key grid');
+		}
+		return $keys;
+	}
+
+	/**
 	 * New sort key for a card landing in $targetStackId after $afterCard
 	 * (null = top of the stack). The moved card may itself be one of the
 	 * neighbours - its still-current key then bounds the result, which is

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -218,10 +218,27 @@ class CardService {
 			// the column is set on INSERT (the DB default backs pre-migration rows).
 			$card->setIsTemplate(false);
 
+			// Insert the card AND its CREATE change row atomically (#3579): a
+			// failed change-row write must roll the card INSERT back, never leave
+			// a card without its delta-sync row. The realtime push is deferred to
+			// after commit - a pre-commit push could surface a card the retry then
+			// rolls back. A unique violation (sort-key or board_seq collision)
+			// rolls the transaction back and drives the re-derive/retry.
+			$this->db->beginTransaction();
 			try {
 				$card = $this->cardMapper->insert($card);
+				$this->changeNotifier->recordChange(
+					$stack->getBoardId(),
+					Change::ENTITY_CARD,
+					$card->getId(),
+					Change::ACTION_CREATE,
+					$uid,
+					Change::VERB_CREATED,
+				);
+				$this->db->commit();
 				break;
 			} catch (\OCP\DB\Exception $e) {
+				$this->db->rollBack();
 				if ($e->getReason() !== \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 					throw $e;
 				}
@@ -234,17 +251,16 @@ class CardService {
 				if ($attempt >= self::MAX_CREATE_ATTEMPTS - 1) {
 					throw new \OverflowException('card create key conflict (sort key or board_seq) after retries', 0, $e);
 				}
+			} catch (\Throwable $e) {
+				// Any other failure (e.g. the change-row insert throwing) also rolls
+				// back the card INSERT so no orphan card lands without a delta row.
+				$this->db->rollBack();
+				throw $e;
 			}
 		}
 
-		$this->changeNotifier->notify(
-			$stack->getBoardId(),
-			Change::ENTITY_CARD,
-			$card->getId(),
-			Change::ACTION_CREATE,
-			$uid,
-			verb: Change::VERB_CREATED,
-		);
+		// Commit succeeded - now it is safe to broadcast the create.
+		$this->changeNotifier->pushBoardChanged($stack->getBoardId());
 
 		// Fan a "new card on a board you watch" notification out to board
 		// watchers. Best-effort - a notification hiccup must never fail the
@@ -404,15 +420,15 @@ class CardService {
 
 		$card->setIsTemplate($isTemplate);
 		$card->setLastModified(time());
-		$card = $this->cardMapper->update($card);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit.
+		$card = $this->writeCardChange(
 			$card->getBoardId(),
-			Change::ENTITY_CARD,
 			$id,
 			Change::ACTION_UPDATE,
 			$uid,
-			verb: Change::VERB_UPDATED,
+			Change::VERB_UPDATED,
+			fn (): Card => $this->cardMapper->update($card),
 		);
 
 		return $card;
@@ -601,15 +617,18 @@ class CardService {
 
 		$now = time();
 		$card->setLastModified($now);
-		$card = $this->cardMapper->update($card);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579): the UPDATE and its delta-sync
+		// row commit together (or roll back together); the realtime push fires only
+		// after commit. Side effects below (mentions, parent auto-complete) run
+		// after the card + its change row have landed.
+		$card = $this->writeCardChange(
 			$card->getBoardId(),
-			Change::ENTITY_CARD,
 			$id,
 			Change::ACTION_UPDATE,
 			$uid,
-			verb: Change::VERB_UPDATED,
+			Change::VERB_UPDATED,
+			fn (): Card => $this->cardMapper->update($card),
 		);
 
 		// A new @mention in the description pings + auto-subscribes readable-board
@@ -641,23 +660,26 @@ class CardService {
 
 		$now = time();
 
-		foreach ($this->cardMapper->findChildren($id) as $child) {
-			$child->setParentCardId(null);
-			$child->setLastModified($now);
-			$this->cardMapper->update($child);
-		}
-
-		$card->setDeletedAt($now);
-		$card->setLastModified($now);
-		$this->cardMapper->update($card);
-
-		$this->changeNotifier->notify(
+		// Detach children, soft-delete the card and append the DELETE change row
+		// atomically (#3579): the child clears, the delete and its delta-sync row
+		// commit together, so a client never sees a detached child without the
+		// parent's DELETE row (or vice versa). Push after commit.
+		$this->writeCardChange(
 			$card->getBoardId(),
-			Change::ENTITY_CARD,
 			$id,
 			Change::ACTION_DELETE,
 			$uid,
-			verb: Change::VERB_DELETED,
+			Change::VERB_DELETED,
+			function () use ($id, $card, $now): Card {
+				foreach ($this->cardMapper->findChildren($id) as $child) {
+					$child->setParentCardId(null);
+					$child->setLastModified($now);
+					$this->cardMapper->update($child);
+				}
+				$card->setDeletedAt($now);
+				$card->setLastModified($now);
+				return $this->cardMapper->update($card);
+			},
 		);
 	}
 
@@ -766,13 +788,12 @@ class CardService {
 			// truth), but DEFER the realtime push until after commit - otherwise a
 			// client could refetch pre-commit state, or get an event for a move
 			// that the unique-key retry then rolls back.
-			$this->changeNotifier->notify(
+			$this->changeNotifier->recordChange(
 				$card->getBoardId(),
 				Change::ENTITY_CARD,
 				$card->getId(),
 				Change::ACTION_MOVE,
 				$uid,
-				false,
 				Change::VERB_MOVED,
 			);
 
@@ -783,7 +804,7 @@ class CardService {
 		}
 
 		// Commit succeeded - now it is safe to broadcast the move.
-		$this->changeNotifier->emitPush($card->getBoardId());
+		$this->changeNotifier->pushBoardChanged($card->getBoardId());
 
 		return $card;
 	}
@@ -838,15 +859,15 @@ class CardService {
 		}
 
 		$card->setLastModified(time());
-		$card = $this->cardMapper->update($card);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit.
+		$card = $this->writeCardChange(
 			$card->getBoardId(),
-			Change::ENTITY_CARD,
 			$id,
 			Change::ACTION_UPDATE,
 			$uid,
-			verb: Change::VERB_UPDATED,
+			Change::VERB_UPDATED,
+			fn (): Card => $this->cardMapper->update($card),
 		);
 
 		return $card;
@@ -980,16 +1001,53 @@ class CardService {
 		$now = time();
 		$parent->setDoneAt($now);
 		$parent->setLastModified($now);
-		$this->cardMapper->update($parent);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit.
+		$this->writeCardChange(
 			$parent->getBoardId(),
-			Change::ENTITY_CARD,
 			$parentId,
 			Change::ACTION_UPDATE,
 			$uid,
-			verb: Change::VERB_UPDATED,
+			Change::VERB_UPDATED,
+			fn (): Card => $this->cardMapper->update($parent),
 		);
+	}
+
+	/**
+	 * Runs a single-card entity write and its `kanso_changes` row atomically
+	 * (#3579): the mapper write in $write and the change-row insert commit
+	 * together, or roll back together on any failure - so no card mutation is ever
+	 * visible without its delta-sync row, and no delta row points at a write that
+	 * was rolled back. The realtime push is emitted only AFTER commit (never inside
+	 * the transaction - a pre-commit push could make a client refetch state a
+	 * rollback then discards). Mirrors {@see self::persistMove()}'s pattern for the
+	 * non-move single-entity mutators (create/update/delete/setParent/…).
+	 *
+	 * @param callable():Card $write performs the entity write and returns the row
+	 * @throws \Throwable rethrows whatever the write or the change-row insert throws
+	 */
+	private function writeCardChange(int $boardId, int $entityId, int $action, ?string $uid, ?int $verb, callable $write): Card {
+		$this->db->beginTransaction();
+		try {
+			$card = $write();
+			$this->changeNotifier->recordChange(
+				$boardId,
+				Change::ENTITY_CARD,
+				$entityId,
+				$action,
+				$uid,
+				$verb,
+			);
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+
+		// Commit succeeded - now it is safe to broadcast.
+		$this->changeNotifier->pushBoardChanged($boardId);
+
+		return $card;
 	}
 
 	/**

--- a/lib/Service/CardTimeEntryService.php
+++ b/lib/Service/CardTimeEntryService.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\CardTimeEntry;
+use OCA\Kanso\Db\CardTimeEntryMapper;
+use OCA\Kanso\Db\Change;
+use OCP\AppFramework\Db\DoesNotExistException;
+
+/**
+ * Manual time tracking on a card (#3536). Each row is a duration (in seconds)
+ * an actor logged against the card, with an optional note; the per-card total
+ * is the SUM of these rows and lives only in the card DETAIL payload (never the
+ * board/summary listings), so the "summaries only" board perf bet is preserved.
+ *
+ * MANUAL entries only - there is deliberately no running-timer state on the
+ * server; a client stopwatch just POSTs a finished duration on stop.
+ *
+ * Gating mirrors {@see CardAttachmentService}: list requires READ, add/delete
+ * require EDIT, and every mutation reuses the card's ENTITY_CARD / ACTION_UPDATE
+ * change row so the existing realtime/delta-sync + ETag path reflects the new
+ * total with no new Change type. Delete is IDOR-guarded (the entry must belong
+ * to the card in the URL, otherwise a 404 - never a leak).
+ */
+class CardTimeEntryService {
+	/**
+	 * Hard cap on a single entry's duration (in seconds): 1000 hours. A manual
+	 * entry larger than this is almost certainly a bad input (e.g. minutes fed
+	 * as seconds) and is rejected rather than stored.
+	 */
+	public const MAX_SECONDS = 1000 * 3600;
+
+	/** Max stored note length (mirrors the note column width). */
+	private const MAX_NOTE_LENGTH = 255;
+
+	public function __construct(
+		private CardTimeEntryMapper $timeEntryMapper,
+		private CardMapper $cardMapper,
+		private BoardMapper $boardMapper,
+		private PermissionService $permissionService,
+		private ChangeNotifier $changeNotifier,
+	) {
+	}
+
+	/**
+	 * A card's time entries (newest first). Requires READ.
+	 *
+	 * @return CardTimeEntry[]
+	 * @throws DoesNotExistException if the card or its board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not read the board
+	 */
+	public function listForCard(int $cardId, string $actorUid): array {
+		$card = $this->loadCard($cardId);
+		$board = $this->loadBoard($card->getBoardId());
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_READ);
+
+		return $this->timeEntryMapper->findByCard($cardId);
+	}
+
+	/**
+	 * Logs a manual time entry against the card. Requires EDIT.
+	 *
+	 * The board id is denormalized from the loaded card (server-side, never
+	 * client-supplied). `$seconds` must be positive and within {@see
+	 * self::MAX_SECONDS}; the note is trimmed and length-capped.
+	 *
+	 * @throws DoesNotExistException if the card or its board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not edit the board
+	 * @throws InvalidInputException if the duration is zero/negative or absurdly large
+	 */
+	public function add(int $cardId, int $seconds, ?string $note, string $actorUid): CardTimeEntry {
+		$card = $this->loadCard($cardId);
+		$board = $this->loadBoard($card->getBoardId());
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
+
+		if ($seconds <= 0) {
+			throw new InvalidInputException('Duration must be greater than zero');
+		}
+		if ($seconds > self::MAX_SECONDS) {
+			throw new InvalidInputException('Duration is too large');
+		}
+
+		$entry = new CardTimeEntry();
+		$entry->setCardId($cardId);
+		$entry->setBoardId($card->getBoardId());
+		$entry->setSeconds($seconds);
+		$entry->setNote($this->sanitizeNote($note));
+		$entry->setCreatedBy($actorUid);
+		$entry->setCreatedAt(time());
+
+		$entry = $this->timeEntryMapper->insert($entry);
+
+		$this->changeNotifier->notify(
+			$card->getBoardId(),
+			Change::ENTITY_CARD,
+			$cardId,
+			Change::ACTION_UPDATE,
+			$actorUid
+		);
+
+		return $entry;
+	}
+
+	/**
+	 * Removes a time entry from the card. Requires EDIT. IDOR-guarded: the entry
+	 * must belong to the card in the URL, otherwise a 404 (not a leak).
+	 *
+	 * @throws DoesNotExistException if the card/board/entry does not exist, is deleted, or the entry is on another card
+	 * @throws NotPermittedException if the actor may not edit the board
+	 */
+	public function delete(int $cardId, int $entryId, string $actorUid): void {
+		$card = $this->loadCard($cardId);
+		$board = $this->loadBoard($card->getBoardId());
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
+
+		$entry = $this->loadEntryOnCard($entryId, $cardId);
+		$this->timeEntryMapper->delete($entry);
+
+		$this->changeNotifier->notify(
+			$card->getBoardId(),
+			Change::ENTITY_CARD,
+			$cardId,
+			Change::ACTION_UPDATE,
+			$actorUid
+		);
+	}
+
+	/**
+	 * Cascade cleanup when a card is PERMANENTLY removed (trash purge). Drops
+	 * every time-entry row of the card in a single statement.
+	 *
+	 * No permission check and no change notification: this is an internal
+	 * cascade invoked by callers ({@see TrashService::purge()}) that have
+	 * already authorized the destructive card removal and emit their own card
+	 * DELETE change row. Safe to call for a card with zero entries.
+	 */
+	public function deleteAllForCard(int $cardId): void {
+		$this->timeEntryMapper->deleteByCard($cardId);
+	}
+
+	/**
+	 * Loads an entry and asserts it belongs to $cardId - the IDOR guard. A
+	 * mismatch is a 404 (not found on THIS card), never a leak.
+	 *
+	 * @throws DoesNotExistException if the entry does not exist or is on another card
+	 */
+	private function loadEntryOnCard(int $entryId, int $cardId): CardTimeEntry {
+		$entry = $this->timeEntryMapper->find($entryId);
+		if ($entry->getCardId() !== $cardId) {
+			throw new DoesNotExistException('Time entry ' . $entryId . ' is not on card ' . $cardId);
+		}
+		return $entry;
+	}
+
+	/**
+	 * Trims and length-caps a client note; an empty note is stored as null.
+	 */
+	private function sanitizeNote(?string $note): ?string {
+		if ($note === null) {
+			return null;
+		}
+		$note = trim($note);
+		if ($note === '') {
+			return null;
+		}
+		if (mb_strlen($note) > self::MAX_NOTE_LENGTH) {
+			$note = mb_substr($note, 0, self::MAX_NOTE_LENGTH);
+		}
+		return $note;
+	}
+
+	/**
+	 * @throws DoesNotExistException if the card does not exist or is deleted
+	 */
+	private function loadCard(int $id): Card {
+		$card = $this->cardMapper->find($id);
+		if ($card->getDeletedAt() > 0) {
+			throw new DoesNotExistException('Card ' . $id . ' is deleted');
+		}
+		return $card;
+	}
+
+	/**
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 */
+	private function loadBoard(int $boardId): Board {
+		$board = $this->boardMapper->find($boardId);
+		if ($board->getDeletedAt() > 0) {
+			throw new DoesNotExistException('Board ' . $boardId . ' is deleted');
+		}
+		return $board;
+	}
+}

--- a/lib/Service/ChangeNotifier.php
+++ b/lib/Service/ChangeNotifier.php
@@ -44,6 +44,7 @@ class ChangeNotifier {
 		private IGroupManager $groupManager,
 		private ContainerInterface $container,
 		private LoggerInterface $logger,
+		private ActivityPublisher $activityPublisher,
 	) {
 	}
 
@@ -135,6 +136,54 @@ class ChangeNotifier {
 				'kanso: failed to emit notify_push event for board ' . $boardId,
 				['exception' => $e]
 			);
+		}
+	}
+
+	/**
+	 * Publishes ONE of the four coarse Activity-stream milestones (card created /
+	 * moved / done, board shared) to everyone with access to the board - the same
+	 * board-scoped audience the realtime push fans out to. This is the choke point
+	 * that keeps Activity consistent with the change log: services call it right
+	 * next to their {@see self::recordChange()} write for these four user-initiated
+	 * events, and never for the fine-grained field edits or the system/cron sweeps.
+	 *
+	 * Best-effort and never throws - the Activity app may be absent (the publisher
+	 * no-ops) and any publish error is swallowed there.
+	 *
+	 * @param 'card_created'|'card_moved'|'card_done' $subject
+	 */
+	public function publishCardActivity(int $boardId, string $subject, int $cardId, string $cardTitle, ?string $actor): void {
+		// System/cron-driven changes carry a null actor (auto-archive sweep,
+		// recurrence spawns, due reminders). Activity is only for user-initiated
+		// milestones, so skip those - it avoids the batch/cron activity spam.
+		if ($actor === null) {
+			return;
+		}
+		try {
+			$recipients = $this->resolveRecipients($boardId);
+			match ($subject) {
+				'card_created' => $this->activityPublisher->cardCreated($boardId, $cardId, $cardTitle, $actor, $recipients),
+				'card_moved' => $this->activityPublisher->cardMoved($boardId, $cardId, $cardTitle, $actor, $recipients),
+				'card_done' => $this->activityPublisher->cardDone($boardId, $cardId, $cardTitle, $actor, $recipients),
+				default => null,
+			};
+		} catch (\Throwable $e) {
+			$this->logger->debug('kanso: failed to publish card activity for board ' . $boardId, ['exception' => $e]);
+		}
+	}
+
+	/**
+	 * Publishes the "board shared" Activity milestone to everyone with access to
+	 * the board (the new participant included). Best-effort, never throws.
+	 */
+	public function publishBoardShared(int $boardId, string $boardTitle, ?string $actor): void {
+		if ($actor === null) {
+			return;
+		}
+		try {
+			$this->activityPublisher->boardShared($boardId, $boardTitle, $actor, $this->resolveRecipients($boardId));
+		} catch (\Throwable $e) {
+			$this->logger->debug('kanso: failed to publish board-shared activity for board ' . $boardId, ['exception' => $e]);
 		}
 	}
 

--- a/lib/Service/ChangeNotifier.php
+++ b/lib/Service/ChangeNotifier.php
@@ -51,14 +51,22 @@ class ChangeNotifier {
 	 * Appends a change row for the mutation and broadcasts it to everyone
 	 * with access to the board.
 	 *
+	 * Convenience wrapper over {@see self::recordChange()} + {@see self::pushBoardChanged()}
+	 * for the simple case: a single mutation that is NOT inside a caller-managed
+	 * transaction and wants one push right away. Callers that write the change row
+	 * inside a DB transaction (so the push must be deferred until after commit), or
+	 * that write many change rows in one batch (so only one push should fire),
+	 * should instead call {@see self::recordChange()} and {@see self::pushBoardChanged()}
+	 * separately.
+	 *
 	 * @param int $entityType one of the Change::ENTITY_* constants
 	 * @param int $action one of the Change::ACTION_* constants
 	 * @param string|null $actor uid of the acting user, null for system actions
 	 * @param bool $push whether to broadcast the push now. Pass false when the
 	 *                   change row is written INSIDE a transaction, and call
-	 *                   {@see self::emitPush()} yourself after commit - otherwise a client
-	 *                   could refetch pre-commit state, or (on rollback) get an event for a
-	 *                   change that never landed.
+	 *                   {@see self::pushBoardChanged()} yourself after commit - otherwise a
+	 *                   client could refetch pre-commit state, or (on rollback) get an event
+	 *                   for a change that never landed.
 	 * @param int|null $verb one of the Change::VERB_* constants for the per-card
 	 *                       Activity feed, or null (renders as a generic "updated"). Additive -
 	 *                       delta-sync keys on (entity_type, action), not the verb.
@@ -66,7 +74,31 @@ class ChangeNotifier {
 	 * @throws \OCP\DB\Exception if inserting the change row fails
 	 */
 	public function notify(int $boardId, int $entityType, int $entityId, int $action, ?string $actor, bool $push = true, ?int $verb = null): Change {
-		$change = $this->changeMapper->insertChange(
+		$change = $this->recordChange($boardId, $entityType, $entityId, $action, $actor, $verb);
+
+		if ($push) {
+			$this->pushBoardChanged($boardId);
+		}
+
+		return $change;
+	}
+
+	/**
+	 * Appends the `kanso_changes` row for a mutation - the delta-sync / ETag
+	 * source of truth - and NOTHING else. No realtime push is emitted. Use this
+	 * (paired with {@see self::pushBoardChanged()}) when the change row is written
+	 * inside a caller-managed transaction, or when many rows are written in one
+	 * batch and only one push should fire for the board.
+	 *
+	 * @param int $entityType one of the Change::ENTITY_* constants
+	 * @param int $action one of the Change::ACTION_* constants
+	 * @param string|null $actor uid of the acting user, null for system actions
+	 * @param int|null $verb one of the Change::VERB_* constants, or null
+	 * @return Change the inserted entry with its id set
+	 * @throws \OCP\DB\Exception if inserting the change row fails
+	 */
+	public function recordChange(int $boardId, int $entityType, int $entityId, int $action, ?string $actor, ?int $verb = null): Change {
+		return $this->changeMapper->insertChange(
 			$boardId,
 			$entityType,
 			$entityId,
@@ -75,20 +107,17 @@ class ChangeNotifier {
 			time(),
 			$verb
 		);
-
-		if ($push) {
-			$this->emitPush($boardId);
-		}
-
-		return $change;
 	}
 
 	/**
-	 * Best-effort notify_push broadcast for a board - never throws. Public so a
-	 * caller that wrote the change row inside a transaction can defer the push
-	 * until after commit (see {@see \OCA\Kanso\Service\CardService::persistMove}).
+	 * Best-effort notify_push broadcast for a board - never throws. The
+	 * per-participant fan-out: one `kanso_board_changed` event per board recipient.
+	 * Public so a caller that deferred the push (change row written inside a
+	 * transaction - see {@see \OCA\Kanso\Service\CardService::persistMove}) or that
+	 * coalesced a batch (many change rows, one push - see
+	 * {@see \OCA\Kanso\Service\ArchiveService::sweep}) can emit it explicitly.
 	 */
-	public function emitPush(int $boardId): void {
+	public function pushBoardChanged(int $boardId): void {
 		try {
 			$queue = $this->getQueue();
 			if ($queue === null) {

--- a/lib/Service/ChecklistService.php
+++ b/lib/Service/ChecklistService.php
@@ -15,6 +15,7 @@ use OCA\Kanso\Db\Change;
 use OCA\Kanso\Db\ChecklistItem;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
 
 /**
  * Flat checklist (todo) items on a card. Mirrors the assignee/label flow:
@@ -35,6 +36,7 @@ class ChecklistService {
 		private ChangeNotifier $changeNotifier,
 		private PermissionService $permissionService,
 		private SortKeyService $sortKeyService,
+		private IDBConnection $db,
 	) {
 	}
 
@@ -80,11 +82,9 @@ class ChecklistService {
 		$item->setDone($done);
 		$item->setSortKey($sortKey);
 		$item->setCreatedAt(time());
-		$saved = $this->itemMapper->insert($item);
 
-		$this->notifyCard($card, $actorUid);
-
-		return $saved;
+		// Atomic item-write + card change-row (#3579); push after commit.
+		return $this->writeItemChange($card, $actorUid, fn (): ChecklistItem => $this->itemMapper->insert($item));
 	}
 
 	/**
@@ -119,10 +119,8 @@ class ChecklistService {
 			return $item;
 		}
 
-		$saved = $this->itemMapper->update($item);
-		$this->notifyCard($card, $actorUid);
-
-		return $saved;
+		// Atomic item-write + card change-row (#3579); push after commit.
+		return $this->writeItemChange($card, $actorUid, fn (): ChecklistItem => $this->itemMapper->update($item));
 	}
 
 	/**
@@ -178,10 +176,9 @@ class ChecklistService {
 		}
 
 		$item->setSortKey($newKey);
-		$saved = $this->itemMapper->update($item);
-		$this->notifyCard($card, $actorUid);
 
-		return $saved;
+		// Atomic item-write + card change-row (#3579); push after commit.
+		return $this->writeItemChange($card, $actorUid, fn (): ChecklistItem => $this->itemMapper->update($item));
 	}
 
 	/**
@@ -196,24 +193,48 @@ class ChecklistService {
 		$board = $this->loadBoard($card->getBoardId());
 		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
 
-		$this->itemMapper->delete($item);
-		$this->notifyCard($card, $actorUid);
+		// Atomic item-delete + card change-row (#3579); push after commit. The
+		// deleted item is returned so the shared helper's contract holds; the
+		// caller (void) ignores it.
+		$this->writeItemChange($card, $actorUid, function () use ($item): ChecklistItem {
+			$this->itemMapper->delete($item);
+			return $item;
+		});
 	}
 
 	/**
-	 * A checklist change is a card update as far as sync is concerned: the
-	 * board ETag bumps and clients refetch the card (items) and the board
-	 * (progress count).
+	 * Runs a checklist-item write and the card's `kanso_changes` row atomically
+	 * (#3579): a checklist change is a card UPDATE as far as sync is concerned
+	 * (the board ETag bumps and clients refetch the card's items + the board's
+	 * progress count). The item write in $write and the card change-row insert
+	 * commit together, or roll back together on any failure; the realtime push is
+	 * emitted only AFTER commit.
+	 *
+	 * @param callable():ChecklistItem $write performs the item write and returns the row
+	 * @throws \Throwable rethrows whatever the write or the change-row insert throws
 	 */
-	private function notifyCard(Card $card, string $actorUid): void {
-		$this->changeNotifier->notify(
-			$card->getBoardId(),
-			Change::ENTITY_CARD,
-			$card->getId(),
-			Change::ACTION_UPDATE,
-			$actorUid,
-			verb: Change::VERB_CHECKLIST,
-		);
+	private function writeItemChange(Card $card, string $actorUid, callable $write): ChecklistItem {
+		$this->db->beginTransaction();
+		try {
+			$saved = $write();
+			$this->changeNotifier->recordChange(
+				$card->getBoardId(),
+				Change::ENTITY_CARD,
+				$card->getId(),
+				Change::ACTION_UPDATE,
+				$actorUid,
+				Change::VERB_CHECKLIST,
+			);
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+
+		// Commit succeeded - now it is safe to broadcast.
+		$this->changeNotifier->pushBoardChanged($card->getBoardId());
+
+		return $saved;
 	}
 
 	/**

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -511,7 +511,9 @@ class ImportService {
 			$review->setState($this->str($r, 'state', CardReview::STATE_PENDING));
 			$review->setRequestedBy($requestedBy);
 			$review->setCreatedAt((int)($r['createdAt'] ?? $now));
-			$review->setReviewTypeId($newType);
+			// review_type_id is NOT NULL (Version001600); 0 = the implicit
+			// single-stage review, mirroring CardReviewMapper::insertRequest.
+			$review->setReviewTypeId($newType ?? 0);
 			$this->cardReviewMapper->insert($review);
 		}
 	}

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -410,7 +410,7 @@ class RecurrenceService {
 
 		// Commit succeeded - now it is safe to broadcast the enrichment UPDATE
 		// row that spawnClone deferred (push=false inside the transaction).
-		$this->changeNotifier->emitPush($card->getBoardId());
+		$this->changeNotifier->pushBoardChanged($card->getBoardId());
 
 		return $card;
 	}

--- a/lib/Service/ReviewService.php
+++ b/lib/Service/ReviewService.php
@@ -25,6 +25,15 @@ use OCP\AppFramework\Db\DoesNotExistException;
  * chip updates over the existing realtime/ETag path (ENTITY_CARD/ACTION_UPDATE
  * - no new Change constant). The done-gate that consumes these rows lives in
  * {@see CardService::move()}, not here.
+ *
+ * Stage gating (#3588): review types carry a `stage` ordering them into a
+ * chain; lower stages gate higher ones. A review of type T (stage N) is GATED
+ * while the card carries any OTHER unapproved review of a lower stage - it stays
+ * `pending` (a gated review is deliberately unapproved, so it still trips the
+ * done-gate) but its reviewer is NOT notified yet and it renders greyed. Gating
+ * is DERIVED here from the stage map, never stored. When the blocking
+ * lower-stage reviews approve, the deferred reviewer notification fires once
+ * (guarded by `notified_at`).
  */
 class ReviewService {
 	public function __construct(
@@ -93,7 +102,7 @@ class ReviewService {
 		}
 
 		try {
-			$this->cardReviewMapper->insertRequest($cardId, $reviewerUid, $actorUid, $reviewTypeId);
+			$review = $this->cardReviewMapper->insertRequest($cardId, $reviewerUid, $actorUid, $reviewTypeId);
 		} catch (\OCP\DB\Exception $e) {
 			if ($e->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 				// Concurrent PUT lost the check-then-insert race - the request
@@ -103,8 +112,20 @@ class ReviewService {
 			throw $e;
 		}
 
+		// Always emit the change row so the chip renders (gated or not). The
+		// reviewer notification is DEFERRED while the new review is gated behind a
+		// lower-stage unapproved review; it fires later from setState() when the
+		// blocking reviews approve. notified_at is stamped only when we notify, so
+		// the deferral is idempotent.
 		$this->notify($card, $actorUid, Change::VERB_REVIEW_REQUESTED);
-		$this->notificationService->notifyReviewRequested($cardId, $reviewerUid, $actorUid);
+
+		$stageMap = $this->reviewTypeMapper->stageMapForBoard($card->getBoardId());
+		$siblings = $this->cardReviewMapper->findByCard($cardId);
+		if (!$this->isGated($review, $siblings, $stageMap)) {
+			$this->notificationService->notifyReviewRequested($cardId, $reviewerUid, $actorUid);
+			$review->setNotifiedAt(time());
+			$this->cardReviewMapper->update($review);
+		}
 	}
 
 	/**
@@ -171,6 +192,12 @@ class ReviewService {
 			$this->notify($card, $actorUid, Change::VERB_REVIEW_VERDICT);
 			// The reviewer has acted - clear their pending "review requested" bell.
 			$this->notificationService->dismissReviewRequested($cardId, $review->getReviewer());
+
+			// A flip to APPROVED may un-gate downstream reviews: fire any deferred
+			// reviewer notification for a now-ungated review that was never notified.
+			if ($state === CardReview::STATE_APPROVED) {
+				$this->fireDeferredNotifications($card);
+			}
 		}
 
 		// A "request changes" reason becomes a comment by the reviewer (even if the
@@ -182,6 +209,115 @@ class ReviewService {
 			} catch (\Throwable) {
 				// Reviewer lacks EDIT to comment - the verdict still stands.
 			}
+		}
+	}
+
+	/**
+	 * Serializes a card's reviews for the detail payload, folding the DERIVED
+	 * `gated` flag (and `blockedBy` - the ids of the lower-stage unapproved
+	 * reviews holding it, for the tooltip) into each row. The stage map is
+	 * fetched ONCE (no N+1). Gating is never stored: a review of type T (stage N)
+	 * is gated iff the card holds any OTHER unapproved review of a lower stage.
+	 *
+	 * @return list<array<string, mixed>>
+	 * @throws \OCP\DB\Exception
+	 * @throws DoesNotExistException if the card does not exist or is deleted
+	 */
+	public function serializeReviewsForCard(int $cardId): array {
+		$card = $this->loadCard($cardId);
+		$reviews = $this->cardReviewMapper->findByCard($cardId);
+		$stageMap = $this->reviewTypeMapper->stageMapForBoard($card->getBoardId());
+
+		$out = [];
+		foreach ($reviews as $review) {
+			$blockedBy = $this->blockingReviewIds($review, $reviews, $stageMap);
+			$out[] = $review->jsonSerialize() + [
+				'gated' => $blockedBy !== [],
+				'blockedBy' => $blockedBy,
+			];
+		}
+		return $out;
+	}
+
+	/**
+	 * Stage of a review, resolved through the type=>stage map. Untyped reviews
+	 * (review_type_id 0/null) and types absent from the map are stage 0.
+	 *
+	 * @param array<int, int> $stageMap type id => stage
+	 */
+	private function stageOf(CardReview $review, array $stageMap): int {
+		$typeId = $review->getReviewTypeId() ?? 0;
+		return $typeId === 0 ? 0 : ($stageMap[$typeId] ?? 0);
+	}
+
+	/**
+	 * The ids of the reviews that gate $review: every OTHER review on the card
+	 * whose stage is strictly lower AND is not yet approved. A not-yet-requested
+	 * prerequisite does NOT block - only reviews that actually exist on the card
+	 * can gate. Empty list => not gated.
+	 *
+	 * @param CardReview[] $siblings all reviews on the card (may include $review)
+	 * @param array<int, int> $stageMap type id => stage
+	 * @return list<int>
+	 */
+	private function blockingReviewIds(CardReview $review, array $siblings, array $stageMap): array {
+		$myStage = $this->stageOf($review, $stageMap);
+		$blocking = [];
+		foreach ($siblings as $other) {
+			if ($other->getId() === $review->getId()) {
+				continue;
+			}
+			if ($other->getState() === CardReview::STATE_APPROVED) {
+				continue;
+			}
+			if ($this->stageOf($other, $stageMap) < $myStage) {
+				$blocking[] = (int)$other->getId();
+			}
+		}
+		return $blocking;
+	}
+
+	/**
+	 * Whether $review is gated within $siblings under $stageMap.
+	 *
+	 * @param CardReview[] $siblings
+	 * @param array<int, int> $stageMap
+	 */
+	private function isGated(CardReview $review, array $siblings, array $stageMap): bool {
+		return $this->blockingReviewIds($review, $siblings, $stageMap) !== [];
+	}
+
+	/**
+	 * Fires the deferred reviewer notification for every review on the card that
+	 * is now UNGATED but was never notified (`notified_at` null). Idempotent:
+	 * stamping `notified_at` on notify means a re-approval never re-notifies.
+	 * Reuses the SAME gating helper as request-time so the two cannot diverge.
+	 * The stage map + sibling set are fetched ONCE per call.
+	 *
+	 * @throws \OCP\DB\Exception
+	 */
+	private function fireDeferredNotifications(Card $card): void {
+		$cardId = $card->getId();
+		$stageMap = $this->reviewTypeMapper->stageMapForBoard($card->getBoardId());
+		$reviews = $this->cardReviewMapper->findByCard($cardId);
+
+		foreach ($reviews as $review) {
+			if ($review->getNotifiedAt() !== null) {
+				continue;
+			}
+			if ($review->getState() === CardReview::STATE_APPROVED) {
+				continue;
+			}
+			if ($this->isGated($review, $reviews, $stageMap)) {
+				continue;
+			}
+			$this->notificationService->notifyReviewRequested(
+				$cardId,
+				$review->getReviewer(),
+				$review->getRequestedBy(),
+			);
+			$review->setNotifiedAt(time());
+			$this->cardReviewMapper->update($review);
 		}
 	}
 

--- a/lib/Service/ReviewService.php
+++ b/lib/Service/ReviewService.php
@@ -246,7 +246,7 @@ class ReviewService {
 	 * @param array<int, int> $stageMap type id => stage
 	 */
 	private function stageOf(CardReview $review, array $stageMap): int {
-		$typeId = $review->getReviewTypeId() ?? 0;
+		$typeId = $review->getReviewTypeId();
 		return $typeId === 0 ? 0 : ($stageMap[$typeId] ?? 0);
 	}
 

--- a/lib/Service/ReviewTypeService.php
+++ b/lib/Service/ReviewTypeService.php
@@ -40,9 +40,9 @@ class ReviewTypeService {
 	/**
 	 * @throws DoesNotExistException if the board does not exist or is deleted
 	 * @throws NotPermittedException if the user may not manage the board
-	 * @throws InvalidInputException on invalid title or color
+	 * @throws InvalidInputException on invalid title, color, or negative stage
 	 */
-	public function create(int $boardId, string $title, ?string $color, string $uid): ReviewType {
+	public function create(int $boardId, string $title, ?string $color, string $uid, ?int $stage = null): ReviewType {
 		$board = $this->loadBoard($boardId);
 		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
 
@@ -50,6 +50,8 @@ class ReviewTypeService {
 		$type->setBoardId($boardId);
 		$type->setTitle($this->validateTitle($title));
 		$type->setColor(ColorValidator::assertValid($color));
+		$this->assertStageValid($stage);
+		$type->setStage($stage ?? 0);
 		$type = $this->reviewTypeMapper->insert($type);
 
 		$this->changeNotifier->notify(
@@ -66,9 +68,9 @@ class ReviewTypeService {
 	/**
 	 * @throws DoesNotExistException if the type or its board does not exist or is deleted
 	 * @throws NotPermittedException if the user may not manage the board
-	 * @throws InvalidInputException on invalid title or color
+	 * @throws InvalidInputException on invalid title, color, or negative stage
 	 */
-	public function update(int $id, ?string $title, ?string $color, string $uid): ReviewType {
+	public function update(int $id, ?string $title, ?string $color, string $uid, ?int $stage = null): ReviewType {
 		$type = $this->reviewTypeMapper->find($id);
 		$board = $this->loadBoard($type->getBoardId());
 		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
@@ -78,6 +80,10 @@ class ReviewTypeService {
 		}
 		if ($color !== null) {
 			$type->setColor(ColorValidator::assertValid($color));
+		}
+		if ($stage !== null) {
+			$this->assertStageValid($stage);
+			$type->setStage($stage);
 		}
 
 		$type = $this->reviewTypeMapper->update($type);
@@ -149,5 +155,17 @@ class ReviewTypeService {
 			);
 		}
 		return $title;
+	}
+
+	/**
+	 * A stage is a non-negative integer ordering the type in the review chain.
+	 * Null (caller keeps the existing / default stage) passes validation.
+	 *
+	 * @throws InvalidInputException on a negative stage
+	 */
+	private function assertStageValid(?int $stage): void {
+		if ($stage !== null && $stage < 0) {
+			throw new InvalidInputException('Stage must not be negative');
+		}
 	}
 }

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -10,6 +10,7 @@ namespace OCA\Kanso\Service;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CommentMapper;
+use OCP\IDBConnection;
 
 /**
  * In-app search over card titles/descriptions and comment bodies. Portable v1:
@@ -37,6 +38,7 @@ class SearchService {
 		private BoardService $boardService,
 		private CardMapper $cardMapper,
 		private CommentMapper $commentMapper,
+		private IDBConnection $db,
 	) {
 	}
 
@@ -55,7 +57,7 @@ class SearchService {
 			return ['query' => $term, 'total' => 0, 'results' => []];
 		}
 
-		$pattern = '%' . $this->escapeLike($term) . '%';
+		$pattern = '%' . $this->db->escapeLikeParameter($term) . '%';
 		$lowerTerm = mb_strtolower($term);
 
 		$results = [];
@@ -115,14 +117,6 @@ class SearchService {
 			return in_array($boardId, $ids, true) ? [$boardId] : [];
 		}
 		return $ids;
-	}
-
-	/**
-	 * Escapes the LIKE wildcards so a term containing % or _ is matched
-	 * literally rather than as a wildcard.
-	 */
-	private function escapeLike(string $term): string {
-		return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $term);
 	}
 
 	private function snippet(string $text): string {

--- a/lib/Service/SortKeyService.php
+++ b/lib/Service/SortKeyService.php
@@ -60,6 +60,63 @@ class SortKeyService {
 	}
 
 	/**
+	 * Returns $n short, strictly-increasing, evenly-spaced keys - the fresh key
+	 * set for a stack {@see rebalance}. Used to reset a stack whose fractional
+	 * keys have grown pathologically long (repeated bisection between the same
+	 * neighbours), restoring generous gaps for future inserts.
+	 *
+	 * The keys are drawn from the two-character space (base-36 squared = 1296
+	 * slots) as evenly-spaced offsets from that range, formatted as a fixed
+	 * two-character prefix plus, only when $n exceeds the 1296 two-char slots, a
+	 * short suffix. In practice a stack is never that large, so every returned
+	 * key is exactly two characters: short, collision-free within the set, and
+	 * strictly increasing. None ends in the minimum digit '0' (that would block
+	 * future before()-insertion), matching the invariant the other generators
+	 * uphold.
+	 *
+	 * @param int $n how many keys to produce (>= 0)
+	 * @return list<string> $n keys, strictly increasing, each <= MAX_KEY_LENGTH
+	 * @throws InvalidInputException if $n is negative
+	 */
+	public function evenlySpaced(int $n): array {
+		if ($n < 0) {
+			throw new InvalidInputException('evenlySpaced() requires n >= 0, got ' . $n);
+		}
+		if ($n === 0) {
+			return [];
+		}
+
+		// Reserve the two-character grid (BASE*BASE slots) and hand out evenly
+		// spaced interior positions, leaving a margin at both ends so before()
+		// and after() still have room. Position i maps to a fraction in (0,1)
+		// via (i+1)/(n+1), scaled across the grid.
+		$slots = self::BASE * self::BASE;
+		$keys = [];
+		$previous = '';
+		for ($i = 0; $i < $n; $i++) {
+			$position = intdiv(($i + 1) * ($slots - 1), $n + 1);
+			$high = intdiv($position, self::BASE);
+			$low = $position % self::BASE;
+			$key = self::ALPHABET[$high] . self::ALPHABET[$low];
+			if ($key[1] === '0') {
+				// Never end in '0' (blocks before()); bump the low digit. Since
+				// position < slots-1 the +1 cannot overflow the low digit into a
+				// new character, and even spacing keeps it below the next slot.
+				$key = self::ALPHABET[$high] . self::ALPHABET[$low + 1];
+			}
+			if ($key === $previous) {
+				// Two positions collapsed onto the same slot (only possible when
+				// $n approaches the grid size). Nudge past the previous key so the
+				// sequence stays strictly increasing.
+				$key = $this->after($previous);
+			}
+			$previous = $key;
+			$keys[] = $this->guardLength($key);
+		}
+		return $keys;
+	}
+
+	/**
 	 * Returns a key k with $a < k < $b (byte comparison).
 	 *
 	 * The result is at most one character longer than the longer input.

--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -56,17 +56,14 @@ class StackService {
 		$stack->setSortKey($sortKey);
 		$stack->setArchived(false);
 		$stack->setDeletedAt(0);
-		$stack = $this->stackMapper->insert($stack);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit.
+		return $this->writeStackChange(
 			$boardId,
-			Change::ENTITY_STACK,
-			$stack->getId(),
 			Change::ACTION_CREATE,
-			$uid
+			$uid,
+			fn (): Stack => $this->stackMapper->insert($stack),
 		);
-
-		return $stack;
 	}
 
 	/**
@@ -109,17 +106,13 @@ class StackService {
 			$stack->setColor($color === '' ? null : ColorValidator::assertValid($color));
 		}
 
-		$stack = $this->stackMapper->update($stack);
-
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit.
+		return $this->writeStackChange(
 			$stack->getBoardId(),
-			Change::ENTITY_STACK,
-			$id,
 			Change::ACTION_UPDATE,
-			$uid
+			$uid,
+			fn (): Stack => $this->stackMapper->update($stack),
 		);
-
-		return $stack;
 	}
 
 	/**
@@ -135,17 +128,14 @@ class StackService {
 
 		$now = time();
 		$stack->setDeletedAt($now);
-		$stack = $this->stackMapper->update($stack);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit.
+		return $this->writeStackChange(
 			$stack->getBoardId(),
-			Change::ENTITY_STACK,
-			$id,
 			Change::ACTION_DELETE,
-			$uid
+			$uid,
+			fn (): Stack => $this->stackMapper->update($stack),
 		);
-
-		return $stack;
 	}
 
 	/**
@@ -167,17 +157,15 @@ class StackService {
 		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_EDIT);
 
 		$stack->setDeletedAt(0);
-		$stack = $this->stackMapper->update($stack);
 
-		$this->changeNotifier->notify(
+		// Atomic entity-write + change-row (#3579); push after commit. Emits an
+		// ACTION_CREATE so clients re-add the restored column.
+		return $this->writeStackChange(
 			$stack->getBoardId(),
-			Change::ENTITY_STACK,
-			$id,
 			Change::ACTION_CREATE,
-			$uid
+			$uid,
+			fn (): Stack => $this->stackMapper->update($stack),
 		);
-
-		return $stack;
 	}
 
 	/**
@@ -208,17 +196,19 @@ class StackService {
 		));
 		$anchor = $afterStackId === null ? null : $this->resolveAnchor($afterStackId, $id, $siblings);
 
+		// Change row is written inside the transaction (delta-sync source of
+		// truth); the realtime push is deferred until after commit.
 		$this->db->beginTransaction();
 		try {
 			$stack->setSortKey($this->deriveMoveKey($siblings, $anchor));
 			$stack = $this->stackMapper->update($stack);
 
-			$this->changeNotifier->notify(
+			$this->changeNotifier->recordChange(
 				$stack->getBoardId(),
 				Change::ENTITY_STACK,
 				$id,
 				Change::ACTION_MOVE,
-				$uid
+				$uid,
 			);
 
 			$this->db->commit();
@@ -226,6 +216,43 @@ class StackService {
 			$this->db->rollBack();
 			throw $e;
 		}
+
+		// Commit succeeded - now it is safe to broadcast the move.
+		$this->changeNotifier->pushBoardChanged($stack->getBoardId());
+
+		return $stack;
+	}
+
+	/**
+	 * Runs a single stack entity write and its `kanso_changes` row atomically
+	 * (#3579): the mapper write in $write and the change-row insert commit
+	 * together, or roll back together on any failure - so no stack mutation is
+	 * visible without its delta-sync row. The realtime push is emitted only AFTER
+	 * commit. Mirrors {@see self::move()}'s pattern for the non-move stack
+	 * mutators (create/update/delete/restore).
+	 *
+	 * @param callable():Stack $write performs the entity write and returns the row
+	 * @throws \Throwable rethrows whatever the write or the change-row insert throws
+	 */
+	private function writeStackChange(int $boardId, int $action, ?string $uid, callable $write): Stack {
+		$this->db->beginTransaction();
+		try {
+			$stack = $write();
+			$this->changeNotifier->recordChange(
+				$boardId,
+				Change::ENTITY_STACK,
+				$stack->getId(),
+				$action,
+				$uid,
+			);
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+
+		// Commit succeeded - now it is safe to broadcast.
+		$this->changeNotifier->pushBoardChanged($boardId);
 
 		return $stack;
 	}

--- a/lib/Service/TrashService.php
+++ b/lib/Service/TrashService.php
@@ -59,6 +59,7 @@ class TrashService {
 		private CardRelationMapper $cardRelationMapper,
 		private ProjectCardMapper $projectCardMapper,
 		private CardAttachmentService $cardAttachmentService,
+		private CardTimeEntryService $cardTimeEntryService,
 	) {
 	}
 
@@ -135,6 +136,9 @@ class TrashService {
 		// goes through the service (it removes both) rather than a plain mapper
 		// deleteByCard - otherwise a purge would leak the bytes on disk (#3526).
 		$this->cardAttachmentService->deleteAllForCard($cardId);
+		// Manual time-tracking entries (#3536) are plain rows scoped by card_id;
+		// drop them too so a purged card strands no time entries.
+		$this->cardTimeEntryService->deleteAllForCard($cardId);
 		$this->cardMapper->delete($card);
 
 		$this->changeNotifier->notify(

--- a/lib/Service/TrashService.php
+++ b/lib/Service/TrashService.php
@@ -12,6 +12,7 @@ use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardContactMapper;
+use OCA\Kanso\Db\CardFieldValueMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardLinkMapper;
 use OCA\Kanso\Db\CardMapper;
@@ -60,6 +61,7 @@ class TrashService {
 		private ProjectCardMapper $projectCardMapper,
 		private CardAttachmentService $cardAttachmentService,
 		private CardTimeEntryService $cardTimeEntryService,
+		private CardFieldValueMapper $cardFieldValueMapper,
 	) {
 	}
 
@@ -139,6 +141,9 @@ class TrashService {
 		// Manual time-tracking entries (#3536) are plain rows scoped by card_id;
 		// drop them too so a purged card strands no time entries.
 		$this->cardTimeEntryService->deleteAllForCard($cardId);
+		// Custom-field values (#3537) are plain rows scoped by card_id; drop them
+		// so a purged card strands no field values.
+		$this->cardFieldValueMapper->deleteByCard($cardId);
 		$this->cardMapper->delete($card);
 
 		$this->changeNotifier->notify(

--- a/scripts/seed-board.mjs
+++ b/scripts/seed-board.mjs
@@ -1,13 +1,33 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Seed script: creates a 'Perf Test Board' with 3 stacks × ~667 cards (2 001 total).
-// Usage: node scripts/seed-board.mjs
+// Seed script: creates a 'Perf Test Board' with N cards spread across S stacks.
+//
+// PARAMETERIZED (env vars, all optional):
+//   CARDS=<total cards>   default 2001  — total cards across all stacks
+//   STACKS=<stack count>  default 3     — number of stacks to spread cards over
+//   TITLE=<board title>   default 'Perf Test Board'
+//
+// Cards within a single stack MUST be created sequentially: two concurrent
+// appends to the same stack derive the same fractional sort key and the loser
+// gets a retryable 409 (rebalance_required). We instead parallelize ACROSS
+// stacks (safe — different key spaces) and go sequentially within each, so more
+// stacks = faster. For a very large board prefer more stacks (e.g. STACKS=20).
+//
+// Examples:
+//   node scripts/seed-board.mjs                 # 2001 cards / 3 stacks (default)
+//   CARDS=5000 STACKS=10 node scripts/seed-board.mjs
+//   CARDS=10000 STACKS=20 node scripts/seed-board.mjs   # very-large board
+//
+// The perf spec (tests/e2e/perf.spec.js) reads the SAME board by title, so seed
+// at the size you want to measure, then run:
+//   npx playwright test --config playwright.perf.config.js
+//
 // Requires the dev stack running at http://localhost:8891.
 
-const BASE = 'http://localhost:8891'
-const USER = 'admin'
-const PASS = 'admin'
+const BASE = process.env.BASE || 'http://localhost:8891'
+const USER = process.env.NC_USER || 'admin'
+const PASS = process.env.NC_PASS || 'admin'
 const API = BASE + '/index.php/apps/kanso/api'
 const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
 const HEADERS = {
@@ -16,9 +36,16 @@ const HEADERS = {
 	Authorization: AUTH,
 }
 
-const BOARD_TITLE = 'Perf Test Board'
-const STACKS = ['Stack A', 'Stack B', 'Stack C']
-const CARDS_PER_STACK = 667 // 3 × 667 = 2 001
+const BOARD_TITLE = process.env.TITLE || 'Perf Test Board'
+const TOTAL_CARDS = Number(process.env.CARDS || 2001)
+const STACK_COUNT = Number(process.env.STACKS || 3)
+
+if (!Number.isFinite(TOTAL_CARDS) || TOTAL_CARDS < 1) {
+	throw new Error(`Invalid CARDS=${process.env.CARDS}`)
+}
+if (!Number.isFinite(STACK_COUNT) || STACK_COUNT < 1) {
+	throw new Error(`Invalid STACKS=${process.env.STACKS}`)
+}
 
 async function apiGet(path) {
 	const r = await fetch(API + path, { headers: HEADERS })
@@ -41,8 +68,20 @@ async function apiDelete(path) {
 	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
 }
 
+// Distribute TOTAL_CARDS as evenly as possible across STACK_COUNT stacks.
+function cardsPerStack() {
+	const base = Math.floor(TOTAL_CARDS / STACK_COUNT)
+	const remainder = TOTAL_CARDS % STACK_COUNT
+	return Array.from({ length: STACK_COUNT }, (_, i) => base + (i < remainder ? 1 : 0))
+}
+
 async function main() {
-	console.log('Cleaning up existing Perf Test Board(s)…')
+	const t0 = Date.now()
+	console.log(
+		`Seeding '${BOARD_TITLE}': ${TOTAL_CARDS} cards across ${STACK_COUNT} stack(s).`,
+	)
+
+	console.log('Cleaning up existing board(s) with this title…')
 	const boards = await apiGet('/boards')
 	for (const b of boards) {
 		if (b.title === BOARD_TITLE) {
@@ -55,38 +94,37 @@ async function main() {
 	const board = await apiPost('/boards', { title: BOARD_TITLE, color: '0082c9' })
 	console.log(`  Board #${board.id} created.`)
 
+	const perStack = cardsPerStack()
 	const stackIds = []
-	for (const title of STACKS) {
-		const s = await apiPost('/stacks', { boardId: board.id, title })
-		stackIds.push(s.id)
-		console.log(`  Stack '${title}' #${s.id} created.`)
+	for (let s = 0; s < STACK_COUNT; s++) {
+		const title = `Stack ${String.fromCharCode(65 + (s % 26))}${s >= 26 ? Math.floor(s / 26) : ''}`
+		const stack = await apiPost('/stacks', { boardId: board.id, title })
+		stackIds.push(stack.id)
 	}
+	console.log(`  ${stackIds.length} stack(s) created.`)
 
-	const total = stackIds.length * CARDS_PER_STACK
+	// Cards within a stack must be sequential (see header note), but stacks are
+	// independent — fill all stacks concurrently. `created` is a shared counter
+	// updated as each POST resolves, so the progress line reflects real totals.
 	let created = 0
-	const BATCH = 20 // Create cards in parallel batches to stay under connection limits
-
-	for (const stackId of stackIds) {
-		console.log(`  Seeding ${CARDS_PER_STACK} cards into stack #${stackId}…`)
-		for (let batch = 0; batch < CARDS_PER_STACK; batch += BATCH) {
-			const end = Math.min(batch + BATCH, CARDS_PER_STACK)
-			const promises = []
-			for (let i = batch; i < end; i++) {
-				promises.push(
-					apiPost('/cards', {
-						stackId,
-						title: `Card ${i + 1} — stack #${stackId}`,
-					}),
-				)
+	const fillStack = async (stackId, count) => {
+		for (let i = 0; i < count; i++) {
+			await apiPost('/cards', {
+				stackId,
+				title: `Card ${i + 1} — stack #${stackId}`,
+			})
+			created++
+			if (created % 25 === 0 || created === TOTAL_CARDS) {
+				process.stdout.write(`\r    ${created}/${TOTAL_CARDS} cards created…`)
 			}
-			await Promise.all(promises)
-			created += end - batch
-			process.stdout.write(`\r    ${created}/${total} cards created…`)
 		}
-		console.log()
 	}
+	await Promise.all(stackIds.map((stackId, s) => fillStack(stackId, perStack[s])))
+	console.log()
 
-	console.log(`\nDone! Board URL: ${BASE}/index.php/apps/kanso#/board/${board.id}`)
+	const secs = ((Date.now() - t0) / 1000).toFixed(1)
+	console.log(`\nDone in ${secs}s. ${created} cards seeded.`)
+	console.log(`Board URL: ${BASE}/index.php/apps/kanso#/board/${board.id}`)
 }
 
 main().catch((err) => {

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -18,16 +18,43 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				class="board-list-table__vrow"
 				:style="{ position: 'absolute', top: 0, left: 0, width: '100%', height: `${vRow.size}px`, transform: `translateY(${vRow.start}px)` }">
 
-				<!-- Stack group header -->
-				<div v-if="rows[vRow.index].type === 'header'" class="board-list-group">
+				<!-- Stack group bar: chevron, title, count/WIP, aggregate progress -->
+				<button
+					v-if="rows[vRow.index].type === 'header'"
+					class="board-list-group"
+					:aria-expanded="!isCollapsed(rows[vRow.index].stack.id)"
+					@click="toggleGroup(rows[vRow.index].stack.id)">
+					<ChevronDownIcon
+						v-if="!isCollapsed(rows[vRow.index].stack.id)"
+						:size="18"
+						class="board-list-group__chevron" />
+					<ChevronRightIcon
+						v-else
+						:size="18"
+						class="board-list-group__chevron" />
 					<span
 						class="board-list-group__dot"
 						:style="rows[vRow.index].stack.color ? { background: cssColor(rows[vRow.index].stack.color) } : {}" />
 					<span class="board-list-group__title">{{ rows[vRow.index].stack.title }}</span>
-					<span class="board-list-group__count">{{ rows[vRow.index].count }}</span>
-				</div>
 
-				<!-- Card row -->
+					<!-- WIP indicator when a limit is set, plain count otherwise -->
+					<span
+						v-if="rows[vRow.index].wip"
+						class="board-list-group__wip"
+						:class="{ 'board-list-group__wip--over': rows[vRow.index].wip.over }">
+						{{ rows[vRow.index].wip.count }} / {{ rows[vRow.index].wip.limit }}
+					</span>
+					<span v-else class="board-list-group__count">{{ rows[vRow.index].count }}</span>
+
+					<!-- Aggregate done/total progress across the group -->
+					<span
+						v-if="rows[vRow.index].progress"
+						class="board-list-group__progress">
+						{{ rows[vRow.index].progress.done }}/{{ rows[vRow.index].progress.total }}
+					</span>
+				</button>
+
+				<!-- Card row (id first, meta pushed right) -->
 				<button
 					v-else
 					class="board-list-row"
@@ -36,6 +63,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						class="board-list-row__status"
 						:class="`board-list-row__status--${statusOf(rows[vRow.index].card)}`"
 						:title="statusLabel(rows[vRow.index].card)" />
+
+					<!-- Human reference id (KAN-123) -->
+					<span
+						v-if="cardHumanId(rows[vRow.index].card)"
+						class="board-list-row__id">
+						{{ cardHumanId(rows[vRow.index].card) }}
+					</span>
+
+					<!-- Labels (colour dots) -->
+					<span
+						v-if="(rows[vRow.index].card.labelIds || []).length"
+						class="board-list-row__labels">
+						<span
+							v-for="labelId in (rows[vRow.index].card.labelIds || []).slice(0, 4)"
+							:key="labelId"
+							class="board-list-row__label-dot"
+							:title="labelTitle(labelId)"
+							:style="{ background: labelColor(labelId) }" />
+					</span>
+
 					<span
 						class="board-list-row__title"
 						:class="{ 'board-list-row__title--done': isDone(rows[vRow.index].card) }">
@@ -43,20 +90,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</span>
 
 					<span class="board-list-row__meta">
-						<!-- Labels (colour dots) -->
-						<span
-							v-for="labelId in (rows[vRow.index].card.labelIds || []).slice(0, 4)"
-							:key="labelId"
-							class="board-list-row__label-dot"
-							:title="labelTitle(labelId)"
-							:style="{ background: labelColor(labelId) }" />
-
 						<!-- Priority -->
 						<span
 							v-if="rows[vRow.index].card.priority > 0"
 							class="board-list-row__priority"
 							:class="`board-list-row__priority--${rows[vRow.index].card.priority}`">
 							{{ priorityLabel(rows[vRow.index].card.priority) }}
+						</span>
+
+						<!-- Progress (checklist, else child cards) -->
+						<span
+							v-if="cardProgress(rows[vRow.index].card)"
+							class="board-list-row__count">
+							<CheckboxMarkedOutlineIcon :size="14" />
+							{{ cardProgress(rows[vRow.index].card).done }}/{{ cardProgress(rows[vRow.index].card).total }}
 						</span>
 
 						<!-- Due date -->
@@ -66,14 +113,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							:class="{ 'board-list-row__due--overdue': isOverdue(rows[vRow.index].card) }">
 							<CalendarIcon :size="14" />
 							{{ formatDue(rows[vRow.index].card.duedate) }}
-						</span>
-
-						<!-- Checklist -->
-						<span
-							v-if="rows[vRow.index].card.checklist && rows[vRow.index].card.checklist.total > 0"
-							class="board-list-row__count">
-							<CheckboxMarkedOutlineIcon :size="14" />
-							{{ rows[vRow.index].card.checklist.done }}/{{ rows[vRow.index].card.checklist.total }}
 						</span>
 
 						<!-- Comments -->
@@ -93,7 +132,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							class="board-list-row__review board-list-row__review--changes" />
 
 						<!-- Assignees -->
-						<span class="board-list-row__assignees">
+						<span
+							v-if="(rows[vRow.index].card.assigneeIds || []).length"
+							class="board-list-row__assignees">
 							<NcAvatar
 								v-for="uid in (rows[vRow.index].card.assigneeIds || []).slice(0, 3)"
 								:key="uid"
@@ -109,7 +150,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
 import { useVirtualizer } from '@tanstack/vue-virtual'
@@ -119,7 +160,10 @@ import CheckboxMarkedOutlineIcon from 'vue-material-design-icons/CheckboxMarkedO
 import CommentOutlineIcon from 'vue-material-design-icons/CommentOutline.vue'
 import CheckDecagramIcon from 'vue-material-design-icons/CheckDecagram.vue'
 import AlertDecagramIcon from 'vue-material-design-icons/AlertDecagram.vue'
+import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import { cssColor } from '../services/color.js'
+import { humanId } from '../services/humanId.js'
 import { PRIORITY_LEVELS } from '../composables/usePriority.js'
 
 const props = defineProps({
@@ -129,19 +173,67 @@ const props = defineProps({
 	cardsByStack: { type: Object, required: true },
 	/** Map<labelId, label>. */
 	labelsById: { type: Object, required: true },
+	/** Board human-id prefix (e.g. "KAN") - composed with card.boardSeq. */
+	boardPrefix: { type: String, default: '' },
 	boardId: { type: [String, Number], required: true },
 })
 
 const router = useRouter()
 const scrollRef = ref(null)
 
-// A flat row model: one header per stack, then its cards. This keeps the board's
-// structure readable while feeding a single virtualized list.
+// Collapsed stack ids, persisted per board (mirrors viewMode/sortMode storage).
+const collapsedKey = computed(() => `kanso.listCollapsed.${props.boardId}`)
+const collapsed = ref(loadCollapsed())
+
+function loadCollapsed() {
+	try {
+		const saved = localStorage.getItem(`kanso.listCollapsed.${props.boardId}`)
+		if (saved) return new Set(JSON.parse(saved))
+	} catch (e) { /* localStorage unavailable - default to all expanded */ }
+	return new Set()
+}
+
+// Reload persisted state when the board changes (component is reused across boards).
+watch(() => props.boardId, () => { collapsed.value = loadCollapsed() })
+
+function isCollapsed(stackId) {
+	return collapsed.value.has(stackId)
+}
+
+function toggleGroup(stackId) {
+	const next = new Set(collapsed.value)
+	if (next.has(stackId)) next.delete(stackId)
+	else next.add(stackId)
+	collapsed.value = next
+	try {
+		localStorage.setItem(collapsedKey.value, JSON.stringify([...next]))
+	} catch (e) { /* localStorage unavailable - collapse is in-memory only */ }
+}
+
+// Aggregate done/total across a group's cards. A card counts toward "done" when
+// it's marked done; the total is the whole group. Returns null for empty groups.
+function groupProgress(cards) {
+	if (!cards.length) return null
+	const done = cards.reduce((n, c) => n + (Number(c.doneAt) > 0 ? 1 : 0), 0)
+	return { done, total: cards.length }
+}
+
+// A flat row model: one header per stack, then its cards (unless collapsed).
+// Collapsed groups drop their card rows entirely so virtualization stays exact.
 const rows = computed(() => {
 	const out = []
 	for (const stack of props.stacks) {
 		const cards = props.cardsByStack.get(stack.id) ?? []
-		out.push({ type: 'header', id: `h${stack.id}`, stack, count: cards.length })
+		const hasWip = typeof stack.wipLimit === 'number' && stack.wipLimit > 0
+		out.push({
+			type: 'header',
+			id: `h${stack.id}`,
+			stack,
+			count: cards.length,
+			wip: hasWip ? { count: cards.length, limit: stack.wipLimit, over: cards.length > stack.wipLimit } : null,
+			progress: groupProgress(cards),
+		})
+		if (isCollapsed(stack.id)) continue
 		for (const card of cards) {
 			out.push({ type: 'card', id: `c${card.id}`, card })
 		}
@@ -151,8 +243,8 @@ const rows = computed(() => {
 
 // Fixed row heights (a table is uniform) - no per-row measureElement, so the
 // virtualizer's positions never thrash on a data refresh.
-const HEADER_H = 38
-const ROW_H = 48
+const HEADER_H = 40
+const ROW_H = 36
 const virtualizer = useVirtualizer(computed(() => ({
 	count: rows.value.length,
 	getScrollElement: () => scrollRef.value,
@@ -163,6 +255,17 @@ const virtualizer = useVirtualizer(computed(() => ({
 
 function openCard(cardId) {
 	router.push({ name: 'card-modal', params: { id: String(props.boardId), cardId: String(cardId) } })
+}
+
+function cardHumanId(card) {
+	return humanId(props.boardPrefix, card.boardSeq)
+}
+
+// Per-card progress: prefer the checklist, fall back to child-card progress.
+function cardProgress(card) {
+	if (card.checklist && card.checklist.total > 0) return card.checklist
+	if (card.childProgress && card.childProgress.total > 0) return card.childProgress
+	return null
 }
 
 function isDone(card) {
@@ -232,38 +335,89 @@ function isOverdue(card) {
 .board-list-group {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 10px;
 	box-sizing: border-box;
+	width: 100%;
 	height: 100%;
-	font-weight: 700;
-	color: var(--color-text-maxcontrast);
+	padding: 0 8px;
+	background: var(--color-background-hover);
+	border: none;
 	border-bottom: 1px solid var(--color-border);
-	text-transform: uppercase;
-	font-size: 0.8rem;
-	letter-spacing: 0.03em;
+	border-radius: 0;
+	text-align: start;
+	cursor: pointer;
+	color: var(--color-main-text);
+}
+
+.board-list-group:hover {
+	background: var(--color-background-dark);
+}
+
+.board-list-group__chevron {
+	flex: 0 0 auto;
+	color: var(--color-text-maxcontrast);
 }
 
 .board-list-group__dot {
-	width: 10px;
-	height: 10px;
+	width: 8px;
+	height: 8px;
 	border-radius: 50%;
 	background: var(--color-primary-element);
 	flex: 0 0 auto;
 }
 
+.board-list-group__title {
+	font-weight: 700;
+	text-transform: uppercase;
+	font-size: 0.8rem;
+	letter-spacing: 0.03em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .board-list-group__count {
 	color: var(--color-text-maxcontrast);
 	font-weight: 400;
+	font-size: 0.8rem;
+	flex: 0 0 auto;
+}
+
+.board-list-group__wip {
+	display: inline-flex;
+	align-items: center;
+	height: 20px;
+	padding: 0 7px;
+	border-radius: 10px;
+	font-size: 0.72rem;
+	font-weight: 700;
+	flex: 0 0 auto;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+}
+
+.board-list-group__wip--over {
+	color: color-mix(in srgb, var(--color-warning) 85%, var(--color-main-text));
+	background: color-mix(in srgb, var(--color-warning) 25%, transparent);
+	outline: 1px solid color-mix(in srgb, var(--color-warning) 50%, transparent);
+}
+
+.board-list-group__progress {
+	margin-inline-start: auto;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+	flex: 0 0 auto;
 }
 
 .board-list-row {
 	display: flex;
 	align-items: center;
-	gap: 12px;
+	gap: 10px;
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
-	padding: 6px 8px;
+	padding: 0 8px;
 	background: transparent;
 	border: none;
 	border-bottom: 1px solid var(--color-border);
@@ -289,12 +443,31 @@ function isOverdue(card) {
 .board-list-row__status--in_progress { background: var(--color-primary-element); border-color: var(--color-primary-element); }
 .board-list-row__status--done { background: var(--color-success, #2fb344); border-color: var(--color-success, #2fb344); }
 
+.board-list-row__id {
+	flex: 0 0 auto;
+	width: 70px;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 0.72rem;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.board-list-row__labels {
+	display: flex;
+	gap: 3px;
+	flex: 0 0 auto;
+}
+
 .board-list-row__title {
 	flex: 1;
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	font-size: 0.875rem;
 }
 
 .board-list-row__title--done {
@@ -305,16 +478,17 @@ function isOverdue(card) {
 .board-list-row__meta {
 	display: flex;
 	align-items: center;
-	gap: 10px;
+	gap: 14px;
 	flex: 0 0 auto;
+	margin-inline-start: auto;
 	color: var(--color-text-maxcontrast);
-	font-size: 0.85rem;
+	font-size: 0.8rem;
 }
 
 .board-list-row__label-dot {
-	width: 12px;
-	height: 12px;
-	border-radius: 50%;
+	width: 8px;
+	height: 8px;
+	border-radius: 2px;
 	flex: 0 0 auto;
 }
 

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -99,7 +99,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								:key="uid"
 								:user="uid"
 								:size="24"
-								:show-user-status="false" />
+								:hide-status="true" />
 						</span>
 					</span>
 				</button>

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -46,6 +46,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</span>
 					<span v-else class="board-list-group__count">{{ rows[vRow.index].count }}</span>
 
+					<!-- Per-group hints: overdue / blocked counts, only when nonzero -->
+					<span
+						v-if="rows[vRow.index].hints && (rows[vRow.index].hints.overdue || rows[vRow.index].hints.blocked)"
+						class="board-list-group__hints">
+						<span
+							v-if="rows[vRow.index].hints.overdue"
+							class="board-list-group__hint board-list-group__hint--overdue">
+							{{ t('kanso', '{n} overdue', { n: rows[vRow.index].hints.overdue }) }}
+						</span>
+						<span
+							v-if="rows[vRow.index].hints.blocked"
+							class="board-list-group__hint">
+							{{ t('kanso', '{n} blocked', { n: rows[vRow.index].hints.blocked }) }}
+						</span>
+					</span>
+
 					<!-- Aggregate done/total progress across the group -->
 					<span
 						v-if="rows[vRow.index].progress"
@@ -150,7 +166,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
 import { useVirtualizer } from '@tanstack/vue-virtual'
@@ -218,6 +234,25 @@ function groupProgress(cards) {
 	return { done, total: cards.length }
 }
 
+// Reactive clock so overdue counts recompute over time (e.g. a board left open
+// across midnight) rather than freezing until the card data changes.
+const now = ref(Date.now())
+let clockTimer = null
+onMounted(() => { clockTimer = setInterval(() => { now.value = Date.now() }, 60_000) })
+onBeforeUnmount(() => { if (clockTimer !== null) { clearInterval(clockTimer); clockTimer = null } })
+
+// Secondary group hints: overdue (not done, past-due) and blocked counts. Mirrors
+// the row-level isOverdue / card.blocked so the header echoes what's in the list.
+function groupHints(cards) {
+	let overdue = 0
+	let blocked = 0
+	for (const c of cards) {
+		if (isOverdue(c)) overdue++
+		if (c.blocked === true) blocked++
+	}
+	return { overdue, blocked }
+}
+
 // A flat row model: one header per stack, then its cards (unless collapsed).
 // Collapsed groups drop their card rows entirely so virtualization stays exact.
 const rows = computed(() => {
@@ -232,6 +267,7 @@ const rows = computed(() => {
 			count: cards.length,
 			wip: hasWip ? { count: cards.length, limit: stack.wipLimit, over: cards.length > stack.wipLimit } : null,
 			progress: groupProgress(cards),
+			hints: groupHints(cards),
 		})
 		if (isCollapsed(stack.id)) continue
 		for (const card of cards) {
@@ -305,7 +341,7 @@ function formatDue(duedate) {
 function isOverdue(card) {
 	if (!card.duedate || isDone(card)) return false
 	const d = new Date(card.duedate)
-	return !Number.isNaN(d.getTime()) && d.getTime() < Date.now()
+	return !Number.isNaN(d.getTime()) && d.getTime() < now.value
 }
 </script>
 
@@ -400,6 +436,32 @@ function isOverdue(card) {
 	color: color-mix(in srgb, var(--color-warning) 85%, var(--color-main-text));
 	background: color-mix(in srgb, var(--color-warning) 25%, transparent);
 	outline: 1px solid color-mix(in srgb, var(--color-warning) 50%, transparent);
+}
+
+/* Secondary hints (overdue · blocked) sit just after the count, muted; the
+   progress badge still anchors to the far end. */
+.board-list-group__hints {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex: 0 0 auto;
+	font-size: 0.75rem;
+	color: var(--color-text-maxcontrast);
+}
+
+.board-list-group__hint {
+	white-space: nowrap;
+}
+
+.board-list-group__hint + .board-list-group__hint::before {
+	content: '·';
+	margin-inline-end: 6px;
+	color: var(--color-text-maxcontrast);
+}
+
+.board-list-group__hint--overdue {
+	color: color-mix(in srgb, var(--color-error) 80%, var(--color-text-maxcontrast));
+	font-weight: 600;
 }
 
 .board-list-group__progress {

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -504,6 +504,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</span>
 						</template>
 
+						<!-- Stage: lower stages gate higher ones -->
+						<label class="review-type-stage" :title="t('kanso', 'Stage — lower stages gate (defer) higher ones')">
+							<span class="review-type-stage__label">{{ t('kanso', 'Stage') }}</span>
+							<input
+								class="review-type-stage__input"
+								type="number"
+								min="0"
+								step="1"
+								:value="rt.stage ?? 0"
+								:disabled="!canManage"
+								:aria-label="t('kanso', 'Stage of review type {title}', { title: rt.title })"
+								@change="saveRtStage(rt, $event)" />
+						</label>
+
 						<!-- Actions (only when canManage) -->
 						<div v-if="canManage" class="label-settings__actions">
 							<button
@@ -592,6 +606,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							:disabled="isCreatingRt"
 							:aria-label="t('kanso', 'New review type name')"
 							@keydown.enter.prevent="submitCreateRt" />
+						<label class="review-type-stage review-type-stage--create" :title="t('kanso', 'Stage — lower stages gate (defer) higher ones')">
+							<span class="review-type-stage__label">{{ t('kanso', 'Stage') }}</span>
+							<input
+								v-model.number="newRtStage"
+								class="review-type-stage__input"
+								type="number"
+								min="0"
+								step="1"
+								:disabled="isCreatingRt"
+								:aria-label="t('kanso', 'Stage for new review type')" />
+						</label>
 						<button
 							class="label-settings__create-btn"
 							type="submit"
@@ -2563,6 +2588,7 @@ async function doDeleteLabel(label) {
 // ── Review types: create state ────────────────────────────────────────────────
 const newRtTitle = ref('')
 const newRtColor = ref('')
+const newRtStage = ref(0)
 const isCreatingRt = ref(false)
 const createRtError = ref('')
 const showNewRtColorPicker = ref(false)
@@ -2574,9 +2600,14 @@ async function submitCreateRt() {
 	createRtError.value = ''
 	showNewRtColorPicker.value = false
 	try {
-		await createReviewType.mutateAsync({ title, color: newRtColor.value || null })
+		await createReviewType.mutateAsync({
+			title,
+			color: newRtColor.value || null,
+			stage: Math.max(0, Number(newRtStage.value) || 0),
+		})
 		newRtTitle.value = ''
 		newRtColor.value = ''
+		newRtStage.value = 0
 	} catch (err) {
 		createRtError.value = err?.response?.data?.error || t('kanso', 'Failed to create review type.')
 	} finally {
@@ -2622,6 +2653,24 @@ async function saveRtRename(rt) {
 		rtError.value = {
 			...rtError.value,
 			[rt.id]: err?.response?.data?.error || t('kanso', 'Failed to rename review type.'),
+		}
+	}
+}
+
+// ── Review types: stage edit ──────────────────────────────────────────────────
+// Lower stages gate higher ones: a review is held (its reviewer un-notified,
+// chip greyed) while the card carries an unapproved review of a lower stage.
+async function saveRtStage(rt, event) {
+	const next = Math.max(0, Number(event.target.value) || 0)
+	// Reflect the clamped value back into the input.
+	event.target.value = String(next)
+	if (next === (rt.stage ?? 0)) return
+	try {
+		await updateReviewType.mutateAsync({ typeId: rt.id, stage: next })
+	} catch (err) {
+		rtError.value = {
+			...rtError.value,
+			[rt.id]: err?.response?.data?.error || t('kanso', 'Failed to update stage.'),
 		}
 	}
 }
@@ -3552,6 +3601,29 @@ async function doDeleteAutoRule(rule) {
 	display: flex;
 	gap: 4px;
 	flex-shrink: 0;
+}
+
+.review-type-stage {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+	font-size: 0.8rem;
+	color: var(--color-text-maxcontrast);
+}
+
+.review-type-stage__label {
+	white-space: nowrap;
+}
+
+.review-type-stage__input {
+	width: 52px;
+	padding: 2px 4px;
+	text-align: center;
+}
+
+.review-type-stage--create {
+	margin-inline: 4px;
 }
 
 .label-settings__action-btn {

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -434,7 +434,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					class="bs-pane"
 					role="tabpanel"
 					aria-labelledby="bs-rail-tab-review-types">
-				<ul class="rt-settings__list" role="list">
+					<div class="rt-settings__intro">
+						<p>
+							{{ t('kanso', 'Review types label the kind of sign-off a card needs — for example Code, QA, or Security. Request one from the Reviews section of a card.') }}
+						</p>
+						<p>
+							{{ t('kanso', 'Stage turns them into a pipeline: a review is held — its reviewer is not notified and its chip shows greyed with a lock — until every lower-stage review on the card is approved. Types on the same stage run in parallel. Keep every stage at 0 to notify all reviewers at once.') }}
+						</p>
+					</div>
+					<ul class="rt-settings__list" role="list">
 					<li v-if="reviewTypes.length === 0" class="label-settings__empty">
 						{{ t('kanso', 'No review types yet. Create one below.') }}
 					</li>
@@ -5005,6 +5013,21 @@ async function doDeleteAutoRule(rule) {
 	margin: 0 0 16px;
 	font-size: 0.8rem;
 	color: var(--color-text-maxcontrast);
+}
+
+.rt-settings__intro {
+	margin: 0 0 16px;
+	font-size: 0.8rem;
+	line-height: 1.4;
+	color: var(--color-text-maxcontrast);
+}
+
+.rt-settings__intro p {
+	margin: 0 0 8px;
+}
+
+.rt-settings__intro p:last-child {
+	margin-bottom: 0;
 }
 
 .automation__group {

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -630,6 +630,174 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</section>
 
 				<section
+					v-show="activeTab === 'card-fields'"
+					id="bs-pane-card-fields"
+					class="bs-pane"
+					role="tabpanel"
+					aria-labelledby="bs-rail-tab-card-fields">
+
+				<ul class="rt-settings__list" role="list">
+					<li v-if="cardFields.length === 0" class="label-settings__empty">
+						{{ t('kanso', 'No custom fields yet. Create one below.') }}
+					</li>
+
+					<li
+						v-for="field in cardFields"
+						:key="field.id"
+						class="label-settings__item cf-settings__item">
+
+						<!-- Inline rename input -->
+						<template v-if="editingCfId === field.id">
+							<input
+								:ref="(el) => setCfEditRef(field.id, el)"
+								v-model="editingCfName"
+								class="label-settings__rename-input"
+								type="text"
+								:aria-label="t('kanso', 'Rename field')"
+								@keydown.enter.prevent="saveCfRename(field)"
+								@keydown.escape="cancelCfRename"
+								@blur="saveCfRename(field)" />
+						</template>
+						<template v-else>
+							<span
+								class="label-settings__name"
+								:class="{ 'label-settings__name--readonly': !canManage }"
+								@click="canManage && startCfRename(field)">
+								{{ field.name }}
+							</span>
+						</template>
+
+						<!-- Type badge -->
+						<span class="cf-settings__type-badge">{{ field.type }}</span>
+
+						<!-- Options preview for select fields -->
+						<span v-if="field.type === 'select' && field.options && field.options.length > 0" class="cf-settings__options-preview">
+							{{ field.options.join(', ') }}
+						</span>
+
+						<!-- Options editor for select fields (MANAGE only) -->
+						<div v-if="field.type === 'select' && canManage && editingCfOptionsId === field.id" class="cf-settings__options-editor">
+							<textarea
+								v-model="editingCfOptions"
+								class="cf-settings__options-textarea"
+								:aria-label="t('kanso', 'Options (one per line or comma-separated)')"
+								:placeholder="t('kanso', 'Option 1\nOption 2\nOption 3')"
+								rows="4"
+								@keydown.escape="editingCfOptionsId = null" />
+							<div class="cf-settings__options-actions">
+								<button
+									class="label-settings__create-btn"
+									:disabled="updateCardField.isPending.value"
+									@click="saveCfOptions(field)">
+									{{ t('kanso', 'Save options') }}
+								</button>
+								<button class="label-settings__confirm-no" @click="editingCfOptionsId = null">
+									{{ t('kanso', 'Cancel') }}
+								</button>
+							</div>
+						</div>
+
+						<!-- Actions (only when canManage) -->
+						<div v-if="canManage" class="label-settings__actions">
+							<button
+								class="label-settings__action-btn"
+								:title="t('kanso', 'Rename')"
+								:aria-label="t('kanso', 'Rename field {name}', { name: field.name })"
+								@click="startCfRename(field)">
+								<PencilIcon :size="14" />
+							</button>
+							<button
+								v-if="field.type === 'select'"
+								class="label-settings__action-btn"
+								:title="t('kanso', 'Edit options')"
+								:aria-label="t('kanso', 'Edit options for field {name}', { name: field.name })"
+								@click="startCfOptionsEdit(field)">
+								<ChevronDownIcon :size="14" />
+							</button>
+							<button
+								class="label-settings__action-btn label-settings__action-btn--danger"
+								:title="t('kanso', 'Delete')"
+								:aria-label="t('kanso', 'Delete field {name}', { name: field.name })"
+								:disabled="confirmDeleteCfId === field.id && isDeletingCf"
+								@click="confirmDeleteCf(field)">
+								<DeleteIcon :size="14" />
+							</button>
+						</div>
+
+						<!-- Inline delete confirm -->
+						<div v-if="confirmDeleteCfId === field.id" class="label-settings__confirm">
+							<span>{{ t('kanso', 'Delete "{name}"?', { name: field.name }) }}</span>
+							<button class="label-settings__confirm-yes" :disabled="isDeletingCf" @click="doDeleteCf(field)">
+								{{ t('kanso', 'Delete') }}
+							</button>
+							<button class="label-settings__confirm-no" @click="confirmDeleteCfId = null">
+								{{ t('kanso', 'Cancel') }}
+							</button>
+							<span v-if="deleteCfError" class="label-settings__error">{{ deleteCfError }}</span>
+						</div>
+
+						<!-- Rename error -->
+						<span v-if="cfError[field.id]" class="label-settings__error">
+							{{ cfError[field.id] }}
+						</span>
+					</li>
+				</ul>
+
+				<!-- Create new custom field form (only when canManage) -->
+				<form
+					v-if="canManage"
+					class="label-settings__create cf-settings__create"
+					data-test="cf-create-form"
+					@submit.prevent="submitCreateCf">
+					<h4 class="label-settings__create-heading">{{ t('kanso', 'Add custom field') }}</h4>
+					<div class="label-settings__create-row cf-settings__create-row">
+						<input
+							v-model="newCfName"
+							class="label-settings__create-input"
+							type="text"
+							:placeholder="t('kanso', 'Field name…')"
+							:disabled="isCreatingCf"
+							:aria-label="t('kanso', 'New custom field name')"
+							data-test="cf-name-input"
+							@keydown.enter.prevent="submitCreateCf" />
+						<select
+							v-model="newCfType"
+							class="workflow__select cf-settings__type-select"
+							:disabled="isCreatingCf"
+							:aria-label="t('kanso', 'Field type')"
+							data-test="cf-type-select">
+							<option value="text">{{ t('kanso', 'Text') }}</option>
+							<option value="number">{{ t('kanso', 'Number') }}</option>
+							<option value="date">{{ t('kanso', 'Date') }}</option>
+							<option value="select">{{ t('kanso', 'Select') }}</option>
+						</select>
+						<button
+							class="label-settings__create-btn"
+							type="submit"
+							:disabled="!newCfName.trim() || isCreatingCf"
+							:aria-label="t('kanso', 'Create custom field')">
+							{{ t('kanso', 'Add') }}
+						</button>
+					</div>
+					<!-- Options textarea: only shown for select type -->
+					<div v-if="newCfType === 'select'" class="cf-settings__new-options">
+						<label class="cf-settings__new-options-label" for="bs-cf-new-options">
+							{{ t('kanso', 'Options (one per line or comma-separated)') }}
+						</label>
+						<textarea
+							id="bs-cf-new-options"
+							v-model="newCfOptionsRaw"
+							class="cf-settings__options-textarea"
+							:disabled="isCreatingCf"
+							:placeholder="t('kanso', 'Option 1\nOption 2\nOption 3')"
+							rows="4"
+							data-test="cf-options-textarea" />
+					</div>
+					<span v-if="createCfError" class="label-settings__error">{{ createCfError }}</span>
+				</form>
+				</section>
+
+				<section
 					v-if="canShare"
 					v-show="activeTab === 'sharing'"
 					id="bs-pane-sharing"
@@ -1780,6 +1948,7 @@ import AccountIcon from 'vue-material-design-icons/Account.vue'
 import AccountGroupIcon from 'vue-material-design-icons/AccountGroup.vue'
 import TagMultipleIcon from 'vue-material-design-icons/TagMultiple.vue'
 import CheckDecagramIcon from 'vue-material-design-icons/CheckDecagram.vue'
+import TableColumnIcon from 'vue-material-design-icons/TableColumn.vue'
 import ShareVariantIcon from 'vue-material-design-icons/ShareVariant.vue'
 import SwapHorizontalIcon from 'vue-material-design-icons/SwapHorizontal.vue'
 import RobotIcon from 'vue-material-design-icons/Robot.vue'
@@ -1793,6 +1962,7 @@ import ChevronUpIcon from 'vue-material-design-icons/ChevronUp.vue'
 import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 import { useLabels } from '../composables/useLabels.js'
 import { useReviewTypes } from '../composables/useReviewTypes.js'
+import { useCardFields } from '../composables/useCardFields.js'
 import { useAcl } from '../composables/useAcl.js'
 import { useQueryClient } from '@tanstack/vue-query'
 import { useBoard } from '../composables/useBoard.js'
@@ -1829,6 +1999,11 @@ const props = defineProps({
 		default: () => [],
 	},
 	reviewTypes: {
+		type: Array,
+		default: () => [],
+	},
+	/** cardFields definitions from board payload */
+	cardFields: {
 		type: Array,
 		default: () => [],
 	},
@@ -2084,6 +2259,7 @@ const railSections = computed(() => {
 		{ id: 'general', name: t('kanso', 'General'), icon: CogIcon },
 		{ id: 'labels', name: t('kanso', 'Labels'), icon: TagMultipleIcon },
 		{ id: 'review-types', name: t('kanso', 'Review types'), icon: CheckDecagramIcon },
+		{ id: 'card-fields', name: t('kanso', 'Custom fields'), icon: TableColumnIcon },
 	]
 	if (canShare.value) {
 		sections.push({ id: 'sharing', name: t('kanso', 'Sharing'), icon: ShareVariantIcon })
@@ -2195,6 +2371,9 @@ const { createLabel, updateLabel, deleteLabel } = useLabels(() => props.boardId)
 
 // ── Review types composable ───────────────────────────────────────────────────
 const { createReviewType, updateReviewType, deleteReviewType } = useReviewTypes(() => props.boardId)
+
+// ── Card fields composable ────────────────────────────────────────────────────
+const { createCardField, updateCardField, deleteCardField } = useCardFields(() => props.boardId)
 
 // ── ACL composable ────────────────────────────────────────────────────────────
 const {
@@ -2715,6 +2894,125 @@ async function doDeleteRt(rt) {
 		deleteRtError.value = err?.response?.data?.error || t('kanso', 'Failed to delete review type.')
 	} finally {
 		isDeletingRt.value = false
+	}
+}
+
+// ── Card fields: create state ─────────────────────────────────────────────────
+const newCfName = ref('')
+const newCfType = ref('text')
+const newCfOptionsRaw = ref('')
+const isCreatingCf = ref(false)
+const createCfError = ref('')
+
+/** Parse the raw options textarea into a trimmed, deduplicated string array. */
+function parseCfOptions(raw) {
+	return raw
+		.split(/[\n,]+/)
+		.map((s) => s.trim())
+		.filter(Boolean)
+}
+
+async function submitCreateCf() {
+	const name = newCfName.value.trim()
+	if (!name) return
+	isCreatingCf.value = true
+	createCfError.value = ''
+	try {
+		const options = newCfType.value === 'select' ? parseCfOptions(newCfOptionsRaw.value) : undefined
+		await createCardField.mutateAsync({ name, type: newCfType.value, options })
+		newCfName.value = ''
+		newCfType.value = 'text'
+		newCfOptionsRaw.value = ''
+	} catch (err) {
+		createCfError.value = err?.response?.data?.error || t('kanso', 'Failed to create custom field.')
+	} finally {
+		isCreatingCf.value = false
+	}
+}
+
+// ── Card fields: rename state ─────────────────────────────────────────────────
+const editingCfId = ref(null)
+const editingCfName = ref('')
+const cfError = ref({})
+const cfEditRefs = {}
+
+function setCfEditRef(id, el) {
+	if (el) {
+		cfEditRefs[id] = el
+	} else {
+		delete cfEditRefs[id]
+	}
+}
+
+async function startCfRename(field) {
+	editingCfId.value = field.id
+	editingCfName.value = field.name
+	cfError.value = { ...cfError.value, [field.id]: '' }
+	await nextTick()
+	cfEditRefs[field.id]?.focus()
+	cfEditRefs[field.id]?.select()
+}
+
+function cancelCfRename() {
+	editingCfId.value = null
+}
+
+async function saveCfRename(field) {
+	const name = editingCfName.value.trim()
+	editingCfId.value = null
+	if (!name || name === field.name) return
+	try {
+		await updateCardField.mutateAsync({ fieldId: field.id, name })
+	} catch (err) {
+		cfError.value = {
+			...cfError.value,
+			[field.id]: err?.response?.data?.error || t('kanso', 'Failed to rename field.'),
+		}
+	}
+}
+
+// ── Card fields: options editor (select fields only) ─────────────────────────
+const editingCfOptionsId = ref(null)
+const editingCfOptions = ref('')
+
+function startCfOptionsEdit(field) {
+	editingCfOptionsId.value = field.id
+	editingCfOptions.value = Array.isArray(field.options) ? field.options.join('\n') : ''
+}
+
+async function saveCfOptions(field) {
+	const options = parseCfOptions(editingCfOptions.value)
+	editingCfOptionsId.value = null
+	try {
+		await updateCardField.mutateAsync({ fieldId: field.id, options })
+	} catch (err) {
+		cfError.value = {
+			...cfError.value,
+			[field.id]: err?.response?.data?.error || t('kanso', 'Failed to update options.'),
+		}
+	}
+}
+
+// ── Card fields: delete state ─────────────────────────────────────────────────
+const confirmDeleteCfId = ref(null)
+const isDeletingCf = ref(false)
+const deleteCfError = ref('')
+
+function confirmDeleteCf(field) {
+	confirmDeleteCfId.value = field.id
+	deleteCfError.value = ''
+}
+
+async function doDeleteCf(field) {
+	isDeletingCf.value = true
+	deleteCfError.value = ''
+	try {
+		await deleteCardField.mutateAsync({ fieldId: field.id })
+		confirmDeleteCfId.value = null
+	} catch (err) {
+		deleteCfError.value = err?.response?.data?.error || t('kanso', 'Failed to delete field.')
+	} finally {
+		isDeletingCf.value = false
 	}
 }
 
@@ -4792,5 +5090,74 @@ async function doDeleteAutoRule(rule) {
 .automation__group-body {
 	padding: 12px;
 	border-top: 1px solid var(--color-border);
+}
+
+/* ── Custom fields pane ──────────────────────────────────────────────────────── */
+
+.cf-settings__item {
+	align-items: flex-start;
+	flex-wrap: wrap;
+}
+
+.cf-settings__type-badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 1px 7px;
+	border: 1px solid var(--color-border);
+	border-radius: 10px;
+	font-size: 0.7rem;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	flex-shrink: 0;
+}
+
+.cf-settings__options-preview {
+	font-size: 0.8rem;
+	color: var(--color-text-maxcontrast);
+	flex: 1 1 100%;
+	padding-left: 2px;
+}
+
+.cf-settings__options-editor {
+	flex: 1 1 100%;
+	margin-top: 4px;
+}
+
+.cf-settings__options-textarea {
+	width: 100%;
+	min-height: 80px;
+	box-sizing: border-box;
+	font-size: 0.875rem;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	padding: 6px 8px;
+	resize: vertical;
+}
+
+.cf-settings__options-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 6px;
+}
+
+.cf-settings__create-row {
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.cf-settings__type-select {
+	flex-shrink: 0;
+}
+
+.cf-settings__new-options {
+	margin-top: 8px;
+}
+
+.cf-settings__new-options-label {
+	display: block;
+	font-size: 0.8rem;
+	color: var(--color-text-maxcontrast);
+	margin-bottom: 4px;
 }
 </style>

--- a/src/components/BoardTimelineView.vue
+++ b/src/components/BoardTimelineView.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
 	<div class="timeline">
-		<!-- Zoom control -->
+		<!-- Zoom control + jump-to-today + legend -->
 		<div class="timeline__toolbar">
 			<span class="timeline__toolbar-label">{{ t('kanso', 'Zoom') }}</span>
 			<div class="timeline__zoom" role="group" :aria-label="t('kanso', 'Timeline zoom')">
@@ -16,6 +16,36 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					@click="zoom = z.key">
 					{{ z.label }}
 				</button>
+			</div>
+			<button
+				class="timeline__today-btn"
+				:disabled="scheduledRows.length === 0"
+				@click="jumpToToday">
+				<CalendarTodayIcon :size="16" />
+				{{ t('kanso', 'Jump to today') }}
+			</button>
+
+			<div v-if="scheduledRows.length > 0" class="timeline__legend">
+				<span class="timeline__legend-item">
+					<span class="timeline__legend-swatch timeline__legend-swatch--not-started" />
+					{{ t('kanso', 'Not started') }}
+				</span>
+				<span class="timeline__legend-item">
+					<span class="timeline__legend-swatch timeline__legend-swatch--in-progress" />
+					{{ t('kanso', 'In progress') }}
+				</span>
+				<span class="timeline__legend-item">
+					<span class="timeline__legend-swatch timeline__legend-swatch--overdue" />
+					{{ t('kanso', 'Overdue') }}
+				</span>
+				<span class="timeline__legend-item">
+					<span class="timeline__legend-swatch timeline__legend-swatch--done" />
+					{{ t('kanso', 'Done') }}
+				</span>
+				<span class="timeline__legend-item">
+					<span class="timeline__legend-swatch timeline__legend-swatch--milestone" />
+					{{ t('kanso', 'Single date') }}
+				</span>
 			</div>
 		</div>
 
@@ -33,12 +63,21 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<div class="timeline__pane">
 				<div class="timeline__pane-head">{{ t('kanso', 'Card') }}</div>
 				<template v-for="grp in groups" :key="`p${grp.stack.id}`">
-					<div class="timeline__group-row">
+					<div
+						class="timeline__group-row"
+						role="button"
+						tabindex="0"
+						:aria-expanded="!isCollapsed(grp.stack.id)"
+						@click="toggleGroup(grp.stack.id)"
+						@keydown.enter.prevent="toggleGroup(grp.stack.id)"
+						@keydown.space.prevent="toggleGroup(grp.stack.id)">
+						<ChevronRightIcon v-if="isCollapsed(grp.stack.id)" class="timeline__group-chevron" :size="16" />
+						<ChevronDownIcon v-else class="timeline__group-chevron" :size="16" />
 						<span
 							class="timeline__group-dot"
 							:style="grp.stack.color ? { background: cssColor(grp.stack.color) } : {}" />
 						<span class="timeline__group-title">{{ grp.stack.title }}</span>
-						<span class="timeline__group-count">{{ grp.rows.length }}</span>
+						<span class="timeline__group-count">{{ grp.count }}</span>
 					</div>
 					<div
 						v-for="row in grp.rows"
@@ -70,7 +109,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</div>
 
 			<!-- Scrollable track -->
-			<div class="timeline__scroll">
+			<div ref="scrollRef" class="timeline__scroll">
 				<div class="timeline__inner" :style="{ width: `${trackWidth}px` }">
 					<!-- Weekend shading (behind everything) -->
 					<div
@@ -164,11 +203,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import CalendarBlankOutlineIcon from 'vue-material-design-icons/CalendarBlankOutline.vue'
+import CalendarTodayIcon from 'vue-material-design-icons/CalendarToday.vue'
+import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import { cssColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
 
@@ -185,6 +227,41 @@ const props = defineProps({
 })
 
 const router = useRouter()
+
+// The horizontally-scrolling track container (for jump-to-today + page-fill sizing).
+const scrollRef = ref(null)
+// Live viewport width of the track, so a short date range can be padded to fill it.
+const viewportWidth = ref(0)
+let resizeObserver = null
+
+// Collapsed stack ids, persisted per board (mirrors the List view's kanso.listCollapsed).
+const collapsedKey = computed(() => `kanso.timelineCollapsed.${props.boardId}`)
+const collapsed = ref(loadCollapsed())
+
+function loadCollapsed() {
+	try {
+		const saved = localStorage.getItem(`kanso.timelineCollapsed.${props.boardId}`)
+		if (saved) return new Set(JSON.parse(saved))
+	} catch (e) { /* localStorage unavailable - default to all expanded */ }
+	return new Set()
+}
+
+// Reload persisted state when the board changes (component is reused across boards).
+watch(() => props.boardId, () => { collapsed.value = loadCollapsed() })
+
+function isCollapsed(stackId) {
+	return collapsed.value.has(stackId)
+}
+
+function toggleGroup(stackId) {
+	const next = new Set(collapsed.value)
+	if (next.has(stackId)) next.delete(stackId)
+	else next.add(stackId)
+	collapsed.value = next
+	try {
+		localStorage.setItem(collapsedKey.value, JSON.stringify([...next]))
+	} catch (e) { /* localStorage unavailable - collapse is in-memory only */ }
+}
 
 const DAY = 86_400_000
 const ZOOMS = [
@@ -206,6 +283,15 @@ onMounted(() => {
 	clockTimer = setInterval(tickNow, 60_000)
 	document.addEventListener('visibilitychange', tickNow)
 	window.addEventListener('focus', tickNow)
+	if (scrollRef.value) {
+		viewportWidth.value = scrollRef.value.clientWidth
+		if (typeof ResizeObserver !== 'undefined') {
+			resizeObserver = new ResizeObserver((entries) => {
+				for (const entry of entries) viewportWidth.value = entry.contentRect.width
+			})
+			resizeObserver.observe(scrollRef.value)
+		}
+	}
 })
 onBeforeUnmount(() => {
 	if (clockTimer !== null) {
@@ -214,6 +300,10 @@ onBeforeUnmount(() => {
 	}
 	document.removeEventListener('visibilitychange', tickNow)
 	window.removeEventListener('focus', tickNow)
+	if (resizeObserver) {
+		resizeObserver.disconnect()
+		resizeObserver = null
+	}
 })
 const zoomCfg = computed(() => ZOOMS.find((z) => z.key === zoom.value) ?? ZOOMS[1])
 const pxPerDay = computed(() => zoomCfg.value.pxPerDay)
@@ -275,42 +365,80 @@ const grouped = computed(() => {
 const scheduledRows = computed(() => grouped.value.groups.flatMap((g) => g.rows))
 const unscheduled = computed(() => grouped.value.unscheduled)
 
-const axisStart = computed(() => {
+// Real extent of the scheduled cards (the dates bars are anchored to). Collapsed
+// groups still count toward the extent so the axis doesn't jump when a group folds.
+const dataStart = computed(() => {
 	const items = scheduledRows.value
 	if (items.length === 0) return null
 	return items.reduce((min, r) => Math.min(min, r.startMs), Infinity)
 })
-const axisEnd = computed(() => {
+const dataEnd = computed(() => {
 	const items = scheduledRows.value
 	if (items.length === 0) return null
 	return items.reduce((max, r) => Math.max(max, r.endMs), -Infinity)
 })
 
-const totalDays = computed(() => {
-	if (axisStart.value === null) return 0
-	return Math.round((axisEnd.value - axisStart.value) / DAY) + 1
+// Rendered axis origin. When today falls before the earliest scheduled card we
+// extend the origin backwards (leading pad) so the today marker stays on-screen;
+// otherwise the axis starts at the real earliest date. Bars are always positioned
+// via xForMs() off this origin, so real positions are never distorted.
+const axisStart = computed(() => {
+	if (dataStart.value === null) return null
+	const today = dayFloor(now.value)
+	return Math.min(dataStart.value, today)
 })
 
-const trackWidth = computed(() => LEFT_PAD * 2 + totalDays.value * pxPerDay.value)
+// The date range must cover the viewport even when the data is short: we pad
+// trailing empty days (and include today) so the track never looks truncated.
+const totalDays = computed(() => {
+	if (axisStart.value === null) return 0
+	const today = dayFloor(now.value)
+	// Extend the real end to at least today, so a short board near today still
+	// paints a continuous track up to the marker.
+	const dataDays = Math.round((Math.max(dataEnd.value, today) - axisStart.value) / DAY) + 1
+	// Days that fit in the current viewport, minus the two side pads.
+	const fitDays = viewportWidth.value > 0
+		? Math.ceil((viewportWidth.value - LEFT_PAD * 2) / pxPerDay.value)
+		: 0
+	return Math.max(dataDays, fitDays)
+})
+
+const trackWidth = computed(() => {
+	const w = LEFT_PAD * 2 + totalDays.value * pxPerDay.value
+	// Guarantee the inner track is never narrower than its viewport (belt-and-braces
+	// against sub-pixel rounding), so it always fills horizontally.
+	return viewportWidth.value > 0 ? Math.max(w, viewportWidth.value) : w
+})
+
+// Rendered end of the axis (last padded day), so the two-tier month axis, gridlines
+// and weekend shading extend across the whole filled width, not just the real data.
+const axisEnd = computed(() => {
+	if (axisStart.value === null) return null
+	return axisStart.value + (totalDays.value - 1) * DAY
+})
 
 function xForMs(ms) {
 	return LEFT_PAD + Math.round((ms - axisStart.value) / DAY) * pxPerDay.value
 }
 
 // Per-group with computed bar geometry, ready to render row-for-row against the pane.
+// A collapsed group keeps its header (with the true card count) but drops its card
+// rows entirely — the SAME reduced `rows` array feeds both the frozen pane and the
+// track, so their row sequences stay identical and pane↔track alignment is exact.
 const groups = computed(() => {
 	if (axisStart.value === null) return []
-	return grouped.value.groups.map((g) => ({
-		stack: g.stack,
-		rows: g.rows.map((r) => {
+	return grouped.value.groups.map((g) => {
+		const isColl = isCollapsed(g.stack.id)
+		const rows = isColl ? [] : g.rows.map((r) => {
 			const left = xForMs(r.startMs)
 			const isMilestone = r.startMs === r.endMs
 			const width = isMilestone ? 0 : Math.max((Math.round((r.endMs - r.startMs) / DAY) + 1) * pxPerDay.value, pxPerDay.value)
 			const overdue = !r.done && r.endMs < now.value
 			const labelInside = !isMilestone && width >= LABEL_MIN_WIDTH
 			return { ...r, left, width, isMilestone, overdue, labelInside }
-		}),
-	}))
+		})
+		return { stack: g.stack, rows, count: g.rows.length }
+	})
 })
 
 const ticks = computed(() => {
@@ -394,6 +522,21 @@ function cardHumanId(card) {
 function openCard(cardId) {
 	router.push({ name: 'card-modal', params: { id: String(props.boardId), cardId: String(cardId) } })
 }
+
+// Scroll the track so today's marker is centered (or as close as the range allows).
+function jumpToToday() {
+	const el = scrollRef.value
+	if (!el) return
+	nextTick(() => {
+		const today = dayFloor(now.value)
+		// Fall back to the axis origin if today isn't on the (padded) axis.
+		const x = (axisStart.value !== null && today >= axisStart.value && today <= axisEnd.value)
+			? xForMs(today)
+			: LEFT_PAD
+		const target = x - el.clientWidth / 2
+		el.scrollTo({ left: Math.max(0, target), behavior: 'smooth' })
+	})
+}
 </script>
 
 <style scoped>
@@ -436,6 +579,81 @@ function openCard(cardId) {
 .timeline__zoom-btn--active {
 	background: var(--color-primary-element);
 	color: var(--color-primary-element-text);
+}
+
+/* ── Jump-to-today ── */
+.timeline__today-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	height: 32px;
+	padding: 0 12px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-pill);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	font-weight: 600;
+	font-size: 0.8rem;
+	white-space: nowrap;
+	cursor: pointer;
+}
+
+.timeline__today-btn:hover:not(:disabled) {
+	background: var(--color-background-hover);
+}
+
+.timeline__today-btn:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
+/* ── Legend ── */
+.timeline__legend {
+	margin-inline-start: auto;
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	font-size: 0.75rem;
+	color: var(--color-text-maxcontrast);
+	flex-wrap: wrap;
+}
+
+.timeline__legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	white-space: nowrap;
+}
+
+.timeline__legend-swatch {
+	width: 20px;
+	height: 8px;
+	border-radius: 4px;
+	flex: 0 0 auto;
+}
+
+.timeline__legend-swatch--not-started {
+	background: var(--color-background-dark);
+}
+
+.timeline__legend-swatch--in-progress {
+	background: var(--color-primary-element);
+}
+
+.timeline__legend-swatch--overdue {
+	background: var(--color-error);
+}
+
+.timeline__legend-swatch--done {
+	background: var(--color-success);
+}
+
+.timeline__legend-swatch--milestone {
+	width: 10px;
+	height: 10px;
+	border-radius: 2px;
+	background: var(--color-text-maxcontrast);
+	transform: rotate(45deg);
 }
 
 .timeline__empty {
@@ -505,6 +723,17 @@ function openCard(cardId) {
 	box-sizing: border-box;
 	background: var(--color-background-hover);
 	border-bottom: 1px solid var(--color-border);
+	cursor: pointer;
+}
+
+.timeline__group-row:hover {
+	background: color-mix(in srgb, var(--color-background-hover) 60%, var(--color-background-dark));
+}
+
+.timeline__group-chevron {
+	color: var(--color-text-maxcontrast);
+	flex: 0 0 auto;
+	display: inline-flex;
 }
 
 .timeline__group-dot {

--- a/src/components/BoardTimelineView.vue
+++ b/src/components/BoardTimelineView.vue
@@ -19,64 +19,133 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</div>
 		</div>
 
-		<div v-if="scheduled.length === 0" class="timeline__empty">
+		<div v-if="scheduledRows.length === 0" class="timeline__empty">
 			<CalendarBlankOutlineIcon :size="40" />
 			<p>{{ t('kanso', 'No cards have a start or due date yet. Add dates on a card to place it on the timeline.') }}</p>
 		</div>
 
-		<!-- Scrollable timeline: sticky date axis + one lane per scheduled card. -->
-		<div v-else class="timeline__scroll">
-			<div class="timeline__inner" :style="{ width: `${trackWidth}px` }">
-				<!-- Gridlines + axis -->
-				<div class="timeline__axis">
+		<!-- Timeline body: a frozen left pane (id/title/assignee) beside a
+		     horizontally-scrollable track (two-tier axis + bars). Both scroll
+		     vertically together as one flex row; only the track scrolls sideways,
+		     so a bar always stays aligned with its row in the frozen pane. -->
+		<div v-else class="timeline__body">
+			<!-- Frozen left pane -->
+			<div class="timeline__pane">
+				<div class="timeline__pane-head">{{ t('kanso', 'Card') }}</div>
+				<template v-for="grp in groups" :key="`p${grp.stack.id}`">
+					<div class="timeline__group-row">
+						<span
+							class="timeline__group-dot"
+							:style="grp.stack.color ? { background: cssColor(grp.stack.color) } : {}" />
+						<span class="timeline__group-title">{{ grp.stack.title }}</span>
+						<span class="timeline__group-count">{{ grp.rows.length }}</span>
+					</div>
+					<div
+						v-for="row in grp.rows"
+						:key="`p${row.card.id}`"
+						class="timeline__pane-row"
+						role="button"
+						tabindex="0"
+						:title="row.card.title"
+						@click="openCard(row.card.id)"
+						@keydown.enter.prevent="openCard(row.card.id)"
+						@keydown.space.prevent="openCard(row.card.id)">
+						<span
+							class="timeline__pane-status"
+							:class="`timeline__pane-status--${statusOf(row)}`" />
+						<span v-if="cardHumanId(row.card)" class="timeline__pane-id">{{ cardHumanId(row.card) }}</span>
+						<span class="timeline__pane-title">{{ row.card.title }}</span>
+						<span
+							v-if="(row.card.assigneeIds || []).length"
+							class="timeline__pane-assignees">
+							<NcAvatar
+								v-for="uid in (row.card.assigneeIds || []).slice(0, 3)"
+								:key="uid"
+								:user="uid"
+								:size="22"
+								:hide-status="true" />
+						</span>
+					</div>
+				</template>
+			</div>
+
+			<!-- Scrollable track -->
+			<div class="timeline__scroll">
+				<div class="timeline__inner" :style="{ width: `${trackWidth}px` }">
+					<!-- Weekend shading (behind everything) -->
+					<div
+						v-for="wk in weekendBands"
+						:key="`w${wk.x}`"
+						class="timeline__weekend"
+						:style="{ left: `${wk.x}px`, width: `${wk.width}px` }" />
+
+					<!-- Gridlines -->
 					<div
 						v-for="tick in ticks"
-						:key="tick.ms"
-						class="timeline__tick"
-						:style="{ left: `${tick.x}px` }">
-						{{ tick.label }}
-					</div>
-				</div>
-				<div
-					v-for="tick in ticks"
-					:key="`g${tick.ms}`"
-					class="timeline__grid"
-					:style="{ left: `${tick.x}px` }" />
+						:key="`g${tick.ms}`"
+						class="timeline__grid"
+						:style="{ left: `${tick.x}px` }" />
 
-				<!-- Today marker -->
-				<div v-if="todayX !== null" class="timeline__today" :style="{ left: `${todayX}px` }" />
+					<!-- Today marker -->
+					<div v-if="todayX !== null" class="timeline__today" :style="{ left: `${todayX}px` }" />
 
-				<!-- Lanes -->
-				<div
-					v-for="row in scheduled"
-					:key="row.card.id"
-					class="timeline__lane"
-					role="button"
-					tabindex="0"
-					:title="row.card.title"
-					:aria-label="row.card.title"
-					@click="openCard(row.card.id)"
-					@keydown.enter.prevent="openCard(row.card.id)"
-					@keydown.space.prevent="openCard(row.card.id)">
-					<div
-						v-if="row.isMilestone"
-						class="timeline__milestone"
-						:class="{ 'timeline__bar--done': row.done, 'timeline__bar--started': row.started }"
-						:style="{ left: `${row.left}px` }">
-						<span class="timeline__label timeline__label--after">{{ row.card.title }}</span>
-					</div>
-					<template v-else>
-						<div
-							class="timeline__bar"
-							:class="{ 'timeline__bar--done': row.done, 'timeline__bar--started': row.started, 'timeline__bar--overdue': row.overdue }"
-							:style="{ left: `${row.left}px`, width: `${row.width}px` }">
-							<span v-if="row.labelInside" class="timeline__label">{{ row.card.title }}</span>
+					<!-- Two-tier axis: months over weeks/days -->
+					<div class="timeline__axis">
+						<div class="timeline__axis-months">
+							<div
+								v-for="m in monthTicks"
+								:key="`m${m.ms}`"
+								class="timeline__axis-month"
+								:style="{ left: `${m.x}px`, width: `${m.width}px` }">
+								{{ m.label }}
+							</div>
 						</div>
-						<!-- Short bars can't hold a legible label; render it beside the bar instead. -->
-						<span
-							v-if="!row.labelInside"
-							class="timeline__bar-outside-label"
-							:style="{ left: `${row.left + row.width + 6}px` }">{{ row.card.title }}</span>
+						<div class="timeline__axis-ticks">
+							<div
+								v-for="tick in ticks"
+								:key="`t${tick.ms}`"
+								class="timeline__tick"
+								:style="{ left: `${tick.x}px` }">
+								{{ tick.label }}
+							</div>
+						</div>
+					</div>
+
+					<!-- Rows, grouped by stack: a group header row then its card rows,
+					     mirroring the frozen pane 1:1 for vertical alignment. -->
+					<template v-for="grp in groups" :key="`t${grp.stack.id}`">
+						<div class="timeline__group-track" />
+						<div
+							v-for="row in grp.rows"
+							:key="`t${row.card.id}`"
+							class="timeline__lane"
+							role="button"
+							tabindex="0"
+							:title="row.card.title"
+							:aria-label="row.card.title"
+							@click="openCard(row.card.id)"
+							@keydown.enter.prevent="openCard(row.card.id)"
+							@keydown.space.prevent="openCard(row.card.id)">
+							<div
+								v-if="row.isMilestone"
+								class="timeline__milestone"
+								:class="{ 'timeline__bar--done': row.done, 'timeline__bar--started': row.started, 'timeline__bar--overdue': row.overdue }"
+								:style="{ left: `${row.left}px` }">
+								<span class="timeline__label timeline__label--after">{{ row.card.title }}</span>
+							</div>
+							<template v-else>
+								<div
+									class="timeline__bar"
+									:class="{ 'timeline__bar--done': row.done, 'timeline__bar--started': row.started, 'timeline__bar--overdue': row.overdue }"
+									:style="{ left: `${row.left}px`, width: `${row.width}px` }">
+									<span v-if="row.labelInside" class="timeline__label">{{ row.card.title }}</span>
+								</div>
+								<span
+									v-if="!row.labelInside"
+									class="timeline__bar-outside-label"
+									:style="{ left: `${row.left + row.width + 6}px` }">{{ row.card.title }}</span>
+							</template>
+						</div>
 					</template>
 				</div>
 			</div>
@@ -98,11 +167,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import CalendarBlankOutlineIcon from 'vue-material-design-icons/CalendarBlankOutline.vue'
+import { cssColor } from '../services/color.js'
+import { humanId } from '../services/humanId.js'
 
 const props = defineProps({
 	/** Filtered, non-archived cards (start_date/duedate carried in the summary). */
 	cards: { type: Array, default: () => [] },
+	/** Non-archived stacks in display order (for group headers + row grouping). */
+	stacks: { type: Array, default: () => [] },
+	/** Map<stackId, card[]> from BoardView - same source the List view groups on. */
+	cardsByStack: { type: Object, default: null },
+	/** Board human-id prefix (e.g. "KAN") - composed with card.boardSeq. */
+	boardPrefix: { type: String, default: '' },
 	boardId: { type: [String, Number], required: true },
 })
 
@@ -153,36 +231,57 @@ function dayFloor(value) {
 	return d.getTime()
 }
 
-// Split into scheduled (has a start and/or due) and unscheduled.
-const scheduledRaw = computed(() => {
-	const out = []
+/** Layout metrics for one card: its ms range + done/started state, or null when unscheduled. */
+function layoutOf(card) {
+	const start = dayFloor(card.startDate)
+	const due = dayFloor(card.duedate)
+	if (start === null && due === null) return null
+	const s = start ?? due
+	const e = due ?? start
+	const done = Number(card.doneAt) > 0
+	return { card, startMs: Math.min(s, e), endMs: Math.max(s, e), done, started: !done && Number(card.startedAt) > 0 }
+}
+
+// Group cards by stack (using the same Map BoardView feeds the List view), keeping
+// stack display order. Each group carries only its scheduled rows; unscheduled
+// cards are collected separately for the footer. Falls back to the flat `cards`
+// prop (single synthetic group) when no stack grouping is supplied.
+const grouped = computed(() => {
+	const groupsOut = []
 	const unsched = []
-	for (const card of props.cards) {
-		const start = dayFloor(card.startDate)
-		const due = dayFloor(card.duedate)
-		if (start === null && due === null) {
-			unsched.push(card)
-			continue
+	if (props.stacks.length && props.cardsByStack) {
+		for (const stack of props.stacks) {
+			const cards = props.cardsByStack.get(stack.id) ?? []
+			const rows = []
+			for (const card of cards) {
+				const l = layoutOf(card)
+				if (l === null) unsched.push(card)
+				else rows.push(l)
+			}
+			if (rows.length) groupsOut.push({ stack, rows })
 		}
-		// A range needs both ends; otherwise it's a single-day milestone.
-		const s = start ?? due
-		const e = due ?? start
-		const done = Number(card.doneAt) > 0
-		out.push({ card, startMs: Math.min(s, e), endMs: Math.max(s, e), done, started: !done && Number(card.startedAt) > 0 })
+	} else {
+		const rows = []
+		for (const card of props.cards) {
+			const l = layoutOf(card)
+			if (l === null) unsched.push(card)
+			else rows.push(l)
+		}
+		if (rows.length) groupsOut.push({ stack: { id: 0, title: t('kanso', 'Cards'), color: null }, rows })
 	}
-	out.sort((a, b) => a.startMs - b.startMs || a.endMs - b.endMs)
-	return { scheduled: out, unscheduled: unsched }
+	return { groups: groupsOut, unscheduled: unsched }
 })
 
-const unscheduled = computed(() => scheduledRaw.value.unscheduled)
+const scheduledRows = computed(() => grouped.value.groups.flatMap((g) => g.rows))
+const unscheduled = computed(() => grouped.value.unscheduled)
 
 const axisStart = computed(() => {
-	const items = scheduledRaw.value.scheduled
+	const items = scheduledRows.value
 	if (items.length === 0) return null
 	return items.reduce((min, r) => Math.min(min, r.startMs), Infinity)
 })
 const axisEnd = computed(() => {
-	const items = scheduledRaw.value.scheduled
+	const items = scheduledRows.value
 	if (items.length === 0) return null
 	return items.reduce((max, r) => Math.max(max, r.endMs), -Infinity)
 })
@@ -198,16 +297,20 @@ function xForMs(ms) {
 	return LEFT_PAD + Math.round((ms - axisStart.value) / DAY) * pxPerDay.value
 }
 
-const scheduled = computed(() => {
+// Per-group with computed bar geometry, ready to render row-for-row against the pane.
+const groups = computed(() => {
 	if (axisStart.value === null) return []
-	return scheduledRaw.value.scheduled.map((r) => {
-		const left = xForMs(r.startMs)
-		const isMilestone = r.startMs === r.endMs
-		const width = isMilestone ? 0 : Math.max((Math.round((r.endMs - r.startMs) / DAY) + 1) * pxPerDay.value, pxPerDay.value)
-		const overdue = !r.done && r.endMs < now.value
-		const labelInside = !isMilestone && width >= LABEL_MIN_WIDTH
-		return { ...r, left, width, isMilestone, overdue, labelInside }
-	})
+	return grouped.value.groups.map((g) => ({
+		stack: g.stack,
+		rows: g.rows.map((r) => {
+			const left = xForMs(r.startMs)
+			const isMilestone = r.startMs === r.endMs
+			const width = isMilestone ? 0 : Math.max((Math.round((r.endMs - r.startMs) / DAY) + 1) * pxPerDay.value, pxPerDay.value)
+			const overdue = !r.done && r.endMs < now.value
+			const labelInside = !isMilestone && width >= LABEL_MIN_WIDTH
+			return { ...r, left, width, isMilestone, overdue, labelInside }
+		}),
+	}))
 })
 
 const ticks = computed(() => {
@@ -217,6 +320,50 @@ const ticks = computed(() => {
 	for (let day = 0; day < totalDays.value; day += step) {
 		const ms = axisStart.value + day * DAY
 		out.push({ ms, x: LEFT_PAD + day * pxPerDay.value, label: labelForMs(ms) })
+	}
+	return out
+})
+
+// Top axis tier: one band per calendar month spanned by the range, sized to its
+// visible slice of the track.
+const monthTicks = computed(() => {
+	if (axisStart.value === null) return []
+	const out = []
+	const end = axisEnd.value
+	let cursor = new Date(axisStart.value)
+	cursor.setDate(1)
+	cursor.setHours(0, 0, 0, 0)
+	while (cursor.getTime() <= end) {
+		const monthStart = cursor.getTime()
+		const next = new Date(cursor)
+		next.setMonth(next.getMonth() + 1)
+		const monthEnd = next.getTime() - DAY
+		const from = Math.max(monthStart, axisStart.value)
+		const to = Math.min(monthEnd, end)
+		const x = xForMs(from)
+		const width = xForMs(to) - x + pxPerDay.value
+		out.push({
+			ms: monthStart,
+			x,
+			width,
+			label: new Date(monthStart).toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),
+		})
+		cursor = next
+	}
+	return out
+})
+
+// Weekend day columns (Sat/Sun) shaded in the track background. Day zoom paints
+// each weekend day; coarser zooms would produce hairlines, so it's day-zoom only.
+const weekendBands = computed(() => {
+	if (axisStart.value === null || zoom.value !== 'day') return []
+	const out = []
+	for (let day = 0; day < totalDays.value; day++) {
+		const d = new Date(axisStart.value + day * DAY)
+		const dow = d.getDay()
+		if (dow === 0 || dow === 6) {
+			out.push({ x: LEFT_PAD + day * pxPerDay.value, width: pxPerDay.value })
+		}
 	}
 	return out
 })
@@ -232,6 +379,16 @@ function labelForMs(ms) {
 	const d = new Date(ms)
 	if (zoom.value === 'month') return d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
 	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function statusOf(row) {
+	if (row.done) return 'done'
+	if (row.started) return 'in_progress'
+	return 'not_started'
+}
+
+function cardHumanId(card) {
+	return humanId(props.boardPrefix, card.boardSeq)
 }
 
 function openCard(cardId) {
@@ -298,53 +455,179 @@ function openCard(cardId) {
 	max-width: 420px;
 }
 
-.timeline__scroll {
+/* Body = frozen pane + scrollable track, scrolling vertically as one unit. */
+.timeline__body {
 	flex: 1;
 	min-height: 0;
-	overflow: auto;
+	display: flex;
+	align-items: stretch;
+	overflow-y: auto;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large, var(--border-radius));
+}
+
+/* ── Frozen left pane ── */
+.timeline__pane {
+	flex: 0 0 300px;
+	width: 300px;
+	box-sizing: border-box;
+	border-right: 1px solid var(--color-border-dark);
+	position: sticky;
+	left: 0;
+	z-index: 4;
+	background: var(--color-main-background);
+}
+
+.timeline__pane-head {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	height: 52px;
+	display: flex;
+	align-items: flex-end;
+	padding: 0 16px 8px;
+	box-sizing: border-box;
+	font-size: 0.7rem;
+	font-weight: 700;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-main-background);
+	border-bottom: 1px solid var(--color-border);
+}
+
+.timeline__group-row {
+	height: 32px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 16px;
+	box-sizing: border-box;
+	background: var(--color-background-hover);
+	border-bottom: 1px solid var(--color-border);
+}
+
+.timeline__group-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: var(--color-primary-element);
+	flex: 0 0 auto;
+}
+
+.timeline__group-title {
+	font-size: 0.75rem;
+	font-weight: 700;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.timeline__group-count {
+	font-size: 0.75rem;
+	color: var(--color-text-maxcontrast);
+	flex: 0 0 auto;
+}
+
+.timeline__pane-row {
+	height: 36px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 16px;
+	box-sizing: border-box;
+	border-bottom: 1px solid var(--color-border);
+	cursor: pointer;
+}
+
+.timeline__pane-row:hover {
+	background: var(--color-background-hover);
+}
+
+.timeline__pane-status {
+	flex: 0 0 auto;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	border: 1px solid var(--color-border-dark);
+	box-sizing: border-box;
+}
+
+.timeline__pane-status--not_started { background: transparent; }
+.timeline__pane-status--in_progress { background: var(--color-primary-element); border-color: var(--color-primary-element); }
+.timeline__pane-status--done { background: var(--color-success, #2fb344); border-color: var(--color-success, #2fb344); }
+
+.timeline__pane-id {
+	flex: 0 0 auto;
+	width: 62px;
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 0.72rem;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.timeline__pane-title {
+	flex: 1;
+	min-width: 0;
+	font-size: 0.8rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.timeline__pane-assignees {
+	display: inline-flex;
+	flex: 0 0 auto;
+}
+
+.timeline__pane-assignees > * + * {
+	margin-inline-start: -8px;
+}
+
+/* ── Scrollable track ── */
+.timeline__scroll {
+	flex: 1;
+	min-width: 0;
+	overflow-x: auto;
+	overflow-y: hidden;
 }
 
 .timeline__inner {
 	position: relative;
-	padding-top: 28px;
 	min-height: 100%;
 }
 
-.timeline__axis {
-	position: sticky;
-	top: 0;
-	height: 28px;
-	z-index: 2;
-}
-
-.timeline__tick {
+.timeline__weekend {
 	position: absolute;
-	top: 0;
-	transform: translateX(-50%);
-	font-size: 0.72rem;
-	color: var(--color-text-maxcontrast);
-	white-space: nowrap;
-	background: var(--color-main-background);
-	padding: 0 3px;
+	top: 52px;
+	bottom: 0;
+	background: var(--color-background-hover);
+	z-index: 0;
 }
 
 .timeline__grid {
 	position: absolute;
-	top: 28px;
+	top: 52px;
 	bottom: 0;
 	width: 1px;
 	background: var(--color-border);
 	opacity: 0.5;
+	z-index: 0;
 }
 
 .timeline__today {
 	position: absolute;
-	top: 28px;
+	top: 48px;
 	bottom: 0;
 	width: 2px;
 	background: var(--color-error);
 	opacity: 0.7;
-	z-index: 1;
+	z-index: 3;
 }
 
 /* A small cap at the top of the today line makes it read as a clear marker. */
@@ -360,10 +643,66 @@ function openCard(cardId) {
 	background: var(--color-error);
 }
 
+/* ── Two-tier axis ── */
+.timeline__axis {
+	position: sticky;
+	top: 0;
+	height: 52px;
+	z-index: 2;
+	background: var(--color-main-background);
+	border-bottom: 1px solid var(--color-border);
+}
+
+.timeline__axis-months {
+	position: relative;
+	height: 24px;
+}
+
+.timeline__axis-month {
+	position: absolute;
+	top: 0;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	padding-left: 8px;
+	box-sizing: border-box;
+	border-right: 1px solid var(--color-border);
+	font-size: 0.75rem;
+	font-weight: 700;
+	white-space: nowrap;
+	overflow: hidden;
+}
+
+.timeline__axis-ticks {
+	position: relative;
+	height: 28px;
+}
+
+.timeline__tick {
+	position: absolute;
+	top: 6px;
+	font-size: 0.72rem;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+	padding-left: 6px;
+}
+
+/* ── Rows ── */
+.timeline__group-track {
+	position: relative;
+	height: 32px;
+	background: color-mix(in srgb, var(--color-background-hover) 70%, transparent);
+	border-bottom: 1px solid var(--color-border);
+	z-index: 1;
+}
+
 .timeline__lane {
 	position: relative;
-	height: 34px;
+	height: 36px;
+	box-sizing: border-box;
+	border-bottom: 1px solid var(--color-border);
 	cursor: pointer;
+	z-index: 1;
 }
 
 .timeline__lane:hover .timeline__bar,
@@ -373,7 +712,7 @@ function openCard(cardId) {
 
 .timeline__bar {
 	position: absolute;
-	top: 5px;
+	top: 6px;
 	height: 24px;
 	border-radius: 6px;
 	/* Default = scheduled but not started (muted). */
@@ -403,7 +742,7 @@ function openCard(cardId) {
 
 .timeline__milestone {
 	position: absolute;
-	top: 9px;
+	top: 10px;
 	width: 16px;
 	height: 16px;
 	transform: translateX(-8px) rotate(45deg);
@@ -417,6 +756,10 @@ function openCard(cardId) {
 
 .timeline__milestone.timeline__bar--done {
 	background: var(--color-success);
+}
+
+.timeline__milestone.timeline__bar--overdue {
+	background: var(--color-error);
 }
 
 .timeline__label {

--- a/src/components/BoardTimelineView.vue
+++ b/src/components/BoardTimelineView.vue
@@ -95,7 +95,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import CalendarBlankOutlineIcon from 'vue-material-design-icons/CalendarBlankOutline.vue'
@@ -115,6 +115,28 @@ const ZOOMS = [
 	{ key: 'month', label: t('kanso', 'Month'), pxPerDay: 4, stepDays: 30 },
 ]
 const zoom = ref('week')
+
+// Reactive clock so the "today" marker and overdue flags recompute over time
+// (e.g. a board left open across midnight). A plain Date.now() inside a computed
+// has no reactive dependency and would stay frozen until `cards` changed.
+const now = ref(Date.now())
+let clockTimer = null
+function tickNow() {
+	now.value = Date.now()
+}
+onMounted(() => {
+	clockTimer = setInterval(tickNow, 60_000)
+	document.addEventListener('visibilitychange', tickNow)
+	window.addEventListener('focus', tickNow)
+})
+onBeforeUnmount(() => {
+	if (clockTimer !== null) {
+		clearInterval(clockTimer)
+		clockTimer = null
+	}
+	document.removeEventListener('visibilitychange', tickNow)
+	window.removeEventListener('focus', tickNow)
+})
 const zoomCfg = computed(() => ZOOMS.find((z) => z.key === zoom.value) ?? ZOOMS[1])
 const pxPerDay = computed(() => zoomCfg.value.pxPerDay)
 
@@ -182,7 +204,7 @@ const scheduled = computed(() => {
 		const left = xForMs(r.startMs)
 		const isMilestone = r.startMs === r.endMs
 		const width = isMilestone ? 0 : Math.max((Math.round((r.endMs - r.startMs) / DAY) + 1) * pxPerDay.value, pxPerDay.value)
-		const overdue = !r.done && r.endMs < Date.now()
+		const overdue = !r.done && r.endMs < now.value
 		const labelInside = !isMilestone && width >= LABEL_MIN_WIDTH
 		return { ...r, left, width, isMilestone, overdue, labelInside }
 	})
@@ -201,7 +223,7 @@ const ticks = computed(() => {
 
 const todayX = computed(() => {
 	if (axisStart.value === null) return null
-	const t0 = dayFloor(Date.now())
+	const t0 = dayFloor(now.value)
 	if (t0 < axisStart.value || t0 > axisEnd.value) return null
 	return xForMs(t0)
 })

--- a/src/components/BoardTimelineView.vue
+++ b/src/components/BoardTimelineView.vue
@@ -110,7 +110,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 			<!-- Scrollable track -->
 			<div ref="scrollRef" class="timeline__scroll">
-				<div class="timeline__inner" :style="{ width: `${trackWidth}px` }">
+				<div ref="trackRef" class="timeline__inner" :class="{ 'timeline__inner--drop-active': dropActive }" :style="{ width: `${trackWidth}px` }">
+					<!-- Drop affordance: a vertical guide at the day under the cursor
+					     while an unscheduled card is dragged over the track. -->
+					<div
+						v-if="dropGuideX !== null"
+						class="timeline__drop-guide"
+						:style="{ left: `${dropGuideX}px` }" />
 					<!-- Weekend shading (behind everything) -->
 					<div
 						v-for="wk in weekendBands"
@@ -192,10 +198,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 		<!-- Unscheduled cards -->
 		<details v-if="unscheduled.length > 0" class="timeline__unscheduled">
-			<summary>{{ n('kanso', '%n unscheduled card', '%n unscheduled cards', unscheduled.length) }}</summary>
+			<summary>
+				{{ n('kanso', '%n unscheduled card', '%n unscheduled cards', unscheduled.length) }}
+				<span v-if="canEdit" class="timeline__unscheduled-hint">{{ t('kanso', 'Drag one onto the track to schedule it') }}</span>
+			</summary>
 			<ul class="timeline__unscheduled-list">
 				<li v-for="card in unscheduled" :key="card.id">
-					<button class="timeline__unscheduled-row" @click="openCard(card.id)">{{ card.title }}</button>
+					<button
+						:ref="(el) => registerUnscheduledRef(card.id, el)"
+						class="timeline__unscheduled-row"
+						:class="{ 'timeline__unscheduled-row--draggable': canEdit, 'timeline__unscheduled-row--dragging': draggingCardId === card.id }"
+						@click="openCard(card.id)">{{ card.title }}</button>
 				</li>
 			</ul>
 		</details>
@@ -205,12 +218,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <script setup>
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
+import { useQueryClient } from '@tanstack/vue-query'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import CalendarBlankOutlineIcon from 'vue-material-design-icons/CalendarBlankOutline.vue'
 import CalendarTodayIcon from 'vue-material-design-icons/CalendarToday.vue'
 import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
+import { updateCard as apiUpdateCard } from '../services/api.js'
+import { boardQueryKey } from '../composables/queryKeys.js'
 import { cssColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
 
@@ -223,13 +240,19 @@ const props = defineProps({
 	cardsByStack: { type: Object, default: null },
 	/** Board human-id prefix (e.g. "KAN") - composed with card.boardSeq. */
 	boardPrefix: { type: String, default: '' },
+	/** Whether the current user may edit cards (board permission bit 2). Gates
+	 *  drag-to-schedule: read-only viewers get no draggable footer cards. */
+	canEdit: { type: Boolean, default: false },
 	boardId: { type: [String, Number], required: true },
 })
 
 const router = useRouter()
+const queryClient = useQueryClient()
 
 // The horizontally-scrolling track container (for jump-to-today + page-fill sizing).
 const scrollRef = ref(null)
+// The inner track element (drop target for scheduling unscheduled cards).
+const trackRef = ref(null)
 // Live viewport width of the track, so a short date range can be padded to fill it.
 const viewportWidth = ref(0)
 let resizeObserver = null
@@ -421,6 +444,16 @@ function xForMs(ms) {
 	return LEFT_PAD + Math.round((ms - axisStart.value) / DAY) * pxPerDay.value
 }
 
+// Inverse of xForMs: an x-offset inside the inner track → the day-floor ms under
+// it. Used by drag-to-schedule to turn a drop position into a due date. Clamped
+// to the rendered axis so a drop just past either edge still lands on a real day.
+function msForTrackX(xInTrack) {
+	if (axisStart.value === null) return null
+	const day = Math.floor((xInTrack - LEFT_PAD) / pxPerDay.value)
+	const clampedDay = Math.max(0, Math.min(day, totalDays.value - 1))
+	return axisStart.value + clampedDay * DAY
+}
+
 // Per-group with computed bar geometry, ready to render row-for-row against the pane.
 // A collapsed group keeps its header (with the true card count) but drops its card
 // rows entirely — the SAME reduced `rows` array feeds both the frozen pane and the
@@ -537,6 +570,122 @@ function jumpToToday() {
 		el.scrollTo({ left: Math.max(0, target), behavior: 'smooth' })
 	})
 }
+
+// ── Drag-to-schedule ────────────────────────────────────────────────────────
+// Unscheduled footer cards are Pragmatic-DnD draggables; the track is a drop
+// target. Dropping a card sets its duedate to the day under the cursor, turning
+// it into a single-date (diamond) card. Scoped to payload type
+// 'timeline-unscheduled' so it never interferes with the board's own card/stack
+// monitors (which use type 'card').
+
+// Which footer card is being dragged (for the drag-visual on the source).
+const draggingCardId = ref(null)
+// x-offset (inside the inner track) of the drop guide line, or null when idle.
+const dropGuideX = ref(null)
+// Whether an unscheduled card is currently hovering the track (subtle highlight).
+const dropActive = ref(false)
+
+// Per-card draggable cleanups, keyed by card id. Rebuilt as the footer's ref
+// callbacks fire; all torn down on unmount.
+const unschedCleanups = new Map()
+
+function boardKey() {
+	return boardQueryKey(props.boardId)
+}
+
+// Optimistically patch the board summary cache with a new duedate for one card,
+// then reconcile with the server. Mirrors useCardActions.setArchived: snapshot →
+// patch → rollback-on-error → invalidate-on-settled. Only this card's duedate is
+// touched, so concurrent in-flight mutations on other cards are never clobbered.
+async function scheduleCard(cardId, dueMs) {
+	if (!props.canEdit || axisStart.value === null) return
+	const iso = new Date(dueMs).toISOString()
+	const key = boardKey()
+	const numericId = Number(cardId)
+
+	await queryClient.cancelQueries({ queryKey: key })
+	const previousBoard = queryClient.getQueryData(key)
+	queryClient.setQueryData(key, (old) => {
+		if (!old || !Array.isArray(old.cards)) return old
+		return {
+			...old,
+			cards: old.cards.map((c) => (c.id === numericId ? { ...c, duedate: iso } : c)),
+		}
+	})
+
+	try {
+		await apiUpdateCard(numericId, { duedate: iso })
+	} catch (e) {
+		if (previousBoard !== undefined) queryClient.setQueryData(key, previousBoard)
+	} finally {
+		queryClient.invalidateQueries({ queryKey: key })
+	}
+}
+
+// Compute the day-floor ms under a drag input (client coords) over the track.
+function dropMsFromInput(clientX) {
+	const inner = trackRef.value
+	if (!inner) return null
+	const rect = inner.getBoundingClientRect()
+	return msForTrackX(clientX - rect.left)
+}
+
+// Update the visual guide to the day under the cursor while dragging over the track.
+function updateGuide(clientX) {
+	const inner = trackRef.value
+	if (!inner || axisStart.value === null) { dropGuideX.value = null; return }
+	const rect = inner.getBoundingClientRect()
+	const ms = msForTrackX(clientX - rect.left)
+	dropGuideX.value = ms === null ? null : xForMs(ms)
+}
+
+// Ref callback for each footer card button: (re)wire it as a draggable. Vue calls
+// this with the element on mount/update and null on unmount.
+function registerUnscheduledRef(cardId, el) {
+	const prev = unschedCleanups.get(cardId)
+	if (prev) { prev(); unschedCleanups.delete(cardId) }
+	if (!el || !props.canEdit) return
+	const cleanup = draggable({
+		element: el,
+		getInitialData: () => ({ type: 'timeline-unscheduled', cardId }),
+		onDragStart: () => { draggingCardId.value = cardId },
+		onDrop: () => { draggingCardId.value = null },
+	})
+	unschedCleanups.set(cardId, cleanup)
+}
+
+let trackDropCleanup = () => {}
+
+// The inner track only renders when there are scheduled cards (the v-else body),
+// so it can mount/unmount as the board's date coverage changes. Wire the drop
+// target whenever the element appears and tear it down when it goes away.
+watch(trackRef, (el) => {
+	trackDropCleanup()
+	trackDropCleanup = () => {}
+	if (!el) return
+	trackDropCleanup = dropTargetForElements({
+		element: el,
+		canDrop: ({ source }) => props.canEdit && source.data.type === 'timeline-unscheduled',
+		onDrag: ({ location }) => {
+			dropActive.value = true
+			updateGuide(location.current.input.clientX)
+		},
+		onDragLeave: () => { dropActive.value = false; dropGuideX.value = null },
+		onDrop: ({ source, location }) => {
+			dropActive.value = false
+			dropGuideX.value = null
+			const cardId = source.data.cardId
+			const dueMs = dropMsFromInput(location.current.input.clientX)
+			if (cardId != null && dueMs !== null) scheduleCard(cardId, dueMs)
+		},
+	})
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+	trackDropCleanup()
+	for (const cleanup of unschedCleanups.values()) cleanup()
+	unschedCleanups.clear()
+})
 </script>
 
 <style scoped>
@@ -1033,6 +1182,13 @@ function jumpToToday() {
 	font-weight: 600;
 }
 
+.timeline__unscheduled-hint {
+	margin-inline-start: 8px;
+	font-weight: 400;
+	font-size: 0.78rem;
+	opacity: 0.85;
+}
+
 .timeline__unscheduled-list {
 	list-style: none;
 	padding: 8px 0 0;
@@ -1053,5 +1209,48 @@ function jumpToToday() {
 
 .timeline__unscheduled-row:hover {
 	background: var(--color-background-hover);
+}
+
+/* Draggable footer card: grab cursor + a faint dashed edge hinting it can be
+ * picked up and dropped onto the track to schedule it. */
+.timeline__unscheduled-row--draggable {
+	cursor: grab;
+	border-style: dashed;
+}
+
+.timeline__unscheduled-row--draggable:active {
+	cursor: grabbing;
+}
+
+.timeline__unscheduled-row--dragging {
+	opacity: 0.4;
+}
+
+/* Subtle track highlight while an unscheduled card hovers over it. */
+.timeline__inner--drop-active {
+	background: color-mix(in srgb, var(--color-primary-element) 6%, transparent);
+}
+
+/* Vertical guide at the day the card would land on. */
+.timeline__drop-guide {
+	position: absolute;
+	top: 52px;
+	bottom: 0;
+	width: 2px;
+	background: var(--color-primary-element);
+	opacity: 0.9;
+	z-index: 5;
+	pointer-events: none;
+}
+
+.timeline__drop-guide::before {
+	content: '';
+	position: absolute;
+	top: -3px;
+	left: 50%;
+	width: 9px;
+	height: 9px;
+	transform: translateX(-50%) rotate(45deg);
+	background: var(--color-primary-element);
 }
 </style>

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -1583,10 +1583,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 													<button
 														class="card-modal__reaction-add"
 														:title="t('kanso', 'Add reaction')"
-														@click.stop="toggleReactionPicker(topComment.id)">
+														@click.stop="toggleReactionPicker(topComment.id, $event)">
 														<EmoticonHappyOutlineIcon :size="14" />
 													</button>
-													<div v-if="reactionPickerFor === topComment.id" class="card-modal__reaction-picker">
+													<div v-if="reactionPickerFor === topComment.id" :style="reactionPickerStyle" class="card-modal__reaction-picker">
 														<button
 															v-for="emoji in reactionEmoji"
 															:key="emoji"
@@ -1681,10 +1681,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 														<button
 															class="card-modal__reaction-add"
 															:title="t('kanso', 'Add reaction')"
-															@click.stop="toggleReactionPicker(reply.id)">
+															@click.stop="toggleReactionPicker(reply.id, $event)">
 																<EmoticonHappyOutlineIcon :size="14" />
 														</button>
-														<div v-if="reactionPickerFor === reply.id" class="card-modal__reaction-picker">
+														<div v-if="reactionPickerFor === reply.id" :style="reactionPickerStyle" class="card-modal__reaction-picker">
 															<button
 																v-for="emoji in reactionEmoji"
 																:key="emoji"
@@ -2926,9 +2926,40 @@ const {
 // summary (mine flag) to decide react vs. unreact.
 const reactionEmoji = REACTION_EMOJI
 const reactionPickerFor = ref(null)
+// The emoji picker is positioned `fixed` (coords computed from the trigger button on
+// open) so it escapes the comment thread's `overflow` clipping and the content pane's
+// stacking — a comment lives inside .card-modal__thread-scroll (overflow:auto), which
+// would otherwise clip the popover when it opens sideways. See toggleReactionPicker.
+const reactionPickerStyle = ref({})
 
-function toggleReactionPicker(commentId) {
-	reactionPickerFor.value = reactionPickerFor.value === commentId ? null : commentId
+function toggleReactionPicker(commentId, ev) {
+	if (reactionPickerFor.value === commentId) {
+		reactionPickerFor.value = null
+		return
+	}
+	reactionPickerFor.value = commentId
+	const btn = ev && ev.currentTarget
+	if (btn && typeof btn.getBoundingClientRect === 'function') {
+		const r = btn.getBoundingClientRect()
+		// Open the picker just above the button. Align it to the button's side that
+		// leaves the most room (right-align when the button sits in the right half of
+		// the viewport, so it opens leftward and stays on-screen; left-align otherwise).
+		const style = {
+			position: 'fixed',
+			bottom: (window.innerHeight - r.top + 4) + 'px',
+			top: 'auto',
+		}
+		if (r.left < window.innerWidth / 2) {
+			style.left = Math.round(r.left) + 'px'
+			style.right = 'auto'
+		} else {
+			style.right = Math.round(window.innerWidth - r.right) + 'px'
+			style.left = 'auto'
+		}
+		reactionPickerStyle.value = style
+	} else {
+		reactionPickerStyle.value = {}
+	}
 }
 
 async function onReactionClick(comment, emoji) {

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -4472,12 +4472,16 @@ async function handleToggleProject(projectId) {
 	position: relative;
 	display: inline-flex;
 	align-items: center;
+	gap: 0;
 }
 .card-modal__watch-btn {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
 	height: 36px;
+	/* !important — NC core sets `button { margin: 3px 3px 3px 0 }`, which otherwise
+	   pushes a 3px gap between the two halves of the split button. */
+	margin: 0 !important;
 	padding: 0 12px;
 	border: 1px solid var(--color-border);
 	border-radius: 100px 0 0 100px;
@@ -4492,8 +4496,10 @@ async function handleToggleProject(projectId) {
 	justify-content: center;
 	width: 28px;
 	height: 36px;
+	margin: 0 !important;
 	/* The left edge is the shared divider; drop the caret's own left border so the
-	   two halves share a single 1px line rather than stacking two. */
+	   two halves share a single 1px line, and sit flush against the left half
+	   (no margin) so there is no gap between them. */
 	border: 1px solid var(--color-border);
 	border-left: 0;
 	border-radius: 0 100px 100px 0;

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -3270,9 +3270,31 @@ function onModalEscape() {
 // inner content has target inside .modal-container, so releasing on the backdrop
 // never closes the card. The handler funnels through onModalClose so it obeys the
 // same picker-first precedence as Escape.
+//
+// It also carries the click-outside dismiss for the attribute popovers (#3665):
+// when ANY picker is open, a mousedown that lands outside the popover AND outside the
+// picker's own (open) trigger clears openPicker — one shared path keyed on openPicker,
+// no per-picker wiring. This runs BEFORE the backdrop-close check so it holds the same
+// picker-first precedence as Escape: an outside click on the backdrop closes the PICKER,
+// not the whole card. The active trigger is excluded via aria-expanded="true" so the
+// same click that would toggle it shut doesn't get double-handled (mousedown closes,
+// then the trigger's click re-opens); the popover interior (options, date input,
+// mention textareas) is excluded so selecting/typing never closes it prematurely.
 function onDocumentMousedown(event) {
 	const target = event.target
-	if (!(target instanceof Element) || !target.classList.contains('modal-wrapper')) {
+	if (!(target instanceof Element)) {
+		return
+	}
+	if (openPicker.value !== null) {
+		if (!target.closest('.card-modal__popover') && !target.closest('[aria-expanded="true"]')) {
+			openPicker.value = null
+			return
+		}
+		// A picker is open and the click is on its trigger or inside the popover —
+		// leave it to the element's own handler; never fall through to backdrop-close.
+		return
+	}
+	if (!target.classList.contains('modal-wrapper')) {
 		return
 	}
 	// Scope to THIS card's modal (guard against other stacked NcModals on the page).

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -4368,6 +4368,14 @@ async function handleToggleProject(projectId) {
 	color: var(--color-success-text, var(--color-success));
 	background: var(--kanso-tint-success, color-mix(in srgb, var(--color-success) 10%, var(--color-main-background)));
 }
+/* Watch control: a single split-button pill — the watch toggle (left half) and
+   the watchers caret (right half) sit flush, sharing one border with a thin 1px
+   divider between them. Only the outer corners are rounded. */
+.card-modal__watch-wrap {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+}
 .card-modal__watch-btn {
 	display: inline-flex;
 	align-items: center;
@@ -4375,22 +4383,11 @@ async function handleToggleProject(projectId) {
 	height: 36px;
 	padding: 0 12px;
 	border: 1px solid var(--color-border);
-	border-radius: 100px;
+	border-radius: 100px 0 0 100px;
 	background: var(--color-main-background);
 	color: var(--color-text-maxcontrast);
 	font-size: 0.875rem;
 	cursor: pointer;
-}
-.card-modal__watch-btn--active {
-	border-color: var(--color-primary-element);
-	background: var(--color-primary-light);
-	color: var(--color-primary-element);
-}
-.card-modal__watch-wrap {
-	position: relative;
-	display: inline-flex;
-	align-items: center;
-	gap: 2px;
 }
 .card-modal__watch-caret {
 	display: inline-flex;
@@ -4398,20 +4395,40 @@ async function handleToggleProject(projectId) {
 	justify-content: center;
 	width: 28px;
 	height: 36px;
+	/* The left edge is the shared divider; drop the caret's own left border so the
+	   two halves share a single 1px line rather than stacking two. */
 	border: 1px solid var(--color-border);
-	border-radius: 100px;
+	border-left: 0;
+	border-radius: 0 100px 100px 0;
 	background: var(--color-main-background);
 	color: var(--color-text-maxcontrast);
 	cursor: pointer;
 }
+.card-modal__watch-btn:hover,
 .card-modal__watch-caret:hover {
 	border-color: var(--color-primary-element);
 	color: var(--color-primary-element);
 }
+/* Keep focus rings on top and the hovered/focused half's border above its
+   neighbour so the shared divider reads correctly. */
+.card-modal__watch-btn:hover,
+.card-modal__watch-btn:focus-visible,
+.card-modal__watch-caret:hover,
+.card-modal__watch-caret:focus-visible {
+	position: relative;
+	z-index: 1;
+}
+/* Active (watching) state styles the whole pill as one control. */
+.card-modal__watch-btn--active,
 .card-modal__watch-caret--active {
 	border-color: var(--color-primary-element);
 	background: var(--color-primary-light);
 	color: var(--color-primary-element);
+}
+.card-modal__watch-caret--active {
+	/* Re-add a left border so the divider stays visible in the active state,
+	   tinted to match the active pill. */
+	border-left: 1px solid var(--color-primary-element);
 }
 .card-modal__watch-panel {
 	min-width: 240px;

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -1539,9 +1539,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 														<TrashCanIcon :size="14" />
 													</button>
 												</template>
-											</div>
-
-											<div class="card-modal__reactions">
 												<button
 													v-for="summary in topComment.reactions"
 													:key="summary.emoji"
@@ -1627,21 +1624,19 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 												<!-- eslint-disable-next-line vue/no-v-html — renderMarkdown sanitises via DOMPurify -->
 												<div v-else class="card-modal__comment-body" v-html="renderedComments.get(reply.id)" @click="handleRefClick" />
 
-												<div
-													v-if="canEdit && currentUserId === reply.author"
-													class="card-modal__comment-controls">
-													<button class="card-modal__comment-icon-btn" :title="t('kanso', 'Edit comment')" @click="startCommentEdit(reply)">
-														<PencilIcon :size="14" />
-													</button>
-													<button
-														class="card-modal__comment-icon-btn card-modal__comment-icon-btn--danger"
-														:title="t('kanso', 'Delete comment')"
-														:disabled="deleteComment.isPending.value"
-														@click="handleDeleteComment(reply)">
-														<TrashCanIcon :size="14" />
-													</button>
-												</div>
-												<div class="card-modal__reactions">
+												<div v-if="canEdit" class="card-modal__comment-controls">
+													<template v-if="currentUserId === reply.author">
+														<button class="card-modal__comment-icon-btn" :title="t('kanso', 'Edit comment')" @click="startCommentEdit(reply)">
+															<PencilIcon :size="14" />
+														</button>
+														<button
+															class="card-modal__comment-icon-btn card-modal__comment-icon-btn--danger"
+															:title="t('kanso', 'Delete comment')"
+															:disabled="deleteComment.isPending.value"
+															@click="handleDeleteComment(reply)">
+															<TrashCanIcon :size="14" />
+														</button>
+													</template>
 													<button
 														v-for="summary in reply.reactions"
 														:key="summary.emoji"
@@ -5724,6 +5719,7 @@ async function handleToggleProject(projectId) {
 }
 .card-modal__comment-controls {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 4px;
 	margin-top: 2px;
@@ -5795,7 +5791,7 @@ async function handleToggleProject(projectId) {
 	justify-content: center;
 	width: 24px;
 	height: 24px;
-	border: 1px solid var(--color-border);
+	border: none;
 	border-radius: 50%;
 	background: transparent;
 	color: var(--color-text-maxcontrast);
@@ -5805,7 +5801,10 @@ async function handleToggleProject(projectId) {
 .card-modal__reaction-picker {
 	position: absolute;
 	bottom: calc(100% + 4px);
-	left: 0;
+	/* Anchor to the right: the add button sits at the right end of the comment
+	   controls row, so open leftward into the comment to avoid the popover being
+	   clipped by the scroll container's / comment group's overflow. */
+	right: 0;
 	z-index: 10;
 	display: flex;
 	gap: 2px;
@@ -5943,6 +5942,7 @@ async function handleToggleProject(projectId) {
 .card-modal__field-clear,
 .card-modal__checklist-item-delete,
 .card-modal__comment-icon-btn,
+.card-modal__reaction-add,
 .card-modal__child-remove,
 .card-modal__icon-btn,
 .card-modal__child-dot,

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -219,7 +219,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 										:user="uid"
 										:display-name="participantName(uid)"
 										:size="24"
-										:show-user-status="false"
+										:hide-status="true"
 										:disable-tooltip="true" />
 									<span class="card-modal__watch-row-name">{{ participantName(uid) }}</span>
 									<button
@@ -249,7 +249,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											:user="p.uid"
 											:display-name="p.displayName"
 											:size="24"
-											:show-user-status="false"
+											:hide-status="true"
 											:disable-tooltip="true" />
 										<span>{{ p.displayName }}</span>
 									</button>
@@ -536,7 +536,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							:user="uid"
 							:display-name="participantName(uid)"
 							:size="22"
-							:show-user-status="false"
+							:hide-status="true"
 							:disable-tooltip="false" />
 						<span class="card-modal__assignee-name">{{ participantName(uid) }}</span>
 						<button
@@ -566,7 +566,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									:user="p.uid"
 									:display-name="p.displayName"
 									:size="24"
-									:show-user-status="false"
+									:hide-status="true"
 									:disable-tooltip="true" />
 								<span>{{ p.displayName }}</span>
 							</button>
@@ -583,7 +583,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								<NcAvatar
 									:display-name="c.displayName"
 									:size="22"
-									:show-user-status="false"
+									:hide-status="true"
 									:disable-tooltip="false" />
 								<span class="card-modal__assignee-name">{{ c.displayName }}</span>
 								<button
@@ -621,7 +621,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											<NcAvatar
 												:display-name="c.displayName"
 												:size="24"
-												:show-user-status="false"
+												:hide-status="true"
 												:disable-tooltip="true" />
 											<span class="card-modal__contact-option-text">
 												<span>{{ c.displayName }}</span>
@@ -778,7 +778,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								:user="review.reviewer"
 								:display-name="participantName(review.reviewer)"
 								:size="22"
-								:show-user-status="false"
+								:hide-status="true"
 								:disable-tooltip="false" />
 							<span class="card-modal__review-name">{{ participantName(review.reviewer) }}</span>
 							<span
@@ -848,7 +848,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 										:user="p.uid"
 										:display-name="p.displayName"
 										:size="24"
-										:show-user-status="false"
+										:hide-status="true"
 										:disable-tooltip="true" />
 									<span>{{ p.displayName }}</span>
 								</button>
@@ -935,7 +935,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 												:user="p.uid"
 												:display-name="p.displayName"
 												:size="24"
-												:show-user-status="false"
+												:hide-status="true"
 												:disable-tooltip="true" />
 											<span>{{ p.displayName }}</span>
 										</li>
@@ -1467,7 +1467,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 										:user="item.actor || ''"
 										:display-name="item.actorName || item.actor || t('kanso', 'System')"
 										:size="24"
-										:show-user-status="false" />
+										:hide-status="true" />
 									<span class="card-modal__activity-text">
 										<strong>{{ item.actorName || item.actor || t('kanso', 'Someone') }}</strong>
 										{{ activityVerbText(item) }}
@@ -1492,7 +1492,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											:user="topComment.author"
 											:display-name="topComment.authorDisplayName || topComment.author"
 											:size="28"
-											:show-user-status="false"
+											:hide-status="true"
 											class="card-modal__comment-avatar" />
 										<div class="card-modal__comment-main">
 											<div class="card-modal__comment-meta">
@@ -1596,7 +1596,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 												:user="reply.author"
 												:display-name="reply.authorDisplayName || reply.author"
 												:size="24"
-												:show-user-status="false"
+												:hide-status="true"
 												class="card-modal__comment-avatar" />
 											<div class="card-modal__comment-main">
 												<div class="card-modal__comment-meta">
@@ -1683,7 +1683,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<NcAvatar
 								:user="currentUserId"
 								:size="28"
-								:show-user-status="false"
+								:hide-status="true"
 								class="card-modal__composer-avatar" />
 							<div class="card-modal__composer-main">
 								<div class="card-modal__mention-wrap">
@@ -1710,7 +1710,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 												:user="p.uid"
 												:display-name="p.displayName"
 												:size="24"
-												:show-user-status="false"
+												:hide-status="true"
 												:disable-tooltip="true" />
 											<span>{{ p.displayName }}</span>
 										</li>

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -887,7 +887,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</div>
 
 				<!-- Body: content (left) | discussion (right) -->
-				<div class="card-modal__body">
+				<div ref="bodyRef" class="card-modal__body" :style="discussionWidthStyle">
 					<!-- LEFT: description · checklist · sub-cards · github · relations -->
 					<div class="card-modal__content">
 						<!-- Description -->
@@ -1446,6 +1446,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</div>
 							<span v-if="relationError" class="card-modal__save-error">{{ relationError }}</span>
 						</section>
+					</div>
+
+					<!-- Drag handle: resizes the split between the main pane and the
+					     discussion pane. Inert below the 680px breakpoint (panes stack). -->
+					<div
+						class="card-modal__resizer"
+						role="separator"
+						aria-orientation="vertical"
+						:aria-label="t('kanso', 'Resize discussion panel')"
+						:aria-valuenow="discussionWidth"
+						:aria-valuemin="DISCUSSION_MIN_WIDTH"
+						:aria-valuemax="DISCUSSION_MAX_WIDTH"
+						tabindex="0"
+						@pointerdown="onResizePointerDown"
+						@keydown="onResizeKeydown">
+						<span class="card-modal__resizer-grip" />
 					</div>
 
 					<!-- RIGHT: discussion pane -->
@@ -3822,6 +3838,87 @@ async function handleRemoveRelation(relationId) {
 // Mobile splits the card and discussion into tabs; desktop shows both panes.
 const viewMode = ref('card')
 
+// Resizable discussion/activity pane (#3661). The body is a two-column grid whose
+// right (discussion) track width is driven by a CSS var; a drag handle updates it
+// live and persists the chosen width per user in localStorage. Below the 680px
+// breakpoint the panes stack and the var/handle are ignored (see <style>).
+const DISCUSSION_WIDTH_KEY = 'kanso.cardDiscussionWidth'
+const DISCUSSION_MIN_WIDTH = 280
+const DISCUSSION_MAX_WIDTH = 720
+const DISCUSSION_DEFAULT_WIDTH = 400
+const DISCUSSION_KEY_STEP = 24
+function clampDiscussionWidth(px) {
+	return Math.min(DISCUSSION_MAX_WIDTH, Math.max(DISCUSSION_MIN_WIDTH, Math.round(px)))
+}
+const discussionWidth = ref(DISCUSSION_DEFAULT_WIDTH)
+try {
+	const saved = parseInt(localStorage.getItem(DISCUSSION_WIDTH_KEY), 10)
+	if (Number.isFinite(saved)) discussionWidth.value = clampDiscussionWidth(saved)
+} catch (e) { /* localStorage unavailable - default width */ }
+const discussionWidthStyle = computed(() => ({ '--kanso-discussion-width': discussionWidth.value + 'px' }))
+function persistDiscussionWidth() {
+	try {
+		localStorage.setItem(DISCUSSION_WIDTH_KEY, String(discussionWidth.value))
+	} catch (e) { /* ignore persistence failure */ }
+}
+const bodyRef = ref(null)
+let resizePointerId = null
+function onResizePointerMove(e) {
+	if (!bodyRef.value) return
+	// The handle sits on the left edge of the discussion pane; width grows as the
+	// pointer moves left, so measure from the body's right edge.
+	const rect = bodyRef.value.getBoundingClientRect()
+	discussionWidth.value = clampDiscussionWidth(rect.right - e.clientX)
+}
+function onResizePointerUp(e) {
+	if (resizePointerId !== null && e.pointerId !== resizePointerId) return
+	window.removeEventListener('pointermove', onResizePointerMove)
+	window.removeEventListener('pointerup', onResizePointerUp)
+	window.removeEventListener('pointercancel', onResizePointerUp)
+	document.body.style.userSelect = ''
+	document.body.style.cursor = ''
+	resizePointerId = null
+	persistDiscussionWidth()
+}
+function onResizePointerDown(e) {
+	// Only resize on desktop layout; below 680px the panes stack.
+	if (window.matchMedia('(max-width: 680px)').matches) return
+	e.preventDefault()
+	resizePointerId = e.pointerId
+	window.addEventListener('pointermove', onResizePointerMove)
+	window.addEventListener('pointerup', onResizePointerUp)
+	window.addEventListener('pointercancel', onResizePointerUp)
+	// Suppress text selection / show a resize cursor for the whole drag.
+	document.body.style.userSelect = 'none'
+	document.body.style.cursor = 'col-resize'
+}
+function onResizeKeydown(e) {
+	if (window.matchMedia('(max-width: 680px)').matches) return
+	// Left arrow shrinks the main pane (grows discussion); Right grows the main pane.
+	if (e.key === 'ArrowLeft') {
+		discussionWidth.value = clampDiscussionWidth(discussionWidth.value + DISCUSSION_KEY_STEP)
+	} else if (e.key === 'ArrowRight') {
+		discussionWidth.value = clampDiscussionWidth(discussionWidth.value - DISCUSSION_KEY_STEP)
+	} else if (e.key === 'Home') {
+		discussionWidth.value = DISCUSSION_MAX_WIDTH
+	} else if (e.key === 'End') {
+		discussionWidth.value = DISCUSSION_MIN_WIDTH
+	} else {
+		return
+	}
+	e.preventDefault()
+	persistDiscussionWidth()
+}
+onBeforeUnmount(() => {
+	if (resizePointerId !== null) {
+		window.removeEventListener('pointermove', onResizePointerMove)
+		window.removeEventListener('pointerup', onResizePointerUp)
+		window.removeEventListener('pointercancel', onResizePointerUp)
+		document.body.style.userSelect = ''
+		document.body.style.cursor = ''
+	}
+})
+
 // Breadcrumb board name + uppercase status chip
 const boardName = computed(() => boardData.value?.board?.title || t('kanso', 'Board'))
 
@@ -4985,10 +5082,39 @@ async function handleToggleProject(projectId) {
 /* ── Body grid ───────────────────────────────────────────────────────────── */
 .card-modal__body {
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) 400px;
+	/* main pane | drag handle | discussion pane (width from a persisted CSS var, #3661) */
+	grid-template-columns: minmax(0, 1fr) 0 var(--kanso-discussion-width, 400px);
 	align-items: stretch;
 	min-height: 0;
 	flex: 1;
+}
+/* Drag handle straddling the border between the two panes. Zero-width in the grid
+   track; widened visually via padding so it's easy to grab without shifting layout. */
+.card-modal__resizer {
+	position: relative;
+	z-index: 5;
+	width: 0;
+	margin: 0 -5px;
+	padding: 0 5px;
+	cursor: col-resize;
+	touch-action: none;
+	display: flex;
+	align-items: stretch;
+	justify-content: center;
+}
+.card-modal__resizer-grip {
+	width: 1px;
+	background: var(--color-border);
+	transition: background 0.12s ease, width 0.12s ease;
+}
+.card-modal__resizer:hover .card-modal__resizer-grip,
+.card-modal__resizer:focus-visible .card-modal__resizer-grip {
+	width: 3px;
+	background: var(--color-primary-element);
+}
+.card-modal__resizer:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -1px;
 }
 .card-modal__content {
 	display: flex;
@@ -6048,6 +6174,8 @@ async function handleToggleProject(projectId) {
 	.card-modal__attrbar { flex-wrap: nowrap; overflow-x: auto; padding: 10px 16px; }
 	.card-modal__attr-right { margin-left: 0; }
 	.card-modal__body { grid-template-columns: 1fr; }
+	/* Panes stack: the persisted split width and its drag handle are ignored. */
+	.card-modal__resizer { display: none; }
 	.card-modal__content,
 	.card-modal__discussion { max-height: none; }
 	.card-modal__discussion { border-left: none; border-top: 1px solid var(--color-border); }

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -1242,6 +1242,61 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<span v-if="attachmentError" class="card-modal__save-error">{{ attachmentError }}</span>
 						</section>
 
+						<!-- Time tracking (#3536): manual entries + per-card total -->
+						<section class="card-modal__section card-modal__section--tight">
+							<div class="card-modal__section-inline">
+								<ClockOutlineIcon :size="16" class="card-modal__eyebrow-icon" />
+								<span class="card-modal__eyebrow">{{ t('kanso', 'Time tracking') }}</span>
+								<span v-if="timeSpentTotal > 0" class="card-modal__attachment-size">{{ formatDuration(timeSpentTotal) }}</span>
+							</div>
+
+							<form v-if="canEdit" class="card-modal__time-add" @submit.prevent="handleAddTimeEntry">
+								<input
+									v-model="timeDurationInput"
+									type="text"
+									class="card-modal__time-duration"
+									:placeholder="t('kanso', 'e.g. 1h 30m')"
+									:disabled="addEntry.isPending.value">
+								<input
+									v-model="timeNoteInput"
+									type="text"
+									class="card-modal__time-note"
+									:placeholder="t('kanso', 'Note (optional)')"
+									:disabled="addEntry.isPending.value">
+								<NcButton
+									type="secondary"
+									native-type="submit"
+									:disabled="addEntry.isPending.value">
+									{{ addEntry.isPending.value ? t('kanso', 'Adding…') : t('kanso', 'Add time') }}
+								</NcButton>
+							</form>
+
+							<ul v-if="cardTimeEntries.length > 0" class="card-modal__links-list">
+								<li v-for="entry in cardTimeEntries" :key="entry.id" class="card-modal__link-row">
+									<div class="card-modal__time-entry">
+										<span class="card-modal__time-entry-duration">{{ formatDuration(entry.seconds) }}</span>
+										<span v-if="entry.note" class="card-modal__time-entry-note">{{ entry.note }}</span>
+										<span class="card-modal__time-entry-meta">
+											<NcAvatar
+												:user="entry.createdBy || ''"
+												:display-name="entry.createdBy || ''"
+												:size="16"
+												:disable-menu="true" />
+											<span class="card-modal__activity-time">{{ relativeTime(entry.createdAt) }}</span>
+										</span>
+									</div>
+									<button
+										v-if="canEdit"
+										class="card-modal__child-remove"
+										:title="t('kanso', 'Remove time entry')"
+										@click="handleRemoveTimeEntry(entry.id)">
+										<CloseIcon :size="14" />
+									</button>
+								</li>
+							</ul>
+							<span v-if="timeEntryError" class="card-modal__save-error">{{ timeEntryError }}</span>
+						</section>
+
 						<!-- Relations - shown only when the card has relations, or the
 						     editor was opened from the ⋯ menu -->
 						<section
@@ -1706,6 +1761,7 @@ import TimerSandIcon from 'vue-material-design-icons/TimerSand.vue'
 import PaletteIcon from 'vue-material-design-icons/Palette.vue'
 import FolderMultipleOutlineIcon from 'vue-material-design-icons/FolderMultipleOutline.vue'
 import PaperclipIcon from 'vue-material-design-icons/Paperclip.vue'
+import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
 import { useMentionAutocomplete } from '../composables/useMentionAutocomplete.js'
 import { useMarkdownToolbar } from '../composables/useMarkdownToolbar.js'
 import FormatBoldIcon from 'vue-material-design-icons/FormatBold.vue'
@@ -1736,6 +1792,7 @@ import { boardQueryKey } from '../composables/queryKeys.js'
 import { useSubscription } from '../composables/useSubscription.js'
 import { useCardLinks, branchName } from '../composables/useCardLinks.js'
 import { useCardAttachments } from '../composables/useCardAttachments.js'
+import { useCardTimeEntries } from '../composables/useCardTimeEntries.js'
 import { useImagePaste } from '../composables/useImagePaste.js'
 import { cardAttachmentUrl, cardAttachmentInlineUrl } from '../services/api.js'
 import { addCardRelation as apiAddCardRelation, removeCardRelation as apiRemoveCardRelation, moveCard as apiMoveCard, getCardActivity as apiGetCardActivity, copyCard as apiCopyCard, fetchBoard as apiFetchBoard, resolveCardRef as apiResolveCardRef, setCardTemplate as apiSetCardTemplate } from '../services/api.js'
@@ -3336,6 +3393,83 @@ async function handleRemoveAttachment(attachmentId) {
 		await removeAttachment.mutateAsync(attachmentId)
 	} catch (e) {
 		attachmentError.value = e?.response?.data?.error || t('kanso', 'Failed to remove attachment.')
+	}
+}
+
+// ── Time tracking (#3536) ────────────────────────────────────────────────────
+const { timeEntries: cardTimeEntriesData, addEntry, removeEntry } = useCardTimeEntries(computed(() => props.cardId))
+const cardTimeEntries = computed(() => cardTimeEntriesData.value ?? [])
+const timeDurationInput = ref('')
+const timeNoteInput = ref('')
+const timeEntryError = ref('')
+
+// The per-card total comes from the card DETAIL payload (kept off the board
+// summaries); the entries list only backs the breakdown and the delete buttons.
+const timeSpentTotal = computed(() => Number(cardData.value?.timeSpent) || 0)
+
+// Human-readable duration: 5400 → "1h 30m", 45 → "45s", 0 → "0m".
+function formatDuration(totalSeconds) {
+	const secs = Math.max(0, Math.floor(Number(totalSeconds) || 0))
+	if (secs === 0) return '0m'
+	const h = Math.floor(secs / 3600)
+	const m = Math.floor((secs % 3600) / 60)
+	const s = secs % 60
+	const parts = []
+	if (h > 0) parts.push(`${h}h`)
+	if (m > 0) parts.push(`${m}m`)
+	// Only surface bare seconds when there is no hour/minute component.
+	if (s > 0 && h === 0 && m === 0) parts.push(`${s}s`)
+	return parts.join(' ')
+}
+
+// Parses "1h 30m", "90m", "1.5h", "45s", or a bare number (minutes) into
+// seconds. Returns 0 for anything unparseable.
+function parseDuration(raw) {
+	const input = String(raw ?? '').trim().toLowerCase()
+	if (input === '') return 0
+	// A bare number is interpreted as minutes.
+	if (/^\d+(\.\d+)?$/.test(input)) {
+		return Math.round(parseFloat(input) * 60)
+	}
+	const re = /(\d+(?:\.\d+)?)\s*(h|m|s)/g
+	let match
+	let seconds = 0
+	let matched = false
+	while ((match = re.exec(input)) !== null) {
+		matched = true
+		const value = parseFloat(match[1])
+		if (match[2] === 'h') seconds += value * 3600
+		else if (match[2] === 'm') seconds += value * 60
+		else seconds += value
+	}
+	return matched ? Math.round(seconds) : 0
+}
+
+async function handleAddTimeEntry() {
+	timeEntryError.value = ''
+	const seconds = parseDuration(timeDurationInput.value)
+	if (seconds <= 0) {
+		timeEntryError.value = t('kanso', 'Enter a duration, e.g. 1h 30m.')
+		return
+	}
+	try {
+		await addEntry.mutateAsync({ seconds, note: timeNoteInput.value.trim() || null })
+		timeDurationInput.value = ''
+		timeNoteInput.value = ''
+		// Refresh the card detail so the total (timeSpent) reflects the new entry.
+		queryClient.invalidateQueries({ queryKey: ['card', props.cardId] })
+	} catch (e) {
+		timeEntryError.value = e?.response?.data?.error || t('kanso', 'Failed to add time entry.')
+	}
+}
+
+async function handleRemoveTimeEntry(entryId) {
+	timeEntryError.value = ''
+	try {
+		await removeEntry.mutateAsync(entryId)
+		queryClient.invalidateQueries({ queryKey: ['card', props.cardId] })
+	} catch (e) {
+		timeEntryError.value = e?.response?.data?.error || t('kanso', 'Failed to remove time entry.')
 	}
 }
 
@@ -5197,6 +5331,46 @@ async function handleToggleProject(projectId) {
 	display: flex;
 	gap: 8px;
 	align-items: center;
+}
+/* Time tracking (#3536) */
+.card-modal__time-add {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+	margin-top: 4px;
+}
+.card-modal__time-duration {
+	width: 110px;
+	flex: 0 0 auto;
+}
+.card-modal__time-note {
+	flex: 1 1 120px;
+	min-width: 120px;
+}
+.card-modal__time-entry {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex: 1;
+	min-width: 0;
+}
+.card-modal__time-entry-duration {
+	font-weight: 600;
+	white-space: nowrap;
+}
+.card-modal__time-entry-note {
+	color: var(--color-text-maxcontrast);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.card-modal__time-entry-meta {
+	margin-left: auto;
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	white-space: nowrap;
 }
 .card-modal__link-add .card-modal__dashed-input {
 	flex: 1;

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -44,9 +44,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</div>
 			</div>
 
-			<!-- Error state -->
+			<!-- Error state - status-aware, with a way out (#3662). A 404/403 from a
+			     dead deep-link/inbox/notification reads as "gone"/"no access" and is a
+			     dead end; a transient failure offers a retry. -->
 			<div v-else-if="isError" class="card-modal__error">
-				{{ t('kanso', 'Failed to load card details.') }}
+				<p class="card-modal__error-msg">{{ cardErrorMessage }}</p>
+				<div class="card-modal__error-actions">
+					<NcButton v-if="cardErrorRetryable" type="primary" @click="retryCardLoad">
+						{{ t('kanso', 'Retry') }}
+					</NcButton>
+					<NcButton v-if="boardData" @click="closeModal">
+						{{ t('kanso', 'Back to board') }}
+					</NcButton>
+					<NcButton :type="boardData ? 'tertiary' : 'primary'" @click="goToBoards">
+						{{ t('kanso', 'Go to boards') }}
+					</NcButton>
+				</div>
 			</div>
 
 			<!-- Card content -->
@@ -1922,7 +1935,7 @@ watch([() => props.cardId, boardId], async ([cardId, bId]) => {
 	}
 }, { immediate: true })
 
-const { data: cardData, isLoading: cardIsLoading, isError: cardIsError, updateCard } = useCard(
+const { data: cardData, isLoading: cardIsLoading, isError: cardIsError, error: cardError, refetch: cardRefetch, updateCard } = useCard(
 	computed(() => props.cardId),
 	// Only fetch once the id is numeric (a human ref is redirected first).
 	computed(() => isOpen.value && isNumericCardId.value),
@@ -1933,6 +1946,36 @@ const isLoading = computed(() => cardIsLoading.value || (!isNumericCardId.value 
 // Surface a failed human-ref resolution through the same error path as a failed
 // card fetch, so the template's not-found branch covers both.
 const isError = computed(() => cardIsError.value || refResolveError.value)
+
+// Distinguish "the card is gone / forbidden" from a transient load failure so the
+// error slot can show friendly, actionable copy instead of a raw failure (#3662).
+// A failed human-ref resolution (refResolveError) means the reference didn't
+// resolve to a live card - treat it as a 404 (gone). Otherwise read the real HTTP
+// status off the axios rejection: 404 = deleted, 403 = access revoked, anything
+// else (incl. a network error with no response) = transient/retryable.
+const cardErrorStatus = computed(() => {
+	if (refResolveError.value) return 404
+	return cardError.value?.response?.status ?? null
+})
+const cardIsGone = computed(() => cardErrorStatus.value === 404)
+const cardIsForbidden = computed(() => cardErrorStatus.value === 403)
+const cardErrorMessage = computed(() => {
+	if (cardIsGone.value) {
+		return t('kanso', 'This card no longer exists — it may have been deleted.')
+	}
+	if (cardIsForbidden.value) {
+		return t('kanso', 'You no longer have access to this card.')
+	}
+	return t('kanso', 'Couldn\'t load this card. Please try again.')
+})
+// A gone/forbidden card is a dead end - there is nothing to retry. A transient
+// failure can be retried by refetching the query. (refResolveError always maps to
+// 404, so a retryable error is always a real numeric-id fetch failure.)
+const cardErrorRetryable = computed(() => !cardIsGone.value && !cardIsForbidden.value)
+
+function retryCardLoad() {
+	cardRefetch()
+}
 
 // Read board data from cache (same queryKey as BoardView - no extra request).
 const { data: boardData } = useBoard(boardId)
@@ -3176,6 +3219,21 @@ function closeModal() {
 	router.push({ name: 'board', params: { id: route.params.id } })
 }
 
+// Escape hatch from a dead card link (#3662): leave the (possibly gone) board
+// entirely. Return to the My Work hub if that's where the user came from,
+// otherwise fall back to the boards list - never route back into a board that
+// may itself no longer exist.
+function goToBoards() {
+	isOpen.value = false
+	const from = route.query.from
+	if (MY_WORK_RETURN_ROUTES.includes(from)) {
+		const query = from === 'my-work' && route.query.tab ? { tab: route.query.tab } : undefined
+		router.push({ name: from, query })
+		return
+	}
+	router.push({ name: 'board-list' })
+}
+
 // Escape at the modal root: an open attribute popover takes precedence — close
 // it, not the whole card (which would discard an in-progress edit). Inline edits
 // (title/description/comment) stop propagation themselves, so they never reach here.
@@ -4108,6 +4166,19 @@ async function handleToggleProject(projectId) {
 	padding: 40px 24px;
 	text-align: center;
 	color: var(--color-error);
+}
+
+.card-modal__error-msg {
+	margin: 0 0 20px;
+	color: var(--color-main-text);
+	font-size: 1.05rem;
+}
+
+.card-modal__error-actions {
+	display: flex;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 10px;
 }
 
 /* ── Verdict banner (review requested) ───────────────────────────────────── */

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -1297,6 +1297,85 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<span v-if="timeEntryError" class="card-modal__save-error">{{ timeEntryError }}</span>
 						</section>
 
+						<!-- Custom fields (#3537): shown only when the board has fields -->
+						<section
+							v-if="boardCardFields.length > 0"
+							class="card-modal__section card-modal__section--tight"
+							data-test="card-custom-fields">
+							<div class="card-modal__section-inline">
+								<TableColumnIcon :size="16" class="card-modal__eyebrow-icon" />
+								<span class="card-modal__eyebrow">{{ t('kanso', 'Custom fields') }}</span>
+							</div>
+							<ul class="card-modal__cf-list">
+								<li
+									v-for="field in boardCardFields"
+									:key="field.id"
+									class="card-modal__cf-row">
+									<label
+										:for="`card-cf-${field.id}`"
+										class="card-modal__cf-label">
+										{{ field.name }}
+									</label>
+									<!-- text -->
+									<input
+										v-if="field.type === 'text'"
+										:id="`card-cf-${field.id}`"
+										class="card-modal__cf-input"
+										type="text"
+										:value="(cardData.fieldValues ?? []).find(fv => fv.fieldId === field.id)?.value ?? ''"
+										:disabled="!canEdit"
+										:aria-label="field.name"
+										:data-test="`cf-input-${field.id}`"
+										@change="handleFieldChange(field, $event.target.value)"
+										@blur="handleFieldChange(field, $event.target.value)">
+									<!-- number -->
+									<input
+										v-else-if="field.type === 'number'"
+										:id="`card-cf-${field.id}`"
+										class="card-modal__cf-input"
+										type="number"
+										:value="(cardData.fieldValues ?? []).find(fv => fv.fieldId === field.id)?.value ?? ''"
+										:disabled="!canEdit"
+										:aria-label="field.name"
+										:data-test="`cf-input-${field.id}`"
+										@change="handleFieldChange(field, $event.target.value)"
+										@blur="handleFieldChange(field, $event.target.value)">
+									<!-- date -->
+									<input
+										v-else-if="field.type === 'date'"
+										:id="`card-cf-${field.id}`"
+										class="card-modal__cf-input"
+										type="date"
+										:value="(cardData.fieldValues ?? []).find(fv => fv.fieldId === field.id)?.value ?? ''"
+										:disabled="!canEdit"
+										:aria-label="field.name"
+										:data-test="`cf-input-${field.id}`"
+										@change="handleFieldChange(field, $event.target.value)">
+									<!-- select -->
+									<select
+										v-else-if="field.type === 'select'"
+										:id="`card-cf-${field.id}`"
+										class="card-modal__cf-select"
+										:value="(cardData.fieldValues ?? []).find(fv => fv.fieldId === field.id)?.value ?? ''"
+										:disabled="!canEdit"
+										:aria-label="field.name"
+										:data-test="`cf-select-${field.id}`"
+										@change="handleFieldChange(field, $event.target.value)">
+										<option value="">{{ t('kanso', '— none —') }}</option>
+										<option
+											v-for="opt in (field.options ?? [])"
+											:key="opt"
+											:value="opt">
+											{{ opt }}
+										</option>
+									</select>
+									<span v-if="cardFieldErrors[field.id]" class="card-modal__save-error">
+										{{ cardFieldErrors[field.id] }}
+									</span>
+								</li>
+							</ul>
+						</section>
+
 						<!-- Relations - shown only when the card has relations, or the
 						     editor was opened from the ⋯ menu -->
 						<section
@@ -1762,6 +1841,7 @@ import PaletteIcon from 'vue-material-design-icons/Palette.vue'
 import FolderMultipleOutlineIcon from 'vue-material-design-icons/FolderMultipleOutline.vue'
 import PaperclipIcon from 'vue-material-design-icons/Paperclip.vue'
 import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
+import TableColumnIcon from 'vue-material-design-icons/TableColumn.vue'
 import { useMentionAutocomplete } from '../composables/useMentionAutocomplete.js'
 import { useMarkdownToolbar } from '../composables/useMarkdownToolbar.js'
 import FormatBoldIcon from 'vue-material-design-icons/FormatBold.vue'
@@ -1797,6 +1877,7 @@ import { useImagePaste } from '../composables/useImagePaste.js'
 import { cardAttachmentUrl, cardAttachmentInlineUrl } from '../services/api.js'
 import { addCardRelation as apiAddCardRelation, removeCardRelation as apiRemoveCardRelation, moveCard as apiMoveCard, getCardActivity as apiGetCardActivity, copyCard as apiCopyCard, fetchBoard as apiFetchBoard, resolveCardRef as apiResolveCardRef, setCardTemplate as apiSetCardTemplate } from '../services/api.js'
 import { useBoards } from '../composables/useBoards.js'
+import { useCardFields } from '../composables/useCardFields.js'
 import { cssColor, LABEL_COLOR_PRESETS, readableColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
 import { renderMarkdown, buildCardRefMap } from '../services/markdown.js'
@@ -1862,6 +1943,27 @@ const isError = computed(() => cardIsError.value || refResolveError.value)
 const { data: boardData } = useBoard(boardId)
 const boardLabels = computed(() => boardData.value?.labels ?? [])
 const boardReviewTypes = computed(() => boardData.value?.reviewTypes ?? [])
+const boardCardFields = computed(() => boardData.value?.cardFields ?? [])
+
+// ── Card fields: value mutations ──────────────────────────────────────────────
+const { setCardFieldValue, clearCardFieldValue } = useCardFields(boardId)
+const cardFieldErrors = ref({})
+
+async function handleFieldChange(field, value) {
+	cardFieldErrors.value = { ...cardFieldErrors.value, [field.id]: '' }
+	try {
+		if (value === '' || value === null || value === undefined) {
+			await clearCardFieldValue.mutateAsync({ cardId: Number(props.cardId), fieldId: field.id })
+		} else {
+			await setCardFieldValue.mutateAsync({ cardId: Number(props.cardId), fieldId: field.id, value: String(value) })
+		}
+	} catch (err) {
+		cardFieldErrors.value = {
+			...cardFieldErrors.value,
+			[field.id]: err?.response?.data?.error || t('kanso', 'Failed to save field value.'),
+		}
+	}
+}
 
 // ── Card lifecycle actions (archive / delete) ────────────────────────────────
 const { setArchived, deleteCard, restoreCard } = useCardActions(boardId, computed(() => props.cardId))
@@ -5926,6 +6028,53 @@ async function handleToggleProject(projectId) {
 }
 .card-modal__assign-option--highlighted {
 	background: var(--color-background-hover);
+}
+
+/* ── Custom fields section (#3537) ──────────────────────────────────────────── */
+
+.card-modal__cf-list {
+	list-style: none;
+	margin: 8px 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.card-modal__cf-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.card-modal__cf-label {
+	flex: 0 0 120px;
+	font-size: 0.8rem;
+	color: var(--color-text-maxcontrast);
+	font-weight: 600;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.card-modal__cf-input,
+.card-modal__cf-select {
+	flex: 1 1 120px;
+	min-width: 80px;
+	max-width: 260px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	padding: 4px 8px;
+	font-size: 0.875rem;
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.card-modal__cf-input:disabled,
+.card-modal__cf-select:disabled {
+	opacity: 0.6;
+	cursor: default;
 }
 </style>
 

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -769,7 +769,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							v-for="review in cardReviews"
 							:key="review.id"
 							class="card-modal__review-pill"
-							:class="[`card-modal__review-pill--${review.state}`, { 'card-modal__review-pill--compact': reviewsCompact }]">
+							:class="[`card-modal__review-pill--${review.state}`, {
+								'card-modal__review-pill--compact': reviewsCompact,
+								'card-modal__review-pill--gated': review.gated,
+							}]"
+							:title="review.gated ? reviewGateTooltip(review) : null">
 							<NcAvatar
 								:user="review.reviewer"
 								:display-name="participantName(review.reviewer)"
@@ -785,11 +789,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									: {}">
 								{{ reviewTypeById(review.reviewTypeId).title }}
 							</span>
-							<span class="card-modal__review-state" :class="`card-modal__review-state--${review.state}`">
-								<CheckDecagramIcon v-if="review.state === 'approved'" :size="12" />
+							<span
+								class="card-modal__review-state"
+								:class="review.gated ? 'card-modal__review-state--gated' : `card-modal__review-state--${review.state}`">
+								<LockOutlineIcon v-if="review.gated" :size="12" />
+								<CheckDecagramIcon v-else-if="review.state === 'approved'" :size="12" />
 								<AlertDecagramIcon v-else-if="review.state === 'changes_requested'" :size="12" />
 								<CheckDecagramOutlineIcon v-else :size="12" />
-								<span class="card-modal__review-state-label">{{ reviewStateLabel(review.state) }}</span>
+								<span class="card-modal__review-state-label">{{ review.gated ? t('kanso', 'Waiting') : reviewStateLabel(review.state) }}</span>
 							</span>
 							<button
 								v-if="canEdit"
@@ -1680,6 +1687,7 @@ import BroomIcon from 'vue-material-design-icons/Broom.vue'
 import TagOutlineIcon from 'vue-material-design-icons/TagOutline.vue'
 import LinkOffIcon from 'vue-material-design-icons/LinkOff.vue'
 import SitemapIcon from 'vue-material-design-icons/Sitemap.vue'
+import LockOutlineIcon from 'vue-material-design-icons/LockOutline.vue'
 import EyeOutlineIcon from 'vue-material-design-icons/EyeOutline.vue'
 import EyeOffOutlineIcon from 'vue-material-design-icons/EyeOffOutline.vue'
 import CheckDecagramIcon from 'vue-material-design-icons/CheckDecagram.vue'
@@ -2180,6 +2188,21 @@ function reviewStateLabel(state) {
 	if (state === 'approved') return t('kanso', 'Approved')
 	if (state === 'changes_requested') return t('kanso', 'Changes requested')
 	return t('kanso', 'Pending')
+}
+
+// A gated review is pending but blocked by a lower-stage review that hasn't
+// been approved yet; its reviewer isn't notified until the blocker clears.
+function reviewGateTooltip(review) {
+	if (!review.gated) return ''
+	const blockers = Array.isArray(review.blockedBy) ? review.blockedBy : []
+	// Name the blocking lower-stage review type(s) when we can resolve them.
+	const names = blockers
+		.map((id) => cardReviews.value.find((r) => r.id === id))
+		.filter(Boolean)
+		.map((r) => (reviewTypeById(r.reviewTypeId)?.title) || t('kanso', 'Review'))
+	const unique = [...new Set(names)]
+	if (unique.length === 0) return t('kanso', 'Waiting on an earlier review')
+	return t('kanso', 'Waiting on {type} review', { type: unique.join(', ') })
 }
 
 // ── Done toggle ──────────────────────────────────────────────────────────────
@@ -4293,6 +4316,15 @@ async function handleToggleProject(projectId) {
 .card-modal__review-pill--pending { border-color: var(--color-warning-text); background: rgba(236, 167, 0, 0.08); }
 .card-modal__review-pill--approved { border-color: var(--color-success-text); background: rgba(70, 186, 97, 0.08); }
 .card-modal__review-pill--changes_requested { border-color: var(--color-error-text); background: rgba(233, 50, 45, 0.08); }
+/* A gated (deferred) review reads as inert: greyed out, dashed border, muted
+   colours. The lock icon + hover tooltip explain it's waiting on an earlier
+   review. Wins over the state colour because the class comes later. */
+.card-modal__review-pill--gated {
+	border-color: var(--color-border-dark);
+	border-style: dashed;
+	background: var(--color-background-dark);
+	opacity: 0.7;
+}
 .card-modal__review-name {
 	max-width: 120px;
 	overflow: hidden;
@@ -4318,6 +4350,7 @@ async function handleToggleProject(projectId) {
 .card-modal__review-state--pending { color: var(--color-warning-text); }
 .card-modal__review-state--approved { color: var(--color-success-text); }
 .card-modal__review-state--changes_requested { color: var(--color-error-text); }
+.card-modal__review-state--gated { color: var(--color-text-maxcontrast); }
 /* Compact mode (3+ reviews): drop the reviewer name and the state text so the
    chip shrinks to avatar + type badge + state icon and N reviews stay on one
    row. The reviewer name is still available via the avatar's hover tooltip and

--- a/src/components/CardPreview.vue
+++ b/src/components/CardPreview.vue
@@ -77,7 +77,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:user="uid"
 					:display-name="participantName(uid)"
 					:size="22"
-					:show-user-status="false"
+					:hide-status="true"
 					:disable-tooltip="false"
 					class="card-preview__avatar" />
 			</div>

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -147,7 +147,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						:key="uid"
 						:user="uid"
 						:size="24"
-						:show-user-status="false"
+						:hide-status="true"
 						:disable-tooltip="false"
 						class="card-tile__avatar" />
 					<span v-if="extraAssigneeCount > 0" class="card-tile__avatar-overflow">

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -14,37 +14,41 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			class="stack-column__header"
 			:class="{ 'stack-column__header--colored': !!stack.color }"
 			:style="stack.color ? { '--stack-color': cssColor(stack.color) } : {}">
-			<input
-				v-if="editingTitle"
-				ref="titleInputRef"
-				v-model="titleDraft"
-				class="stack-column__title-input"
-				:aria-label="t('kanso', 'Column name')"
-				@keydown.enter.prevent="saveTitle"
-				@keydown.esc.prevent="cancelEditTitle"
-				@blur="onTitleBlur">
-			<span
-				v-else
-				class="stack-column__title"
-				:class="{ 'stack-column__title--editable': !!onRenameStack }"
-				:role="onRenameStack ? 'button' : null"
-				:tabindex="onRenameStack ? 0 : null"
-				:title="onRenameStack ? t('kanso', 'Rename column') : null"
-				@click="startEditTitle"
-				@keydown.enter="startEditTitle">{{ stack.title }}</span>
-			<span
-				v-if="stack.role > 0"
-				class="stack-column__role-chip"
-				:class="`stack-column__role-chip--${stack.role}`"
-				:title="roleLabel(stack.role)">
-				{{ roleLabel(stack.role) }}
-			</span>
-			<span
-				class="stack-column__badge"
-				:class="{ 'stack-column__badge--over-limit': isOverLimit }">
-				{{ wipBadgeText }}
-			</span>
-			<!-- Stack actions menu - rendered whenever at least one edit action is wired -->
+			<div class="stack-column__header-row">
+				<input
+					v-if="editingTitle"
+					ref="titleInputRef"
+					v-model="titleDraft"
+					class="stack-column__title-input"
+					:aria-label="t('kanso', 'Column name')"
+					@keydown.enter.prevent="saveTitle"
+					@keydown.esc.prevent="cancelEditTitle"
+					@blur="onTitleBlur">
+				<span
+					v-else
+					class="stack-column__title"
+					:class="{ 'stack-column__title--editable': !!onRenameStack }"
+					:role="onRenameStack ? 'button' : null"
+					:tabindex="onRenameStack ? 0 : null"
+					:title="onRenameStack ? t('kanso', 'Rename column') : null"
+					@click="startEditTitle"
+					@keydown.enter="startEditTitle">{{ stack.title }}</span>
+				<!-- Plain card count / WIP text (mockup: "12" or "4 / 3"). The count/limit
+				     text is kept here (not a pill) so the WIP figure stays visible; the
+				     visual "over limit" cue is the meter bar + caption below. -->
+				<span
+					class="stack-column__badge"
+					:class="{ 'stack-column__badge--over-limit': isOverLimit }">
+					{{ wipBadgeText }}
+				</span>
+				<span
+					v-if="stack.role > 0"
+					class="stack-column__role-chip"
+					:class="`stack-column__role-chip--${stack.role}`"
+					:title="roleLabel(stack.role)">
+					{{ roleLabel(stack.role) }}
+				</span>
+				<!-- Stack actions menu - rendered whenever at least one edit action is wired -->
 			<NcActions
 				v-if="onDeleteStack || onRenameStack || onSetRole || onSetWip"
 				class="stack-column__actions"
@@ -129,6 +133,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</NcActionButton>
 				</template>
 			</NcActions>
+			</div>
+
+			<!-- WIP meter (mockup 1a): a 2px fill bar under the header. With a WIP
+			     limit set, the fill tracks fill ratio (capped at 100%) and turns to
+			     the warning colour once at/over the limit; without a limit it stays a
+			     neutral track. Replaces the old count/limit pill badge. -->
+			<div
+				class="stack-column__wip-meter"
+				:class="{ 'stack-column__wip-meter--over': isOverLimit, 'stack-column__wip-meter--at': isAtLimit && !isOverLimit }"
+				role="presentation">
+				<div
+					v-if="hasWipLimit"
+					class="stack-column__wip-fill"
+					:style="{ width: wipFillPct + '%' }" />
+			</div>
+			<div v-if="isOverLimit" class="stack-column__wip-caption">
+				{{ t('kanso', '{n} over the WIP limit', { n: cards.length - stack.wipLimit }) }}
+			</div>
 		</div>
 
 		<!-- Inline card composer at TOP - signature rapid-entry UX -->
@@ -544,6 +566,14 @@ async function handleSetColor(color) {
  */
 const hasWipLimit = computed(() => typeof props.stack.wipLimit === 'number' && props.stack.wipLimit > 0)
 const isOverLimit = computed(() => hasWipLimit.value && props.cards.length > props.stack.wipLimit)
+const isAtLimit = computed(() => hasWipLimit.value && props.cards.length >= props.stack.wipLimit)
+
+/** Meter fill ratio (0-100), capped at 100 once at/over the limit. */
+const wipFillPct = computed(() => {
+	if (!hasWipLimit.value) return 0
+	const pct = (props.cards.length / props.stack.wipLimit) * 100
+	return Math.max(0, Math.min(100, pct))
+})
 
 const wipBadgeText = computed(() => {
 	if (!hasWipLimit.value) return String(props.cards.length)
@@ -787,6 +817,9 @@ async function createFromTemplate(templateId) {
 </script>
 
 <style scoped>
+/* Quiet-columns (variant 1a): a white / raised column surface that lifts off the
+   sunken board canvas. --color-main-background + a soft shadow gives the "raised"
+   read against the board-view__stacks-wrap sunken background. */
 .stack-column {
 	position: relative;
 	flex-shrink: 0;
@@ -794,11 +827,12 @@ async function createFromTemplate(templateId) {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	background: var(--color-background-hover);
+	background: var(--color-main-background);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius-large);
 	padding: 12px;
 	max-height: calc(100vh - 140px);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 .stack-column--dragging {
@@ -827,17 +861,26 @@ async function createFromTemplate(templateId) {
 
 .stack-column__header {
 	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-	padding-bottom: 8px;
-	border-bottom: 1px solid var(--color-border);
+	flex-direction: column;
+	gap: 0;
 	cursor: grab;
 }
-/* Coloured column: a bottom accent bar in the stack colour. */
-.stack-column__header--colored {
-	border-bottom-color: var(--stack-color);
-	border-bottom-width: 3px;
+.stack-column__header-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+/* Coloured column: the meter track below the header takes the stack colour as its
+   accent (see --stack-color usage in the meter rules). */
+/* Actions menu - sits at the far right; margin-left:auto pushes it right when
+   no role chip is present (when a role chip is present it already took the auto
+   margin and the menu simply trails it). */
+.stack-column__actions {
+	flex-shrink: 0;
+	margin-left: auto;
+}
+.stack-column__role-chip + .stack-column__actions {
+	margin-left: 4px;
 }
 .stack-column__swatch {
 	display: inline-block;
@@ -884,19 +927,58 @@ async function createFromTemplate(templateId) {
 	margin: 0;
 }
 
+/* Card count / WIP figure - plain muted text next to the title (mockup 1a).
+   No longer a filled pill; the "over limit" signal is the meter + caption. */
 .stack-column__badge {
 	flex-shrink: 0;
 	display: inline-flex;
 	align-items: center;
-	justify-content: center;
-	min-width: 20px;
-	height: 20px;
-	padding: 0 6px;
-	border-radius: 10px;
-	background: var(--color-border);
+	font-size: 0.8rem;
+	font-weight: 500;
 	color: var(--color-text-maxcontrast);
-	font-size: 0.75rem;
+}
+
+.stack-column__badge--over-limit {
+	color: color-mix(in srgb, var(--color-warning, #eca700) 85%, var(--color-main-text));
 	font-weight: 600;
+}
+
+/* WIP meter - a 2px track under the header. Neutral track by default; with a
+   limit the fill tracks the ratio and shifts to the warning colour at/over it.
+   Mirrors the --kanso-tint-* color-mix fallback pattern used elsewhere. */
+.stack-column__wip-meter {
+	position: relative;
+	height: 2px;
+	margin-top: 10px;
+	border-radius: 1px;
+	background: var(--color-border);
+	overflow: hidden;
+}
+/* Coloured column: tint the meter track with the stack colour. */
+.stack-column__header--colored .stack-column__wip-meter {
+	background: color-mix(in srgb, var(--stack-color) 40%, var(--color-border));
+}
+.stack-column__wip-fill {
+	position: absolute;
+	inset: 0 auto 0 0;
+	height: 100%;
+	background: var(--color-primary-element, #0082c9);
+	border-radius: 1px;
+	transition: width 0.2s ease;
+}
+.stack-column__wip-meter--at .stack-column__wip-fill {
+	background: color-mix(in srgb, var(--color-warning, #eca700) 90%, transparent);
+}
+.stack-column__wip-meter--over {
+	background: var(--kanso-tint-warning, color-mix(in srgb, var(--color-warning, #eca700) 20%, transparent));
+}
+.stack-column__wip-meter--over .stack-column__wip-fill {
+	background: var(--color-warning, #eca700);
+}
+.stack-column__wip-caption {
+	margin-top: 6px;
+	font-size: 0.7rem;
+	color: color-mix(in srgb, var(--color-warning, #eca700) 85%, var(--color-main-text));
 }
 
 /* Card composer */
@@ -972,9 +1054,10 @@ async function createFromTemplate(templateId) {
 	border-radius: var(--border-radius);
 }
 
-/* Role chip */
+/* Role chip - pushed to the right edge of the header row (mockup 1a). */
 .stack-column__role-chip {
 	flex-shrink: 0;
+	margin-left: auto;
 	display: inline-flex;
 	align-items: center;
 	height: 18px;

--- a/src/composables/useBoard.js
+++ b/src/composables/useBoard.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { computed } from 'vue'
+import { computed, onScopeDispose } from 'vue'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
 	fetchBoard,
@@ -14,6 +14,7 @@ import {
 } from '../services/api.js'
 import { pushActive } from '../services/realtime.js'
 import { isBoardMovePending } from './useCardMove.js'
+import { seedCursor, syncBoardDelta } from './useBoardDelta.js'
 import { boardQueryKey } from './queryKeys.js'
 // Re-export from the shared key module so existing callers of
 // import { boardQueryKey } from './useBoard.js' continue to work.
@@ -34,17 +35,39 @@ export function useBoard(id) {
 
 	const query = useQuery({
 		queryKey: boardKey,
-		queryFn: () => fetchBoard(typeof id === 'object' ? id.value : id),
-		// Delta polling: the fallback realtime channel (5s, cheap thanks to
-		// ETag/304) or a slow safety net when push covers realtime (60s).
-		// Never fires mid-drag - a refetch would clobber optimistic patches.
+		queryFn: async () => {
+			const boardId = typeof id === 'object' ? id.value : id
+			const data = await fetchBoard(boardId)
+			// Seed / re-seed the delta-sync cursor from the board payload's
+			// latest change id, so the delta poll can advance from here (#3675).
+			seedCursor(boardId, data.cursor)
+			return data
+		},
+		// Belt-and-suspenders full refetch (charter's state pattern): a slow 60s
+		// safety net that self-heals any missed delta and re-seeds the cursor.
+		// The fast realtime channel is now the delta poll below, not this refetch,
+		// so even without push we only fall back to a full board read once a
+		// minute. Never fires mid-drag - a refetch would clobber optimistic patches.
 		refetchInterval: () => {
 			if (isBoardMovePending(id)) {
 				return false
 			}
-			return pushActive() ? 60_000 : 5_000
+			return 60_000
 		},
 	})
+
+	// Delta poll (#3675): instead of re-downloading the whole board, fetch only
+	// the changes since our cursor and PATCH the cache. Fast when push is absent
+	// (5s), a slow secondary safety net when push covers realtime (30s, since the
+	// push handler in main.js already delta-syncs on each mutation). Guarded to
+	// never run mid-drag inside syncBoardDelta.
+	const deltaTimer = setInterval(() => {
+		if (isBoardMovePending(id)) {
+			return
+		}
+		syncBoardDelta(queryClient, id)
+	}, pushActive() ? 30_000 : 5_000)
+	onScopeDispose(() => clearInterval(deltaTimer))
 
 	const createStack = useMutation({
 		mutationFn: (data) => apiCreateStack(data),

--- a/src/composables/useBoardDelta.js
+++ b/src/composables/useBoardDelta.js
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { fetchBoardChanges } from '../services/api.js'
+import { isBoardMovePending } from './useCardMove.js'
+import { boardQueryKey } from './queryKeys.js'
+
+/**
+ * Board delta-sync (#3675). A single change no longer re-downloads the whole
+ * board: the client polls `GET /api/boards/{id}/changes?since=<cursor>` and
+ * PATCHES the TanStack cache with only the touched cards/stacks - O(delta), not
+ * O(boardSize).
+ *
+ * Cursor lifecycle (database-first, per the charter's state pattern):
+ *  - seedCursor() is called with `data.cursor` on every full fetchBoard, so the
+ *    cursor is always re-seeded from the server's source of truth.
+ *  - syncBoardDelta() advances the cursor only AFTER a successful cache patch.
+ *  - on resync (server says the delta is unusable) or any error, the cursor is
+ *    dropped and a full board invalidate re-seeds it. The query's own slow 60s
+ *    refetchInterval is the belt-and-suspenders that self-heals any missed delta.
+ *
+ * Mid-drag safety: never patch while a move is pending for the board - a patch
+ * (like a refetch) would clobber the optimistic move placement. The move queue's
+ * drain invalidate (useCardMove) is the post-drag reconciliation point.
+ */
+
+// Module-level cursor registry, keyed by String(boardId) (mirrors
+// useCardMove's pendingByBoard). Shared across every consumer of the board
+// cache (the useBoard poll and the main.js push handler) so they advance the
+// same cursor.
+const cursorByBoard = new Map()
+
+function keyOf(boardId) {
+	const value = typeof boardId === 'object' && boardId !== null && boardId.value !== undefined
+		? boardId.value
+		: boardId
+	return String(value)
+}
+
+/**
+ * Seed / re-seed the board's cursor from a full board payload's `data.cursor`.
+ * Called after every fetchBoard so a full refetch always resets the cursor to
+ * the server's latest change id.
+ *
+ * @param {number|string|import('vue').Ref} boardId
+ * @param {number} cursor the board's latest change id from the board payload
+ */
+export function seedCursor(boardId, cursor) {
+	if (typeof cursor === 'number' && Number.isFinite(cursor)) {
+		cursorByBoard.set(keyOf(boardId), cursor)
+	}
+}
+
+/**
+ * Drop the board's cursor - forces the next full fetchBoard to re-seed it.
+ *
+ * @param {number|string|import('vue').Ref} boardId
+ */
+export function dropCursor(boardId) {
+	cursorByBoard.delete(keyOf(boardId))
+}
+
+/**
+ * Immutably apply a `{upsert, remove}` delta to an array of entities keyed by
+ * `id`: upsert replaces-by-id-or-appends, remove filters out the given ids.
+ *
+ * @param {Array<object>} list the current cached entities
+ * @param {{upsert?: Array<object>, remove?: Array<number>}} delta
+ * @return {Array<object>} a new array (never mutated in place)
+ */
+function applyDelta(list, delta) {
+	const current = Array.isArray(list) ? list : []
+	const upsert = delta?.upsert ?? []
+	const removeIds = new Set(delta?.remove ?? [])
+
+	const byId = new Map(current.map((e) => [e.id, e]))
+	for (const entity of upsert) {
+		byId.set(entity.id, entity)
+	}
+	const next = []
+	for (const entity of byId.values()) {
+		if (!removeIds.has(entity.id)) {
+			next.push(entity)
+		}
+	}
+	return next
+}
+
+/**
+ * Fetch and apply the board delta since the client's cursor, patching the
+ * TanStack cache in place. A no-op when there's no cursor yet (a full fetch
+ * hasn't seeded one), when a move is pending (never patch mid-drag), or when
+ * there's no cached board to patch. On `resync` or any error it drops the cursor
+ * and invalidates the board query (a full refetch re-seeds the cursor).
+ *
+ * @param {import('@tanstack/vue-query').QueryClient} queryClient
+ * @param {number|string|import('vue').Ref} boardId
+ * @return {Promise<void>}
+ */
+export async function syncBoardDelta(queryClient, boardId) {
+	if (isBoardMovePending(boardId)) {
+		return
+	}
+	const key = keyOf(boardId)
+	const since = cursorByBoard.get(key)
+	if (since === undefined) {
+		// No cursor yet: let the query's own fetch seed one instead of guessing.
+		return
+	}
+	const boardKey = boardQueryKey(boardId)
+
+	let delta
+	try {
+		delta = await fetchBoardChanges(key, since)
+	} catch {
+		// A failed delta read must never leave the client silently stale: drop the
+		// cursor and fall back to a full refetch (which re-seeds the cursor).
+		dropCursor(boardId)
+		queryClient.invalidateQueries({ queryKey: boardKey })
+		return
+	}
+
+	if (delta?.resync) {
+		dropCursor(boardId)
+		queryClient.invalidateQueries({ queryKey: boardKey })
+		return
+	}
+
+	// A move may have STARTED while the delta was in flight - re-check before
+	// patching so we never clobber an optimistic placement mid-drag.
+	if (isBoardMovePending(boardId)) {
+		return
+	}
+
+	const existing = queryClient.getQueryData(boardKey)
+	if (!existing) {
+		// Nothing cached to patch (board not loaded / evicted): just record the
+		// advanced cursor; a future full fetch re-seeds from the payload anyway.
+		cursorByBoard.set(key, delta.cursor)
+		return
+	}
+
+	queryClient.setQueryData(boardKey, (old) => {
+		if (!old) return old
+		return {
+			...old,
+			cards: applyDelta(old.cards, delta.cards),
+			stacks: applyDelta(old.stacks, delta.stacks),
+		}
+	})
+
+	// Advance the cursor only after a successful patch.
+	cursorByBoard.set(key, delta.cursor)
+}

--- a/src/composables/useCardFields.js
+++ b/src/composables/useCardFields.js
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useQueryClient, useMutation } from '@tanstack/vue-query'
+import {
+	createCardField as apiCreateCardField,
+	updateCardField as apiUpdateCardField,
+	deleteCardField as apiDeleteCardField,
+	setCardFieldValue as apiSetCardFieldValue,
+	clearCardFieldValue as apiClearCardFieldValue,
+} from '../services/api.js'
+import { boardQueryKey } from './useBoard.js'
+
+function resolveBoardId(boardId) {
+	if (typeof boardId === 'function') return boardId()
+	if (boardId !== null && typeof boardId === 'object' && boardId.value !== undefined) return boardId.value
+	return boardId
+}
+
+/**
+ * Custom fields (#3537). DEFINITION mutations (create/update/delete) ride the
+ * board payload, so they invalidate the board query. VALUE mutations
+ * (set/clear) live in the card detail payload; the caller passes a cardId and
+ * we invalidate that card's query so the modal refetches the fresh values.
+ */
+export function useCardFields(boardId) {
+	const queryClient = useQueryClient()
+
+	function getBoardKey() {
+		return boardQueryKey(resolveBoardId(boardId))
+	}
+
+	const createCardField = useMutation({
+		mutationFn: ({ name, type, options }) =>
+			apiCreateCardField(resolveBoardId(boardId), name, type, options ?? null),
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+		},
+	})
+
+	const updateCardField = useMutation({
+		mutationFn: ({ fieldId, name, options, sortKey }) =>
+			apiUpdateCardField(fieldId, {
+				...(name !== undefined ? { name } : {}),
+				...(options !== undefined ? { options } : {}),
+				...(sortKey !== undefined ? { sortKey } : {}),
+			}),
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+		},
+	})
+
+	const deleteCardField = useMutation({
+		mutationFn: ({ fieldId }) => apiDeleteCardField(fieldId),
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+		},
+	})
+
+	const setCardFieldValue = useMutation({
+		mutationFn: ({ cardId, fieldId, value }) => apiSetCardFieldValue(cardId, fieldId, value),
+		onSettled: (_data, _err, { cardId }) => {
+			queryClient.invalidateQueries({ queryKey: ['card', String(cardId)] })
+		},
+	})
+
+	const clearCardFieldValue = useMutation({
+		mutationFn: ({ cardId, fieldId }) => apiClearCardFieldValue(cardId, fieldId),
+		onSettled: (_data, _err, { cardId }) => {
+			queryClient.invalidateQueries({ queryKey: ['card', String(cardId)] })
+		},
+	})
+
+	return {
+		createCardField,
+		updateCardField,
+		deleteCardField,
+		setCardFieldValue,
+		clearCardFieldValue,
+	}
+}

--- a/src/composables/useCardTimeEntries.js
+++ b/src/composables/useCardTimeEntries.js
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * useCardTimeEntries - a card's manual time-tracking entries (#3536).
+ *
+ * Loaded separately from the card detail (like comments/attachments): the list
+ * of entries stays off the hot card-open path, while the per-card TOTAL travels
+ * in the card detail payload as `timeSpent`. Add/delete are mutations that
+ * invalidate the list; delete is optimistic with rollback (mirrors
+ * useCardAttachments' remove).
+ *
+ * `cardId` may be a plain value, a Vue ref, or a getter function.
+ */
+
+import { computed, unref } from 'vue'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import {
+	fetchCardTimeEntries,
+	addCardTimeEntry as apiAdd,
+	deleteCardTimeEntry as apiDelete,
+} from '../services/api.js'
+
+/**
+ * @param {import('vue').Ref<string|number>|string|number|Function} cardId
+ */
+export function useCardTimeEntries(cardId) {
+	const queryClient = useQueryClient()
+
+	const resolvedId = computed(() => {
+		const v = typeof cardId === 'function' ? cardId() : unref(cardId)
+		return String(v)
+	})
+
+	const key = computed(() => ['card-time-entries', resolvedId.value])
+
+	const query = useQuery({
+		queryKey: key,
+		queryFn: () => fetchCardTimeEntries(resolvedId.value),
+	})
+
+	const addEntry = useMutation({
+		mutationFn: ({ seconds, note }) => apiAdd(resolvedId.value, seconds, note),
+		onSettled: () => queryClient.invalidateQueries({ queryKey: key.value }),
+	})
+
+	const removeEntry = useMutation({
+		mutationFn: (entryId) => apiDelete(resolvedId.value, entryId),
+		onMutate: async (entryId) => {
+			await queryClient.cancelQueries({ queryKey: key.value })
+			const previous = queryClient.getQueryData(key.value)
+			queryClient.setQueryData(key.value, (old) =>
+				Array.isArray(old) ? old.filter((e) => e.id !== entryId) : old,
+			)
+			return { previous }
+		},
+		onError: (_err, _id, context) => {
+			if (context?.previous !== undefined) {
+				queryClient.setQueryData(key.value, context.previous)
+			}
+		},
+		onSettled: () => queryClient.invalidateQueries({ queryKey: key.value }),
+	})
+
+	return { ...query, timeEntries: query.data, addEntry, removeEntry }
+}

--- a/src/composables/useReviewTypes.js
+++ b/src/composables/useReviewTypes.js
@@ -23,18 +23,19 @@ export function useReviewTypes(boardId) {
 	}
 
 	const createReviewType = useMutation({
-		mutationFn: ({ title, color }) =>
-			apiCreateReviewType(resolveBoardId(boardId), title, color || null),
+		mutationFn: ({ title, color, stage }) =>
+			apiCreateReviewType(resolveBoardId(boardId), title, color || null, stage),
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
 		},
 	})
 
 	const updateReviewType = useMutation({
-		mutationFn: ({ typeId, title, color }) =>
+		mutationFn: ({ typeId, title, color, stage }) =>
 			apiUpdateReviewType(typeId, {
 				...(title !== undefined ? { title } : {}),
 				...(color !== undefined ? { color } : {}),
+				...(stage !== undefined ? { stage } : {}),
 			}),
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import App from './App.vue'
 import { router } from './router/index.js'
 import { initRealtime } from './services/realtime.js'
 import { isBoardMovePending } from './composables/useCardMove.js'
-import { boardQueryKey } from './composables/queryKeys.js'
+import { syncBoardDelta } from './composables/useBoardDelta.js'
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -25,19 +25,15 @@ createApp(App)
 	.use(VueQueryPlugin, { queryClient })
 	.mount(document.getElementById('kanso'))
 
-// Realtime: a push event means someone changed the board - refetch it,
-// unless our own moves are still in flight (the move queue's drain
-// invalidate syncs afterwards; refetching now would show pre-move state).
-// Board query keys are ['board', <route param>]; boardQueryKey coerces the
-// realtime boardId to the same string key the board query is registered under.
-// Cancel any in-flight board refetch before invalidating (mirrors
-// useBoardSubscription): otherwise a pre-change response already on the wire
-// can settle after the push-triggered refetch and overwrite fresher data.
-initRealtime(async (boardId) => {
+// Realtime: a push event means someone changed the board - delta-sync it (#3675)
+// instead of re-downloading the whole board. syncBoardDelta fetches only the
+// changes since our cursor and PATCHES the cache (O(delta), not O(boardSize));
+// on a resync signal or error it falls back to a full board invalidate, and it
+// re-checks the move-pending guard internally so it never clobbers an optimistic
+// move (the move queue's drain invalidate reconciles afterwards).
+initRealtime((boardId) => {
 	if (isBoardMovePending(boardId)) {
 		return
 	}
-	const boardKey = boardQueryKey(boardId)
-	await queryClient.cancelQueries({ queryKey: boardKey })
-	queryClient.invalidateQueries({ queryKey: boardKey })
+	syncBoardDelta(queryClient, boardId)
 })

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -314,6 +314,17 @@ export const cardAttachmentUrl = (cardId, attachmentId) =>
 export const cardAttachmentInlineUrl = (cardId, attachmentId) =>
 	url(`/api/cards/${cardId}/attachments/${attachmentId}/inline`)
 
+// Card time tracking (#3536). Manual entries (seconds + optional note); the
+// per-card total lives in the card detail payload's `timeSpent`.
+export const fetchCardTimeEntries = (cardId) =>
+	axios.get(url(`/api/cards/${cardId}/time-entries`)).then((r) => r.data)
+
+export const addCardTimeEntry = (cardId, seconds, note) =>
+	axios.post(url(`/api/cards/${cardId}/time-entries`), { seconds, note }).then((r) => r.data)
+
+export const deleteCardTimeEntry = (cardId, entryId) =>
+	axios.delete(url(`/api/cards/${cardId}/time-entries/${entryId}`)).then((r) => r.data)
+
 // Deck import
 export const fetchDeckImportBoards = () =>
 	axios.get(url('/api/deck-import/boards')).then((r) => r.data)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -430,6 +430,32 @@ export const updateReviewType = (id, data) =>
 export const deleteReviewType = (id) =>
 	axios.delete(url(`/api/review-types/${id}`)).then((r) => r.data)
 
+// Custom fields (#3537): per-board field DEFINITIONS (MANAGE-gated). The board
+// payload carries the definition list; these mutate it.
+export const createCardField = (boardId, name, type, options) =>
+	axios.post(url('/api/card-fields'), {
+		boardId,
+		name,
+		type,
+		...(options != null ? { options } : {}),
+	}).then((r) => r.data)
+
+export const updateCardField = (id, data) =>
+	axios.patch(url(`/api/card-fields/${id}`), data).then((r) => r.data)
+
+export const deleteCardField = (id) =>
+	axios.delete(url(`/api/card-fields/${id}`)).then((r) => r.data)
+
+// Per-card custom-field VALUES (#3537, EDIT-gated). A set is an upsert; an
+// empty/absent value clears it. Values ride the card detail payload.
+export const setCardFieldValue = (cardId, fieldId, value) =>
+	axios.put(url(`/api/cards/${cardId}/fields/${fieldId}`),
+		value != null ? { value } : {},
+	).then((r) => r.data)
+
+export const clearCardFieldValue = (cardId, fieldId) =>
+	axios.delete(url(`/api/cards/${cardId}/fields/${fieldId}`)).then((r) => r.data)
+
 // Per-card activity feed (read-only view over the change log)
 export const getCardActivity = (cardId) =>
 	axios.get(url(`/api/cards/${cardId}/activity`)).then((r) => r.data)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -405,8 +405,13 @@ export const getMyCards = () =>
 	axios.get(url('/api/my-cards')).then((r) => r.data)
 
 // Review types
-export const createReviewType = (boardId, title, color) =>
-	axios.post(url('/api/review-types'), { boardId, title, color: color || null }).then((r) => r.data)
+export const createReviewType = (boardId, title, color, stage) =>
+	axios.post(url('/api/review-types'), {
+		boardId,
+		title,
+		color: color || null,
+		...(stage != null ? { stage } : {}),
+	}).then((r) => r.data)
 
 export const updateReviewType = (id, data) =>
 	axios.patch(url(`/api/review-types/${id}`), data).then((r) => r.data)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -13,6 +13,12 @@ export const fetchBoards = () =>
 export const fetchBoard = (id) =>
 	axios.get(url(`/api/boards/${id}`)).then((r) => r.data)
 
+// Delta-sync read (#3675): the board's changes since `since` (the client's
+// cursor). Returns { cursor, resync, cards:{upsert,remove}, stacks:{upsert,remove} }.
+// When resync is true the client drops its cursor and does a full fetchBoard.
+export const fetchBoardChanges = (id, since) =>
+	axios.get(url(`/api/boards/${id}/changes`), { params: { since } }).then((r) => r.data)
+
 export const createBoard = (data) =>
 	axios.post(url('/api/boards'), data).then((r) => r.data)
 

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -227,6 +227,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			:board-id="props.id"
 			:labels="boardLabels"
 			:review-types="boardData.reviewTypes ?? []"
+			:card-fields="boardData.cardFields ?? []"
 			:acl="boardData.acl ?? []"
 			:permissions="boardData.permissions ?? 0"
 			:participants="participants.data.value ?? []"

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -255,9 +255,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<button class="board-view__move-error-dismiss" @click="dismissActionError">×</button>
 		</div>
 
-		<!-- Error -->
+		<!-- Error - status-aware (#3662): a gone/forbidden board explains itself and
+		     links back to the boards list; a transient failure offers a retry. -->
 		<div v-if="isError" class="board-view__error">
-			{{ t('kanso', 'Failed to load board.') }}
+			<p class="board-view__error-msg">{{ boardErrorMessage }}</p>
+			<div class="board-view__error-actions">
+				<NcButton v-if="!boardIsGoneOrForbidden" type="primary" @click="boardRefetch">
+					{{ t('kanso', 'Retry') }}
+				</NcButton>
+				<NcButton :type="boardIsGoneOrForbidden ? 'primary' : 'tertiary'" @click="router.push({ name: 'board-list' })">
+					{{ t('kanso', 'Go to boards') }}
+				</NcButton>
+			</div>
 		</div>
 
 		<!-- Stacks row (Board view). Kept mounted under v-show so its drag-and-drop
@@ -611,7 +620,24 @@ function sortCards(cards) {
 	}
 	return arr.sort(bySortKey)
 }
-const { data: boardData, isLoading, isError, createStack, createCard, updateStack, deleteStack, restoreStack } = useBoard(boardId)
+const { data: boardData, isLoading, isError, error: boardError, refetch: boardRefetch, createStack, createCard, updateStack, deleteStack, restoreStack } = useBoard(boardId)
+
+// Status-aware board error copy (#3662). A dead deep-link/notification to a
+// deleted board 404s; a revoked share 403s. Both should read as an explanatory
+// message with a way back to the boards list - not the generic error box. A
+// transient network/5xx failure stays retryable.
+const boardErrorStatus = computed(() => boardError.value?.response?.status ?? null)
+const boardIsGoneOrForbidden = computed(() =>
+	boardErrorStatus.value === 404 || boardErrorStatus.value === 403)
+const boardErrorMessage = computed(() => {
+	if (boardErrorStatus.value === 403) {
+		return t('kanso', 'This board no longer exists or you no longer have access.')
+	}
+	if (boardErrorStatus.value === 404) {
+		return t('kanso', 'This board no longer exists.')
+	}
+	return t('kanso', 'Couldn\'t load this board. Please try again.')
+})
 const { enqueueMove, lastError: moveError, dismissError: dismissMoveError } = useCardMove(boardId)
 const { toggle: boardWatchToggle } = useBoardSubscription(boardId)
 // The chosen background preset resolved to its CSS gradient (null = none). The
@@ -1643,8 +1669,22 @@ const onBulkDelete = () => runBulkAction('delete', {})
 }
 
 .board-view__error {
-	padding: 16px 24px;
+	padding: 40px 24px;
+	text-align: center;
 	color: var(--color-error);
+}
+
+.board-view__error-msg {
+	margin: 0 0 20px;
+	color: var(--color-main-text);
+	font-size: 1.05rem;
+}
+
+.board-view__error-actions {
+	display: flex;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 10px;
 }
 
 .board-view__move-error {

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1595,14 +1595,18 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	background: var(--board-background);
 }
 
+/* One consolidated toolbar (variant 1a): a single opaque header row holding the
+   back button, board title, then the right-aligned control cluster (search, view
+   toggle, sort, swimlanes, filters, and the icon actions). A tighter gap groups
+   the controls so they read as one bar rather than scattered buttons. */
 .board-view__header {
 	display: flex;
 	align-items: center;
-	gap: 16px;
+	gap: 8px;
 	/* Extra left padding reserves room for the NcAppNavigation toggle, which is
 	   pinned to the top-left of the app content area and would otherwise overlap
 	   the "All boards" button. */
-	padding: 12px 24px 12px 52px;
+	padding: 10px 20px 10px 52px;
 	border-bottom: 1px solid var(--color-border);
 	background: var(--color-main-background);
 	flex-shrink: 0;
@@ -1708,7 +1712,10 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	padding: 0 4px;
 }
 
-/* Stacks scrollable row */
+/* Stacks scrollable row - the "sunken" board canvas (variant 1a). A recessed
+   surface so the white/raised columns lift off it. When a custom board
+   background gradient is active we stay transparent so the gradient shows
+   through instead (see the --has-background override below). */
 .board-view__stacks-wrap {
 	display: flex;
 	flex-direction: row;
@@ -1718,6 +1725,13 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	overflow-x: auto;
 	overflow-y: hidden;
 	flex: 1;
+	background: var(--color-background-hover);
+}
+
+/* With a custom board background, let the gradient be the canvas. */
+.board-view--has-background .board-view__stacks-wrap,
+.board-view--has-background .board-view__swimlanes-wrap {
+	background: transparent;
 }
 
 /* Swimlanes (grouped board): vertical scroll region holding stacked lanes.

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -354,6 +354,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			:stacks="sortedStacks"
 			:cards-by-stack="cardsByStack"
 			:labels-by-id="labelsById"
+			:board-prefix="boardData?.board?.prefix ?? ''"
 			:board-id="props.id" />
 
 		<!-- Timeline (Gantt) view - cards on a date axis by start→due. -->

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -62,42 +62,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</NcActionRadio>
 			</NcActions>
 
-			<!-- Swimlanes - client-side grouping of the Board view into horizontal
-			     lanes by assignee / label / priority. View-only over the summary
-			     payload; persisted per board per user. Only shown in Board view. -->
-			<NcActions
-				v-if="boardData && viewMode === 'board'"
-				class="board-view__swimlane-menu"
-				:menu-name="swimlaneModeLabel">
-				<template #icon>
-					<ViewAgendaOutlineIcon :size="20" />
-				</template>
-				<NcActionRadio
-					:model-value="swimlaneMode === 'none'"
-					name="kanso-swimlane"
-					@change="setSwimlaneMode('none')">
-					{{ t('kanso', 'No swimlanes') }}
-				</NcActionRadio>
-				<NcActionRadio
-					:model-value="swimlaneMode === 'assignee'"
-					name="kanso-swimlane"
-					@change="setSwimlaneMode('assignee')">
-					{{ t('kanso', 'Group by assignee') }}
-				</NcActionRadio>
-				<NcActionRadio
-					:model-value="swimlaneMode === 'label'"
-					name="kanso-swimlane"
-					@change="setSwimlaneMode('label')">
-					{{ t('kanso', 'Group by label') }}
-				</NcActionRadio>
-				<NcActionRadio
-					:model-value="swimlaneMode === 'priority'"
-					name="kanso-swimlane"
-					@change="setSwimlaneMode('priority')">
-					{{ t('kanso', 'Group by priority') }}
-				</NcActionRadio>
-			</NcActions>
-
 			<!-- Display sort - a view-only reorder within each stack (Board + List). -->
 			<NcActions
 				v-if="boardData"
@@ -137,88 +101,129 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				@delete-saved="handleDeleteSavedFilter" />
 			<div v-if="filterError" class="board-view__filter-error">{{ filterError }}</div>
 
-			<!-- Archived cards page button - only shown when ≥1 archived card -->
-			<NcButton
-				v-if="boardData && archivedCards.length > 0"
-				class="board-view__archived-btn"
-				:title="t('kanso', 'View archived cards')"
-				:aria-label="t('kanso', 'View archived cards ({count})', { count: archivedCards.length })"
-				@click="goToArchived">
-				<template #icon>
-					<ArchiveIcon :size="20" />
-				</template>
-				{{ archivedCards.length }}
-			</NcButton>
-
-			<!-- Watch / unwatch this board - subscribes to a "new card created"
-			     notification. Uses the same eye icon as the card-level watcher:
-			     eye-off (crossed) when watching, plain eye outline when not. -->
-			<NcButton
+			<!-- Consolidated "More" overflow (variant 1a): the secondary board
+			     actions live behind a single ⋯ menu so the toolbar reads as one
+			     bar. Every action here stays fully reachable and keeps its handler,
+			     permission gate, and any keyboard shortcut (e.g. the settings panel
+			     is still toggled by its own control). Swimlanes (a view-only Board
+			     grouping) are the radio group at the top; the rest are actions. -->
+			<NcActions
 				v-if="boardData"
-				class="board-view__watch-btn"
-				:type="isBoardSubscribed ? 'secondary' : 'tertiary'"
-				:title="isBoardSubscribed
-					? t('kanso', 'Watching this board (click to stop)')
-					: t('kanso', 'Watch this board for new cards')"
-				:aria-label="isBoardSubscribed ? t('kanso', 'Unwatch board') : t('kanso', 'Watch board')"
-				:aria-pressed="isBoardSubscribed ? 'true' : 'false'"
-				@click="toggleBoardWatch">
+				v-model:open="moreMenuOpen"
+				class="board-view__more-menu"
+				:menu-name="t('kanso', 'More')"
+				:aria-label="t('kanso', 'More board actions')">
 				<template #icon>
-					<EyeOffOutlineIcon v-if="isBoardSubscribed" :size="20" />
-					<EyeOutlineIcon v-else :size="20" />
+					<DotsHorizontalIcon :size="20" />
 				</template>
-			</NcButton>
 
-			<!-- Trash button - always visible when board is loaded; opens the Trash page -->
-			<NcButton
-				v-if="boardData"
-				class="board-view__trash-btn"
-				:title="t('kanso', 'View deleted cards')"
-				:aria-label="t('kanso', 'View deleted cards')"
-				@click="goToTrash">
-				<template #icon>
-					<DeleteIcon :size="20" />
+				<!-- Swimlanes - client-side grouping of the Board view into
+				     horizontal lanes by assignee / label / priority. View-only over
+				     the summary payload; persisted per board per user. Only shown in
+				     Board view. -->
+				<template v-if="viewMode === 'board'">
+					<NcActionCaption :name="t('kanso', 'Swimlanes')" />
+					<NcActionRadio
+						:model-value="swimlaneMode === 'none'"
+						name="kanso-swimlane"
+						@change="setSwimlaneMode('none')">
+						{{ t('kanso', 'No swimlanes') }}
+					</NcActionRadio>
+					<NcActionRadio
+						:model-value="swimlaneMode === 'assignee'"
+						name="kanso-swimlane"
+						@change="setSwimlaneMode('assignee')">
+						{{ t('kanso', 'Group by assignee') }}
+					</NcActionRadio>
+					<NcActionRadio
+						:model-value="swimlaneMode === 'label'"
+						name="kanso-swimlane"
+						@change="setSwimlaneMode('label')">
+						{{ t('kanso', 'Group by label') }}
+					</NcActionRadio>
+					<NcActionRadio
+						:model-value="swimlaneMode === 'priority'"
+						name="kanso-swimlane"
+						@change="setSwimlaneMode('priority')">
+						{{ t('kanso', 'Group by priority') }}
+					</NcActionRadio>
+					<NcActionSeparator />
 				</template>
-			</NcButton>
 
-			<!-- Analytics button - navigates to the board stats page -->
-			<NcButton
-				v-if="boardData"
-				class="board-view__analytics-btn"
-				:title="t('kanso', 'Board analytics')"
-				:aria-label="t('kanso', 'Board analytics')"
-				@click="goToStats">
-				<template #icon>
-					<ChartBarIcon :size="20" />
-				</template>
-			</NcButton>
+				<!-- Archived cards page - only offered when ≥1 archived card. The
+				     visible label already carries the count, so no separate aria-label
+				     is set (that would override the accessible name). -->
+				<NcActionButton
+					v-if="archivedCards.length > 0"
+					class="board-view__archived-btn"
+					@click="goToArchived">
+					<template #icon>
+						<ArchiveIcon :size="20" />
+					</template>
+					{{ t('kanso', 'Archived cards ({count})', { count: archivedCards.length }) }}
+				</NcActionButton>
 
-			<!-- Multi-select mode toggle -->
-			<NcButton
-				v-if="boardData"
-				class="board-view__multiselect-btn"
-				:type="bulk.selectionMode.value ? 'secondary' : 'tertiary'"
-				:title="t('kanso', 'Select multiple cards')"
-				:aria-label="t('kanso', 'Select multiple cards')"
-				:aria-pressed="bulk.selectionMode.value ? 'true' : 'false'"
-				@click="bulk.selectionMode.value ? bulk.exitMode() : bulk.enterMode()">
-				<template #icon>
-					<SelectMultipleIcon :size="20" />
-				</template>
-			</NcButton>
+				<!-- Watch / unwatch this board - subscribes to a "new card created"
+				     notification. Uses the same eye icon as the card-level watcher:
+				     eye-off (crossed) when watching, plain eye outline when not. -->
+				<NcActionButton
+					class="board-view__watch-btn"
+					:aria-pressed="isBoardSubscribed ? 'true' : 'false'"
+					@click="moreMenuOpen = false; toggleBoardWatch()">
+					<template #icon>
+						<EyeOffOutlineIcon v-if="isBoardSubscribed" :size="20" />
+						<EyeOutlineIcon v-else :size="20" />
+					</template>
+					{{ isBoardSubscribed ? t('kanso', 'Unwatch board') : t('kanso', 'Watch board') }}
+				</NcActionButton>
 
-			<!-- Settings (gear) button - toggles the right-docked settings panel -->
-			<NcButton
-				v-if="boardData"
-				class="board-view__settings-btn"
-				:title="t('kanso', 'Board settings')"
-				:aria-label="t('kanso', 'Board settings')"
-				:aria-expanded="showSettings ? 'true' : 'false'"
-				@click="showSettings = !showSettings">
-				<template #icon>
-					<CogIcon :size="20" />
-				</template>
-			</NcButton>
+				<!-- Trash - opens the routed Trash page -->
+				<NcActionButton
+					class="board-view__trash-btn"
+					@click="goToTrash">
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
+					{{ t('kanso', 'Deleted cards') }}
+				</NcActionButton>
+
+				<!-- Analytics - navigates to the board stats page -->
+				<NcActionButton
+					class="board-view__analytics-btn"
+					@click="goToStats">
+					<template #icon>
+						<ChartBarIcon :size="20" />
+					</template>
+					{{ t('kanso', 'Board analytics') }}
+				</NcActionButton>
+
+				<!-- Multi-select mode toggle -->
+				<NcActionButton
+					class="board-view__multiselect-btn"
+					:aria-pressed="bulk.selectionMode.value ? 'true' : 'false'"
+					@click="moreMenuOpen = false; bulk.selectionMode.value ? bulk.exitMode() : bulk.enterMode()">
+					<template #icon>
+						<SelectMultipleIcon :size="20" />
+					</template>
+					{{ bulk.selectionMode.value ? t('kanso', 'Exit multi-select') : t('kanso', 'Select multiple cards') }}
+				</NcActionButton>
+
+				<NcActionSeparator />
+
+				<!-- Settings - toggles the right-docked settings panel. Closing the
+				     overflow menu first is required: the panel is a non-blocking
+				     docked drawer, so a lingering menu popover would sit over it and
+				     swallow clicks / Escape. -->
+				<NcActionButton
+					class="board-view__settings-btn"
+					:aria-expanded="showSettings ? 'true' : 'false'"
+					@click="moreMenuOpen = false; showSettings = !showSettings">
+					<template #icon>
+						<CogIcon :size="20" />
+					</template>
+					{{ t('kanso', 'Board settings') }}
+				</NcActionButton>
+			</NcActions>
 		</div>
 
 		<!-- Board settings modal (Labels + Sharing tabs) -->
@@ -471,7 +476,11 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
+import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
+import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
 import ArchiveIcon from 'vue-material-design-icons/Archive.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
@@ -482,7 +491,6 @@ import FormatListBulletedIcon from 'vue-material-design-icons/FormatListBulleted
 import SortIcon from 'vue-material-design-icons/Sort.vue'
 import ChartTimelineIcon from 'vue-material-design-icons/ChartTimeline.vue'
 import ChartBarIcon from 'vue-material-design-icons/ChartBar.vue'
-import ViewAgendaOutlineIcon from 'vue-material-design-icons/ViewAgendaOutline.vue'
 import SelectMultipleIcon from 'vue-material-design-icons/SelectMultiple.vue'
 import StackColumn from '../components/StackColumn.vue'
 import BulkActionBar from '../components/BulkActionBar.vue'
@@ -596,13 +604,6 @@ function setSwimlaneMode(mode) {
 		localStorage.setItem(`kanso.swimlaneMode.${props.id}`, mode)
 	} catch (e) { /* ignore persistence failure */ }
 }
-const swimlaneModeLabel = computed(() => ({
-	none: t('kanso', 'No swimlanes'),
-	assignee: t('kanso', 'By assignee'),
-	label: t('kanso', 'By label'),
-	priority: t('kanso', 'By priority'),
-}[swimlaneMode.value] ?? t('kanso', 'No swimlanes')))
-
 /**
  * View-only comparator for the active display sort. Every non-manual mode falls
  * back to the fractional sort key as a stable tiebreaker.
@@ -670,6 +671,11 @@ let boardCleanup = () => {}
 
 // Label settings panel visibility
 const showSettings = ref(false)
+
+// The consolidated ⋯ "More" overflow menu open state. Controlled so in-place
+// actions (settings panel, multi-select, watch) can dismiss the menu explicitly
+// — otherwise its popover lingers over the docked settings panel and eats clicks.
+const moreMenuOpen = ref(false)
 
 // ── Card-template manager (#3634) ─────────────────────────────────────────────
 // Board-scoped modal to view / edit / delete / unmark / create templates (which
@@ -1761,7 +1767,8 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	color: var(--color-text-maxcontrast);
 }
 
-.board-view__swimlane-menu {
+/* The consolidated "More" overflow menu trigger. */
+.board-view__more-menu {
 	flex-shrink: 0;
 }
 

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -361,6 +361,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<BoardTimelineView
 			v-if="viewMode === 'timeline' && boardData"
 			:cards="allVisibleCards"
+			:stacks="sortedStacks"
+			:cards-by-stack="cardsByStack"
+			:board-prefix="boardData?.board?.prefix ?? ''"
 			:board-id="props.id" />
 
 		<!-- Keyboard shortcuts overlay -->

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -364,6 +364,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			:stacks="sortedStacks"
 			:cards-by-stack="cardsByStack"
 			:board-prefix="boardData?.board?.prefix ?? ''"
+			:can-edit="canEditBoard"
 			:board-id="props.id" />
 
 		<!-- Keyboard shortcuts overlay -->

--- a/tests/e2e/activity.spec.js
+++ b/tests/e2e/activity.spec.js
@@ -117,4 +117,52 @@ test.describe('Card Activity feed', () => {
 
 		expect(activityErrors).toEqual([])
 	})
+
+	// #3659 — the Activity feed must not fire a request storm. Every NcAvatar in
+	// the modal used to fetch the actor's user_status per instance (the prop was
+	// `show-user-status`, which @nextcloud/vue 9 doesn't have — the real one is
+	// `hide-status`), so a feed of N rows by the same actor issued ~N presence
+	// lookups. With `:hide-status="true"` the count must be bounded regardless of
+	// how many entries share an actor.
+	test('a multi-entry feed with a repeated actor stays O(actors), not O(entries)', async ({ page }) => {
+		// One card with MANY activity rows, all authored by the same actor (admin).
+		const stack = await api('POST', '/stacks', { boardId: state.boardId, title: 'Storm' })
+		const card = await api('POST', '/cards', { stackId: stack.id, title: 'Storm card' })
+		for (let i = 0; i < 15; i++) {
+			await api('POST', `/cards/${card.id}/comments`, { body: `note ${i}` })
+			await api('PATCH', `/cards/${card.id}`, { priority: i % 3 })
+		}
+		const cardUrl = `${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${card.id}`
+
+		// Count avatar / user-status / displayname network calls. These are the
+		// per-actor lookups that must NOT scale with the number of entries.
+		const perActorReqs = []
+		const perActorRe = /\/avatar\/|\/user_status\/api\/v1\/statuses\/|\/displaynames/
+		page.on('request', (req) => {
+			if (perActorRe.test(req.url())) perActorReqs.push(req.url())
+		})
+
+		await ncLogin(page)
+		await page.goto(cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// Open the Activity tab and wait for a genuinely multi-entry feed.
+		await page.locator('.card-modal__discussion-tab', { hasText: 'Activity' }).click()
+		const rows = page.locator('.card-modal__activity-row')
+		await expect(rows.first()).toBeVisible({ timeout: 8_000 })
+		await expect.poll(async () => await rows.count()).toBeGreaterThanOrEqual(10)
+
+		// Let any straggling avatar/status requests settle.
+		await page.waitForTimeout(1500)
+
+		const rowCount = await rows.count()
+		// Dedup by URL: a correct implementation resolves each actor's avatar and
+		// status ONCE and reuses it. Even counting raw (non-deduped) requests, the
+		// total must be far below one-per-row — bound it well under the row count.
+		expect(perActorReqs.length).toBeLessThan(rowCount)
+		// And the DISTINCT per-actor endpoints hit must be a small constant
+		// (a single actor here → a handful of URLs at most), never O(entries).
+		const distinct = new Set(perActorReqs).size
+		expect(distinct).toBeLessThanOrEqual(4)
+	})
 })

--- a/tests/e2e/archived-view.spec.js
+++ b/tests/e2e/archived-view.spec.js
@@ -63,12 +63,19 @@ test.describe('Archived cards page', () => {
 		await page.reload()
 		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
 
-		// The card tile is gone from the board.
+		// The board has re-hydrated (the ⋯ menu trigger is present) and the card
+		// tile is gone from the board.
+		await page.waitForSelector('.board-view__more-menu', { timeout: 10_000 })
 		await expect(page.locator('.card-tile').filter({ hasText: 'Archivable Card' })).not.toBeVisible()
 
-		// The archived badge button appears (count ≥ 1) — click it to open the page.
-		const archivedBtn = page.locator('.board-view__archived-btn')
-		await expect(archivedBtn).toBeVisible({ timeout: 8000 })
+		// The archived action lives in the consolidated ⋯ More overflow menu and is
+		// only offered when ≥1 archived card exists. Open the menu, then assert the
+		// item is present (carrying the count) — the item renders reactively once
+		// the board GET (which carries the archived count) resolves, so the menu can
+		// stay open while it appears.
+		await page.getByRole('button', { name: 'More' }).click()
+		const archivedBtn = page.getByRole('menuitem', { name: /Archived cards \(\d+\)/ })
+		await expect(archivedBtn).toBeVisible({ timeout: 10_000 })
 		await archivedBtn.click()
 
 		// Routed, deep-linkable page.

--- a/tests/e2e/automation-rules.spec.js
+++ b/tests/e2e/automation-rules.spec.js
@@ -102,8 +102,9 @@ test.describe('Automation rules (#3400)', () => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 
-		// Open board settings → Automation tab.
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Open board settings → Automation tab (settings now in the ⋯ More menu).
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /automation/i }).click()
 
 		// The card-rules "Add rule" form: pick In-progress role + add-label, then submit.

--- a/tests/e2e/avatar-status-storm.spec.js
+++ b/tests/e2e/avatar-status-storm.spec.js
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Card #3663 — Perf: guard against the NcAvatar user-status request storm on
+// board load. `NcAvatar` (@nextcloud/vue 9) has NO `show-user-status` prop; the
+// real one is `hide-status`. `:show-user-status="false"` was a no-op, so every
+// assignee avatar mounted a `GET /user_status/api/v1/statuses/{uid}` request —
+// O(cards × assignees) on board load. With `:hide-status="true"` the status dot
+// is hidden and no status request should fire.
+//
+// This spec loads a board with several assigned cards and asserts the number of
+// user_status requests is bounded (ideally zero) — not proportional to the
+// card × assignee count.
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// Several assigned cards so a per-avatar storm (O(cards × assignees)) would be
+// visibly larger than the O(unique actors) bound we assert.
+const CARD_COUNT = 8
+
+test.describe('Avatar user-status storm on board load (#3663)', () => {
+	const state = { boardId: 0, stackId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'StatusStorm ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'To do' })).id
+		for (let i = 0; i < CARD_COUNT; i++) {
+			const card = await api('POST', '/cards', { stackId: state.stackId, title: `Assigned ${i}` })
+			// Assign admin (the only actor available in the dev stack) to each card.
+			await api('PUT', `/cards/${card.id}/assignees/${USER}`)
+		}
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('board load issues at most O(unique actors) user_status requests', async ({ page }) => {
+		await ncLogin(page)
+
+		// Count every user_status API request the page fires.
+		const statusRequests = []
+		page.on('request', (req) => {
+			if (/\/user_status\/api\/v1\/statuses?\b/.test(req.url())) {
+				statusRequests.push(req.url())
+			}
+		})
+
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+
+		// Wait for the assignee avatars to actually render — this is the mount
+		// point that used to fire the storm.
+		await page.waitForSelector('.card-tile__avatar', { timeout: 30_000 })
+		await expect(page.locator('.card-tile__avatar').first()).toBeVisible()
+		// Give any (mis)fired status requests a moment to land.
+		await page.waitForTimeout(1500)
+
+		const uniqueActors = 1 // only admin is assigned across all cards
+		// eslint-disable-next-line no-console
+		console.log(`[#3663] user_status requests on board load: ${statusRequests.length} (cards=${CARD_COUNT}, unique actors=${uniqueActors})`)
+
+		// The status dot is hidden, so ideally ZERO status requests fire. Guard
+		// against the O(cards × assignees) storm: the count must be bounded by the
+		// number of unique actors, never by the card count. Allow a small slack
+		// (+1) for any unrelated one-off status probe (e.g. the top-bar own-status
+		// widget) without letting a per-avatar storm through.
+		expect(statusRequests.length).toBeLessThanOrEqual(uniqueActors + 1)
+		expect(statusRequests.length).toBeLessThan(CARD_COUNT)
+	})
+})

--- a/tests/e2e/board-archive.spec.js
+++ b/tests/e2e/board-archive.spec.js
@@ -59,9 +59,11 @@ test.describe('Board archiving', () => {
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
 		// Board settings → General tab → Archive (board actions moved into the
-		// General tab's danger zone; #3614). The modal opens on the labels tab, so
+		// General tab's danger zone; #3614). Board settings now lives in the
+		// consolidated ⋯ More overflow menu. The modal opens on the labels tab, so
 		// switch to General first.
-		await page.getByRole('button', { name: /board settings/i }).click()
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: 'General' }).click()
 		const general = page.locator('#bs-pane-general')
 		await general.locator('.board-actions__danger').getByRole('button', { name: 'Archive' }).click()

--- a/tests/e2e/board-background.spec.js
+++ b/tests/e2e/board-background.spec.js
@@ -56,7 +56,9 @@ test.describe('Board background preset (#3528)', () => {
 		// No background to start with.
 		await expect(boardView).not.toHaveClass(/board-view--has-background/)
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /general/i }).click()
 		await expect(page.locator('#bs-pane-general')).toBeVisible({ timeout: 8_000 })
 
@@ -74,7 +76,9 @@ test.describe('Board background preset (#3528)', () => {
 		await expect(page.locator('.board-view')).toHaveClass(/board-view--has-background/, { timeout: 8_000 })
 
 		// Clearing it removes the background again.
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /general/i }).click()
 		await expect(page.locator('#bs-pane-general')).toBeVisible({ timeout: 8_000 })
 		await page.locator('[data-test="board-bg-none"]').click()

--- a/tests/e2e/board-delta-sync.spec.js
+++ b/tests/e2e/board-delta-sync.spec.js
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Delta sync (#3675): when board B reflects a change made on board A, it must do
+// so via the `?since=` delta endpoint (GET /boards/{id}/changes) and PATCH only
+// the touched card into its cache - NOT re-download the whole board via
+// GET /boards/{id}. This runs on the dev/ docker stack (like realtime.spec.js).
+
+import { test, expect } from '@playwright/test'
+import { execSync } from 'node:child_process'
+
+const BASE = 'http://localhost:8891'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const ADMIN_AUTH = 'Basic ' + Buffer.from('admin:admin').toString('base64')
+const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: ADMIN_AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPatch(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PATCH',
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`PATCH ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page, user, pass) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return
+	await page.fill('#user', user)
+	await page.fill('#password', pass)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// notify_push is disabled for this suite so B takes the deterministic 5s delta
+// poll (the push path also delta-syncs, but the poll is what we can reliably
+// force on any runner). Mirrors realtime.spec.js's fallback handling.
+const SKIP_NOTIFY_PUSH = process.env.KANSO_SKIP_NOTIFY_PUSH === '1'
+
+function occSafe(command) {
+	if (SKIP_NOTIFY_PUSH) return
+	try {
+		execSync(`docker exec -u www-data kanso-dev php occ ${command}`, { stdio: 'pipe' })
+	} catch {
+		// notify_push not installed on this runner - nothing to toggle.
+	}
+}
+
+test.describe('Board delta sync (#3675)', () => {
+	const state = { boardId: 0, stackId: 0, cardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === 'Delta Sync Board') {
+				await apiDelete(`/boards/${b.id}`)
+			}
+		}
+		const board = await apiPost('/boards', { title: 'Delta Sync Board' })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'S1' })
+		state.stackId = stack.id
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'delta-original' })
+		state.cardId = card.id
+		await apiPost(`/boards/${board.id}/acl`, {
+			participant: TESTER.user,
+			participantType: 'user',
+			permission: 3,
+		})
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		occSafe('app:enable notify_push')
+		if (state.boardId) await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('B reflects an edit via /changes, not a full board refetch', async ({ browser }) => {
+		// Force the poll path: disable notify_push and wait for the capability to
+		// stop being advertised (a fixed sleep was a flake source in realtime.spec).
+		occSafe('app:disable notify_push')
+		for (let i = 0; i < 20; i++) {
+			const r = await fetch(BASE + '/ocs/v2.php/cloud/capabilities?format=json', {
+				headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+			})
+			const caps = (await r.json())?.ocs?.data?.capabilities ?? {}
+			if (!('notify_push' in caps)) break
+			await new Promise((resolve) => setTimeout(resolve, 500))
+		}
+
+		const testerCtx = await browser.newContext()
+		try {
+			const testerPage = await testerCtx.newPage()
+			await ncLogin(testerPage, TESTER.user, TESTER.pass)
+
+			// Track B's board API calls. The initial full load hits /boards/{id};
+			// after that, reflecting A's edit must go through /boards/{id}/changes.
+			const fullReads = []
+			const deltaReads = []
+			testerPage.on('request', (req) => {
+				const u = req.url()
+				if (u.includes(`/boards/${state.boardId}/changes`)) {
+					deltaReads.push(u)
+				} else if (new RegExp(`/boards/${state.boardId}(\\?|$)`).test(u)) {
+					fullReads.push(u)
+				}
+			})
+
+			await testerPage.goto(state.boardUrl)
+			await expect(testerPage.locator('.stack-column').first()).toBeVisible({ timeout: 15_000 })
+			await expect(
+				testerPage.locator('.card-tile').filter({ hasText: 'delta-original' }),
+			).toBeVisible({ timeout: 15_000 })
+
+			// The initial load did at least one full board read; from here we only
+			// tolerate delta reads for reflecting the change.
+			const fullReadsAfterLoad = fullReads.length
+
+			// Admin edits the card title. Its change row bumps the board cursor.
+			await apiPatch(`/cards/${state.cardId}`, { title: 'delta-edited' })
+
+			// B must reflect the new title WITHOUT any interaction, via the 5s poll.
+			await expect(
+				testerPage.locator('.card-tile').filter({ hasText: 'delta-edited' }),
+			).toBeVisible({ timeout: 15_000 })
+			await expect(
+				testerPage.locator('.card-tile').filter({ hasText: 'delta-original' }),
+			).toHaveCount(0)
+
+			// The reflection came through the delta endpoint, and it did NOT trigger
+			// a new full-board download (the whole point of #3675).
+			expect(deltaReads.length).toBeGreaterThan(0)
+			expect(fullReads.length).toBe(fullReadsAfterLoad)
+		} finally {
+			occSafe('app:enable notify_push')
+			await testerCtx.close()
+		}
+	})
+})

--- a/tests/e2e/board-duplicate.spec.js
+++ b/tests/e2e/board-duplicate.spec.js
@@ -59,7 +59,9 @@ test.describe('Duplicate board (#3543)', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 
 		// Board actions moved into the General tab; open it first.
 		await page.getByRole('tab', { name: 'General' }).click()

--- a/tests/e2e/board-settings-rail.spec.js
+++ b/tests/e2e/board-settings-rail.spec.js
@@ -51,7 +51,9 @@ test.describe('Board settings section rail', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 
 		// The rail exposes a proper vertical tablist (holding only the section tabs).
 		const rail = page.locator('.bs-rail .bs-rail__tabs[role="tablist"]')
@@ -98,7 +100,9 @@ test.describe('Board settings section rail', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /automation/i }).click()
 
 		// Column automations starts expanded → its rule form is visible.

--- a/tests/e2e/board-settings-switches.spec.js
+++ b/tests/e2e/board-settings-switches.spec.js
@@ -54,7 +54,9 @@ test.describe('Board settings enable switches (public link + calendar feed)', ()
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /automation/i }).click()
 		await expect(page.locator('#bs-pane-automation')).toBeVisible({ timeout: 8_000 })
 

--- a/tests/e2e/board-stats.spec.js
+++ b/tests/e2e/board-stats.spec.js
@@ -58,7 +58,9 @@ test.describe('Board analytics', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 10_000 })
 
-		await page.locator('.board-view__analytics-btn').click()
+		// Board analytics now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: 'Board analytics' }).click()
 
 		await expect(page).toHaveURL(new RegExp(`#/board/${state.boardId}/stats`))
 		const view = page.locator('.board-stats__body')

--- a/tests/e2e/bulk-edit.spec.js
+++ b/tests/e2e/bulk-edit.spec.js
@@ -68,8 +68,9 @@ test.describe('Bulk edit cards (multi-select)', () => {
 		await page.waitForSelector('.stack-column', { timeout: 15_000 })
 		await expect(page.locator('.card-tile', { hasText: 'Alpha' })).toBeVisible({ timeout: 10_000 })
 
-		// Enter multi-select mode via the toolbar toggle.
-		await page.getByRole('button', { name: 'Select multiple cards' }).click()
+		// Enter multi-select mode via the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: 'Select multiple cards' }).click()
 
 		// Selection checkboxes now appear on the tiles; select Alpha and Bravo.
 		await page.locator('.card-tile', { hasText: 'Alpha' }).click()

--- a/tests/e2e/card-fields.spec.js
+++ b/tests/e2e/card-fields.spec.js
@@ -181,7 +181,9 @@ test.describe('Custom fields', () => {
 		await page.goto(state.boardUrl)
 		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /custom fields/i }).click()
 
 		await page.locator('[data-test="cf-name-input"]').fill('Team')

--- a/tests/e2e/card-fields.spec.js
+++ b/tests/e2e/card-fields.spec.js
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPut(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PUT',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`PUT ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return // Already logged in
+
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Custom fields', () => {
+	const state = {
+		boardId: 0,
+		stackId: 0,
+		cardId: 0,
+		fields: {},
+		cardUrl: '',
+		boardUrl: '',
+	}
+
+	test.beforeAll(async () => {
+		// Clean up any stale board from a previous run
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === 'Custom Fields E2E Board') {
+				await apiDelete(`/boards/${b.id}`)
+			}
+		}
+
+		const board = await apiPost('/boards', { title: 'Custom Fields E2E Board' })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'Backlog' })
+		state.stackId = stack.id
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'Card with fields' })
+		state.cardId = card.id
+
+		// Define one field per type via the API.
+		state.fields.text = (await apiPost('/card-fields', {
+			boardId: board.id, name: 'Owner note', type: 'text',
+		})).id
+		state.fields.number = (await apiPost('/card-fields', {
+			boardId: board.id, name: 'Story points', type: 'number',
+		})).id
+		state.fields.date = (await apiPost('/card-fields', {
+			boardId: board.id, name: 'Target date', type: 'date',
+		})).id
+		state.fields.select = (await apiPost('/card-fields', {
+			boardId: board.id, name: 'Severity', type: 'select', options: ['low', 'high'],
+		})).id
+
+		// Set a value per field on the card (a set is an upsert).
+		await apiPut(`/cards/${card.id}/fields/${state.fields.text}`, { value: 'ship it' })
+		await apiPut(`/cards/${card.id}/fields/${state.fields.number}`, { value: '8' })
+		await apiPut(`/cards/${card.id}/fields/${state.fields.date}`, { value: '2026-09-02' })
+		await apiPut(`/cards/${card.id}/fields/${state.fields.select}`, { value: 'high' })
+
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) {
+			await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+		}
+	})
+
+	// ── Definitions ride the board payload; values ride card detail ──────────
+
+	test('definitions are on the board payload, values only on card detail', async () => {
+		const boardPayload = await apiGet(`/boards/${state.boardId}`)
+		expect(Array.isArray(boardPayload.cardFields)).toBe(true)
+		expect(boardPayload.cardFields.map((f) => f.name).sort())
+			.toEqual(['Owner note', 'Severity', 'Story points', 'Target date'])
+		// The board summary must NOT leak values.
+		for (const c of boardPayload.cards) {
+			expect(c.fieldValues).toBeUndefined()
+		}
+
+		const cardPayload = await apiGet(`/cards/${state.cardId}`)
+		const byField = Object.fromEntries(cardPayload.fieldValues.map((v) => [v.fieldId, v.value]))
+		expect(byField[state.fields.text]).toBe('ship it')
+		expect(byField[state.fields.number]).toBe('8')
+		expect(byField[state.fields.date]).toBe('2026-09-02')
+		expect(byField[state.fields.select]).toBe('high')
+	})
+
+	// ── Card modal renders each field's current value as an editable input ───
+
+	test('card modal renders the custom fields with their values', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 12_000 })
+
+		const section = page.locator('[data-test="card-custom-fields"]')
+		await expect(section).toBeVisible({ timeout: 8_000 })
+
+		await expect(section.locator(`[data-test="cf-input-${state.fields.text}"]`)).toHaveValue('ship it')
+		await expect(section.locator(`[data-test="cf-input-${state.fields.number}"]`)).toHaveValue('8')
+		await expect(section.locator(`[data-test="cf-input-${state.fields.date}"]`)).toHaveValue('2026-09-02')
+		await expect(section.locator(`[data-test="cf-select-${state.fields.select}"]`)).toHaveValue('high')
+	})
+
+	// ── Editing a value in the modal upserts it ──────────────────────────────
+
+	test('editing a text field in the modal persists the new value', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 12_000 })
+
+		const input = page.locator(`[data-test="cf-input-${state.fields.text}"]`)
+		await input.fill('done and dusted')
+		await input.blur()
+
+		await expect.poll(async () => {
+			const cardPayload = await apiGet(`/cards/${state.cardId}`)
+			const byField = Object.fromEntries(cardPayload.fieldValues.map((v) => [v.fieldId, v.value]))
+			return byField[state.fields.text]
+		}, { timeout: 8_000 }).toBe('done and dusted')
+	})
+
+	// ── Board settings: create a new field via the UI form ───────────────────
+
+	test('can define a new field via the board settings panel', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+
+		await page.getByRole('button', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /custom fields/i }).click()
+
+		await page.locator('[data-test="cf-name-input"]').fill('Team')
+		await page.locator('[data-test="cf-type-select"]').selectOption('text')
+		await page.locator('[data-test="cf-create-form"]').getByRole('button', { name: /add|create/i }).click()
+
+		await expect.poll(async () => {
+			const boardPayload = await apiGet(`/boards/${state.boardId}`)
+			return boardPayload.cardFields.some((f) => f.name === 'Team')
+		}, { timeout: 8_000 }).toBe(true)
+	})
+})

--- a/tests/e2e/card-modal-resize.spec.js
+++ b/tests/e2e/card-modal-resize.spec.js
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return // Already logged in
+
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// The persisted-width localStorage key mirrors CardModal.vue (DISCUSSION_WIDTH_KEY).
+const WIDTH_KEY = 'kanso.cardDiscussionWidth'
+
+test.describe('Card modal resizable discussion pane (#3661)', () => {
+	const BOARD_TITLE = 'Modal Resize E2E Board ' + Date.now()
+	const state = { boardId: 0, stackId: 0, cardId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === BOARD_TITLE) await apiDelete(`/boards/${b.id}`)
+		}
+		const board = await apiPost('/boards', { title: BOARD_TITLE })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'To Do' })
+		state.stackId = stack.id
+		const card = await apiPost('/cards', {
+			stackId: stack.id,
+			title: 'Resize Test Card',
+			description: 'Card used to verify the resizable discussion pane.',
+		})
+		state.cardId = card.id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('dragging the handle resizes the discussion pane and clamps within bounds', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		// Start from a clean, known width so the assertion is deterministic.
+		await page.addInitScript(() => { try { localStorage.removeItem('kanso.cardDiscussionWidth') } catch (e) {} })
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal__resizer', { timeout: 15_000 })
+
+		const before = await page.locator('.card-modal__discussion').boundingBox()
+		expect(before).not.toBeNull()
+
+		// Drag the handle LEFT by 120px → the discussion pane grows.
+		const handle = await page.locator('.card-modal__resizer').boundingBox()
+		expect(handle).not.toBeNull()
+		const cx = handle.x + handle.width / 2
+		const cy = handle.y + handle.height / 2
+		await page.mouse.move(cx, cy)
+		await page.mouse.down()
+		await page.mouse.move(cx - 120, cy, { steps: 10 })
+		await page.mouse.up()
+
+		const after = await page.locator('.card-modal__discussion').boundingBox()
+		expect(after.width).toBeGreaterThan(before.width + 60)
+
+		// Clamp check: drag far RIGHT past the min → pane never collapses below 280px.
+		const h2 = await page.locator('.card-modal__resizer').boundingBox()
+		await page.mouse.move(h2.x + h2.width / 2, h2.y + h2.height / 2)
+		await page.mouse.down()
+		await page.mouse.move(h2.x + 2000, h2.y, { steps: 10 })
+		await page.mouse.up()
+		const clamped = await page.locator('.card-modal__discussion').boundingBox()
+		expect(clamped.width).toBeGreaterThanOrEqual(279)
+	})
+
+	test('the chosen width persists across reload', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal__resizer', { timeout: 15_000 })
+		// Reset to a known width, then reopen so the modal starts from the default.
+		await page.evaluate((k) => { try { localStorage.removeItem(k) } catch (e) {} }, WIDTH_KEY)
+		await page.reload()
+		await page.waitForSelector('.card-modal__resizer', { timeout: 15_000 })
+
+		// Drag to widen the discussion pane.
+		const handle = await page.locator('.card-modal__resizer').boundingBox()
+		const cx = handle.x + handle.width / 2
+		const cy = handle.y + handle.height / 2
+		await page.mouse.move(cx, cy)
+		await page.mouse.down()
+		await page.mouse.move(cx - 100, cy, { steps: 10 })
+		await page.mouse.up()
+
+		const widened = await page.locator('.card-modal__discussion').boundingBox()
+
+		// The width is written to localStorage under the shared key.
+		const stored = await page.evaluate((k) => localStorage.getItem(k), WIDTH_KEY)
+		expect(stored).not.toBeNull()
+		expect(parseInt(stored, 10)).toBeGreaterThan(400)
+
+		// Reload → the pane comes back at (approximately) the persisted width.
+		await page.reload()
+		await page.waitForSelector('.card-modal__discussion', { timeout: 15_000 })
+		const restored = await page.locator('.card-modal__discussion').boundingBox()
+		expect(Math.abs(restored.width - widened.width)).toBeLessThanOrEqual(6)
+	})
+
+	test('the handle is keyboard-accessible and arrow keys nudge the width', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		await page.addInitScript(() => { try { localStorage.removeItem('kanso.cardDiscussionWidth') } catch (e) {} })
+		await page.goto(state.cardUrl)
+		const handle = page.locator('.card-modal__resizer')
+		await handle.waitFor({ timeout: 15_000 })
+
+		// a11y contract: role=separator, vertical orientation, focusable.
+		await expect(handle).toHaveAttribute('role', 'separator')
+		await expect(handle).toHaveAttribute('aria-orientation', 'vertical')
+		await expect(handle).toHaveAttribute('tabindex', '0')
+
+		const before = await page.locator('.card-modal__discussion').boundingBox()
+		await handle.focus()
+		// ArrowLeft grows the discussion pane.
+		await handle.press('ArrowLeft')
+		await handle.press('ArrowLeft')
+		await handle.press('ArrowLeft')
+		const after = await page.locator('.card-modal__discussion').boundingBox()
+		expect(after.width).toBeGreaterThan(before.width)
+	})
+
+	test('below the 680px breakpoint the panes stack and the handle is inert', async ({ page }) => {
+		await page.setViewportSize({ width: 500, height: 800 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal__body', { timeout: 15_000 })
+
+		// The resizer is hidden (display:none) in the stacked mobile layout.
+		await expect(page.locator('.card-modal__resizer')).toBeHidden()
+	})
+})

--- a/tests/e2e/card-picker-click-outside.spec.js
+++ b/tests/e2e/card-picker-click-outside.spec.js
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #3665 — the attribute pickers in the card view (Assign, priority, type, due,
+// estimate, cover, status, labels…) all close on a click OUTSIDE the popover, via
+// one shared document-level mousedown handler keyed on openPicker. This exercises:
+//   - open a picker → click a neutral spot in the modal → popover closes
+//   - open a picker → click an option → applies AND closes
+//   - open the due picker → click inside the date input → stays open
+//   - open a picker → Escape closes the PICKER, not the whole card (picker-first)
+//   - open a picker → outside click closes the PICKER, not the whole card
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return // Already logged in
+
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Card picker click-outside dismiss (#3665)', () => {
+	const BOARD_TITLE = 'Picker Outside Board ' + Date.now()
+	const state = { boardId: 0, stackId: 0, cardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title.startsWith('Picker Outside Board')) {
+				await apiDelete(`/boards/${b.id}`)
+			}
+		}
+		const board = await apiPost('/boards', { title: BOARD_TITLE })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'Backlog' })
+		state.stackId = stack.id
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'Picker Outside Card' })
+		state.cardId = card.id
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) {
+			await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+		}
+	})
+
+	async function openCardModal(page) {
+		await page.goto(state.boardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-tile', { timeout: 10_000 })
+		const tile = page.locator('.card-tile').filter({ hasText: 'Picker Outside Card' })
+		await expect(tile).toBeVisible({ timeout: 5000 })
+		await tile.click()
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+	}
+
+	test('open Assign → click a neutral spot in the modal → popover closes', async ({ page }) => {
+		await ncLogin(page)
+		await openCardModal(page)
+
+		const assignPill = page.locator('.card-modal__attrbar button.card-modal__pill', { hasText: 'Assign' })
+		await expect(assignPill).toBeVisible({ timeout: 5000 })
+		await assignPill.click()
+
+		// Popover is open.
+		const popover = page.locator('.card-modal__popover')
+		await expect(popover.first()).toBeVisible({ timeout: 3000 })
+
+		// Click a neutral area of the modal (the header) — outside popover + trigger.
+		await page.locator('.card-modal__header').click()
+
+		// Popover closes; the card modal stays open.
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal')).toBeVisible()
+	})
+
+	test('open priority → click an option → applies AND closes', async ({ page }) => {
+		await ncLogin(page)
+		await openCardModal(page)
+
+		const attrbar = page.locator('.card-modal__attrbar')
+		const priorityPill = attrbar.locator('button.card-modal__pill').first()
+		await priorityPill.click()
+		await page.locator('.card-modal__popover .card-modal__popover-opt', { hasText: /^High$/ }).click()
+
+		// Selection applied…
+		await expect(attrbar.locator('.card-modal__pill--priority-3')).toBeVisible({ timeout: 5000 })
+		// …and the popover closed as part of the same click.
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+	})
+
+	test('open due → click inside the date input → stays open', async ({ page }) => {
+		await ncLogin(page)
+		await openCardModal(page)
+
+		const duePill = page.locator('.card-modal__attrbar button[data-pill="due"]')
+		await expect(duePill).toBeVisible({ timeout: 5000 })
+		await duePill.click()
+
+		const dateInput = page.locator('.card-modal__popover .card-modal__date-input').first()
+		await expect(dateInput).toBeVisible({ timeout: 3000 })
+
+		// Clicking inside the popover's own input must NOT dismiss it.
+		await dateInput.click()
+		await expect(page.locator('.card-modal__popover')).toBeVisible()
+		await expect(dateInput).toBeVisible()
+	})
+
+	test('picker open → Escape closes the picker, not the whole card', async ({ page }) => {
+		await ncLogin(page)
+		await openCardModal(page)
+
+		const priorityPill = page.locator('.card-modal__attrbar button.card-modal__pill').first()
+		await priorityPill.click()
+		await expect(page.locator('.card-modal__popover').first()).toBeVisible({ timeout: 3000 })
+
+		await page.keyboard.press('Escape')
+
+		// Picker-first precedence: picker gone, card still open.
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal')).toBeVisible()
+
+		// A second Escape now closes the card.
+		await page.keyboard.press('Escape')
+		await page.waitForSelector('.card-modal', { state: 'hidden', timeout: 5000 }).catch(() => {})
+		await expect(page.locator('.card-modal')).toHaveCount(0)
+	})
+
+	test('picker open → click on the modal backdrop closes the picker, not the card', async ({ page }) => {
+		await ncLogin(page)
+		await openCardModal(page)
+
+		const priorityPill = page.locator('.card-modal__attrbar button.card-modal__pill').first()
+		await priorityPill.click()
+		await expect(page.locator('.card-modal__popover').first()).toBeVisible({ timeout: 3000 })
+
+		// The dismiss handler is a document-level mousedown (capture) that keys on
+		// event.target being the dark backdrop (.modal-wrapper). Dispatch that exact
+		// event on the wrapper — Playwright's .click() would refuse it as the modal
+		// header overlaps the wrapper's own bounding box, but the real handler only
+		// cares about the mousedown target, not pointer geometry.
+		const fireWrapperMousedown = () => page.evaluate(() => {
+			const wrapper = document.querySelector('.card-modal-modal .modal-wrapper')
+			wrapper.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }))
+		})
+
+		// Picker-first precedence: the backdrop mousedown clears the picker only.
+		await fireWrapperMousedown()
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal')).toBeVisible()
+
+		// With no picker open, a second backdrop mousedown now closes the card.
+		await fireWrapperMousedown()
+		await page.waitForSelector('.card-modal', { state: 'hidden', timeout: 5000 }).catch(() => {})
+		await expect(page.locator('.card-modal')).toHaveCount(0)
+	})
+})

--- a/tests/e2e/card-time-tracking.spec.js
+++ b/tests/e2e/card-time-tracking.spec.js
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	const text = await r.text()
+	return { ok: r.ok, status: r.status, body: text ? JSON.parse(text) : null }
+}
+
+// Card time tracking (#3536): manual entries (seconds + optional note), a
+// per-card total in the DETAIL payload (never the summaries), board-EDIT gated,
+// IDOR-guarded delete, and purge-cascade cleanup.
+test.describe('Card time tracking', () => {
+	let boardId = 0
+	let stackId = 0
+	let cardId = 0
+	let otherCardId = 0
+
+	test.beforeAll(async () => {
+		boardId = (await api('POST', '/boards', { title: 'Time Tracking E2E' })).body.id
+		stackId = (await api('POST', '/stacks', { boardId, title: 'Tasks' })).body.id
+		cardId = (await api('POST', '/cards', { stackId, title: 'Card with time' })).body.id
+		otherCardId = (await api('POST', '/cards', { stackId, title: 'Other card' })).body.id
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await api('DELETE', `/boards/${boardId}`)
+	})
+
+	test('add entries, list them, and the per-card total updates', async () => {
+		// Starts empty; the detail total is 0.
+		let res = await api('GET', `/cards/${cardId}/time-entries`)
+		expect(res.ok).toBe(true)
+		expect(res.body).toEqual([])
+
+		res = await api('GET', `/cards/${cardId}`)
+		expect(res.body.timeSpent).toBe(0)
+
+		// Add 1h 30m (5400s) with a note.
+		const a = await api('POST', `/cards/${cardId}/time-entries`, { seconds: 5400, note: 'Pairing' })
+		expect(a.ok).toBe(true)
+		expect(a.body.seconds).toBe(5400)
+		expect(a.body.note).toBe('Pairing')
+		expect(a.body.createdBy).toBe(USER)
+
+		// Add another 30m, no note.
+		const b = await api('POST', `/cards/${cardId}/time-entries`, { seconds: 1800 })
+		expect(b.ok).toBe(true)
+		expect(b.body.note).toBeNull()
+
+		// Both show up, newest first.
+		res = await api('GET', `/cards/${cardId}/time-entries`)
+		expect(res.body).toHaveLength(2)
+		expect(res.body[0].id).toBe(b.body.id)
+
+		// The card detail total is the SUM (5400 + 1800).
+		res = await api('GET', `/cards/${cardId}`)
+		expect(res.body.timeSpent).toBe(7200)
+
+		// Delete one entry; the total drops.
+		res = await api('DELETE', `/cards/${cardId}/time-entries/${a.body.id}`)
+		expect(res.ok).toBe(true)
+		res = await api('GET', `/cards/${cardId}`)
+		expect(res.body.timeSpent).toBe(1800)
+
+		// Clean up the remaining entry.
+		await api('DELETE', `/cards/${cardId}/time-entries/${b.body.id}`)
+		res = await api('GET', `/cards/${cardId}`)
+		expect(res.body.timeSpent).toBe(0)
+	})
+
+	test('the per-card total is NOT in the board summaries (perf bet preserved)', async () => {
+		await api('POST', `/cards/${cardId}/time-entries`, { seconds: 600 })
+		const board = await api('GET', `/boards/${boardId}`)
+		expect(board.ok).toBe(true)
+		// Find the card in the board payload; the summary must not carry timeSpent.
+		const json = JSON.stringify(board.body)
+		expect(json).not.toContain('timeSpent')
+		// Clean up.
+		const entries = await api('GET', `/cards/${cardId}/time-entries`)
+		for (const e of entries.body) {
+			await api('DELETE', `/cards/${cardId}/time-entries/${e.id}`)
+		}
+	})
+
+	test('a zero or negative duration is rejected', async () => {
+		let res = await api('POST', `/cards/${cardId}/time-entries`, { seconds: 0 })
+		expect(res.ok).toBe(false)
+		expect(res.status).toBe(400)
+
+		res = await api('POST', `/cards/${cardId}/time-entries`, { seconds: -60 })
+		expect(res.ok).toBe(false)
+		expect(res.status).toBe(400)
+	})
+
+	test('IDOR: a time entry of one card cannot be deleted via another card', async () => {
+		const a = await api('POST', `/cards/${cardId}/time-entries`, { seconds: 120 })
+		expect(a.ok).toBe(true)
+
+		// Deleting via the OTHER card's URL must 404 (not a leak).
+		const del = await api('DELETE', `/cards/${otherCardId}/time-entries/${a.body.id}`)
+		expect(del.ok).toBe(false)
+		expect(del.status).toBe(404)
+
+		// It still exists on its real card.
+		const res = await api('GET', `/cards/${cardId}/time-entries`)
+		expect(res.body.some((e) => e.id === a.body.id)).toBe(true)
+
+		await api('DELETE', `/cards/${cardId}/time-entries/${a.body.id}`)
+	})
+
+	test('purging a card removes its time entries', async () => {
+		const doomed = (await api('POST', '/cards', { stackId, title: 'Doomed' })).body.id
+		await api('POST', `/cards/${doomed}/time-entries`, { seconds: 900 })
+		let res = await api('GET', `/cards/${doomed}/time-entries`)
+		expect(res.body).toHaveLength(1)
+
+		// Trash then purge (hard delete).
+		await api('DELETE', `/cards/${doomed}`)
+		const purge = await api('DELETE', `/cards/${doomed}/purge`)
+		expect(purge.ok).toBe(true)
+
+		// The card is gone; its entries were cascaded (no strays).
+		res = await api('GET', `/cards/${doomed}/time-entries`)
+		expect(res.ok).toBe(false)
+	})
+
+	test('add a time entry through the CardModal UI and see the total on reopen', async ({ page }) => {
+		await ncLogin(page)
+		const cardUrl = `${BASE}/index.php/apps/kanso#/board/${boardId}/card/${cardId}`
+		await page.goto(cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// Fill the duration + note and submit the add-time form.
+		await page.fill('.card-modal__time-duration', '1h 30m')
+		await page.fill('.card-modal__time-note', 'UI logged')
+		await page.locator('.card-modal__time-add button', { hasText: 'Add time' }).click()
+
+		// The entry row appears with the formatted duration + note.
+		const row = page.locator('.card-modal__link-row', { hasText: 'UI logged' })
+		await expect(row).toHaveCount(1, { timeout: 8000 })
+		await expect(row).toContainText('1h 30m')
+
+		// Reopen the card fresh; the per-card total (from the detail payload) shows.
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${boardId}`)
+		await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {})
+		await page.goto(cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+		await expect(page.locator('.card-modal__time-entry-duration', { hasText: '1h 30m' }))
+			.toHaveCount(1, { timeout: 8000 })
+
+		// Clean up so the shared card resets.
+		const entries = await api('GET', `/cards/${cardId}/time-entries`)
+		for (const e of entries.body) {
+			await api('DELETE', `/cards/${cardId}/time-entries/${e.id}`)
+		}
+	})
+})

--- a/tests/e2e/color-swatch.spec.js
+++ b/tests/e2e/color-swatch.spec.js
@@ -50,8 +50,10 @@ test.describe('Colour-pick swatch shape', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		// Open board settings → Labels tab.
-		await page.click('.board-view__settings-btn')
+		// Open board settings → Labels tab. Board settings now lives in the
+		// consolidated ⋯ More overflow menu, so open that first.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: 'Board settings' }).click()
 		await page.waitForSelector('.label-settings__swatch', { timeout: 10_000 })
 
 		const box = await page.locator('.label-settings__swatch').first().boundingBox()

--- a/tests/e2e/dead-links.spec.js
+++ b/tests/e2e/dead-links.spec.js
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Dead-link UX (#3662): a deep-link/inbox/notification pointing at a card or
+// board that no longer exists must land on a friendly, actionable message - not
+// a raw "failed to load" error. This asserts:
+//   1. Opening a card route for a non-existent card id under a live board shows
+//      "This card no longer exists" + a "Go to boards" way out (not a raw error).
+//   2. Opening a board route for a deleted board shows "This board no longer
+//      exists" + a "Go to boards" link (not the generic error box).
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const ADMIN = 'admin'
+const ADMIN_PASS = 'admin'
+
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const ADMIN_AUTH = 'Basic ' + Buffer.from(`${ADMIN}:${ADMIN_PASS}`).toString('base64')
+
+async function apiRequest(path, { method = 'GET', body } = {}) {
+	const opts = { method, headers: { ...HEADERS, Authorization: ADMIN_AUTH } }
+	if (body !== undefined) opts.body = JSON.stringify(body)
+	return fetch(API + path, opts)
+}
+
+async function apiGet(path) {
+	const r = await apiRequest(path)
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await apiRequest(path, { method: 'POST', body })
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	await apiRequest(path, { method: 'DELETE' })
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	const isLoginPage = await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return
+	await page.fill('#user', ADMIN)
+	await page.fill('#password', ADMIN_PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Dead card/board links (#3662)', () => {
+	const state = { liveBoardId: 0, deadBoardId: 0 }
+	const TITLE = 'Dead Links E2E Board'
+
+	test.beforeAll(async () => {
+		// Clean any leftovers from a prior run.
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === TITLE) await apiDelete(`/boards/${b.id}`)
+		}
+
+		// A live board to host a bogus card deep-link.
+		const live = await apiPost('/boards', { title: TITLE })
+		state.liveBoardId = live.id
+		await apiPost('/stacks', { boardId: live.id, title: 'To Do' })
+
+		// A second board we delete, to exercise the gone-board path.
+		const dead = await apiPost('/boards', { title: TITLE })
+		state.deadBoardId = dead.id
+		await apiDelete(`/boards/${dead.id}`)
+	})
+
+	test.afterAll(async () => {
+		if (state.liveBoardId) await apiDelete(`/boards/${state.liveBoardId}`)
+	})
+
+	test.beforeEach(async ({ page }) => {
+		await ncLogin(page)
+	})
+
+	test('a card that no longer exists shows a friendly message + a way out', async ({ page }) => {
+		// Deep-link to a non-existent card id under the LIVE board (the card fetch
+		// 404s while the board loads fine).
+		const bogusCardId = 2_000_000_000
+		await page.goto(
+			`${BASE}/index.php/apps/kanso#/board/${state.liveBoardId}/card/${bogusCardId}`,
+		)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+
+		const err = page.locator('.card-modal__error')
+		await expect(err).toBeVisible({ timeout: 15_000 })
+		await expect(err).toContainText('no longer exists')
+		// Not the old generic copy.
+		await expect(err).not.toContainText('Failed to load card details')
+		// A dead card is a dead end - no Retry, but a way out to the boards list.
+		await expect(err.getByRole('button', { name: 'Go to boards' })).toBeVisible()
+		await expect(err.getByRole('button', { name: 'Retry' })).toHaveCount(0)
+
+		// The way out actually leaves the (broken) card.
+		await err.getByRole('button', { name: 'Go to boards' }).click()
+		await expect(page).toHaveURL(/#\/$/, { timeout: 10_000 })
+	})
+
+	test('a board that no longer exists explains itself + links to the boards list', async ({ page }) => {
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.deadBoardId}`)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+
+		const err = page.locator('.board-view__error')
+		await expect(err).toBeVisible({ timeout: 15_000 })
+		await expect(err).toContainText('no longer exists')
+		await expect(err).not.toContainText('Failed to load board.')
+		await expect(err.getByRole('button', { name: 'Go to boards' })).toBeVisible()
+	})
+})

--- a/tests/e2e/estimations.spec.js
+++ b/tests/e2e/estimations.spec.js
@@ -108,7 +108,9 @@ test.describe('Card estimations (#3443)', () => {
 	test('the board settings Workflow tab switches the scale', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /workflow/i }).click()
 
 		const select = page.locator(`#estimate-scale-${state.boardId}`)

--- a/tests/e2e/labels.spec.js
+++ b/tests/e2e/labels.spec.js
@@ -72,7 +72,9 @@ test.describe('Labels', () => {
 	test('colored label created via the settings panel renders colored everywhere', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(state.boardUrl)
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 
 		// Pick the first preset (red e74c3c), name it, create it
 		await page.getByRole('button', { name: /pick color for new label/i }).click()

--- a/tests/e2e/list-view.spec.js
+++ b/tests/e2e/list-view.spec.js
@@ -74,4 +74,28 @@ test.describe('Board List view (#3444)', () => {
 		await expect(page).toHaveURL(new RegExp(`/board/${state.boardId}/card/`), { timeout: 8_000 })
 		await expect(page.locator('.card-modal')).toBeVisible({ timeout: 10_000 })
 	})
+
+	test('collapsing a group hides its cards; expanding shows them again', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// Switch to List view.
+		await page.locator('.board-view__view-menu button').first().click()
+		await page.getByText('List', { exact: true }).click()
+
+		const row = page.locator('.board-list-row', { hasText: state.cardTitle })
+		const group = page.locator('.board-list-group', { hasText: 'To do' })
+		await expect(row).toBeVisible({ timeout: 8_000 })
+		await expect(group).toBeVisible()
+
+		// Collapse the group → its card row disappears from the virtualized list.
+		await group.dispatchEvent('click')
+		await expect(row).toBeHidden({ timeout: 8_000 })
+		await expect(group).toBeVisible()
+
+		// Expand again → the card row comes back.
+		await group.dispatchEvent('click')
+		await expect(row).toBeVisible({ timeout: 8_000 })
+	})
 })

--- a/tests/e2e/list-view.spec.js
+++ b/tests/e2e/list-view.spec.js
@@ -39,6 +39,10 @@ test.describe('Board List view (#3444)', () => {
 		state.boardId = board.id
 		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To do' })
 		await api('POST', '/cards', { stackId: stack.id, title: state.cardTitle })
+		// A second card with a due date well in the past → the group header should
+		// surface an "overdue" hint for it (variant 1d per-group hints).
+		const overdue = await api('POST', '/cards', { stackId: stack.id, title: 'Overdue row card' })
+		await api('PATCH', `/cards/${overdue.id}`, { duedate: '2020-01-01T00:00:00+00:00' })
 	})
 
 	test.afterAll(async () => {
@@ -60,6 +64,10 @@ test.describe('Board List view (#3444)', () => {
 		const row = page.locator('.board-list-row', { hasText: state.cardTitle })
 		await expect(row).toBeVisible({ timeout: 8_000 })
 		await expect(page.locator('.board-view__stacks-wrap')).toBeHidden()
+
+		// The group header surfaces a per-group overdue hint for the past-due card.
+		await expect(page.locator('.board-list-group__hint--overdue', { hasText: 'overdue' }))
+			.toBeVisible({ timeout: 8_000 })
 
 		// Toggle back to Board → columns visible again (round-trip, no modal open).
 		await setView('Board')

--- a/tests/e2e/new-cards-top.spec.js
+++ b/tests/e2e/new-cards-top.spec.js
@@ -60,9 +60,11 @@ test.describe('New cards on top', () => {
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
 		// Open board settings → General tab → turn on "Add new cards to the top".
-		// The settings dialog is a teleported modal; on the slow runner it takes a
-		// beat to mount, so wait for each control to be actionable before clicking.
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu. The
+		// settings dialog is a teleported modal; on the slow runner it takes a beat
+		// to mount, so wait for each control to be actionable before clicking.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		const generalTab = page.getByRole('tab', { name: 'General' })
 		await expect(generalTab).toBeVisible({ timeout: 10_000 })
 		await generalTab.click()

--- a/tests/e2e/perf.spec.js
+++ b/tests/e2e/perf.spec.js
@@ -1,11 +1,56 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// @perf - excluded from the default `npm run test:e2e` run.
-// Run explicitly: npx playwright test --grep @perf
+// @perf - excluded from the default `npm run test:e2e` run (see
+// playwright.config.js `testIgnore`). This is an ON-DEMAND benchmark, NOT a
+// gating spec. Run it explicitly against the dev instance:
 //
-// This spec requires the 'Perf Test Board' seeded by scripts/seed-board.mjs
-// (3 stacks × 667 cards = 2 001 total).
+//   node scripts/seed-board.mjs                    # seed the board first
+//   npx playwright test --config playwright.perf.config.js
+//
+// Seed size is parameterized in the seed script (CARDS / STACKS env vars); this
+// spec measures WHATEVER 'Perf Test Board' is currently seeded and prints its
+// real card count, so the numbers are always self-describing.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// WHAT THIS MEASURES (baseline for the delta-sync card #3675)
+//
+//   1. Initial load     — board payload bytes, time-to-first-tile, DOM node
+//                          count (proves virtualization holds at scale).
+//   2. Scroll           — rAF frame rate during a virtual scroll (no jank).
+//   3. Polling (KEY)    — the two fallback-refetch paths, side by side:
+//        a. NOTHING changed → a conditional GET returns 304 (cheap).
+//        b. ONE card changed elsewhere → the WHOLE board re-downloads and the
+//           client re-renders everything. We capture BOTH the payload bytes and
+//           the client main-thread (long-task) cost of the re-render.
+//      (b) is the number that proves the O(boardSize)-per-change problem: a
+//      single-card edit anywhere costs a full-board download + re-render for
+//      every viewer. The board read has ETag/304 but NO `?since` delta yet
+//      (BoardController::show, appinfo/routes.php), so any real change busts the
+//      ETag and forces the full path.
+//
+// BASELINE NUMBERS (captured 2026-08-06, dev docker stack, headless Chromium):
+//   Board size measured: 2001 cards / 3 stacks.
+//     - Initial render (first tile):  ~617 ms
+//     - Board payload (full, 200):    34,370 bytes raw  (~33.8 KB on the wire,
+//                                       gzipped transferSize)
+//     - DOM tiles rendered:           39  (of 2001 cards) — virtualization holds
+//     - Scroll frame rate:            ~54 fps (no jank)
+//     - Poll, NOTHING changed (304):  0 bytes body  (cheap conditional GET works)
+//     - Poll, ONE card changed (200): 34,370 bytes  (FULL re-download of the
+//                                       whole board — identical to the initial load)
+//   => A single-card edit anywhere re-downloads the ENTIRE board. A true delta
+//      for that one change would be ~17 bytes (payload / card count), so the
+//      current path ships ~2000x more than necessary. This is the O(boardSize)-
+//      per-change cost #3675's delta sync must eliminate. See the [PERF SUMMARY]
+//      lines in the run output for exact numbers at the size YOU seeded.
+//   The harness SUPPORTS 10k — seed it with:
+//      CARDS=10000 STACKS=20 node scripts/seed-board.mjs
+//   then re-run this spec to capture the large-board numbers. (Seeding is
+//   sequential-per-stack to avoid sort-key collisions, ~9 cards/s on the dev
+//   stack, so 10k takes ~15-20 min; more stacks does not currently raise
+//   throughput much as the dev DB serializes the writes.)
+// ─────────────────────────────────────────────────────────────────────────────
 
 import { test, expect } from '@playwright/test'
 
@@ -19,10 +64,31 @@ const HEADERS = {
 }
 const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
 
-async function apiGet(path) {
-	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: AUTH } })
-	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+async function apiGet(path, extraHeaders = {}) {
+	const r = await fetch(API + path, {
+		headers: { ...HEADERS, Authorization: AUTH, ...extraHeaders },
+	})
+	if (!r.ok && r.status !== 304) throw new Error(`GET ${path} → ${r.status}`)
+	return r
+}
+
+async function apiPatch(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PATCH',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`PATCH ${path} → ${r.status}: ${await r.text()}`)
 	return r.json()
+}
+
+// Best-effort content length of a fetch Response: prefer the header, else read
+// the body and measure it. Returns bytes.
+async function responseBytes(res) {
+	const cl = res.headers.get('content-length')
+	if (cl != null) return Number(cl)
+	const buf = await res.arrayBuffer()
+	return buf.byteLength
 }
 
 async function ncLogin(page) {
@@ -40,76 +106,79 @@ async function ncLogin(page) {
 	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
 }
 
-test.describe('@perf 2000-card board performance', () => {
+test.describe('@perf large-board performance', () => {
+	let boardId = 0
 	let boardUrl = ''
+	let cardCount = 0
+	let stackCount = 0
 
 	test.beforeAll(async () => {
-		const boards = await apiGet('/boards')
+		const boards = await (await apiGet('/boards')).json()
 		const perfBoard = boards.find((b) => b.title === 'Perf Test Board')
 		if (!perfBoard) {
 			throw new Error('Perf Test Board not found. Run: node scripts/seed-board.mjs')
 		}
-		boardUrl = `${BASE}/index.php/apps/kanso#/board/${perfBoard.id}`
-		console.log('Perf Test Board URL:', boardUrl)
+		boardId = perfBoard.id
+		boardUrl = `${BASE}/index.php/apps/kanso#/board/${boardId}`
+		const payload = await (await apiGet(`/boards/${boardId}`)).json()
+		cardCount = Array.isArray(payload.cards) ? payload.cards.length : 0
+		stackCount = Array.isArray(payload.stacks) ? payload.stacks.length : 0
+		console.log(`[PERF] Board #${boardId}: ${cardCount} cards / ${stackCount} stacks — ${boardUrl}`)
 	})
 
-	test('@perf initial render time and frame rate during scroll', async ({ page }) => {
+	test('@perf initial load, virtualization, and scroll frame rate', async ({ page }) => {
 		await ncLogin(page)
 
-		// ── Measure initial render time ────────────────────────────────────────
-		// Use addInitScript to stamp performance.now() on every new page load.
-		// This fires synchronously before any page scripts, so it captures the
-		// very start of the document lifecycle for the board URL navigation.
+		// ── Initial render time ────────────────────────────────────────────────
 		await page.addInitScript(() => {
 			window.__perfStart = performance.now()
 		})
 
 		const navStart = Date.now()
 		await page.goto(boardUrl)
+		await page.waitForSelector('.card-tile-wrap', { timeout: 45_000 })
 
-		// Wait for the first tile to appear in the DOM
-		await page.waitForSelector('.card-tile-wrap', { timeout: 30_000 })
-
-		// Two measurements: in-page timing (performance.now delta from init script)
-		// and wall-clock navigation-to-tile time.
-		const initialRenderMs = await page.evaluate(() => {
-			return performance.now() - (window.__perfStart ?? 0)
-		})
+		const initialRenderMs = await page.evaluate(() => performance.now() - (window.__perfStart ?? 0))
 		const wallClockMs = Date.now() - navStart
 		console.log(`[PERF] Initial render (first tile visible): ${initialRenderMs.toFixed(1)} ms (wall: ${wallClockMs} ms)`)
 
-
-		// ── Measure board payload size ─────────────────────────────────────────
+		// ── Board payload size (from the browser's own resource timing) ─────────
 		const payloadKB = await page.evaluate(() => {
 			const entries = performance.getEntriesByType('resource')
-			// Find the kanso board API call (board endpoint returns stacks+cards)
 			const boardEntry = entries.find(
-				(e) => e.name.includes('/apps/kanso/api/boards/') && !e.name.includes('/cards') && !e.name.includes('/stacks'),
+				(e) => e.name.includes('/apps/kanso/api/boards/')
+					&& !e.name.includes('/cards')
+					&& !e.name.includes('/stacks')
+					&& !e.name.includes('/participants'),
 			)
 			if (boardEntry && boardEntry.transferSize) {
 				return (boardEntry.transferSize / 1024).toFixed(1)
 			}
-			// Fallback: sum all kanso API calls
 			const total = entries
 				.filter((e) => e.name.includes('/apps/kanso/'))
 				.reduce((sum, e) => sum + (e.transferSize || 0), 0)
 			return (total / 1024).toFixed(1)
 		})
-		console.log(`[PERF] Board payload size: ${payloadKB} KB`)
+		console.log(`[PERF] Board payload size (browser transferSize): ${payloadKB} KB`)
 
-		// ── Measure rAF frame rate during a 3-second programmatic scroll ───────
+		// ── DOM node count — proves virtualization holds at scale ──────────────
+		// A non-virtualized board would render one tile per card; the virtualizer
+		// keeps only the visible window (plus overscan) in the DOM.
+		const domTiles = await page.locator('.card-tile-wrap').count()
+		const totalDomNodes = await page.evaluate(() => document.querySelectorAll('*').length)
+		console.log(`[PERF] DOM tiles rendered: ${domTiles} (of ${cardCount} cards) | total DOM nodes: ${totalDomNodes}`)
+
+		// ── rAF frame rate during a 3s programmatic scroll ─────────────────────
 		const column = page.locator('.stack-column').first()
 		const cardList = column.locator('.stack-column__cards')
 		const cardListBox = await cardList.boundingBox()
 		if (!cardListBox) throw new Error('Could not find card list element')
 
-		// Hover over the card list so scroll events land on it
 		await page.mouse.move(
 			cardListBox.x + cardListBox.width / 2,
 			cardListBox.y + cardListBox.height / 2,
 		)
 
-		// Inject rAF counter before scrolling
 		await page.evaluate(() => {
 			window.__rafCount = 0
 			window.__rafRunning = true
@@ -121,13 +190,10 @@ test.describe('@perf 2000-card board performance', () => {
 			requestAnimationFrame(raf)
 		})
 
-		// Programmatically scroll the card list element over ~3 seconds via
-		// repeated mouse wheel events so the virtualizer recalculates visible items.
 		const SCROLL_DURATION_MS = 3000
-		const SCROLL_STEP = 200 // px per tick
-		const TICK_INTERVAL = 100 // ms between ticks
+		const SCROLL_STEP = 300
+		const TICK_INTERVAL = 100
 		const ticks = Math.ceil(SCROLL_DURATION_MS / TICK_INTERVAL)
-
 		for (let i = 0; i < ticks; i++) {
 			await page.mouse.wheel(0, SCROLL_STEP)
 			await page.waitForTimeout(TICK_INTERVAL)
@@ -137,22 +203,142 @@ test.describe('@perf 2000-card board performance', () => {
 			window.__rafRunning = false
 			return window.__rafCount
 		})
-
 		const avgFps = (rafCount / (SCROLL_DURATION_MS / 1000)).toFixed(1)
 		console.log(`[PERF] rAF frames in ${SCROLL_DURATION_MS}ms scroll: ${rafCount} → avg ${avgFps} fps`)
 
-		// Verify some tiles are still in DOM (virtualizer working during scroll)
 		const domTilesAfterScroll = await page.locator('.card-tile-wrap').count()
 		console.log(`[PERF] DOM tile count after scroll: ${domTilesAfterScroll}`)
 
-		// Sanity assertions - not strict perf budgets, just ensure things work
-		expect(initialRenderMs).toBeLessThan(10_000) // under 10s
+		// Sanity assertions — not strict budgets, just prove the harness works and
+		// virtualization holds (far fewer DOM tiles than cards on a large board).
+		expect(initialRenderMs).toBeLessThan(45_000)
 		expect(domTilesAfterScroll).toBeGreaterThan(0)
-		expect(Number(avgFps)).toBeGreaterThan(10) // at least 10 fps (headless baseline)
+		expect(Number(avgFps)).toBeGreaterThan(10)
+		if (cardCount > 300) {
+			// Virtualization MUST keep the DOM bounded well below the card count.
+			expect(domTiles).toBeLessThan(cardCount)
+		}
 
-		// Summary line for easy grepping
 		console.log(
-			`[PERF SUMMARY] render=${initialRenderMs.toFixed(0)}ms | fps=${avgFps} | payload=${payloadKB}KB | dom_tiles=${domTilesAfterScroll}`,
+			`[PERF SUMMARY] load | cards=${cardCount} render=${initialRenderMs.toFixed(0)}ms `
+			+ `fps=${avgFps} payload=${payloadKB}KB dom_tiles=${domTiles} dom_nodes=${totalDomNodes}`,
 		)
+	})
+
+	test('@perf polling cost: 304 no-op vs full re-download on one change', async () => {
+		// This test hits the API directly (no browser) to measure the two
+		// server-side polling paths precisely. This is the O(boardSize) proof.
+
+		// Baseline: a full (unconditional) board GET → the ETag + payload size.
+		const t0 = Date.now()
+		const fullRes = await apiGet(`/boards/${boardId}`)
+		const etag = (fullRes.headers.get('etag') || '').replace(/^W\//, '').replace(/"/g, '')
+		const fullBody = await fullRes.text()
+		const fullBytesActual = Number(fullRes.headers.get('content-length')) || Buffer.byteLength(fullBody, 'utf8')
+		const fullMs = Date.now() - t0
+		console.log(`[PERF] Full board GET: status=${fullRes.status} bytes=${fullBytesActual} etag=${etag} (${fullMs}ms)`)
+
+		// ── Path A: NOTHING changed → conditional GET should 304 (cheap) ───────
+		const noopStart = Date.now()
+		const noopRes = await apiGet(`/boards/${boardId}`, { 'If-None-Match': `"${etag}"` })
+		const noopBytes = await responseBytes(noopRes)
+		const noopBody = noopRes.status === 304 ? '' : await noopRes.text()
+		const noopBytesActual = noopBytes || Buffer.byteLength(noopBody, 'utf8')
+		const noopMs = Date.now() - noopStart
+		console.log(`[PERF] Poll, NOTHING changed: status=${noopRes.status} bytes=${noopBytesActual} (${noopMs}ms)`)
+		expect(noopRes.status).toBe(304) // proves the cheap conditional path works
+
+		// ── Path B: ONE card changed elsewhere → ETag busts, full re-download ──
+		// Touch a single card's title. That bumps the board's latest change id
+		// (the ETag), so the SAME If-None-Match now MISSES and the whole board
+		// (all cards) comes back down. This is the per-change cost every viewer
+		// pays today with no delta sync.
+		const cards = (await (await apiGet(`/boards/${boardId}`)).json()).cards
+		const victim = cards[0]
+		await apiPatch(`/cards/${victim.id}`, { title: `${victim.title} *` })
+
+		const changedStart = Date.now()
+		const changedRes = await apiGet(`/boards/${boardId}`, { 'If-None-Match': `"${etag}"` })
+		const changedBody = await changedRes.text()
+		const changedBytes = Number(changedRes.headers.get('content-length')) || Buffer.byteLength(changedBody, 'utf8')
+		const changedMs = Date.now() - changedStart
+		console.log(`[PERF] Poll, ONE card changed: status=${changedRes.status} bytes=${changedBytes} (${changedMs}ms)`)
+
+		// The proof: a one-card change returns a full 200 payload, NOT a small
+		// delta. Its size is on the order of the whole board, not one card.
+		expect(changedRes.status).toBe(200)
+		// Per-card cost if this WERE a delta (what #3675 should approach): the full
+		// payload divided by the card count. The gap between that and full_200 is
+		// the waste a single-card change incurs today.
+		const idealDeltaBytes = Math.round(changedBytes / Math.max(cardCount, 1))
+		console.log(
+			`[PERF SUMMARY] polling | cards=${cardCount} `
+			+ `noop_304_body=${noopBytesActual}B full_200=${changedBytes}B `
+			+ `~per_card=${idealDeltaBytes}B `
+			+ `(one-card change re-downloads the whole board; a delta would be ~${idealDeltaBytes}B)`,
+		)
+
+		// Sanity: the changed-path payload must dwarf a single card's worth of
+		// data, confirming O(boardSize)-per-change (the full board comes back for
+		// a one-card edit).
+		expect(changedBytes).toBeGreaterThan(idealDeltaBytes * 10)
+	})
+
+	test('@perf client re-render cost of a full-board refetch (main-thread)', async ({ page }) => {
+		// Measures the CLIENT side of path B: when the board query is refetched
+		// and the whole payload re-lands, how long is the main thread busy
+		// re-processing/re-rendering it? Captured via long-task observation.
+		await ncLogin(page)
+		await page.goto(boardUrl)
+		await page.waitForSelector('.card-tile-wrap', { timeout: 45_000 })
+
+		// Install a long-task observer, then trigger a fresh full board fetch and
+		// let Vue/TanStack re-reconcile. We drive the refetch the same way the
+		// realtime path does: refetch the board resource, which the app already
+		// polls. Simplest reliable trigger: reload the board data by re-fetching
+		// the API in-page and forcing the query cache to update is app-internal,
+		// so instead we measure the main-thread busy time across a hard refetch
+		// via a full navigation re-mount (worst case, but representative of the
+		// re-render+re-parse work a full payload imposes).
+		const busyMs = await page.evaluate(async () => {
+			let total = 0
+			const obs = new PerformanceObserver((list) => {
+				for (const entry of list.getEntries()) total += entry.duration
+			})
+			try {
+				obs.observe({ entryTypes: ['longtask'] })
+			} catch {
+				return -1 // longtask not supported in this browser build
+			}
+			// Fetch the full board payload again (the network shape of a poll that
+			// found a change) and JSON-parse it on the main thread — the parse +
+			// downstream reactivity is the per-change client cost.
+			const t0 = performance.now()
+			const res = await fetch(
+				window.location.origin + '/index.php/apps/kanso/api/boards/'
+					+ window.location.hash.split('/board/')[1],
+				{ headers: { 'OCS-APIREQUEST': 'true' } },
+			)
+			await res.json()
+			// Give the browser a moment to flush any long tasks from parsing.
+			await new Promise((r) => setTimeout(r, 500))
+			obs.disconnect()
+			const elapsed = performance.now() - t0
+			return { total, elapsed }
+		})
+
+		if (busyMs === -1) {
+			console.log('[PERF] longtask API unavailable — skipping main-thread measurement')
+		} else {
+			console.log(
+				`[PERF] Full-refetch client cost: main-thread long-tasks=${busyMs.total.toFixed(0)}ms `
+				+ `over ${busyMs.elapsed.toFixed(0)}ms total`,
+			)
+			console.log(
+				`[PERF SUMMARY] refetch-client | cards=${cardCount} `
+				+ `longtask_ms=${busyMs.total.toFixed(0)} wall_ms=${busyMs.elapsed.toFixed(0)}`,
+			)
+		}
+		expect(true).toBe(true) // measurement-only, no budget
 	})
 })

--- a/tests/e2e/review-gating.spec.js
+++ b/tests/e2e/review-gating.spec.js
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPut(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PUT',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body ? JSON.stringify(body) : undefined,
+	})
+	if (!r.ok) throw new Error(`PUT ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPatch(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PATCH',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body ? JSON.stringify(body) : undefined,
+	})
+	if (!r.ok) throw new Error(`PATCH ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return // Already logged in
+
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Review-type stage gating', () => {
+	const state = {
+		boardId: 0,
+		stackId: 0,
+		cardId: 0,
+		codeTypeId: 0,
+		qaTypeId: 0,
+		cardUrl: '',
+	}
+
+	test.beforeAll(async () => {
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === 'Review Gating E2E Board') {
+				await apiDelete(`/boards/${b.id}`)
+			}
+		}
+
+		const board = await apiPost('/boards', { title: 'Review Gating E2E Board' })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'Backlog' })
+		state.stackId = stack.id
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'Gated card' })
+		state.cardId = card.id
+
+		// Code = stage 0, QA = stage 1. Lower stage gates higher.
+		const code = await apiPost('/review-types', { boardId: board.id, title: 'Code', stage: 0 })
+		state.codeTypeId = code.id
+		const qa = await apiPost('/review-types', { boardId: board.id, title: 'QA', stage: 1 })
+		state.qaTypeId = qa.id
+
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) {
+			await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+		}
+	})
+
+	test('QA renders gated while Code is pending, then un-gates once Code is approved', async ({ page }) => {
+		// Request both reviews from admin (one per type is allowed on the same card).
+		await apiPut(`/cards/${state.cardId}/reviews/${USER}`, { reviewTypeId: state.codeTypeId })
+		await apiPut(`/cards/${state.cardId}/reviews/${USER}`, { reviewTypeId: state.qaTypeId })
+
+		// The server should mark the QA (stage 1) review gated, blocked by the Code
+		// (stage 0) review, and QA's notification should be deferred (notifiedAt null).
+		let detail = await apiGet(`/cards/${state.cardId}`)
+		let qa = detail.reviews.find((r) => r.reviewTypeId === state.qaTypeId)
+		let code = detail.reviews.find((r) => r.reviewTypeId === state.codeTypeId)
+		expect(qa.gated).toBe(true)
+		expect(qa.blockedBy).toContain(code.id)
+		expect(qa.notifiedAt).toBeNull()
+		// Code (stage 0) is not gated and was notified at request time.
+		expect(code.gated).toBe(false)
+
+		// The QA chip should render distinctly gated in the modal.
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.card-modal', { timeout: 12_000 })
+		const gatedChip = page.locator('.card-modal__review-pill--gated')
+		await expect(gatedChip).toBeVisible({ timeout: 8_000 })
+		await expect(gatedChip.locator('.card-modal__review-type-badge')).toContainText('QA')
+
+		// Approve the Code review → QA un-gates and its deferred notification fires.
+		await apiPatch(`/cards/${state.cardId}/reviews/${code.id}`, { state: 'approved' })
+
+		detail = await apiGet(`/cards/${state.cardId}`)
+		qa = detail.reviews.find((r) => r.reviewTypeId === state.qaTypeId)
+		expect(qa.gated).toBe(false)
+		expect(qa.blockedBy).toEqual([])
+		expect(qa.state).toBe('pending')
+		// The deferred notification fired: notifiedAt is now stamped.
+		expect(qa.notifiedAt).not.toBeNull()
+
+		// The gated chip is gone in the UI after reload.
+		await page.reload()
+		await page.waitForSelector('.card-modal', { timeout: 12_000 })
+		await expect(page.locator('.card-modal__review-pill--gated')).toHaveCount(0, { timeout: 8_000 })
+	})
+})

--- a/tests/e2e/review-types.spec.js
+++ b/tests/e2e/review-types.spec.js
@@ -105,8 +105,9 @@ test.describe('Review types', () => {
 		await page.goto(state.boardUrl)
 		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
 
-		// Open board settings
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Open board settings (now in the consolidated ⋯ More overflow menu)
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 
 		// Click the Review types tab
 		await page.getByRole('tab', { name: /review types/i }).click()
@@ -128,7 +129,8 @@ test.describe('Review types', () => {
 		await page.goto(state.boardUrl)
 		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
 
-		await page.getByRole('button', { name: /board settings/i }).click()
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.getByRole('tab', { name: /review types/i }).click()
 
 		// Pick a color for the new type

--- a/tests/e2e/settings-panel.spec.js
+++ b/tests/e2e/settings-panel.spec.js
@@ -83,8 +83,9 @@ test.describe('Settings panel (right-docked drawer)', () => {
 		const card = page.locator('.card-tile', { hasText: 'First card' })
 		await expect(card).toBeVisible({ timeout: 20_000 })
 
-		// Open settings panel via gear button
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Open settings panel via the ⋯ More overflow menu → Board settings.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 
 		// Panel must be visible
 		const panel = page.locator('.bs-modal')
@@ -123,8 +124,9 @@ test.describe('Settings panel (right-docked drawer)', () => {
 
 		await page.locator('.card-tile').first().waitFor({ state: 'visible', timeout: 20_000 })
 
-		// Open panel
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Open panel via the ⋯ More overflow menu → Board settings.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		const panel = page.locator('.bs-modal')
 		await expect(panel).toBeVisible({ timeout: 5_000 })
 
@@ -133,21 +135,26 @@ test.describe('Settings panel (right-docked drawer)', () => {
 		await expect(panel).not.toBeVisible({ timeout: 3_000 })
 	})
 
-	test('gear button toggles the panel (second click closes)', async ({ page }) => {
+	test('Board settings menu item toggles the panel (second invocation closes)', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(state.boardUrl)
 
 		await page.locator('.card-tile').first().waitFor({ state: 'visible', timeout: 20_000 })
 
-		const gearBtn = page.getByRole('button', { name: /board settings/i })
+		const moreBtn = page.getByRole('button', { name: 'More' })
+		const settingsItem = page.getByRole('menuitem', { name: /board settings/i })
 		const panel = page.locator('.bs-modal')
 
-		// First click opens
-		await gearBtn.click()
+		// First invocation opens (Board settings now lives in the ⋯ More overflow
+		// menu; selecting it dismisses the menu but leaves the docked panel open).
+		await moreBtn.click()
+		await settingsItem.click()
 		await expect(panel).toBeVisible({ timeout: 5_000 })
 
-		// Second click closes (toggle behavior)
-		await gearBtn.click()
+		// Second invocation closes (the same handler still toggles). Re-open the
+		// menu — its item is hidden while the menu is dismissed — then invoke again.
+		await moreBtn.click()
+		await settingsItem.click()
 		await expect(panel).not.toBeVisible({ timeout: 3_000 })
 	})
 })

--- a/tests/e2e/swimlanes.spec.js
+++ b/tests/e2e/swimlanes.spec.js
@@ -61,8 +61,9 @@ test.describe('Swimlanes (#3406)', () => {
 		await expect(page.locator('.board-view__stacks-wrap')).toBeVisible()
 		await expect(page.locator('.swimlane')).toHaveCount(0)
 
-		// Open the swimlane menu and pick "Group by label".
-		await page.locator('.board-view__swimlane-menu button').first().click()
+		// Swimlanes now live under the consolidated ⋯ More overflow menu. Open it
+		// and pick "Group by label".
+		await page.getByRole('button', { name: 'More' }).click()
 		await page.getByText('Group by label', { exact: true }).click()
 
 		// Lanes appear: the "Frontend" label lane and the trailing "No label" lane.
@@ -85,7 +86,7 @@ test.describe('Swimlanes (#3406)', () => {
 		await expect(page.locator('.swimlane')).toHaveCount(2)
 
 		// Toggle back to "No swimlanes" → flat board restored, lanes gone.
-		await page.locator('.board-view__swimlane-menu button').first().click()
+		await page.getByRole('button', { name: 'More' }).click()
 		await page.getByText('No swimlanes', { exact: true }).click()
 		await expect(page.locator('.swimlane')).toHaveCount(0)
 		await expect(page.locator('.board-view__stacks-wrap')).toBeVisible()

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -175,6 +175,77 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await expect(page.locator('.timeline__lane')).toHaveCount(laneRowsBefore)
 	})
 
+	test('dragging an unscheduled card onto the track schedules it (persisted)', async ({ page }) => {
+		// A dedicated unscheduled card for this test, so it can't collide with the
+		// shared "Someday task" the other specs assert on.
+		const dragTitle = 'Drag me to schedule ' + Math.floor(Date.now() / 1000)
+		const stack = (await api('GET', `/boards/${state.boardId}`)).stacks[0]
+		const card = await api('POST', '/cards', { stackId: stack.id, title: dragTitle })
+
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await page.locator('.board-view__view-menu button').first().click()
+		await page.getByText('Timeline', { exact: true }).click()
+
+		// The track must be present (there are already scheduled cards on this board).
+		const track = page.locator('.timeline__inner')
+		await expect(track).toBeVisible({ timeout: 8_000 })
+
+		// Expand the unscheduled footer and locate the draggable row for our card.
+		await page.locator('.timeline__unscheduled summary').click()
+		const footerRow = page.locator('.timeline__unscheduled-row', { hasText: dragTitle })
+		await expect(footerRow).toBeVisible({ timeout: 8_000 })
+
+		// Drop near the horizontal centre of the visible track (position→day math is
+		// sensitive, so we assert "got scheduled", never an exact calendar day).
+		const trackBox = await track.boundingBox()
+		const dropX = trackBox.x + Math.min(trackBox.width, 800) * 0.5
+		const dropY = trackBox.y + trackBox.height / 2
+		await dragOnto(page, footerRow, dropX, dropY)
+
+		// Give the optimistic patch + server round-trip generous room on slow CI.
+		await page.waitForTimeout(1500)
+
+		// Primary (UI) assertion: the card left the unscheduled footer and now shows
+		// up on the track. A newly single-dated card renders as a milestone diamond;
+		// accept a bar too in case the drop math produced a range, so the check is
+		// tolerant to layout specifics rather than a brittle pixel position.
+		const scheduledMarker = page.locator(
+			`.timeline__milestone:has-text("${dragTitle}"), .timeline__bar:has-text("${dragTitle}")`,
+		)
+		const scheduledUi = await scheduledMarker.first().isVisible({ timeout: 6_000 }).catch(() => false)
+		const leftFooter = !(await page.locator('.timeline__unscheduled-row', { hasText: dragTitle })
+			.isVisible({ timeout: 2_000 }).catch(() => false))
+
+		if (scheduledUi && leftFooter) {
+			await expect(scheduledMarker.first()).toBeVisible()
+		} else {
+			// Fallback: Pragmatic DnD can be flaky to drive from Playwright on a slow
+			// runner. Rather than fail on a visual-position race, confirm the drop set
+			// a duedate via the API — that's the behaviour under test.
+			await expect
+				.poll(async () => (await api('GET', `/cards/${card.id}`)).duedate, { timeout: 8_000 })
+				.not.toBeNull()
+		}
+
+		// Persistence: after a reload the card still carries a due date (it stays
+		// scheduled and does not fall back into the unscheduled footer).
+		await expect
+			.poll(async () => (await api('GET', `/cards/${card.id}`)).duedate, { timeout: 10_000 })
+			.not.toBeNull()
+
+		await page.reload()
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await page.locator('.board-view__view-menu button').first().click()
+		await page.getByText('Timeline', { exact: true }).click()
+		await expect(page.locator('.timeline__inner')).toBeVisible({ timeout: 8_000 })
+		// It appears on the track and is no longer offered as unscheduled.
+		await expect(page.locator(
+			`.timeline__milestone:has-text("${dragTitle}"), .timeline__bar:has-text("${dragTitle}")`,
+		).first()).toBeVisible({ timeout: 8_000 })
+	})
+
 	test('a lane is keyboard-openable: focus + Enter opens the card (#3512)', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -76,6 +76,14 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await expect(page.locator('.timeline__unscheduled summary')).toContainText('unscheduled')
 		await expect(page.locator('.timeline__unscheduled')).toContainText('Someday task')
 
+		// 2a: the frozen left pane lists each scheduled card by id/title beside a
+		// stack group-header row, aligned with its bar on the right (#3623).
+		await expect(page.locator('.timeline__pane-head')).toBeVisible()
+		await expect(page.locator('.timeline__group-row')).toContainText('To do')
+		await expect(page.locator('.timeline__pane-row', { hasText: 'Ranged task' })).toBeVisible()
+		// Two-tier axis: a month band sits over the week/day ticks.
+		await expect(page.locator('.timeline__axis-month').first()).toBeVisible()
+
 		// Clicking a lane opens the card modal (dispatchEvent avoids a race with
 		// the board poll re-render).
 		await page.locator('.timeline__lane', { hasText: 'Ranged task' }).dispatchEvent('click')

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -91,6 +91,67 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await expect(page.locator('.card-modal')).toBeVisible({ timeout: 10_000 })
 	})
 
+	test('chrome: jump-to-today scrolls, legend renders, groups collapse, track fills the viewport', async ({ page }) => {
+		await ncLogin(page)
+		// Start from a clean slate so a prior run's collapsed state doesn't leak in.
+		await page.addInitScript(() => { try { localStorage.clear() } catch (e) {} })
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await page.locator('.board-view__view-menu button').first().click()
+		await page.getByText('Timeline', { exact: true }).click()
+
+		await expect(page.locator('.timeline__bar', { hasText: 'Ranged task' })).toBeVisible({ timeout: 8_000 })
+
+		// Legend renders with all five swatches.
+		const legend = page.locator('.timeline__legend')
+		await expect(legend).toBeVisible()
+		await expect(legend).toContainText('Not started')
+		await expect(legend).toContainText('In progress')
+		await expect(legend).toContainText('Overdue')
+		await expect(legend).toContainText('Done')
+		await expect(legend).toContainText('Single date')
+		await expect(page.locator('.timeline__legend-swatch')).toHaveCount(5)
+
+		// Page-fill: on this short-range board the inner track still fills the viewport.
+		const fill = await page.locator('.timeline__scroll').evaluate((el) => {
+			return { scroll: el.scrollWidth, client: el.clientWidth }
+		})
+		expect(fill.scroll).toBeGreaterThanOrEqual(fill.client)
+
+		// Jump-to-today scrolls the track horizontally toward the today marker.
+		const todayBtn = page.getByRole('button', { name: 'Jump to today' })
+		await expect(todayBtn).toBeVisible()
+		const scrollBefore = await page.locator('.timeline__scroll').evaluate((el) => {
+			el.scrollLeft = 0
+			return el.scrollLeft
+		})
+		await todayBtn.click()
+		await page.waitForTimeout(700) // smooth scroll settles
+		const scrollAfter = await page.locator('.timeline__scroll').evaluate((el) => el.scrollLeft)
+		// With a track wider than the viewport and today near the right edge, the
+		// jump moves the scroll position off zero (or leaves it at zero only when
+		// today is already centered within the first viewport).
+		expect(scrollAfter).toBeGreaterThanOrEqual(scrollBefore)
+
+		// Group-collapse: the header chevron folds away its card rows in the pane.
+		const paneRowsBefore = await page.locator('.timeline__pane-row').count()
+		expect(paneRowsBefore).toBeGreaterThan(0)
+		const laneRowsBefore = await page.locator('.timeline__lane').count()
+		// Pane rows and track lanes mirror 1:1 for alignment.
+		expect(laneRowsBefore).toBe(paneRowsBefore)
+
+		await page.locator('.timeline__group-row').first().click()
+		await expect(page.locator('.timeline__pane-row')).toHaveCount(0)
+		await expect(page.locator('.timeline__lane')).toHaveCount(0)
+		// Header still visible with its count.
+		await expect(page.locator('.timeline__group-row').first()).toBeVisible()
+
+		// Expand again restores the exact row set in both pane and track.
+		await page.locator('.timeline__group-row').first().click()
+		await expect(page.locator('.timeline__pane-row')).toHaveCount(paneRowsBefore)
+		await expect(page.locator('.timeline__lane')).toHaveCount(laneRowsBefore)
+	})
+
 	test('a lane is keyboard-openable: focus + Enter opens the card (#3512)', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -20,6 +20,29 @@ async function api(method, path, body) {
 	return method === 'DELETE' ? null : r.json()
 }
 
+// Pragmatic-DnD needs a real pointer gesture with intermediate moves (a single
+// jump won't cross its drag threshold), mirroring dnd.spec.js's dragWithMouse.
+async function dragOnto(page, sourceLocator, targetX, targetY) {
+	const srcBox = await sourceLocator.boundingBox()
+	if (!srcBox) throw new Error('Could not get bounding box for drag source')
+	const srcX = srcBox.x + srcBox.width / 2
+	const srcY = srcBox.y + srcBox.height / 2
+	await page.mouse.move(srcX, srcY)
+	await page.mouse.down()
+	const steps = 15
+	for (let i = 1; i <= steps; i++) {
+		await page.mouse.move(
+			srcX + (targetX - srcX) * (i / steps),
+			srcY + (targetY - srcY) * (i / steps),
+			{ steps: 1 },
+		)
+		await page.waitForTimeout(20)
+	}
+	await page.waitForTimeout(150)
+	await page.mouse.up()
+	await page.waitForTimeout(500)
+}
+
 async function ncLogin(page) {
 	await page.goto(BASE + '/index.php/login')
 	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})

--- a/tests/e2e/trash.spec.js
+++ b/tests/e2e/trash.spec.js
@@ -62,7 +62,9 @@ async function ncLogin(page) {
 // ── Helpers for opening the routed Trash page ────────────────────────────────
 
 async function openTrashPage(page) {
-	const trashBtn = page.locator('.board-view__trash-btn')
+	// Trash now lives in the consolidated ⋯ More overflow menu.
+	await page.getByRole('button', { name: 'More' }).click()
+	const trashBtn = page.getByRole('menuitem', { name: 'Deleted cards' })
 	await expect(trashBtn).toBeVisible({ timeout: 8000 })
 	await trashBtn.click()
 	// Deep-linkable routed page.

--- a/tests/e2e/visual.spec.js
+++ b/tests/e2e/visual.spec.js
@@ -50,7 +50,9 @@ test.describe('Visual proportions', () => {
 	test('label color-option swatches render as true circles (width === height)', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(state.boardUrl)
-		await page.getByRole('button', { name: /board settings/i }).click()
+		// Board settings now lives in the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
 
 		// Open the new-label color picker grid
 		await page.getByRole('button', { name: /pick color for new label/i }).click()

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,9 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
-  <file src="lib/Service/CardService.php">
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$card]]></code>
-      <code><![CDATA[$card]]></code>
-    </PossiblyUndefinedVariable>
-  </file>
 </files>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -4,7 +4,6 @@
     <PossiblyUndefinedVariable>
       <code><![CDATA[$card]]></code>
       <code><![CDATA[$card]]></code>
-      <code><![CDATA[$card]]></code>
     </PossiblyUndefinedVariable>
   </file>
 </files>

--- a/tests/unit/Activity/ProviderTest.php
+++ b/tests/unit/Activity/ProviderTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Activity;
+
+use OCA\Kanso\Activity\Provider;
+use OCP\Activity\Exceptions\UnknownActivityException;
+use OCP\Activity\IEvent;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ProviderTest extends TestCase {
+	private IFactory&MockObject $l10nFactory;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IUserManager&MockObject $userManager;
+	private Provider $provider;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->provider = new Provider(
+			$this->l10nFactory,
+			$this->urlGenerator,
+			$this->userManager,
+		);
+
+		// IL10N is not in the OCP dev stub; a tiny stand-in with a printf-style
+		// t() suffices (IFactory::get has no declared return type).
+		$l = new class {
+			public function t(string $text, array $parameters = []): string {
+				return $parameters === [] ? $text : vsprintf($text, $parameters);
+			}
+		};
+		$this->l10nFactory->method('get')->willReturn($l);
+		$this->urlGenerator->method('imagePath')->willReturn('/img/app.svg');
+		$this->urlGenerator->method('getAbsoluteURL')->willReturnArgument(0);
+	}
+
+	/**
+	 * @param array<string, mixed> $params
+	 */
+	private function event(string $app, string $subject, array $params, string $objectId = '9'): IEvent&MockObject {
+		$e = $this->createMock(IEvent::class);
+		$e->method('getApp')->willReturn($app);
+		$e->method('getSubject')->willReturn($subject);
+		$e->method('getSubjectParameters')->willReturn($params);
+		$e->method('getObjectId')->willReturn($objectId);
+		$e->method('getLink')->willReturn('https://nc.example/apps/kanso/#/board/3/card/9');
+		$e->method('setIcon')->willReturnSelf();
+		$e->method('setParsedSubject')->willReturnSelf();
+		return $e;
+	}
+
+	private function stubActor(?string $displayName): void {
+		if ($displayName === null) {
+			$this->userManager->method('get')->willReturn(null);
+			return;
+		}
+		$actor = $this->createMock(IUser::class);
+		$actor->method('getDisplayName')->willReturn($displayName);
+		$this->userManager->method('get')->willReturn($actor);
+	}
+
+	public function testParseRejectsForeignApp(): void {
+		$e = $this->event('files', Provider::SUBJECT_CARD_CREATED, ['actor' => 'alice', 'name' => 'Card']);
+		$this->expectException(UnknownActivityException::class);
+		// The card requires the short-circuit to be an \InvalidArgumentException;
+		// UnknownActivityException extends it.
+		$this->expectException(\InvalidArgumentException::class);
+		$this->provider->parse('en', $e);
+	}
+
+	public function testParseRejectsUnknownSubject(): void {
+		$e = $this->event('kanso', 'card_exploded', ['actor' => 'alice', 'name' => 'Card']);
+		$this->expectException(UnknownActivityException::class);
+		$this->provider->parse('en', $e);
+	}
+
+	public function testParseCardCreatedBuildsRichSubject(): void {
+		$this->stubActor('Alice A.');
+		$e = $this->event('kanso', Provider::SUBJECT_CARD_CREATED, ['actor' => 'alice', 'name' => 'Fix the bug']);
+
+		$e->expects(self::once())->method('setParsedSubject')->with('Alice A. created Fix the bug')->willReturnSelf();
+		$e->expects(self::once())->method('setRichSubject')
+			->with(
+				'{actor} created {object}',
+				self::callback(static fn (array $p): bool
+					=> $p['actor']['type'] === 'user'
+					&& $p['actor']['id'] === 'alice'
+					&& $p['actor']['name'] === 'Alice A.'
+					&& $p['object']['type'] === 'highlight'
+					&& $p['object']['id'] === '9'
+					&& $p['object']['name'] === 'Fix the bug')
+			)->willReturnSelf();
+
+		self::assertSame($e, $this->provider->parse('en', $e));
+	}
+
+	public function testParseCardDoneUsesDoneWording(): void {
+		$this->stubActor('Alice A.');
+		$e = $this->event('kanso', Provider::SUBJECT_CARD_DONE, ['actor' => 'alice', 'name' => 'Ship it']);
+
+		$e->expects(self::once())->method('setParsedSubject')->with('Alice A. marked Ship it as done')->willReturnSelf();
+		$e->expects(self::once())->method('setRichSubject')
+			->with('{actor} marked {object} as done', self::anything())->willReturnSelf();
+
+		$this->provider->parse('en', $e);
+	}
+
+	public function testParseBoardSharedUsesShareWording(): void {
+		$this->stubActor('Alice A.');
+		$e = $this->event('kanso', Provider::SUBJECT_BOARD_SHARED, ['actor' => 'alice', 'name' => 'Roadmap'], '3');
+
+		$e->expects(self::once())->method('setParsedSubject')->with('Alice A. shared Roadmap with you')->willReturnSelf();
+		$e->expects(self::once())->method('setRichSubject')
+			->with('{actor} shared {object} with you', self::anything())->willReturnSelf();
+
+		$this->provider->parse('en', $e);
+	}
+
+	public function testParseFallsBackToUidWhenActorMissing(): void {
+		// An actor with no user account renders as the raw uid, not a crash.
+		$this->stubActor(null);
+		$e = $this->event('kanso', Provider::SUBJECT_CARD_MOVED, ['actor' => 'ghost', 'name' => 'Card']);
+
+		$e->expects(self::once())->method('setParsedSubject')->with('ghost moved Card')->willReturnSelf();
+		$e->method('setRichSubject')->willReturnSelf();
+
+		$this->provider->parse('en', $e);
+	}
+}

--- a/tests/unit/Controller/BoardControllerTest.php
+++ b/tests/unit/Controller/BoardControllerTest.php
@@ -14,6 +14,7 @@ use OCA\Kanso\Db\Board;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardContactMapper;
+use OCA\Kanso\Db\CardFieldMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardRelationMapper;
@@ -56,6 +57,7 @@ class BoardControllerTest extends TestCase {
 	private CardContactMapper&MockObject $cardContactMapper;
 	private CardReviewMapper&MockObject $cardReviewMapper;
 	private ReviewTypeMapper&MockObject $reviewTypeMapper;
+	private CardFieldMapper&MockObject $cardFieldMapper;
 	private ChecklistItemMapper&MockObject $checklistItemMapper;
 	private CommentMapper&MockObject $commentMapper;
 	private AclMapper&MockObject $aclMapper;
@@ -80,6 +82,7 @@ class BoardControllerTest extends TestCase {
 		$this->cardContactMapper = $this->createMock(CardContactMapper::class);
 		$this->cardReviewMapper = $this->createMock(CardReviewMapper::class);
 		$this->reviewTypeMapper = $this->createMock(ReviewTypeMapper::class);
+		$this->cardFieldMapper = $this->createMock(CardFieldMapper::class);
 		$this->checklistItemMapper = $this->createMock(ChecklistItemMapper::class);
 		$this->commentMapper = $this->createMock(CommentMapper::class);
 		$this->aclMapper = $this->createMock(AclMapper::class);
@@ -107,6 +110,7 @@ class BoardControllerTest extends TestCase {
 			$this->cardContactMapper,
 			$this->cardReviewMapper,
 			$this->reviewTypeMapper,
+			$this->cardFieldMapper,
 			$this->checklistItemMapper,
 			$this->commentMapper,
 			$this->aclMapper,

--- a/tests/unit/Controller/BoardControllerTest.php
+++ b/tests/unit/Controller/BoardControllerTest.php
@@ -19,6 +19,7 @@ use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardRelationMapper;
 use OCA\Kanso\Db\CardReviewMapper;
+use OCA\Kanso\Db\Change;
 use OCA\Kanso\Db\ChangeMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
@@ -319,6 +320,200 @@ class BoardControllerTest extends TestCase {
 			->willThrowException(new DoesNotExistException('gone'));
 
 		$response = $this->controller->participants(1);
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+	// ---- changes() delta-sync (#3675) --------------------------------------
+
+	private function change(int $id, int $entityType, int $entityId, int $action): Change {
+		$change = new Change();
+		$change->setId($id);
+		$change->setBoardId(1);
+		$change->setEntityType($entityType);
+		$change->setEntityId($entityId);
+		$change->setAction($action);
+		return $change;
+	}
+
+	/**
+	 * Stubs the board-wide enrichment maps serializeCardSummaries() reads, so a
+	 * changes() test that expects an upsert gets the full (board-shaped) card.
+	 */
+	private function stubEnrichmentEmpty(): void {
+		$this->cardLabelMapper->method('findLabelIdsByBoard')->willReturn([]);
+		$this->cardAssigneeMapper->method('findUserIdsByBoard')->willReturn([]);
+		$this->cardContactMapper->method('findContactsByBoard')->willReturn([]);
+		$this->checklistItemMapper->method('progressByBoard')->willReturn([]);
+		$this->cardMapper->method('childProgressByBoard')->willReturn([]);
+		$this->commentMapper->method('countsByBoard')->willReturn([]);
+		$this->cardReviewMapper->method('reviewStatesByBoard')->willReturn([]);
+		$this->cardRelationMapper->method('blockedCardIdsByBoard')->willReturn([]);
+	}
+
+	public function testChangesResyncsWhenCursorIsZero(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(9);
+		// No window read at all for a cursorless client.
+		$this->changeMapper->expects(self::never())->method('findSince');
+
+		$response = $this->controller->changes(1, 0);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertTrue($response->getData()['resync']);
+		self::assertSame(9, $response->getData()['cursor']);
+	}
+
+	public function testChangesResyncsWhenCursorBelowRetainedTail(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(50);
+		// Oldest retained change is 20; a cursor of 5 has fallen off the pruned tail.
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(20);
+		$this->changeMapper->expects(self::never())->method('findSince');
+
+		$response = $this->controller->changes(1, 5);
+		self::assertTrue($response->getData()['resync']);
+		self::assertSame(50, $response->getData()['cursor']);
+	}
+
+	public function testChangesResyncsWhenWindowIsSaturated(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(600);
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(1);
+		// A full page (limit=500) of rows means the client is more than one page
+		// behind - a truncated delta, so force a resync.
+		$rows = [];
+		for ($i = 1; $i <= 500; $i++) {
+			$rows[] = $this->change($i, Change::ENTITY_CARD, $i, Change::ACTION_UPDATE);
+		}
+		$this->changeMapper->method('findSince')->with(1, 5, 500)->willReturn($rows);
+
+		$response = $this->controller->changes(1, 5);
+		self::assertTrue($response->getData()['resync']);
+	}
+
+	public function testChangesResyncsOnOutOfScopeEntity(): void {
+		// The MVP scope cut: a label edit in the window → resync rather than
+		// replicate board-wide label/acl enrichment in the delta path.
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(9);
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(1);
+		$this->changeMapper->method('findSince')->willReturn([
+			$this->change(8, Change::ENTITY_CARD, 42, Change::ACTION_UPDATE),
+			$this->change(9, Change::ENTITY_LABEL, 7, Change::ACTION_UPDATE),
+		]);
+		// A resync must not even attempt a per-id card re-serialize.
+		$this->cardMapper->expects(self::never())->method('findSummariesByIds');
+
+		$response = $this->controller->changes(1, 5);
+		self::assertTrue($response->getData()['resync']);
+		self::assertSame(9, $response->getData()['cursor']);
+	}
+
+	public function testChangesUpsertsOnlyTheEditedCardWithFullShape(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(8);
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(1);
+		$this->changeMapper->method('findSince')->willReturn([
+			$this->change(8, Change::ENTITY_CARD, 42, Change::ACTION_UPDATE),
+		]);
+		$this->stubEnrichmentEmpty();
+
+		$card = new Card();
+		$card->setId(42);
+		$card->setBoardId(1);
+		$card->setStackId(3);
+		$card->setTitle('Edited elsewhere');
+		$this->cardMapper->expects(self::once())
+			->method('findSummariesByIds')->with(1, [42])->willReturn([$card]);
+		// Only the touched cards are re-read - never the whole board.
+		$this->cardMapper->expects(self::never())->method('findSummariesByBoard');
+		$this->stackMapper->method('findByIds')->with(1, [])->willReturn([]);
+
+		$response = $this->controller->changes(1, 5);
+		$data = $response->getData();
+		self::assertFalse($data['resync']);
+		self::assertSame(8, $data['cursor']);
+		self::assertCount(1, $data['cards']['upsert']);
+		self::assertSame(42, $data['cards']['upsert'][0]['id']);
+		// Full board-card shape (enrichment keys present, description absent).
+		self::assertSame([], $data['cards']['upsert'][0]['labelIds']);
+		self::assertSame(['total' => 0, 'done' => 0], $data['cards']['upsert'][0]['checklist']);
+		self::assertFalse($data['cards']['upsert'][0]['blocked']);
+		self::assertArrayNotHasKey('description', $data['cards']['upsert'][0]);
+		self::assertSame([], $data['cards']['remove']);
+	}
+
+	public function testChangesCarriesNewPlacementOnMove(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(8);
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(1);
+		$this->changeMapper->method('findSince')->willReturn([
+			$this->change(8, Change::ENTITY_CARD, 42, Change::ACTION_MOVE),
+		]);
+		$this->stubEnrichmentEmpty();
+
+		$card = new Card();
+		$card->setId(42);
+		$card->setBoardId(1);
+		$card->setStackId(99); // moved to a new stack
+		$card->setSortKey('mm');
+		$card->setTitle('Moved card');
+		$this->cardMapper->method('findSummariesByIds')->with(1, [42])->willReturn([$card]);
+		$this->stackMapper->method('findByIds')->willReturn([]);
+
+		$data = $this->controller->changes(1, 5)->getData();
+		self::assertSame(99, $data['cards']['upsert'][0]['stackId']);
+		self::assertSame('mm', $data['cards']['upsert'][0]['sortKey']);
+	}
+
+	public function testChangesEmitsRemoveForDeletedCard(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(8);
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(1);
+		$this->changeMapper->method('findSince')->willReturn([
+			$this->change(8, Change::ENTITY_CARD, 42, Change::ACTION_DELETE),
+		]);
+		$this->stubEnrichmentEmpty();
+
+		// The deleted card is absent from the live summary query → it is a remove.
+		$this->cardMapper->method('findSummariesByIds')->with(1, [42])->willReturn([]);
+		$this->stackMapper->method('findByIds')->willReturn([]);
+
+		$data = $this->controller->changes(1, 5)->getData();
+		self::assertFalse($data['resync']);
+		self::assertSame([], $data['cards']['upsert']);
+		self::assertSame([42], $data['cards']['remove']);
+	}
+
+	public function testChangesEmptyWindowStillAdvancesCursor(): void {
+		$this->boardService->method('find')->with(1, 'alice')->willReturn($this->board());
+		$this->changeMapper->method('getLatestChangeId')->with(1)->willReturn(5);
+		$this->changeMapper->method('getOldestChangeId')->with(1)->willReturn(1);
+		// Client is already caught up: no rows newer than its cursor.
+		$this->changeMapper->method('findSince')->willReturn([]);
+		$this->stubEnrichmentEmpty();
+		$this->cardMapper->method('findSummariesByIds')->willReturn([]);
+		$this->stackMapper->method('findByIds')->willReturn([]);
+
+		$data = $this->controller->changes(1, 5)->getData();
+		self::assertFalse($data['resync']);
+		self::assertSame(5, $data['cursor']);
+		self::assertSame([], $data['cards']['upsert']);
+		self::assertSame([], $data['cards']['remove']);
+	}
+
+	public function testChangesMapsNotPermittedTo403(): void {
+		$this->boardService->method('find')->willThrowException(new NotPermittedException());
+
+		$response = $this->controller->changes(1, 5);
+		self::assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		self::assertArrayHasKey('error', $response->getData());
+	}
+
+	public function testChangesMapsDoesNotExistTo404(): void {
+		$this->boardService->method('find')
+			->willThrowException(new DoesNotExistException('gone'));
+
+		$response = $this->controller->changes(1, 5);
 		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 	}
 

--- a/tests/unit/Controller/CardControllerTest.php
+++ b/tests/unit/Controller/CardControllerTest.php
@@ -14,6 +14,7 @@ use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardContactMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\CardTimeEntryMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
@@ -50,6 +51,7 @@ class CardControllerTest extends TestCase {
 	private CardRelationService&MockObject $relationService;
 	private ProjectCardMapper&MockObject $projectCardMapper;
 	private CardAttachmentMapper&MockObject $cardAttachmentMapper;
+	private CardTimeEntryMapper&MockObject $cardTimeEntryMapper;
 	private CardController $controller;
 
 	protected function setUp(): void {
@@ -80,6 +82,8 @@ class CardControllerTest extends TestCase {
 			->willReturn([]);
 		$this->cardAttachmentMapper = $this->createMock(CardAttachmentMapper::class);
 		$this->cardAttachmentMapper->method('countByCard')->willReturn(0);
+		$this->cardTimeEntryMapper = $this->createMock(CardTimeEntryMapper::class);
+		$this->cardTimeEntryMapper->method('sumSecondsByCard')->willReturn(0);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -103,7 +107,8 @@ class CardControllerTest extends TestCase {
 			$this->subscriptionService,
 			$this->relationService,
 			$this->projectCardMapper,
-			$this->cardAttachmentMapper
+			$this->cardAttachmentMapper,
+			$this->cardTimeEntryMapper
 		);
 	}
 

--- a/tests/unit/Controller/CardControllerTest.php
+++ b/tests/unit/Controller/CardControllerTest.php
@@ -14,7 +14,6 @@ use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardContactMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
-use OCA\Kanso\Db\CardReviewMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
@@ -25,6 +24,7 @@ use OCA\Kanso\Service\ContactService;
 use OCA\Kanso\Service\InvalidInputException;
 use OCA\Kanso\Service\LabelService;
 use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\ReviewService;
 use OCA\Kanso\Service\SubscriptionService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
@@ -42,7 +42,7 @@ class CardControllerTest extends TestCase {
 	private CardLabelMapper&MockObject $cardLabelMapper;
 	private CardAssigneeMapper&MockObject $cardAssigneeMapper;
 	private CardContactMapper&MockObject $cardContactMapper;
-	private CardReviewMapper&MockObject $cardReviewMapper;
+	private ReviewService&MockObject $reviewService;
 	private ChecklistItemMapper&MockObject $checklistItemMapper;
 	private CardMapper&MockObject $cardMapper;
 	private CommentMapper&MockObject $commentMapper;
@@ -64,7 +64,8 @@ class CardControllerTest extends TestCase {
 		$this->cardAssigneeMapper = $this->createMock(CardAssigneeMapper::class);
 		$this->cardContactMapper = $this->createMock(CardContactMapper::class);
 		$this->cardContactMapper->method('findContactsByCard')->willReturn([]);
-		$this->cardReviewMapper = $this->createMock(CardReviewMapper::class);
+		$this->reviewService = $this->createMock(ReviewService::class);
+		$this->reviewService->method('serializeReviewsForCard')->willReturn([]);
 		$this->checklistItemMapper = $this->createMock(ChecklistItemMapper::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->commentMapper = $this->createMock(CommentMapper::class);
@@ -95,7 +96,7 @@ class CardControllerTest extends TestCase {
 			$this->cardLabelMapper,
 			$this->cardAssigneeMapper,
 			$this->cardContactMapper,
-			$this->cardReviewMapper,
+			$this->reviewService,
 			$this->checklistItemMapper,
 			$this->cardMapper,
 			$this->commentMapper,

--- a/tests/unit/Controller/CardControllerTest.php
+++ b/tests/unit/Controller/CardControllerTest.php
@@ -12,6 +12,7 @@ use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardContactMapper;
+use OCA\Kanso\Db\CardFieldValueMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardTimeEntryMapper;
@@ -52,6 +53,7 @@ class CardControllerTest extends TestCase {
 	private ProjectCardMapper&MockObject $projectCardMapper;
 	private CardAttachmentMapper&MockObject $cardAttachmentMapper;
 	private CardTimeEntryMapper&MockObject $cardTimeEntryMapper;
+	private CardFieldValueMapper&MockObject $cardFieldValueMapper;
 	private CardController $controller;
 
 	protected function setUp(): void {
@@ -84,6 +86,8 @@ class CardControllerTest extends TestCase {
 		$this->cardAttachmentMapper->method('countByCard')->willReturn(0);
 		$this->cardTimeEntryMapper = $this->createMock(CardTimeEntryMapper::class);
 		$this->cardTimeEntryMapper->method('sumSecondsByCard')->willReturn(0);
+		$this->cardFieldValueMapper = $this->createMock(CardFieldValueMapper::class);
+		$this->cardFieldValueMapper->method('findByCard')->willReturn([]);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -108,7 +112,8 @@ class CardControllerTest extends TestCase {
 			$this->relationService,
 			$this->projectCardMapper,
 			$this->cardAttachmentMapper,
-			$this->cardTimeEntryMapper
+			$this->cardTimeEntryMapper,
+			$this->cardFieldValueMapper
 		);
 	}
 

--- a/tests/unit/Db/CardMapperTest.php
+++ b/tests/unit/Db/CardMapperTest.php
@@ -262,6 +262,39 @@ class CardMapperTest extends TestCase {
 		self::assertNull($this->mapper->findByBoardAndSeq(7, 999));
 	}
 
+	// ---- findSummariesByIds (delta-sync per-card re-serialize, #3675) ------
+
+	public function testFindSummariesByIdsHydratesTheRequestedCards(): void {
+		// The delta window touched card 42 → it comes back as a hydrated summary
+		// (same shape as findSummariesByBoard, no description).
+		$this->stubQuery([[
+			'id' => 42,
+			'board_id' => 7,
+			'stack_id' => 3,
+			'title' => 'Edited elsewhere',
+			'sort_key' => 'aa',
+			'deleted_at' => 0,
+			'is_template' => false,
+		]]);
+
+		$cards = $this->mapper->findSummariesByIds(7, [42]);
+		self::assertCount(1, $cards);
+		self::assertSame(42, $cards[0]->getId());
+		self::assertSame('Edited elsewhere', $cards[0]->getTitle());
+	}
+
+	public function testFindSummariesByIdsEmptySetShortCircuitsWithoutQuery(): void {
+		// An empty id set must never emit `IN ()` - no DB call at all.
+		$this->db->expects(self::never())->method('getQueryBuilder');
+		self::assertSame([], $this->mapper->findSummariesByIds(7, []));
+	}
+
+	public function testFindSummariesByIdsExcludesTemplates(): void {
+		// A card turned into a template between the cursor and now must not come
+		// back as an upsert (the controller then emits it as a remove).
+		$this->assertFiltersTemplates(fn (CardMapper $m) => $m->findSummariesByIds(7, [42]));
+	}
+
 	// ---- findTemplatesByBoard (per-board template picker, #3409) -----------
 
 	public function testFindTemplatesByBoardHydratesTemplateRows(): void {

--- a/tests/unit/Db/ChangeMapperTest.php
+++ b/tests/unit/Db/ChangeMapperTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Db;
+
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Db\ChangeMapper;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mapper-level tests for the delta-sync reads (#3675). The DB is mocked so these
+ * verify the pure-PHP contract: findSince hydrates the change rows a `?since=`
+ * window returns (ordered/filtered by SQL, asserted at the e2e layer), and
+ * getOldestChangeId maps MIN(id) / no-rows to an int (0 for an empty board).
+ */
+class ChangeMapperTest extends TestCase {
+	private IDBConnection&MockObject $db;
+	private ChangeMapper $mapper;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->mapper = new ChangeMapper($this->db);
+	}
+
+	private static function exprSink(): object {
+		return new class {
+			public function __call(string $name, array $args): string {
+				return '';
+			}
+		};
+	}
+
+	/**
+	 * A spying expression builder recording the column of each comparison, so a
+	 * test can assert findSince emits the `id` (id > since) and `board_id` filters
+	 * the delta window needs.
+	 *
+	 * @param array<int, string> $collector
+	 */
+	private static function spyExpr(array &$collector): object {
+		return new class($collector) {
+			/** @param array<int, string> $seen */
+			public function __construct(
+				private array &$seen,
+			) {
+			}
+
+			public function __call(string $name, array $args): string {
+				if ($args !== [] && \is_string($args[0])) {
+					$this->seen[] = $args[0];
+				}
+				return '';
+			}
+		};
+	}
+
+	/**
+	 * A fluent query-builder mock that ignores chained calls and, on
+	 * executeQuery(), returns a result iterating $rows once (for findEntities) or
+	 * yielding $one from fetchOne() (for the MAX/MIN aggregates).
+	 *
+	 * @param list<array<string, mixed>> $rows
+	 * @param array<int, string> $columns filled with each filtered column when passed
+	 */
+	private function buildQb(array $rows, mixed $one = false, ?array &$columns = null): IQueryBuilder&MockObject {
+		$qb = $this->createMock(IQueryBuilder::class);
+		foreach (['select', 'from', 'where', 'andWhere', 'orderBy', 'addOrderBy', 'setMaxResults'] as $method) {
+			$qb->method($method)->willReturnSelf();
+		}
+		$qb->method('expr')->willReturn($columns !== null ? self::spyExpr($columns) : self::exprSink());
+		$qb->method('func')->willReturn(self::exprSink());
+		$qb->method('createNamedParameter')->willReturn('?');
+		$qb->method('createFunction')->willReturn('fn');
+
+		$result = $this->createMock(IResult::class);
+		$queue = $rows;
+		$result->method('fetch')->willReturnCallback(static function () use (&$queue) {
+			$row = array_shift($queue);
+			return $row ?? false;
+		});
+		$result->method('fetchOne')->willReturn($one);
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}
+
+	public function testFindSinceHydratesTheWindowRows(): void {
+		// Two rows newer than the cursor come back as hydrated Change entities.
+		$this->db->method('getQueryBuilder')->willReturn($this->buildQb([
+			['id' => 6, 'board_id' => 7, 'entity_type' => Change::ENTITY_CARD, 'entity_id' => 42, 'action' => Change::ACTION_UPDATE, 'actor' => 'alice', 'created_at' => 1000],
+			['id' => 7, 'board_id' => 7, 'entity_type' => Change::ENTITY_STACK, 'entity_id' => 3, 'action' => Change::ACTION_CREATE, 'actor' => 'alice', 'created_at' => 1001],
+		]));
+
+		$rows = $this->mapper->findSince(7, 5);
+		self::assertCount(2, $rows);
+		self::assertSame(6, $rows[0]->getId());
+		self::assertSame(Change::ENTITY_CARD, $rows[0]->getEntityType());
+		self::assertSame(42, $rows[0]->getEntityId());
+		self::assertSame(7, $rows[1]->getId());
+		self::assertSame(Change::ENTITY_STACK, $rows[1]->getEntityType());
+	}
+
+	public function testFindSinceFiltersOnBoardAndCursor(): void {
+		$columns = [];
+		$this->db->method('getQueryBuilder')->willReturn($this->buildQb([], false, $columns));
+
+		$this->mapper->findSince(7, 5);
+
+		// The window read is bounded to the board and to rows newer than the cursor.
+		self::assertContains('board_id', $columns);
+		self::assertContains('id', $columns);
+	}
+
+	public function testFindSinceEmptyWindowReturnsEmpty(): void {
+		$this->db->method('getQueryBuilder')->willReturn($this->buildQb([]));
+		self::assertSame([], $this->mapper->findSince(7, 999));
+	}
+
+	public function testGetOldestChangeIdReturnsMin(): void {
+		$this->db->method('getQueryBuilder')->willReturn($this->buildQb([], '3'));
+		self::assertSame(3, $this->mapper->getOldestChangeId(7));
+	}
+
+	public function testGetOldestChangeIdEmptyBoardIsZero(): void {
+		// No rows → MIN(id) is null → 0 (mirrors getLatestChangeId's empty case).
+		$this->db->method('getQueryBuilder')->willReturn($this->buildQb([], false));
+		self::assertSame(0, $this->mapper->getOldestChangeId(7));
+	}
+}

--- a/tests/unit/Db/StackMapperTest.php
+++ b/tests/unit/Db/StackMapperTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Db;
+
+use OCA\Kanso\Db\StackMapper;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mapper-level tests for the delta-sync stack read (#3675). The DB is mocked, so
+ * these verify the pure-PHP contract of findByIds: an explicit id set hydrates
+ * the matching stacks, and an empty set short-circuits without touching the DB
+ * (never emit `IN ()`, which is invalid SQL).
+ */
+class StackMapperTest extends TestCase {
+	private IDBConnection&MockObject $db;
+	private StackMapper $mapper;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->mapper = new StackMapper($this->db);
+	}
+
+	private static function exprSink(): object {
+		return new class {
+			public function __call(string $name, array $args): string {
+				return '';
+			}
+		};
+	}
+
+	/**
+	 * @param list<array<string, mixed>> $rows
+	 */
+	private function buildQb(array $rows): IQueryBuilder&MockObject {
+		$qb = $this->createMock(IQueryBuilder::class);
+		foreach (['select', 'from', 'where', 'andWhere', 'orderBy', 'setMaxResults'] as $method) {
+			$qb->method($method)->willReturnSelf();
+		}
+		$qb->method('expr')->willReturn(self::exprSink());
+		$qb->method('createNamedParameter')->willReturn('?');
+
+		$result = $this->createMock(IResult::class);
+		$queue = $rows;
+		$result->method('fetch')->willReturnCallback(static function () use (&$queue) {
+			$row = array_shift($queue);
+			return $row ?? false;
+		});
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}
+
+	public function testFindByIdsHydratesTheRequestedStacks(): void {
+		$this->db->method('getQueryBuilder')->willReturn($this->buildQb([
+			['id' => 3, 'board_id' => 7, 'title' => 'Doing', 'sort_key' => 'aa', 'deleted_at' => 0],
+		]));
+
+		$stacks = $this->mapper->findByIds(7, [3]);
+		self::assertCount(1, $stacks);
+		self::assertSame(3, $stacks[0]->getId());
+		self::assertSame('Doing', $stacks[0]->getTitle());
+	}
+
+	public function testFindByIdsEmptySetShortCircuitsWithoutQuery(): void {
+		$this->db->expects(self::never())->method('getQueryBuilder');
+		self::assertSame([], $this->mapper->findByIds(7, []));
+	}
+}

--- a/tests/unit/Migration/PrimaryKeyNameLengthTest.php
+++ b/tests/unit/Migration/PrimaryKeyNameLengthTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Migration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards against the "Primary index name on X is too long" install failure.
+ *
+ * Nextcloud 30-32 enforce a length limit on the AUTO-GENERATED name of a
+ * table's PRIMARY KEY. A table whose physical name (the `oc_` prefix + the
+ * logical name passed to createTable) is long enough pushes that derived name
+ * over the limit, so `occ maintenance:install` aborts and NONE of the app's
+ * tables are created. NC 33/34 relaxed the check, so this only reproduces on
+ * the NC 30-32 install matrix — a ~1.5h feedback loop. Every table at risk
+ * must therefore give its primary key an explicit short name
+ * (`$table->setPrimaryKey(['id'], 'kanso_<abbrev>_pk')`).
+ *
+ * This is a static source scan (no DB needed) so it runs in the fast unit job
+ * and catches the whole class of bug on every PR, before the slow matrix does.
+ * It reproduces what surfaced #3d1620c (comment_reactions et al.) and the later
+ * kanso_card_field_values regression.
+ */
+class PrimaryKeyNameLengthTest extends TestCase {
+	/**
+	 * Physical table names at or above this length must not rely on the default
+	 * primary-key name. 20 is deliberately conservative: the two known real
+	 * failures were 26 and 23 chars, and the fix convention already named
+	 * 20-char tables defensively.
+	 */
+	private const PHYSICAL_LENGTH_LIMIT = 20;
+
+	/** The dev/default Nextcloud table prefix that createTable() names get. */
+	private const PREFIX = 'oc_';
+
+	public function testEveryLongTableNamesItsPrimaryKey(): void {
+		$dir = __DIR__ . '/../../../lib/Migration';
+		$files = glob($dir . '/Version*.php');
+		self::assertNotEmpty($files, 'no migration files found');
+
+		$violations = [];
+		foreach ($files as $file) {
+			$src = file_get_contents($file);
+			self::assertNotFalse($src, "could not read $file");
+
+			// Walk createTable(...) and setPrimaryKey(...) calls in source order.
+			$pattern = "/createTable\\(\\s*'([a-z0-9_]+)'\\s*\\)"
+				. "|setPrimaryKey\\(\\s*\\[[^\\]]*\\]\\s*(?:,\\s*'([a-z0-9_]+)')?\\s*\\)/";
+			preg_match_all($pattern, $src, $matches, PREG_SET_ORDER);
+
+			$currentTable = null;
+			foreach ($matches as $m) {
+				$isCreateTable = $m[1] !== '';
+				if ($isCreateTable) {
+					$currentTable = $m[1];
+					continue;
+				}
+				$explicitName = $m[2] ?? '';
+				$physical = self::PREFIX . (string)$currentTable;
+				if ($explicitName === '' && strlen($physical) >= self::PHYSICAL_LENGTH_LIMIT) {
+					$violations[] = sprintf(
+						'%s: table "%s" (physical %d chars) uses a default primary key; '
+							. "give it setPrimaryKey(['id'], 'kanso_<abbrev>_pk')",
+						basename($file),
+						$physical,
+						strlen($physical)
+					);
+				}
+			}
+		}
+
+		self::assertSame(
+			[],
+			$violations,
+			"Primary-key names would overflow NC 30-32's limit and fail install:\n"
+				. implode("\n", $violations)
+		);
+	}
+}

--- a/tests/unit/Migration/PrimaryKeyNameLengthTest.php
+++ b/tests/unit/Migration/PrimaryKeyNameLengthTest.php
@@ -55,7 +55,9 @@ class PrimaryKeyNameLengthTest extends TestCase {
 
 			$currentTable = null;
 			foreach ($matches as $m) {
-				$isCreateTable = $m[1] !== '';
+				// A setPrimaryKey(['id']) (no explicit name) match populates neither
+				// capture group, so group 1 is absent — coalesce before comparing.
+				$isCreateTable = ($m[1] ?? '') !== '';
 				if ($isCreateTable) {
 					$currentTable = $m[1];
 					continue;

--- a/tests/unit/Service/ArchiveServiceTest.php
+++ b/tests/unit/Service/ArchiveServiceTest.php
@@ -23,6 +23,7 @@ use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\PermissionService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -36,6 +37,7 @@ class ArchiveServiceTest extends TestCase {
 	private ChangeNotifier&MockObject $changeNotifier;
 	private PermissionService&MockObject $permissionService;
 	private ITimeFactory&MockObject $time;
+	private IDBConnection&MockObject $db;
 	private ArchiveService $service;
 
 	protected function setUp(): void {
@@ -48,6 +50,7 @@ class ArchiveServiceTest extends TestCase {
 		$this->permissionService = $this->createMock(PermissionService::class);
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->time->method('getTime')->willReturn(self::NOW);
+		$this->db = $this->createMock(IDBConnection::class);
 		$this->service = new ArchiveService(
 			$this->ruleMapper,
 			$this->cardMapper,
@@ -56,6 +59,7 @@ class ArchiveServiceTest extends TestCase {
 			$this->changeNotifier,
 			$this->permissionService,
 			$this->time,
+			$this->db,
 		);
 	}
 
@@ -283,7 +287,14 @@ class ArchiveServiceTest extends TestCase {
 
 	// ---- sweep ------------------------------------------------------------
 
-	public function testSweepArchivesEligibleAndEmitsPerCardChange(): void {
+	/**
+	 * #3418 + #3579: a batch sweep records ONE change row per archived card (so no
+	 * client delta is lost) but coalesces the realtime fan-out into a SINGLE
+	 * pushBoardChanged for the whole batch (the push body is only {boardId}, so
+	 * one push suffices - clients delta/collapse the N rows). Each card's archive
+	 * write + its change row commit atomically (a per-item transaction).
+	 */
+	public function testSweepRecordsPerCardChangeButEmitsOneCoalescedPush(): void {
 		$rule = $this->rule();
 		$this->cardMapper->method('findEligibleForArchive')
 			->willReturn([$this->card(10), $this->card(11)]);
@@ -297,9 +308,10 @@ class ArchiveServiceTest extends TestCase {
 				return $c;
 			});
 
+		// N change rows recorded (never the push-emitting notify()).
 		$notified = [];
 		$this->changeNotifier->expects(self::exactly(2))
-			->method('notify')
+			->method('recordChange')
 			->willReturnCallback(function (int $boardId, int $entity, int $entityId, int $action, ?string $actor) use (&$notified): Change {
 				self::assertSame(1, $boardId);
 				self::assertSame(Change::ENTITY_CARD, $entity);
@@ -308,6 +320,13 @@ class ArchiveServiceTest extends TestCase {
 				$notified[] = $entityId;
 				return new Change();
 			});
+		$this->changeNotifier->expects(self::never())->method('notify');
+		// Exactly ONE coalesced push for the whole batch, not one per card.
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
+		// Each card is committed in its own transaction.
+		$this->db->expects(self::exactly(2))->method('beginTransaction');
+		$this->db->expects(self::exactly(2))->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
 
 		$count = $this->service->sweep($rule);
 		self::assertSame(2, $count);
@@ -319,9 +338,35 @@ class ArchiveServiceTest extends TestCase {
 		$rule = $this->rule();
 		$this->cardMapper->method('findEligibleForArchive')->willReturn([]);
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
+		// An empty sweep emits no push at all.
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+		$this->db->expects(self::never())->method('beginTransaction');
 
 		self::assertSame(0, $this->service->sweep($rule));
+	}
+
+	/**
+	 * #3579: if a card's change-row write throws mid-sweep, that card's archive
+	 * write rolls back (per-item transaction) rather than leaving it archived
+	 * without a delta row.
+	 */
+	public function testSweepRollsBackCardWhenChangeRowInsertThrows(): void {
+		$rule = $this->rule();
+		$this->cardMapper->method('findEligibleForArchive')->willReturn([$this->card(10)]);
+		$this->cardMapper->expects(self::once())->method('update')->willReturnArgument(0);
+		$this->changeNotifier->expects(self::once())
+			->method('recordChange')
+			->willThrowException(new \RuntimeException('change row insert failed'));
+
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('rollBack');
+		$this->db->expects(self::never())->method('commit');
+		// A failed item aborts the sweep before the coalesced push.
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->sweep($rule);
 	}
 
 	// ---- archiveNow -------------------------------------------------------
@@ -336,7 +381,7 @@ class ArchiveServiceTest extends TestCase {
 			->with($board, 'alice', PermissionService::PERMISSION_MANAGE);
 		$this->cardMapper->method('findEligibleForArchive')->willReturn([$this->card(10)]);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		self::assertSame(1, $this->service->archiveNow(3, 'alice'));
 	}
@@ -362,7 +407,7 @@ class ArchiveServiceTest extends TestCase {
 		$this->cardMapper->method('findEligibleForArchive')
 			->willReturnOnConsecutiveCalls([$this->card(10)], [$this->card(11), $this->card(12)]);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		self::assertSame(3, $this->service->runEnabledRules());
 	}
@@ -382,7 +427,7 @@ class ArchiveServiceTest extends TestCase {
 				return [$this->card(11)];
 			});
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		self::assertSame(1, $this->service->runEnabledRules());
 	}

--- a/tests/unit/Service/AutomationServiceTest.php
+++ b/tests/unit/Service/AutomationServiceTest.php
@@ -24,6 +24,7 @@ use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\PermissionService;
 use OCA\Kanso\Service\ReviewService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +39,7 @@ class AutomationServiceTest extends TestCase {
 	private LabelMapper&MockObject $labelMapper;
 	private CardLabelMapper&MockObject $cardLabelMapper;
 	private ChangeNotifier&MockObject $changeNotifier;
+	private IDBConnection&MockObject $db;
 	private AutomationService $service;
 
 	protected function setUp(): void {
@@ -49,6 +51,7 @@ class AutomationServiceTest extends TestCase {
 		$this->labelMapper = $this->createMock(LabelMapper::class);
 		$this->cardLabelMapper = $this->createMock(CardLabelMapper::class);
 		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
+		$this->db = $this->createMock(IDBConnection::class);
 		$this->service = new AutomationService(
 			$this->ruleMapper,
 			$this->boardMapper,
@@ -57,6 +60,7 @@ class AutomationServiceTest extends TestCase {
 			$this->labelMapper,
 			$this->cardLabelMapper,
 			$this->changeNotifier,
+			$this->db,
 		);
 	}
 
@@ -199,9 +203,14 @@ class AutomationServiceTest extends TestCase {
 		$this->ruleMapper->method('findEnabledByBoardAndTrigger')->willReturn([$rule]);
 		$this->cardLabelMapper->method('exists')->with(99, 55)->willReturn(false);
 		$this->cardLabelMapper->expects($this->once())->method('insertAssignment')->with(99, 55);
+		// #3579: the label assignment + change row commit atomically; the push
+		// fires after commit.
 		$this->changeNotifier->expects($this->once())
-			->method('notify')
+			->method('recordChange')
 			->with(self::BOARD_ID, Change::ENTITY_CARD, 99, Change::ACTION_UPDATE, self::ACTOR);
+		$this->changeNotifier->expects($this->once())->method('pushBoardChanged')->with(self::BOARD_ID);
+		$this->db->expects($this->once())->method('beginTransaction');
+		$this->db->expects($this->once())->method('commit');
 
 		$this->service->runCardEnteredRole($this->card(), Stack::ROLE_IN_PROGRESS, self::ACTOR);
 	}
@@ -211,7 +220,7 @@ class AutomationServiceTest extends TestCase {
 		$this->ruleMapper->method('findEnabledByBoardAndTrigger')->willReturn([$rule]);
 		$this->cardLabelMapper->method('exists')->willReturn(true);
 		$this->cardLabelMapper->expects($this->never())->method('insertAssignment');
-		$this->changeNotifier->expects($this->never())->method('notify');
+		$this->changeNotifier->expects($this->never())->method('recordChange');
 
 		$this->service->runCardEnteredRole($this->card(), Stack::ROLE_IN_PROGRESS, self::ACTOR);
 	}

--- a/tests/unit/Service/CardFieldServiceTest.php
+++ b/tests/unit/Service/CardFieldServiceTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\CardField;
+use OCA\Kanso\Db\CardFieldMapper;
+use OCA\Kanso\Db\CardFieldValueMapper;
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Service\CardFieldService;
+use OCA\Kanso\Service\ChangeNotifier;
+use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\PermissionService;
+use OCA\Kanso\Service\SortKeyService;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CardFieldServiceTest extends TestCase {
+	private CardFieldMapper&MockObject $cardFieldMapper;
+	private CardFieldValueMapper&MockObject $cardFieldValueMapper;
+	private BoardMapper&MockObject $boardMapper;
+	private ChangeNotifier&MockObject $changeNotifier;
+	private PermissionService&MockObject $permissionService;
+	private IDBConnection&MockObject $db;
+	private CardFieldService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->cardFieldMapper = $this->createMock(CardFieldMapper::class);
+		$this->cardFieldValueMapper = $this->createMock(CardFieldValueMapper::class);
+		$this->boardMapper = $this->createMock(BoardMapper::class);
+		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->service = new CardFieldService(
+			$this->cardFieldMapper,
+			$this->cardFieldValueMapper,
+			$this->boardMapper,
+			$this->changeNotifier,
+			$this->permissionService,
+			new SortKeyService(),
+			$this->db
+		);
+	}
+
+	private function board(int $id = 1): Board {
+		$board = new Board();
+		$board->setId($id);
+		$board->setOwner('alice');
+		$board->setDeletedAt(0);
+		return $board;
+	}
+
+	private function field(int $id = 3, int $boardId = 1, string $type = CardField::TYPE_TEXT): CardField {
+		$field = new CardField();
+		$field->setId($id);
+		$field->setBoardId($boardId);
+		$field->setName('Severity');
+		$field->setType($type);
+		$field->setSortKey('I');
+		return $field;
+	}
+
+	// ---- create -----------------------------------------------------------
+
+	public function testCreateInsertsFieldAndWritesChangeRow(): void {
+		$board = $this->board();
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->cardFieldMapper->method('lastSortKey')->with(1)->willReturn(null);
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'alice', PermissionService::PERMISSION_MANAGE);
+		$this->cardFieldMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardField $f): CardField {
+				self::assertSame('Priority', $f->getName());
+				self::assertSame(CardField::TYPE_TEXT, $f->getType());
+				self::assertSame(1, $f->getBoardId());
+				self::assertNotSame('', $f->getSortKey());
+				$f->setId(3);
+				return $f;
+			});
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD_FIELD, 3, Change::ACTION_CREATE, 'alice')
+			->willReturn(new Change());
+
+		$field = $this->service->create(1, 'Priority', CardField::TYPE_TEXT, null, 'alice');
+		self::assertSame(3, $field->getId());
+	}
+
+	public function testCreateAppendsSortKeyAfterLast(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('lastSortKey')->with(1)->willReturn('I');
+		$this->cardFieldMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardField $f): CardField {
+				// A key strictly after 'I'.
+				self::assertGreaterThan(0, strcmp($f->getSortKey(), 'I'));
+				$f->setId(4);
+				return $f;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->create(1, 'Team', CardField::TYPE_TEXT, null, 'alice');
+	}
+
+	public function testCreateRejectsEmptyName(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->create(1, '   ', CardField::TYPE_TEXT, null, 'alice');
+	}
+
+	public function testCreateRejectsUnknownType(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->create(1, 'Field', 'currency', null, 'alice');
+	}
+
+	public function testCreateRejectsOptionsOnNonSelectType(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('lastSortKey')->willReturn(null);
+		$this->cardFieldMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->create(1, 'Field', CardField::TYPE_TEXT, ['a', 'b'], 'alice');
+	}
+
+	public function testCreateStoresSelectOptionsAsJson(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('lastSortKey')->willReturn(null);
+		$this->cardFieldMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardField $f): CardField {
+				self::assertSame(['low', 'high'], $f->getOptionsArray());
+				$f->setId(5);
+				return $f;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->create(1, 'Sev', CardField::TYPE_SELECT, [' low ', 'high'], 'alice');
+	}
+
+	public function testCreateAssertsManagePermission(): void {
+		$board = $this->board();
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'mallory', PermissionService::PERMISSION_MANAGE)
+			->willThrowException(new NotPermittedException());
+		$this->cardFieldMapper->expects(self::never())->method('insert');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->create(1, 'Field', CardField::TYPE_TEXT, null, 'mallory');
+	}
+
+	// ---- update -----------------------------------------------------------
+
+	public function testUpdateAppliesNameAndWritesChangeRow(): void {
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with(self::anything(), 'alice', PermissionService::PERMISSION_MANAGE);
+		$this->cardFieldMapper->expects(self::once())->method('update')->willReturnArgument(0);
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD_FIELD, 3, Change::ACTION_UPDATE, 'alice')
+			->willReturn(new Change());
+
+		$updated = $this->service->update(3, 'Impact', null, null, 'alice');
+		self::assertSame('Impact', $updated->getName());
+	}
+
+	public function testUpdateRejectsOptionsOnNonSelectField(): void {
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field(3, 1, CardField::TYPE_TEXT));
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(3, null, ['x'], null, 'alice');
+	}
+
+	public function testUpdateAssertsManagePermission(): void {
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->willThrowException(new NotPermittedException());
+		$this->cardFieldMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->update(3, 'Impact', null, null, 'mallory');
+	}
+
+	// ---- delete -----------------------------------------------------------
+
+	public function testDeleteCascadesValuesTransactionallyAndWritesChangeRow(): void {
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with(self::anything(), 'alice', PermissionService::PERMISSION_MANAGE);
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+		$this->cardFieldValueMapper->expects(self::once())->method('deleteByField')->with(3)->willReturn(2);
+		$this->cardFieldMapper->expects(self::once())->method('delete');
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD_FIELD, 3, Change::ACTION_DELETE, 'alice')
+			->willReturn(new Change());
+
+		$this->service->delete(3, 'alice');
+	}
+
+	public function testDeleteRollsBackOnThrow(): void {
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::never())->method('commit');
+		$this->db->expects(self::once())->method('rollBack');
+		$this->cardFieldValueMapper->method('deleteByField')->with(3)
+			->willThrowException(new \RuntimeException('boom'));
+		$this->cardFieldMapper->expects(self::never())->method('delete');
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->delete(3, 'alice');
+	}
+
+	public function testDeleteAssertsManagePermission(): void {
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->willThrowException(new NotPermittedException());
+		$this->db->expects(self::never())->method('beginTransaction');
+		$this->cardFieldValueMapper->expects(self::never())->method('deleteByField');
+		$this->cardFieldMapper->expects(self::never())->method('delete');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->delete(3, 'mallory');
+	}
+}

--- a/tests/unit/Service/CardFieldValueServiceTest.php
+++ b/tests/unit/Service/CardFieldValueServiceTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardField;
+use OCA\Kanso\Db\CardFieldMapper;
+use OCA\Kanso\Db\CardFieldValue;
+use OCA\Kanso\Db\CardFieldValueMapper;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Service\CardFieldValueService;
+use OCA\Kanso\Service\ChangeNotifier;
+use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\PermissionService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CardFieldValueServiceTest extends TestCase {
+	private CardFieldValueMapper&MockObject $cardFieldValueMapper;
+	private CardFieldMapper&MockObject $cardFieldMapper;
+	private CardMapper&MockObject $cardMapper;
+	private BoardMapper&MockObject $boardMapper;
+	private ChangeNotifier&MockObject $changeNotifier;
+	private PermissionService&MockObject $permissionService;
+	private CardFieldValueService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->cardFieldValueMapper = $this->createMock(CardFieldValueMapper::class);
+		$this->cardFieldMapper = $this->createMock(CardFieldMapper::class);
+		$this->cardMapper = $this->createMock(CardMapper::class);
+		$this->boardMapper = $this->createMock(BoardMapper::class);
+		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->service = new CardFieldValueService(
+			$this->cardFieldValueMapper,
+			$this->cardFieldMapper,
+			$this->cardMapper,
+			$this->boardMapper,
+			$this->changeNotifier,
+			$this->permissionService
+		);
+	}
+
+	private function board(int $id = 1): Board {
+		$board = new Board();
+		$board->setId($id);
+		$board->setOwner('alice');
+		$board->setDeletedAt(0);
+		return $board;
+	}
+
+	private function card(int $id = 9, int $boardId = 1): Card {
+		$card = new Card();
+		$card->setId($id);
+		$card->setBoardId($boardId);
+		return $card;
+	}
+
+	private function field(int $id = 3, int $boardId = 1, string $type = CardField::TYPE_TEXT, ?string $options = null): CardField {
+		$field = new CardField();
+		$field->setId($id);
+		$field->setBoardId($boardId);
+		$field->setName('Field');
+		$field->setType($type);
+		$field->setOptions($options);
+		$field->setSortKey('I');
+		return $field;
+	}
+
+	// ---- set: happy path & upsert ----------------------------------------
+
+	public function testSetInsertsWhenNoExistingValue(): void {
+		$board = $this->board();
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'alice', PermissionService::PERMISSION_EDIT);
+		$this->cardFieldValueMapper->method('findByCardAndField')->with(9, 3)->willReturn(null);
+		$this->cardFieldValueMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardFieldValue $v): CardFieldValue {
+				self::assertSame(9, $v->getCardId());
+				self::assertSame(3, $v->getFieldId());
+				self::assertSame('hello', $v->getValue());
+				return $v;
+			});
+		$this->cardFieldValueMapper->expects(self::never())->method('update');
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice', true, Change::VERB_UPDATED)
+			->willReturn(new Change());
+
+		$this->service->set(9, 3, 'hello', 'alice');
+	}
+
+	public function testSetUpdatesWhenValueAlreadyExists(): void {
+		// (card_id, field_id) upsert uniqueness: a second write updates the row.
+		$existing = new CardFieldValue();
+		$existing->setId(50);
+		$existing->setCardId(9);
+		$existing->setFieldId(3);
+		$existing->setValue('old');
+
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->cardFieldValueMapper->method('findByCardAndField')->with(9, 3)->willReturn($existing);
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+		$this->cardFieldValueMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(static function (CardFieldValue $v): CardFieldValue {
+				self::assertSame(50, $v->getId());
+				self::assertSame('new', $v->getValue());
+				return $v;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->set(9, 3, 'new', 'alice');
+	}
+
+	public function testSetEmptyValueClears(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+		$this->cardFieldValueMapper->expects(self::once())->method('deleteByCardAndField')->with(9, 3);
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->set(9, 3, '   ', 'alice');
+	}
+
+	// ---- set: permission --------------------------------------------------
+
+	public function testSetAssertsEditPermission(): void {
+		$board = $this->board();
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'mallory', PermissionService::PERMISSION_EDIT)
+			->willThrowException(new NotPermittedException());
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+		$this->cardFieldValueMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->set(9, 3, 'x', 'mallory');
+	}
+
+	public function testSetRejectsFieldFromAnotherBoard(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card(9, 1));
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Field belongs to board 2, card to board 1.
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field(3, 2));
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->set(9, 3, 'x', 'alice');
+	}
+
+	// ---- set: per-type validation ----------------------------------------
+
+	public function testSetRejectsNonNumericNumber(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field(3, 1, CardField::TYPE_NUMBER));
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->set(9, 3, 'not-a-number', 'alice');
+	}
+
+	public function testSetAcceptsNumber(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field(3, 1, CardField::TYPE_NUMBER));
+		$this->cardFieldValueMapper->method('findByCardAndField')->willReturn(null);
+		$this->cardFieldValueMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardFieldValue $v): CardFieldValue {
+				self::assertSame('42.5', $v->getValue());
+				return $v;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->set(9, 3, '42.5', 'alice');
+	}
+
+	public function testSetRejectsBadDate(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field(3, 1, CardField::TYPE_DATE));
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->set(9, 3, '2026-13-99', 'alice');
+	}
+
+	public function testSetNormalizesDate(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field(3, 1, CardField::TYPE_DATE));
+		$this->cardFieldValueMapper->method('findByCardAndField')->willReturn(null);
+		$this->cardFieldValueMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardFieldValue $v): CardFieldValue {
+				self::assertSame('2026-09-02', $v->getValue());
+				return $v;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->set(9, 3, '2026-09-02T10:30:00Z', 'alice');
+	}
+
+	public function testSetRejectsNonMemberSelectOption(): void {
+		$options = json_encode(['low', 'high']);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)
+			->willReturn($this->field(3, 1, CardField::TYPE_SELECT, $options));
+		$this->cardFieldValueMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->set(9, 3, 'medium', 'alice');
+	}
+
+	public function testSetAcceptsSelectOptionMember(): void {
+		$options = json_encode(['low', 'high']);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)
+			->willReturn($this->field(3, 1, CardField::TYPE_SELECT, $options));
+		$this->cardFieldValueMapper->method('findByCardAndField')->willReturn(null);
+		$this->cardFieldValueMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (CardFieldValue $v): CardFieldValue {
+				self::assertSame('high', $v->getValue());
+				return $v;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->set(9, 3, 'high', 'alice');
+	}
+
+	// ---- clear ------------------------------------------------------------
+
+	public function testClearDeletesValueAndBumpsCard(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardFieldMapper->method('find')->with(3)->willReturn($this->field());
+		$this->cardFieldValueMapper->expects(self::once())->method('deleteByCardAndField')->with(9, 3);
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice', true, Change::VERB_UPDATED)
+			->willReturn(new Change());
+
+		$this->service->clear(9, 3, 'alice');
+	}
+
+	public function testClearAssertsEditPermission(): void {
+		$board = $this->board();
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'mallory', PermissionService::PERMISSION_EDIT)
+			->willThrowException(new NotPermittedException());
+		$this->cardFieldValueMapper->expects(self::never())->method('deleteByCardAndField');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->clear(9, 3, 'mallory');
+	}
+}

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -149,7 +149,7 @@ class CardServiceTest extends TestCase {
 				return $card;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_CARD,
@@ -177,7 +177,7 @@ class CardServiceTest extends TestCase {
 				return $card;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->willReturn(new Change());
 
 		$this->service->create(5, 'A card', 'alice');
@@ -198,7 +198,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->create(5, 'A card', 'alice');
 	}
@@ -207,7 +207,7 @@ class CardServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->expects(self::never())->method('insert');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->create(5, '   ', 'alice');
@@ -231,7 +231,7 @@ class CardServiceTest extends TestCase {
 			->with($board, 'bob', PermissionService::PERMISSION_EDIT)
 			->willThrowException(new NotPermittedException());
 		$this->cardMapper->expects(self::never())->method('insert');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->create(5, 'A card', 'bob');
@@ -271,7 +271,7 @@ class CardServiceTest extends TestCase {
 				return $card;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_CREATE, 'alice')
 			->willReturn(new Change());
 
@@ -290,9 +290,45 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->expects(self::exactly(5))
 			->method('insert')
 			->willReturnCallback(fn (Card $card): Card => throw $this->uniqueViolation());
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(\OverflowException::class);
+		$this->service->create(5, 'A card', 'alice');
+	}
+
+	/**
+	 * #3579: the card INSERT and its CREATE change row are one transaction. If the
+	 * change-row write throws, the whole transaction rolls back - no orphan card
+	 * is left without its delta-sync row, and no realtime push is emitted for a
+	 * mutation that never landed.
+	 */
+	public function testCreateRollsBackWhenChangeRowInsertThrows(): void {
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('findLastInStack')->with(5)->willReturn(null);
+		$this->cardMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (Card $card): Card {
+				$card->setId(9);
+				return $card;
+			});
+		// The change-row insert fails - the transaction must roll back, and a
+		// non-unique DB error is not retried (it propagates).
+		$dbError = $this->createMock(\OCP\DB\Exception::class);
+		$dbError->method('getReason')->willReturn(\OCP\DB\Exception::REASON_CONNECTION_LOST);
+		$this->changeNotifier->expects(self::once())
+			->method('recordChange')
+			->willThrowException($dbError);
+
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('rollBack');
+		$this->db->expects(self::never())->method('commit');
+		// No push for a create that never committed.
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+		// The board-watcher fan-out is downstream of commit - never reached either.
+		$this->subscriptionService->expects(self::never())->method('notifyBoardCardCreated');
+
+		$this->expectException(\OCP\DB\Exception::class);
 		$this->service->create(5, 'A card', 'alice');
 	}
 
@@ -308,7 +344,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->create(5, 'A card', 'alice');
 	}
@@ -328,7 +364,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$card = $this->service->create(5, 'A card', 'alice');
 		self::assertSame(42, $card->getBoardSeq());
@@ -346,7 +382,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->create(5, 'A card', 'alice');
 	}
@@ -372,7 +408,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('recordChange')->willReturn(new Change());
 
 		$card = $this->service->create(5, 'A card', 'alice');
 		self::assertSame(8, $card->getBoardSeq());
@@ -397,7 +433,7 @@ class CardServiceTest extends TestCase {
 				return $card;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_CREATE, 'alice')
 			->willReturn(new Change());
 
@@ -413,7 +449,7 @@ class CardServiceTest extends TestCase {
 			$card->setId(9);
 			return $card;
 		});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$card = $this->service->create(5, 'A card', 'alice', '2026-08-01T10:00:00+02:00');
 		self::assertSame(
@@ -434,7 +470,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->create(5, 'A card', 'alice');
 	}
@@ -445,7 +481,7 @@ class CardServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->expects(self::never())->method('insert');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->create(5, 'A card', 'alice', 'tomorrow');
@@ -463,7 +499,7 @@ class CardServiceTest extends TestCase {
 				$card->setId(9);
 				return $card;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->create(5, 'A card', 'alice', '');
 	}
@@ -579,7 +615,7 @@ class CardServiceTest extends TestCase {
 			->method('update')
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_CARD,
@@ -603,7 +639,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, null, null, null, 'alice');
 		self::assertSame('Existing card', $updated->getTitle());
@@ -618,7 +654,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, '', null, null, 'alice');
 		self::assertNull($updated->getDuedate());
@@ -629,7 +665,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Positional: …, uid, priority, startDate, status, estimate, allDay.
 		$updated = $this->service->update(9, null, null, '2026-08-15T00:00:00+00:00', null, null, 'alice', null, null, null, null, true);
@@ -644,7 +680,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, '', null, null, 'alice');
 		self::assertNull($updated->getDuedate());
@@ -659,7 +695,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Moving the due date forward re-arms both reminders (markers cleared).
 		$updated = $this->service->update(9, null, null, '2026-08-05T10:00:00+00:00', null, null, 'alice');
@@ -675,7 +711,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Re-setting the identical due date must NOT re-arm (no re-spam).
 		$updated = $this->service->update(9, null, null, '2026-08-01T10:00:00+00:00', null, null, 'alice');
@@ -688,7 +724,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Positional: …, uid, priority, startDate, status, estimate, allDay, dueReminderDayBefore.
 		$updated = $this->service->update(9, null, null, null, null, null, 'alice', null, null, null, null, null, true);
@@ -700,7 +736,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Set (positional: …, uid, priority, startDate).
 		$set = $this->service->update(9, null, null, null, null, null, 'alice', null, '2026-08-01T00:00:00+00:00');
@@ -717,7 +753,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($board);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// positional: …, uid, priority, startDate, status, estimate
 		$updated = $this->service->update(9, null, null, null, null, null, 'alice', null, null, null, '8');
@@ -753,7 +789,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($board);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, null, null, null, 'alice', null, null, null, '');
 		self::assertNull($updated->getEstimate());
@@ -766,7 +802,7 @@ class CardServiceTest extends TestCase {
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 
@@ -782,7 +818,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, null, null, null, 'alice', null, null, null, null, null, null, '');
 		self::assertNull($updated->getCoverColor());
@@ -792,7 +828,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		// Not a bare 6-hex value (a leading '#' is rejected by ColorValidator).
@@ -805,7 +841,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// coverColor omitted (null) → the existing cover colour is preserved.
 		$updated = $this->service->update(9, 'Renamed', null, null, null, null, 'alice');
@@ -829,7 +865,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, '2026-08-01T10:00:00+02:00', null, null, 'alice');
 		self::assertSame(
@@ -842,7 +878,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// JS Date.toISOString() shape: milliseconds + 'Z'.
 		$updated = $this->service->update(9, null, null, '2026-08-01T10:00:00.000Z', null, null, 'alice');
@@ -856,7 +892,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->update(9, null, null, 'tomorrow', null, null, 'alice');
@@ -866,7 +902,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		// createFromFormat would silently roll February 30th to March 2nd.
 		$this->expectException(InvalidInputException::class);
@@ -877,7 +913,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, null, true, null, 'alice');
 		self::assertGreaterThan(0, $updated->getDoneAt());
@@ -889,7 +925,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, null, true, null, 'alice');
 		self::assertSame(12345, $updated->getDoneAt());
@@ -901,7 +937,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(9, null, null, null, false, null, 'alice');
 		self::assertSame(0, $updated->getDoneAt());
@@ -931,7 +967,7 @@ class CardServiceTest extends TestCase {
 			->with(self::callback(static fn (Card $c): bool => $c->getDeletedAt() > 0))
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_CARD,
@@ -960,18 +996,18 @@ class CardServiceTest extends TestCase {
 			->method('update')
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_CARD,
 				9,
 				Change::ACTION_MOVE,
 				'alice',
-				false, // push deferred until after commit
+				Change::VERB_MOVED,
 			)
 			->willReturn(new Change());
 		// The realtime broadcast fires only after the transaction commits.
-		$this->changeNotifier->expects(self::once())->method('emitPush')->with(1);
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		// before('I') === 'H'
@@ -988,7 +1024,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertSame('I', $moved->getSortKey());
@@ -1011,7 +1047,7 @@ class CardServiceTest extends TestCase {
 			->method('update')
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->willReturn(new Change());
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('commit');
@@ -1035,7 +1071,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findNextInStack')->with(6, 'J')->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, 10, 'alice');
 		// after('J') === 'K'
@@ -1061,7 +1097,7 @@ class CardServiceTest extends TestCase {
 				$this->card(9, 6, 1, 'II')
 			);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$firstKey = $this->service->move(9, 6, 10, 'alice')->getSortKey();
 		$secondKey = $this->service->move(12, 6, 10, 'alice')->getSortKey();
@@ -1080,7 +1116,7 @@ class CardServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(6)->willReturn($this->stack(6, 2));
 		$this->db->expects(self::never())->method('beginTransaction');
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->move(9, 6, null, 'alice');
@@ -1178,7 +1214,7 @@ class CardServiceTest extends TestCase {
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('rollBack');
 		$this->db->expects(self::never())->method('commit');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(\RuntimeException::class);
 		$this->service->move(9, 6, null, 'alice');
@@ -1206,10 +1242,10 @@ class CardServiceTest extends TestCase {
 				}
 				return $card;
 			});
-		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('recordChange')->willReturn(new Change());
 		// The push fires exactly once — after the SUCCESSFUL commit, never for the
 		// rolled-back first attempt.
-		$this->changeNotifier->expects(self::once())->method('emitPush')->with(1);
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
 		$this->db->expects(self::exactly(2))->method('beginTransaction');
 		$this->db->expects(self::once())->method('rollBack');
 		$this->db->expects(self::once())->method('commit');
@@ -1233,9 +1269,9 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->expects(self::exactly(2))
 			->method('update')
 			->willReturnCallback(fn (Card $card): Card => throw $this->uniqueViolation());
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 		// Nothing committed → no realtime broadcast for a move that never landed.
-		$this->changeNotifier->expects(self::never())->method('emitPush');
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
 		$this->db->expects(self::exactly(2))->method('beginTransaction');
 		$this->db->expects(self::exactly(2))->method('rollBack');
 		$this->db->expects(self::never())->method('commit');
@@ -1262,7 +1298,7 @@ class CardServiceTest extends TestCase {
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('rollBack');
 		$this->db->expects(self::never())->method('commit');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(\OCP\DB\Exception::class);
 		$this->service->move(9, 6, null, 'alice');
@@ -1279,7 +1315,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardReviewMapper->method('hasUnapprovedReviews')->with(9)->willReturn(true);
 		$this->db->expects(self::never())->method('beginTransaction');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->move(9, 6, null, 'alice');
@@ -1313,7 +1349,7 @@ class CardServiceTest extends TestCase {
 		$this->cardReviewMapper->method('hasUnapprovedReviews')->with(9)->willReturn(false);
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertSame(6, $moved->getStackId());
@@ -1333,7 +1369,7 @@ class CardServiceTest extends TestCase {
 		$this->cardReviewMapper->method('hasUnapprovedReviews')->willReturn(true);
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertSame(6, $moved->getStackId());
@@ -1360,7 +1396,7 @@ class CardServiceTest extends TestCase {
 			$updated[] = $c->getId();
 			return $c;
 		});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->update(9, null, null, null, true, null, 'alice');
 
@@ -1386,7 +1422,7 @@ class CardServiceTest extends TestCase {
 			$updated[] = $c->getId();
 			return $c;
 		});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->update(9, null, null, null, true, null, 'alice');
 
@@ -1413,7 +1449,7 @@ class CardServiceTest extends TestCase {
 			$updated[] = $c->getId();
 			return $c;
 		});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->update(9, null, null, null, true, null, 'alice');
 
@@ -1436,7 +1472,7 @@ class CardServiceTest extends TestCase {
 			$updated[] = $c->getId();
 			return $c;
 		});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->update(9, null, null, null, true, null, 'alice');
 
@@ -1460,11 +1496,11 @@ class CardServiceTest extends TestCase {
 			->with(self::callback(static fn (Card $c): bool => $c->getDoneAt() > 0))
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
-			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_MOVE, 'alice', false)
+			->method('recordChange')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_MOVE, 'alice', Change::VERB_MOVED)
 			->willReturn(new Change());
 		// Push is emitted once, AFTER commit (not inside the transaction).
-		$this->changeNotifier->expects(self::once())->method('emitPush')->with(1);
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('commit');
 		$this->db->expects(self::never())->method('rollBack');
@@ -1484,7 +1520,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertSame(12345, $moved->getDoneAt());
@@ -1508,7 +1544,7 @@ class CardServiceTest extends TestCase {
 			->method('update')
 			->with(self::callback(static fn (Card $c): bool => $c->getDoneAt() === 0 && $c->getStartedAt() === 0))
 			->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('commit');
 
@@ -1530,7 +1566,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertSame(12345, $moved->getDoneAt());
@@ -1547,7 +1583,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertGreaterThan(0, $moved->getStartedAt());
@@ -1567,7 +1603,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertGreaterThan(0, $moved->getStartedAt());
@@ -1579,7 +1615,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// in_progress → started stamped, not done.
 		$r = $this->service->update(9, null, null, null, null, null, 'alice', null, null, 'in_progress');
@@ -1616,7 +1652,7 @@ class CardServiceTest extends TestCase {
 		});
 		$this->cardMapper->method('findFirstInStack')->with(6)->willReturn(null);
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(9, 6, null, 'alice');
 		self::assertSame(12345, $moved->getDoneAt());
@@ -1643,7 +1679,7 @@ class CardServiceTest extends TestCase {
 				return $c;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 
@@ -1662,7 +1698,7 @@ class CardServiceTest extends TestCase {
 				self::assertNull($c->getParentCardId());
 				return $c;
 			});
-		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('recordChange')->willReturn(new Change());
 
 		$this->service->setParent(9, null, 'alice');
 	}
@@ -1672,7 +1708,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($child);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->service->setParent(9, null, 'alice');
 	}
@@ -1688,7 +1724,7 @@ class CardServiceTest extends TestCase {
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('hasChildren')->with(9)->willReturn(false);
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->service->setParent(9, 20, 'alice');
 	}
@@ -1807,7 +1843,7 @@ class CardServiceTest extends TestCase {
 			$updated[$c->getId()] = $c;
 			return $c;
 		});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->delete(9, 'alice');
 
@@ -1825,7 +1861,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('recordChange')->willReturn(new Change());
 
 		$result = $this->service->update(9, null, null, null, null, null, 'alice', 3);
 		self::assertSame(3, $result->getPriority());
@@ -1858,7 +1894,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('recordChange')->willReturn(new Change());
 
 		$result = $this->service->update(9, null, null, null, null, null, 'alice', type: 'bug');
 		self::assertSame('bug', $result->getType());
@@ -1870,7 +1906,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($card);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('recordChange')->willReturn(new Change());
 
 		$result = $this->service->update(9, null, null, null, null, null, 'alice', type: '');
 		self::assertSame('', $result->getType());
@@ -1954,7 +1990,7 @@ class CardServiceTest extends TestCase {
 			return $c;
 		});
 		$this->cardMapper->method('update')->willReturnCallback(static fn (Card $c): Card => $c);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Same-board: source label ids re-assigned directly (no cross-board mapping).
 		$this->cardLabelMapper->method('findLabelIdsByCard')->with(9)->willReturn([11, 12]);
@@ -2019,7 +2055,7 @@ class CardServiceTest extends TestCase {
 			return $c;
 		});
 		$this->cardMapper->method('update')->willReturnCallback(static fn (Card $c): Card => $c);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 		$this->checklistItemMapper->method('findByCard')->with(9)->willReturn([]);
 
 		// Source card carries labels 11 (Bug/e01) and 12 (Secret/abc).
@@ -2091,7 +2127,7 @@ class CardServiceTest extends TestCase {
 			->with(self::callback(static fn (Card $c): bool => $c->getIsTemplate() === true))
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 
@@ -2103,7 +2139,7 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->templateCard());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->cardMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->setTemplate(9, false, 'alice');
 		self::assertFalse($updated->getIsTemplate());
@@ -2118,7 +2154,7 @@ class CardServiceTest extends TestCase {
 			->with($board, 'bob', PermissionService::PERMISSION_EDIT)
 			->willThrowException(new NotPermittedException());
 		$this->cardMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->setTemplate(9, true, 'bob');
@@ -2175,7 +2211,7 @@ class CardServiceTest extends TestCase {
 			return $c;
 		});
 		$this->cardMapper->method('update')->willReturnCallback(static fn (Card $c): Card => $c);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Same board → source label ids re-assigned directly.
 		$this->cardLabelMapper->method('findLabelIdsByCard')->with(9)->willReturn([11, 12]);

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -1285,6 +1285,24 @@ class CardServiceTest extends TestCase {
 		$this->service->move(9, 6, null, 'alice');
 	}
 
+	public function testMoveToDoneBlockedWhileGatedReviewSitsUpstream(): void {
+		// A gated (deferred) review is still pending, i.e. unapproved, so the
+		// done-gate blocks exactly as it does for any unapproved review (#3588):
+		// the gate consumes hasUnapprovedReviews(), which counts pending rows
+		// regardless of whether they are gated.
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card(9, 5, 1, 'V'));
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->stackMapper->method('find')->willReturnCallback(fn (int $id): Stack => match ($id) {
+			5 => $this->stack(5, 1, Stack::ROLE_REVIEW),
+			6 => $this->stack(6, 1, Stack::ROLE_DONE),
+		});
+		$this->cardReviewMapper->method('hasUnapprovedReviews')->with(9)->willReturn(true);
+		$this->db->expects(self::never())->method('beginTransaction');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->move(9, 6, null, 'alice');
+	}
+
 	public function testMoveFromReviewToDoneAllowedWhenAllApproved(): void {
 		$this->cardMapper->method('find')->willReturnCallback(fn (int $id): Card => $this->card(9, 5, 1, 'V'));
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -2300,4 +2300,132 @@ class CardServiceTest extends TestCase {
 		// A plain card serializes false.
 		self::assertFalse($this->card()->jsonSerializeSummary()['isTemplate']);
 	}
+
+	// ---- rebalanceStack (409 rebalance_required recovery) -----------------
+
+	public function testRebalanceStackRewritesToShortStrictlyIncreasingKeysOrderPreserved(): void {
+		// A stack whose keys have grown pathologically long (the overflow case).
+		$long = str_repeat('I', 40);
+		$cards = [
+			$this->card(9, 5, 1, $long . 'A'),
+			$this->card(10, 5, 1, $long . 'B'),
+			$this->card(11, 5, 1, $long . 'C'),
+		];
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack(5));
+		$this->cardMapper->expects(self::once())
+			->method('findByStackForUpdate')
+			->with(5)
+			->willReturn($cards);
+
+		// Capture every sort-key write in order (pass 1 temp keys + pass 2 finals).
+		$writes = [];
+		$this->cardMapper->method('updateSortKeyById')
+			->willReturnCallback(static function (int $id, string $key) use (&$writes): void {
+				$writes[] = [$id, $key];
+			});
+
+		$this->changeNotifier->expects(self::once())
+			->method('recordChange')
+			->with(1, Change::ENTITY_STACK, 5, Change::ACTION_MOVE, null, Change::VERB_MOVED)
+			->willReturn(new Change());
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+
+		$count = $this->service->rebalanceStack(5);
+		self::assertSame(3, $count);
+
+		// Two passes of 3 writes each.
+		self::assertCount(6, $writes);
+
+		// Pass 1 parks each row at a distinct three-character temporary key,
+		// disjoint from the current keys and (by length) from the finals, so no
+		// write collides with a not-yet-rewritten row.
+		$sortKeyService = new SortKeyService();
+		$oldKeys = [$long . 'A', $long . 'B', $long . 'C'];
+		$tempWrites = array_slice($writes, 0, 3);
+		$tempKeys = array_map(static fn (array $w): string => $w[1], $tempWrites);
+		self::assertSame([9, 10, 11], array_map(static fn (array $w): int => $w[0], $tempWrites));
+		self::assertSame($tempKeys, array_unique($tempKeys), 'temp keys must be distinct');
+		self::assertSame([], array_intersect($tempKeys, $oldKeys), 'temp keys must not reuse a current key');
+		foreach ($tempKeys as $k) {
+			self::assertSame(3, strlen($k), 'temp keys are three characters');
+			self::assertMatchesRegularExpression('/^[0-9A-Z]{3}$/', $k);
+		}
+
+		// Pass 2 writes the final evenly-spaced keys, same row order preserved.
+		$finalWrites = array_slice($writes, 3, 3);
+		self::assertSame([9, 10, 11], array_map(static fn (array $w): int => $w[0], $finalWrites));
+		$finalKeys = array_map(static fn (array $w): string => $w[1], $finalWrites);
+
+		// Short, strictly increasing, and no final key collides with a temp key.
+		for ($i = 0; $i < 3; $i++) {
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($finalKeys[$i]));
+			self::assertStringEndsNotWith('0', $finalKeys[$i]);
+			if ($i > 0) {
+				self::assertLessThan(0, strcmp($finalKeys[$i - 1], $finalKeys[$i]));
+			}
+		}
+		self::assertSame([], array_intersect($finalKeys, $tempKeys));
+
+		// The recovery invariant: a between() at any gap of the fresh keys no
+		// longer overflows (the very thing the 409 could not do before).
+		$mid = $sortKeyService->between($finalKeys[0], $finalKeys[1]);
+		self::assertLessThan(0, strcmp($finalKeys[0], $mid));
+		self::assertLessThan(0, strcmp($mid, $finalKeys[1]));
+	}
+
+	public function testRebalanceStackOnEmptyStackIsANoOpButStillCommits(): void {
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack(5));
+		$this->cardMapper->method('findByStackForUpdate')->with(5)->willReturn([]);
+		$this->cardMapper->expects(self::never())->method('updateSortKeyById');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+
+		self::assertSame(0, $this->service->rebalanceStack(5));
+	}
+
+	public function testRebalanceStackRollsBackOnWriteFailure(): void {
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack(5));
+		$this->cardMapper->method('findByStackForUpdate')->with(5)
+			->willReturn([$this->card(9, 5, 1, 'I')]);
+		$this->cardMapper->method('updateSortKeyById')
+			->willThrowException(new \RuntimeException('boom'));
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('rollBack');
+		$this->db->expects(self::never())->method('commit');
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->rebalanceStack(5);
+	}
+
+	public function testRebalanceStackRejectsDeletedStack(): void {
+		$stack = $this->stack(5);
+		$stack->setDeletedAt(123);
+		$this->stackMapper->method('find')->with(5)->willReturn($stack);
+		$this->db->expects(self::never())->method('beginTransaction');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->service->rebalanceStack(5);
+	}
+
+	public function testRebalanceBoardRebalancesEveryStack(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board(1));
+		$this->stackMapper->method('findByBoard')->with(1)
+			->willReturn([$this->stack(5, 1), $this->stack(6, 1)]);
+		$this->stackMapper->method('find')->willReturnCallback(fn (int $id): Stack => $this->stack($id, 1));
+		$this->cardMapper->method('findByStackForUpdate')->willReturnCallback(
+			fn (int $stackId): array => $stackId === 5
+				? [$this->card(9, 5, 1, 'I'), $this->card(10, 5, 1, 'J')]
+				: [$this->card(11, 6, 1, 'I')]
+		);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+
+		$result = $this->service->rebalanceBoard(1);
+		self::assertSame([5 => 2, 6 => 1], $result);
+	}
 }

--- a/tests/unit/Service/CardTimeEntryServiceTest.php
+++ b/tests/unit/Service/CardTimeEntryServiceTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\CardTimeEntry;
+use OCA\Kanso\Db\CardTimeEntryMapper;
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Service\CardTimeEntryService;
+use OCA\Kanso\Service\ChangeNotifier;
+use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\PermissionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CardTimeEntryServiceTest extends TestCase {
+	private CardTimeEntryMapper&MockObject $timeEntryMapper;
+	private CardMapper&MockObject $cardMapper;
+	private BoardMapper&MockObject $boardMapper;
+	private PermissionService&MockObject $permissionService;
+	private ChangeNotifier&MockObject $changeNotifier;
+	private CardTimeEntryService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->timeEntryMapper = $this->createMock(CardTimeEntryMapper::class);
+		$this->cardMapper = $this->createMock(CardMapper::class);
+		$this->boardMapper = $this->createMock(BoardMapper::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
+
+		$this->service = new CardTimeEntryService(
+			$this->timeEntryMapper,
+			$this->cardMapper,
+			$this->boardMapper,
+			$this->permissionService,
+			$this->changeNotifier,
+		);
+	}
+
+	private function board(int $id = 1): Board {
+		$b = new Board();
+		$b->setId($id);
+		$b->setDeletedAt(0);
+		return $b;
+	}
+
+	private function card(int $id = 9, int $boardId = 1): Card {
+		$c = new Card();
+		$c->setId($id);
+		$c->setBoardId($boardId);
+		$c->setDeletedAt(0);
+		return $c;
+	}
+
+	private function expectCardLoaded(): Board {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$board = $this->board();
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		return $board;
+	}
+
+	// ---- listForCard ------------------------------------------------------
+
+	public function testListForCardRequiresRead(): void {
+		$board = $this->expectCardLoaded();
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'stranger', PermissionService::PERMISSION_READ)
+			->willThrowException(new NotPermittedException());
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->listForCard(9, 'stranger');
+	}
+
+	public function testListForCardReturnsEntries(): void {
+		$this->expectCardLoaded();
+		$e = new CardTimeEntry();
+		$e->setId(1);
+		$e->setCardId(9);
+		$e->setSeconds(3600);
+		$this->timeEntryMapper->method('findByCard')->with(9)->willReturn([$e]);
+
+		$result = $this->service->listForCard(9, 'bob');
+		self::assertCount(1, $result);
+		self::assertSame(3600, $result[0]->getSeconds());
+	}
+
+	// ---- add (happy path + gating + edge) ---------------------------------
+
+	public function testAddRequiresEdit(): void {
+		$board = $this->expectCardLoaded();
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'stranger', PermissionService::PERMISSION_EDIT)
+			->willThrowException(new NotPermittedException());
+		$this->timeEntryMapper->expects(self::never())->method('insert');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->add(9, 3600, 'work', 'stranger');
+	}
+
+	public function testAddStoresEntryAndNotifies(): void {
+		$this->expectCardLoaded();
+
+		$captured = null;
+		$this->timeEntryMapper->method('insert')->willReturnCallback(
+			function (CardTimeEntry $e) use (&$captured): CardTimeEntry {
+				$e->setId(7);
+				$captured = $e;
+				return $e;
+			}
+		);
+		// The mutation reuses the card ACTION_UPDATE change row (realtime/delta-sync).
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'bob');
+
+		$result = $this->service->add(9, 5400, '  Pairing session  ', 'bob');
+
+		self::assertSame(7, $result->getId());
+		self::assertSame(9, $captured->getCardId());
+		// board_id is denormalized from the loaded card, never client-supplied.
+		self::assertSame(1, $captured->getBoardId());
+		self::assertSame(5400, $captured->getSeconds());
+		// The note is trimmed.
+		self::assertSame('Pairing session', $captured->getNote());
+		self::assertSame('bob', $captured->getCreatedBy());
+	}
+
+	public function testAddStoresNullNoteWhenEmpty(): void {
+		$this->expectCardLoaded();
+		$captured = null;
+		$this->timeEntryMapper->method('insert')->willReturnCallback(
+			function (CardTimeEntry $e) use (&$captured): CardTimeEntry {
+				$captured = $e;
+				return $e;
+			}
+		);
+
+		$this->service->add(9, 60, '   ', 'bob');
+		self::assertNull($captured->getNote());
+	}
+
+	public function testAddRejectsZeroSeconds(): void {
+		$this->expectCardLoaded();
+		$this->timeEntryMapper->expects(self::never())->method('insert');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->add(9, 0, null, 'bob');
+	}
+
+	public function testAddRejectsNegativeSeconds(): void {
+		$this->expectCardLoaded();
+		$this->timeEntryMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->add(9, -120, null, 'bob');
+	}
+
+	public function testAddRejectsAbsurdlyLargeSeconds(): void {
+		$this->expectCardLoaded();
+		$this->timeEntryMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->add(9, CardTimeEntryService::MAX_SECONDS + 1, null, 'bob');
+	}
+
+	public function testAddRejectsDeletedCard(): void {
+		$deleted = $this->card();
+		$deleted->setDeletedAt(time());
+		$this->cardMapper->method('find')->with(9)->willReturn($deleted);
+		$this->timeEntryMapper->expects(self::never())->method('insert');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->service->add(9, 60, null, 'bob');
+	}
+
+	// ---- delete (gating + IDOR) -------------------------------------------
+
+	public function testDeleteRequiresEdit(): void {
+		$board = $this->expectCardLoaded();
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'stranger', PermissionService::PERMISSION_EDIT)
+			->willThrowException(new NotPermittedException());
+		$this->timeEntryMapper->expects(self::never())->method('delete');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->delete(9, 1, 'stranger');
+	}
+
+	public function testDeleteRejectsCrossCardEntry(): void {
+		$this->expectCardLoaded();
+		$other = new CardTimeEntry();
+		$other->setId(5);
+		$other->setCardId(99); // belongs to a different card - IDOR guard
+		$this->timeEntryMapper->method('find')->with(5)->willReturn($other);
+		$this->timeEntryMapper->expects(self::never())->method('delete');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->service->delete(9, 5, 'bob');
+	}
+
+	public function testDeleteRemovesRowAndNotifies(): void {
+		$this->expectCardLoaded();
+		$entry = new CardTimeEntry();
+		$entry->setId(5);
+		$entry->setCardId(9);
+		$this->timeEntryMapper->method('find')->with(5)->willReturn($entry);
+		$this->timeEntryMapper->expects(self::once())->method('delete')->with($entry);
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'bob');
+
+		$this->service->delete(9, 5, 'bob');
+	}
+
+	// ---- deleteAllForCard (cascade on purge) ------------------------------
+
+	public function testDeleteAllForCardDropsRowsWithoutGateOrNotify(): void {
+		$this->timeEntryMapper->expects(self::once())->method('deleteByCard')->with(9);
+		$this->permissionService->expects(self::never())->method('assertPermission');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$this->service->deleteAllForCard(9);
+	}
+}

--- a/tests/unit/Service/ChangeNotifierTest.php
+++ b/tests/unit/Service/ChangeNotifierTest.php
@@ -13,6 +13,7 @@ use OCA\Kanso\Db\Board;
 use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\Change;
 use OCA\Kanso\Db\ChangeMapper;
+use OCA\Kanso\Service\ActivityPublisher;
 use OCA\Kanso\Service\ChangeNotifier;
 use OCA\NotifyPush\Queue\IQueue;
 use OCP\IGroup;
@@ -30,6 +31,7 @@ class ChangeNotifierTest extends TestCase {
 	private IGroupManager&MockObject $groupManager;
 	private ContainerInterface&MockObject $container;
 	private LoggerInterface&MockObject $logger;
+	private ActivityPublisher&MockObject $activityPublisher;
 	private ChangeNotifier $notifier;
 
 	protected function setUp(): void {
@@ -40,13 +42,15 @@ class ChangeNotifierTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->activityPublisher = $this->createMock(ActivityPublisher::class);
 		$this->notifier = new ChangeNotifier(
 			$this->changeMapper,
 			$this->boardMapper,
 			$this->aclMapper,
 			$this->groupManager,
 			$this->container,
-			$this->logger
+			$this->logger,
+			$this->activityPublisher
 		);
 	}
 
@@ -219,5 +223,64 @@ class ChangeNotifierTest extends TestCase {
 		$this->boardMapper->expects(self::never())->method('find');
 
 		$this->notifier->notify(1, Change::ENTITY_BOARD, 1, Change::ACTION_CREATE, 'alice');
+	}
+
+	public function testPublishCardActivityFansOutToBoardRecipients(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board(1, 'alice'));
+		$this->aclMapper->method('findByBoard')->with(1)->willReturn([$this->userAcl('bob')]);
+
+		$this->activityPublisher->expects(self::once())
+			->method('cardDone')
+			->with(1, 7, 'Ship it', 'alice', ['alice', 'bob']);
+		$this->activityPublisher->expects(self::never())->method('cardCreated');
+		$this->activityPublisher->expects(self::never())->method('cardMoved');
+
+		$this->notifier->publishCardActivity(1, 'card_done', 7, 'Ship it', 'alice');
+	}
+
+	public function testPublishCardActivityRoutesEachSubject(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board(1, 'alice'));
+		$this->aclMapper->method('findByBoard')->with(1)->willReturn([]);
+
+		$this->activityPublisher->expects(self::once())->method('cardCreated')->with(1, 7, 'A', 'alice', ['alice']);
+		$this->activityPublisher->expects(self::once())->method('cardMoved')->with(1, 7, 'A', 'alice', ['alice']);
+
+		$this->notifier->publishCardActivity(1, 'card_created', 7, 'A', 'alice');
+		$this->notifier->publishCardActivity(1, 'card_moved', 7, 'A', 'alice');
+	}
+
+	public function testPublishCardActivitySkipsSystemActor(): void {
+		// A null actor is a system/cron sweep (auto-archive, recurrence) - never
+		// an activity. No recipient resolution, no publish.
+		$this->boardMapper->expects(self::never())->method('find');
+		$this->activityPublisher->expects(self::never())->method('cardCreated');
+		$this->activityPublisher->expects(self::never())->method('cardMoved');
+		$this->activityPublisher->expects(self::never())->method('cardDone');
+
+		$this->notifier->publishCardActivity(1, 'card_moved', 7, 'A', null);
+	}
+
+	public function testPublishCardActivityNeverPropagates(): void {
+		// A recipient-resolution failure must never break the mutation that
+		// already committed.
+		$this->boardMapper->method('find')->willThrowException(new \RuntimeException('db hiccup'));
+		$this->logger->expects(self::once())->method('debug');
+		$this->activityPublisher->expects(self::never())->method('cardMoved');
+
+		$this->notifier->publishCardActivity(1, 'card_moved', 7, 'A', 'alice');
+	}
+
+	public function testPublishBoardSharedFansOutAndSkipsSystemActor(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board(1, 'alice'));
+		$this->aclMapper->method('findByBoard')->with(1)->willReturn([$this->userAcl('bob')]);
+
+		$this->activityPublisher->expects(self::once())
+			->method('boardShared')
+			->with(1, 'My Board', 'alice', ['alice', 'bob']);
+
+		$this->notifier->publishBoardShared(1, 'My Board', 'alice');
+
+		// A null actor short-circuits without touching the publisher.
+		$this->notifier->publishBoardShared(1, 'My Board', null);
 	}
 }

--- a/tests/unit/Service/ChangeNotifierTest.php
+++ b/tests/unit/Service/ChangeNotifierTest.php
@@ -97,6 +97,51 @@ class ChangeNotifierTest extends TestCase {
 		self::assertSame($change, $this->notifier->notify(1, Change::ENTITY_CARD, 7, Change::ACTION_UPDATE, 'alice'));
 	}
 
+	public function testRecordChangeInsertsRowAndEmitsNoPush(): void {
+		$change = new Change();
+		$this->changeMapper->expects(self::once())
+			->method('insertChange')
+			->with(
+				1,
+				Change::ENTITY_CARD,
+				7,
+				Change::ACTION_UPDATE,
+				'alice',
+				self::greaterThan(0),
+				Change::VERB_UPDATED
+			)
+			->willReturn($change);
+		// recordChange must NOT touch the push path at all - no queue lookup, no
+		// recipient resolution (that is pushBoardChanged's job).
+		$this->container->expects(self::never())->method('get');
+		$this->boardMapper->expects(self::never())->method('find');
+
+		self::assertSame(
+			$change,
+			$this->notifier->recordChange(1, Change::ENTITY_CARD, 7, Change::ACTION_UPDATE, 'alice', Change::VERB_UPDATED)
+		);
+	}
+
+	public function testPushBoardChangedFansOutWithoutRecordingAChangeRow(): void {
+		// pushBoardChanged is push-only: it never writes a change row.
+		$this->changeMapper->expects(self::never())->method('insertChange');
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board(1, 'alice'));
+		$this->aclMapper->method('findByBoard')->with(1)->willReturn([$this->userAcl('bob')]);
+
+		$pushed = [];
+		$queue = $this->createMock(IQueue::class);
+		$queue->expects(self::exactly(2))
+			->method('push')
+			->willReturnCallback(static function (string $channel, $event) use (&$pushed): void {
+				$pushed[] = $event['user'];
+			});
+		$this->container->method('get')->willReturn($queue);
+
+		$this->notifier->pushBoardChanged(1);
+
+		self::assertSame(['alice', 'bob'], $pushed);
+	}
+
 	public function testEmitsOnePushPerRecipientIncludingExpandedGroups(): void {
 		$this->changeMapper->method('insertChange')->willReturn(new Change());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board(1, 'alice'));

--- a/tests/unit/Service/ChecklistServiceTest.php
+++ b/tests/unit/Service/ChecklistServiceTest.php
@@ -21,6 +21,7 @@ use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\PermissionService;
 use OCA\Kanso\Service\SortKeyService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -30,6 +31,7 @@ class ChecklistServiceTest extends TestCase {
 	private BoardMapper&MockObject $boardMapper;
 	private ChangeNotifier&MockObject $changeNotifier;
 	private PermissionService&MockObject $permissionService;
+	private IDBConnection&MockObject $db;
 	private ChecklistService $service;
 
 	protected function setUp(): void {
@@ -39,6 +41,7 @@ class ChecklistServiceTest extends TestCase {
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->db = $this->createMock(IDBConnection::class);
 		// A real SortKeyService - the fractional-key maths is deterministic and
 		// central to reorder behaviour, so exercise it rather than mock it.
 		$this->service = new ChecklistService(
@@ -48,6 +51,7 @@ class ChecklistServiceTest extends TestCase {
 			$this->changeNotifier,
 			$this->permissionService,
 			new SortKeyService(),
+			$this->db,
 		);
 	}
 
@@ -106,7 +110,7 @@ class ChecklistServiceTest extends TestCase {
 				return $item;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 
@@ -124,7 +128,7 @@ class ChecklistServiceTest extends TestCase {
 				self::assertGreaterThan(0, strcmp($item->getSortKey(), 'I'));
 				return $item;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->addItem(9, 'Second', 'alice');
 	}
@@ -132,7 +136,7 @@ class ChecklistServiceTest extends TestCase {
 	public function testAddItemRejectsEmptyTitle(): void {
 		$this->expectCardLoaded();
 		$this->itemMapper->expects(self::never())->method('insert');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->addItem(9, '   ', 'alice');
@@ -153,7 +157,7 @@ class ChecklistServiceTest extends TestCase {
 			->with($board, 'mallory', PermissionService::PERMISSION_EDIT)
 			->willThrowException(new NotPermittedException());
 		$this->itemMapper->expects(self::never())->method('insert');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->addItem(9, 'Nope', 'mallory');
@@ -200,7 +204,7 @@ class ChecklistServiceTest extends TestCase {
 				return $i;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 
@@ -218,7 +222,7 @@ class ChecklistServiceTest extends TestCase {
 				self::assertSame('new title', $i->getTitle());
 				return $i;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->updateItem(50, '  new title  ', null, 'alice');
 	}
@@ -229,7 +233,7 @@ class ChecklistServiceTest extends TestCase {
 		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->itemMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		// Same title, same done state → nothing to persist.
 		$result = $this->service->updateItem(50, 'todo', true, 'alice');
@@ -280,7 +284,7 @@ class ChecklistServiceTest extends TestCase {
 				self::assertLessThan(0, strcmp($i->getSortKey(), 'M'));
 				return $i;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->moveItem(3, null, 'alice');
 	}
@@ -301,7 +305,7 @@ class ChecklistServiceTest extends TestCase {
 				self::assertLessThan(0, strcmp($i->getSortKey(), 'T'));
 				return $i;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->moveItem(3, 1, 'alice');
 	}
@@ -320,7 +324,7 @@ class ChecklistServiceTest extends TestCase {
 				self::assertGreaterThan(0, strcmp($i->getSortKey(), 'T'));
 				return $i;
 			});
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$this->service->moveItem(3, 2, 'alice');
 	}
@@ -375,7 +379,7 @@ class ChecklistServiceTest extends TestCase {
 			->with($board, 'alice', PermissionService::PERMISSION_EDIT);
 		$this->itemMapper->expects(self::once())->method('delete')->with($item);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -361,7 +361,7 @@ class RecurrenceServiceTest extends TestCase {
 		$this->changeNotifier->expects(self::once())
 			->method('notify')
 			->with(1, Change::ENTITY_CARD, 99, Change::ACTION_UPDATE, 'alice', false, Change::VERB_UPDATED);
-		$this->changeNotifier->expects(self::once())->method('emitPush')->with(1);
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
 
 		$this->ruleMapper->expects(self::once())->method('update')->willReturnArgument(0);
 
@@ -437,7 +437,7 @@ class RecurrenceServiceTest extends TestCase {
 		$this->changeNotifier->expects(self::once())
 			->method('notify')
 			->with(1, Change::ENTITY_CARD, 10, Change::ACTION_UPDATE, 'alice', false, Change::VERB_UPDATED);
-		$this->changeNotifier->expects(self::once())->method('emitPush')->with(1);
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(1);
 
 		$this->ruleMapper->expects(self::once())->method('update')->willReturnArgument(0);
 
@@ -604,7 +604,7 @@ class RecurrenceServiceTest extends TestCase {
 		$this->db->method('commit')->willReturnCallback(function () use (&$order): void {
 			$order[] = 'commit';
 		});
-		$this->changeNotifier->method('emitPush')->willReturnCallback(function () use (&$order): void {
+		$this->changeNotifier->method('pushBoardChanged')->willReturnCallback(function () use (&$order): void {
 			$order[] = 'push';
 		});
 

--- a/tests/unit/Service/ReviewServiceTest.php
+++ b/tests/unit/Service/ReviewServiceTest.php
@@ -101,6 +101,14 @@ class ReviewServiceTest extends TestCase {
 		return $board;
 	}
 
+	/**
+	 * @param CardReview[] $siblings the findByCard() result the gating fold sees
+	 */
+	private function expectInsertReturns(CardReview $inserted, array $siblings): void {
+		$this->cardReviewMapper->method('insertRequest')->willReturn($inserted);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn($siblings);
+	}
+
 	// ---- requestReview ----------------------------------------------------
 
 	public function testRequestInsertsRowWritesChangeAndNotifies(): void {
@@ -112,9 +120,15 @@ class ReviewServiceTest extends TestCase {
 			->with($board, 'bob')
 			->willReturn(PermissionService::PERMISSION_READ);
 		$this->cardReviewMapper->method('existsForType')->with(9, 'bob', 0)->willReturn(false);
+		$inserted = $this->review('bob');
 		$this->cardReviewMapper->expects(self::once())
 			->method('insertRequest')
-			->with(9, 'bob', 'alice', null);
+			->with(9, 'bob', 'alice', null)
+			->willReturn($inserted);
+		// No lower-stage review exists → not gated → the notification fires and
+		// notified_at is stamped (one update).
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$inserted]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([]);
 		$this->changeNotifier->expects(self::once())
 			->method('notify')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'alice')
@@ -122,8 +136,62 @@ class ReviewServiceTest extends TestCase {
 		$this->notificationService->expects(self::once())
 			->method('notifyReviewRequested')
 			->with(9, 'bob', 'alice');
+		$this->cardReviewMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(static function (CardReview $r): CardReview {
+				self::assertNotNull($r->getNotifiedAt());
+				return $r;
+			});
 
 		$this->service->requestReview(9, 'bob', 'alice');
+	}
+
+	public function testRequestDefersNotificationWhenGated(): void {
+		// A stage-1 QA review requested while a stage-0 Code review sits unapproved
+		// on the card: the change row still fires (chip renders) but the reviewer
+		// notification is suppressed and notified_at is left null.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')->willReturn(PermissionService::PERMISSION_READ);
+		$this->reviewTypeMapper->method('find')->with(2)->willReturn($this->reviewType(2, 1));
+		$this->cardReviewMapper->method('existsForType')->with(9, 'bob', 2)->willReturn(false);
+
+		$code = $this->review('carol', CardReview::STATE_PENDING, 1, 9);
+		$code->setReviewTypeId(1); // stage 0
+		$qa = $this->review('bob', CardReview::STATE_PENDING, 2, 9);
+		$qa->setReviewTypeId(2); // stage 1
+		$this->cardReviewMapper->method('insertRequest')->willReturn($qa);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$code, $qa]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([1 => 0, 2 => 1]);
+
+		$this->changeNotifier->expects(self::once())->method('notify')->willReturn(new Change());
+		$this->notificationService->expects(self::never())->method('notifyReviewRequested');
+		$this->cardReviewMapper->expects(self::never())->method('update');
+
+		$this->service->requestReview(9, 'bob', 'alice', 2);
+	}
+
+	public function testRequestNotifiesWhenPrerequisiteNotYetRequested(): void {
+		// A stage-1 review whose stage-0 prerequisite has NOT been requested is
+		// NOT gated - a not-yet-requested prerequisite must not block.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')->willReturn(PermissionService::PERMISSION_READ);
+		$this->reviewTypeMapper->method('find')->with(2)->willReturn($this->reviewType(2, 1));
+		$this->cardReviewMapper->method('existsForType')->with(9, 'bob', 2)->willReturn(false);
+
+		$qa = $this->review('bob', CardReview::STATE_PENDING, 2, 9);
+		$qa->setReviewTypeId(2); // stage 1, alone on the card
+		$this->cardReviewMapper->method('insertRequest')->willReturn($qa);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$qa]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([1 => 0, 2 => 1]);
+
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->notificationService->expects(self::once())
+			->method('notifyReviewRequested')->with(9, 'bob', 'alice');
+		$this->cardReviewMapper->expects(self::once())->method('update');
+
+		$this->service->requestReview(9, 'bob', 'alice', 2);
 	}
 
 	public function testRequestSameReviewerDifferentTypeIsAllowed(): void {
@@ -133,7 +201,12 @@ class ReviewServiceTest extends TestCase {
 		$this->reviewTypeMapper->method('find')->with(5)->willReturn($this->reviewType(5, 1));
 		// bob already has an untyped review (type 0) but not a type-5 one.
 		$this->cardReviewMapper->method('existsForType')->with(9, 'bob', 5)->willReturn(false);
-		$this->cardReviewMapper->expects(self::once())->method('insertRequest')->with(9, 'bob', 'alice', 5);
+		$inserted = $this->review('bob', CardReview::STATE_PENDING, 7, 9);
+		$inserted->setReviewTypeId(5);
+		$this->cardReviewMapper->expects(self::once())->method('insertRequest')->with(9, 'bob', 'alice', 5)
+			->willReturn($inserted);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$inserted]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([5 => 0]);
 		$this->changeNotifier->method('notify')->willReturn(new Change());
 
 		$this->service->requestReview(9, 'bob', 'alice', 5);
@@ -216,9 +289,14 @@ class ReviewServiceTest extends TestCase {
 			->with($board, 'bob')->willReturn(PermissionService::PERMISSION_READ);
 		$this->reviewTypeMapper->method('find')->with(3)->willReturn($this->reviewType(3, 1));
 		$this->cardReviewMapper->method('existsForType')->with(9, 'bob', 3)->willReturn(false);
+		$inserted = $this->review('bob', CardReview::STATE_PENDING, 7, 9);
+		$inserted->setReviewTypeId(3);
 		$this->cardReviewMapper->expects(self::once())
 			->method('insertRequest')
-			->with(9, 'bob', 'alice', 3);
+			->with(9, 'bob', 'alice', 3)
+			->willReturn($inserted);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$inserted]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([3 => 0]);
 		$this->changeNotifier->method('notify')->willReturn(new Change());
 
 		$this->service->requestReview(9, 'bob', 'alice', 3);
@@ -289,7 +367,8 @@ class ReviewServiceTest extends TestCase {
 		$this->permissionService->method('getPermissions')
 			->with($board, 'bob')
 			->willReturn(PermissionService::PERMISSION_READ);
-		$this->cardReviewMapper->method('findById')->with(1)->willReturn($this->review('bob'));
+		$review = $this->review('bob');
+		$this->cardReviewMapper->method('findById')->with(1)->willReturn($review);
 		$this->cardReviewMapper->expects(self::once())
 			->method('update')
 			->willReturnCallback(static function (CardReview $r): CardReview {
@@ -300,6 +379,70 @@ class ReviewServiceTest extends TestCase {
 		$this->notificationService->expects(self::once())
 			->method('dismissReviewRequested')
 			->with(9, 'bob');
+		// The approve triggers a deferred-notification sweep; nothing downstream
+		// to un-gate here (the approved review is skipped).
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$review]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([]);
+		$this->notificationService->expects(self::never())->method('notifyReviewRequested');
+
+		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
+	}
+
+	public function testApprovingBlockerFiresDeferredNotificationOnce(): void {
+		// Card holds a stage-0 Code review (bob, pending) and a deferred stage-1 QA
+		// review (carol, pending, notified_at null). When bob approves, the QA
+		// review un-gates and its reviewer is notified exactly once, with
+		// notified_at stamped so a re-approval never re-fires.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')->willReturn(PermissionService::PERMISSION_READ);
+
+		$code = $this->review('bob', CardReview::STATE_PENDING, 1, 9);
+		$code->setReviewTypeId(1); // stage 0
+		$qa = $this->review('carol', CardReview::STATE_PENDING, 2, 9);
+		$qa->setReviewTypeId(2); // stage 1
+		$qa->setRequestedBy('alice');
+		$qa->setNotifiedAt(null); // deferred at request time
+
+		$this->cardReviewMapper->method('findById')->with(1)->willReturn($code);
+		// After bob's verdict is written, findByCard returns the now-approved code
+		// review plus the still-pending QA one.
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$code, $qa]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([1 => 0, 2 => 1]);
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		// QA notified exactly once (targeting carol, from requester alice).
+		$this->notificationService->expects(self::once())
+			->method('notifyReviewRequested')->with(9, 'carol', 'alice');
+		// Two updates: bob's verdict flip + stamping QA's notified_at.
+		$stamped = false;
+		$this->cardReviewMapper->expects(self::exactly(2))
+			->method('update')
+			->willReturnCallback(function (CardReview $r) use (&$stamped): CardReview {
+				if ($r->getReviewer() === 'carol') {
+					self::assertNotNull($r->getNotifiedAt());
+					$stamped = true;
+				}
+				return $r;
+			});
+
+		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
+		self::assertTrue($stamped, 'QA review notified_at must be stamped');
+	}
+
+	public function testReApprovingBlockerDoesNotReNotify(): void {
+		// Idempotency: the QA review was already notified (notified_at set). A
+		// no-op re-approve of the (already-approved) blocker must not re-notify.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')->willReturn(PermissionService::PERMISSION_READ);
+
+		// The blocker is ALREADY approved, so setState is a no-op (no flip) and the
+		// deferred-notification sweep never runs.
+		$code = $this->review('bob', CardReview::STATE_APPROVED, 1, 9);
+		$this->cardReviewMapper->method('findById')->with(1)->willReturn($code);
+		$this->cardReviewMapper->expects(self::never())->method('update');
+		$this->notificationService->expects(self::never())->method('notifyReviewRequested');
 
 		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
 	}
@@ -392,6 +535,81 @@ class ReviewServiceTest extends TestCase {
 		$this->commentService->expects(self::never())->method('addComment');
 
 		$this->service->setState(9, 1, CardReview::STATE_CHANGES_REQUESTED, 'bob', '   ');
+	}
+
+	// ---- serializeReviewsForCard (derived gating) -------------------------
+
+	public function testSerializeFoldsGatedAndBlockedByForDownstreamReview(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+
+		$code = $this->review('carol', CardReview::STATE_PENDING, 1, 9);
+		$code->setReviewTypeId(1); // stage 0
+		$qa = $this->review('bob', CardReview::STATE_PENDING, 2, 9);
+		$qa->setReviewTypeId(2); // stage 1
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$code, $qa]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([1 => 0, 2 => 1]);
+
+		$out = $this->service->serializeReviewsForCard(9);
+
+		// stage-0 Code review: not gated (nothing lower).
+		self::assertFalse($out[0]['gated']);
+		self::assertSame([], $out[0]['blockedBy']);
+		// stage-1 QA review: gated by the unapproved stage-0 Code review (id 1).
+		self::assertTrue($out[1]['gated']);
+		self::assertSame([1], $out[1]['blockedBy']);
+	}
+
+	public function testSerializeUngatesWhenLowerStageApproved(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+
+		$code = $this->review('carol', CardReview::STATE_APPROVED, 1, 9);
+		$code->setReviewTypeId(1); // stage 0, approved
+		$qa = $this->review('bob', CardReview::STATE_PENDING, 2, 9);
+		$qa->setReviewTypeId(2); // stage 1
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$code, $qa]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([1 => 0, 2 => 1]);
+
+		$out = $this->service->serializeReviewsForCard(9);
+
+		self::assertFalse($out[1]['gated'], 'QA un-gates once the stage-0 Code review is approved');
+		self::assertSame([], $out[1]['blockedBy']);
+	}
+
+	public function testSerializeUntypedReviewIsStageZeroAndNeverGated(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+
+		// An untyped review (type 0) alongside a stage-1 QA review: the untyped one
+		// is stage 0, never gated; the QA one is gated by the untyped (id 1).
+		$untyped = $this->review('carol', CardReview::STATE_PENDING, 1, 9);
+		$untyped->setReviewTypeId(0);
+		$qa = $this->review('bob', CardReview::STATE_PENDING, 2, 9);
+		$qa->setReviewTypeId(2);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$untyped, $qa]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([2 => 1]);
+
+		$out = $this->service->serializeReviewsForCard(9);
+
+		self::assertFalse($out[0]['gated']);
+		self::assertTrue($out[1]['gated']);
+		self::assertSame([1], $out[1]['blockedBy']);
+	}
+
+	public function testSerializeSameStageReviewsDoNotGateEachOther(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+
+		// Two stage-0 reviews: neither is strictly lower than the other, so neither
+		// gates.
+		$a = $this->review('carol', CardReview::STATE_PENDING, 1, 9);
+		$a->setReviewTypeId(1);
+		$b = $this->review('bob', CardReview::STATE_PENDING, 2, 9);
+		$b->setReviewTypeId(2);
+		$this->cardReviewMapper->method('findByCard')->with(9)->willReturn([$a, $b]);
+		$this->reviewTypeMapper->method('stageMapForBoard')->with(1)->willReturn([1 => 0, 2 => 0]);
+
+		$out = $this->service->serializeReviewsForCard(9);
+
+		self::assertFalse($out[0]['gated']);
+		self::assertFalse($out[1]['gated']);
 	}
 
 	// ---- findMine ---------------------------------------------------------

--- a/tests/unit/Service/ReviewTypeServiceTest.php
+++ b/tests/unit/Service/ReviewTypeServiceTest.php
@@ -100,6 +100,42 @@ class ReviewTypeServiceTest extends TestCase {
 		$this->service->create(1, '   ', null, 'alice');
 	}
 
+	public function testCreatePersistsStage(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->reviewTypeMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (ReviewType $t): ReviewType {
+				self::assertSame(2, $t->getStage());
+				$t->setId(3);
+				return $t;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->create(1, 'QA', null, 'alice', 2);
+	}
+
+	public function testCreateDefaultsStageToZeroWhenOmitted(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->reviewTypeMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static function (ReviewType $t): ReviewType {
+				self::assertSame(0, $t->getStage());
+				$t->setId(3);
+				return $t;
+			});
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->service->create(1, 'QA', null, 'alice');
+	}
+
+	public function testCreateRejectsNegativeStage(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->reviewTypeMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->create(1, 'QA', null, 'alice', -1);
+	}
+
 	public function testCreateAssertsManagePermission(): void {
 		$board = $this->board();
 		$this->boardMapper->method('find')->with(1)->willReturn($board);
@@ -132,6 +168,39 @@ class ReviewTypeServiceTest extends TestCase {
 		$updated = $this->service->update(3, 'Code', 'ddeeff', 'alice');
 		self::assertSame('Code', $updated->getTitle());
 		self::assertSame('ddeeff', $updated->getColor());
+	}
+
+	public function testUpdatePersistsStage(): void {
+		$this->reviewTypeMapper->method('find')->with(3)->willReturn($this->type());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->reviewTypeMapper->expects(self::once())->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$updated = $this->service->update(3, null, null, 'alice', 5);
+		self::assertSame(5, $updated->getStage());
+	}
+
+	public function testUpdateRejectsNegativeStage(): void {
+		$this->reviewTypeMapper->method('find')->with(3)->willReturn($this->type());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->reviewTypeMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(3, null, null, 'alice', -1);
+	}
+
+	public function testUpdateAssertsManagePermissionOnStageEdit(): void {
+		// Permission denial specifically on a stage-only edit.
+		$this->reviewTypeMapper->method('find')->with(3)->willReturn($this->type());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with(self::anything(), 'mallory', PermissionService::PERMISSION_MANAGE)
+			->willThrowException(new NotPermittedException());
+		$this->reviewTypeMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->update(3, null, null, 'mallory', 2);
 	}
 
 	// ---- delete -----------------------------------------------------------

--- a/tests/unit/Service/SearchServiceTest.php
+++ b/tests/unit/Service/SearchServiceTest.php
@@ -13,6 +13,7 @@ use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Service\BoardService;
 use OCA\Kanso\Service\SearchService;
+use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -20,6 +21,7 @@ class SearchServiceTest extends TestCase {
 	private BoardService&MockObject $boardService;
 	private CardMapper&MockObject $cardMapper;
 	private CommentMapper&MockObject $commentMapper;
+	private IDBConnection&MockObject $db;
 	private SearchService $service;
 
 	protected function setUp(): void {
@@ -27,10 +29,16 @@ class SearchServiceTest extends TestCase {
 		$this->boardService = $this->createMock(BoardService::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->commentMapper = $this->createMock(CommentMapper::class);
+		$this->db = $this->createMock(IDBConnection::class);
+		// Mirror the platform helper's backslash-escaping of LIKE wildcards.
+		$this->db->method('escapeLikeParameter')->willReturnCallback(
+			static fn (string $s): string => str_replace(['\\', '_', '%'], ['\\\\', '\\_', '\\%'], $s),
+		);
 		$this->service = new SearchService(
 			$this->boardService,
 			$this->cardMapper,
 			$this->commentMapper,
+			$this->db,
 		);
 	}
 

--- a/tests/unit/Service/SortKeyServiceTest.php
+++ b/tests/unit/Service/SortKeyServiceTest.php
@@ -137,4 +137,88 @@ class SortKeyServiceTest extends TestCase {
 			);
 		}
 	}
+
+	// ---- evenlySpaced (rebalance key set) ---------------------------------
+
+	public function testEvenlySpacedZeroReturnsEmpty(): void {
+		self::assertSame([], $this->service->evenlySpaced(0));
+	}
+
+	public function testEvenlySpacedRejectsNegative(): void {
+		$this->expectException(InvalidInputException::class);
+		$this->service->evenlySpaced(-1);
+	}
+
+	public function testEvenlySpacedSingleKeyIsCentred(): void {
+		$keys = $this->service->evenlySpaced(1);
+		self::assertCount(1, $keys);
+		self::assertMatchesRegularExpression('/^[0-9A-Z]+$/', $keys[0]);
+		self::assertStringEndsNotWith('0', $keys[0]);
+		self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($keys[0]));
+	}
+
+	public function testEvenlySpacedProducesShortStrictlyIncreasingKeys(): void {
+		foreach ([2, 3, 10, 50, 200, 1000] as $n) {
+			$keys = $this->service->evenlySpaced($n);
+			self::assertCount($n, $keys);
+			for ($i = 0; $i < $n; $i++) {
+				self::assertMatchesRegularExpression('/^[0-9A-Z]+$/', $keys[$i]);
+				self::assertStringEndsNotWith('0', $keys[$i]);
+				// Short: two-character keys for realistic stack sizes.
+				self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($keys[$i]));
+				if ($i > 0) {
+					self::assertLessThan(
+						0,
+						strcmp($keys[$i - 1], $keys[$i]),
+						"evenlySpaced($n) not strictly increasing at index $i"
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * The whole point of a rebalance: after resetting a stack to evenly-spaced
+	 * keys, a between() at ANY gap must fit without overflowing. This is the
+	 * recovery invariant for the 409 rebalance_required path.
+	 */
+	public function testBetweenAtEveryGapOfEvenlySpacedNeverOverflows(): void {
+		$keys = $this->service->evenlySpaced(100);
+		for ($i = 1; $i < count($keys); $i++) {
+			$mid = $this->service->between($keys[$i - 1], $keys[$i]);
+			self::assertLessThan(0, strcmp($keys[$i - 1], $mid));
+			self::assertLessThan(0, strcmp($mid, $keys[$i]));
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($mid));
+		}
+		// ...and appending after the last key also fits.
+		$tail = $this->service->after($keys[count($keys) - 1]);
+		self::assertLessThan(0, strcmp($keys[count($keys) - 1], $tail));
+	}
+
+	/**
+	 * A stack that has hit the overflow wall (colliding/at-capacity long keys)
+	 * is rescued: the rewritten keys are short and a subsequent between() no
+	 * longer throws where the original pair did.
+	 */
+	public function testEvenlySpacedRescuesAnAtCapacityPair(): void {
+		// Two adjacent keys so long that between() overflows (the 409 case).
+		$a = str_repeat('I', SortKeyService::MAX_KEY_LENGTH);
+		$b = $a . 'I';
+		// Sanity: the original pair genuinely overflows.
+		$overflowed = false;
+		try {
+			$this->service->between($a, $b);
+		} catch (OverflowException) {
+			$overflowed = true;
+		}
+		self::assertTrue($overflowed, 'precondition: the long pair must overflow');
+
+		// Rebalance the (2-card) stack; the fresh keys are short and insertable.
+		$keys = $this->service->evenlySpaced(2);
+		self::assertLessThanOrEqual(2, strlen($keys[0]));
+		self::assertLessThanOrEqual(2, strlen($keys[1]));
+		$mid = $this->service->between($keys[0], $keys[1]);
+		self::assertLessThan(0, strcmp($keys[0], $mid));
+		self::assertLessThan(0, strcmp($mid, $keys[1]));
+	}
 }

--- a/tests/unit/Service/StackServiceTest.php
+++ b/tests/unit/Service/StackServiceTest.php
@@ -79,7 +79,7 @@ class StackServiceTest extends TestCase {
 				return $stack;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_STACK,
@@ -108,7 +108,7 @@ class StackServiceTest extends TestCase {
 				return $stack;
 			});
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->willReturn(new Change());
 
 		$this->service->create(1, 'Done', 'alice');
@@ -122,7 +122,7 @@ class StackServiceTest extends TestCase {
 			->with($board, 'bob', PermissionService::PERMISSION_EDIT)
 			->willThrowException(new NotPermittedException());
 		$this->stackMapper->expects(self::never())->method('insert');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->create(1, 'To do', 'bob');
@@ -135,7 +135,7 @@ class StackServiceTest extends TestCase {
 			->method('update')
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_STACK,
@@ -157,7 +157,7 @@ class StackServiceTest extends TestCase {
 			->method('update')
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_STACK, 5, Change::ACTION_UPDATE, 'alice')
 			->willReturn(new Change());
 
@@ -169,7 +169,7 @@ class StackServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->stackMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		// Positional: id, title, archived, role, wipLimit, uid, color.
 		$set = $this->service->update(5, null, null, null, null, 'alice', 'e74c3c');
@@ -192,7 +192,7 @@ class StackServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->stackMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->update(5, null, null, 6, null, 'alice');
@@ -211,7 +211,7 @@ class StackServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->stackMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(5, null, null, null, 3, 'alice');
 		self::assertSame(3, $updated->getWipLimit());
@@ -223,7 +223,7 @@ class StackServiceTest extends TestCase {
 		$this->stackMapper->method('find')->with(5)->willReturn($stack);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->stackMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$updated = $this->service->update(5, null, null, null, 0, 'alice');
 		self::assertSame(0, $updated->getWipLimit());
@@ -247,7 +247,7 @@ class StackServiceTest extends TestCase {
 			->with($board, 'bob', PermissionService::PERMISSION_EDIT)
 			->willThrowException(new NotPermittedException());
 		$this->stackMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->update(5, null, null, Stack::ROLE_DONE, null, 'bob');
@@ -261,7 +261,7 @@ class StackServiceTest extends TestCase {
 			->with(self::callback(static fn (Stack $s): bool => $s->getDeletedAt() > 0))
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_STACK,
@@ -290,7 +290,7 @@ class StackServiceTest extends TestCase {
 			->with(self::callback(static fn (Stack $s): bool => $s->getDeletedAt() === 0))
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_STACK, 5, Change::ACTION_CREATE, 'alice')
 			->willReturn(new Change());
 
@@ -302,7 +302,7 @@ class StackServiceTest extends TestCase {
 		// A live stack must not be resurrected by a stale undo.
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->stackMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(DoesNotExistException::class);
 		$this->service->restore(5, 'alice');
@@ -337,7 +337,7 @@ class StackServiceTest extends TestCase {
 			->method('update')
 			->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(
 				1,
 				Change::ENTITY_STACK,
@@ -364,7 +364,7 @@ class StackServiceTest extends TestCase {
 		]);
 		$this->stackMapper->method('update')->willReturnArgument(0);
 		$this->changeNotifier->expects(self::once())
-			->method('notify')
+			->method('recordChange')
 			->with(1, Change::ENTITY_STACK, 7, Change::ACTION_MOVE, 'alice')
 			->willReturn(new Change());
 
@@ -381,7 +381,7 @@ class StackServiceTest extends TestCase {
 			$this->stack(6, 1, 'J'),
 		]);
 		$this->stackMapper->method('update')->willReturnArgument(0);
-		$this->changeNotifier->method('notify')->willReturn(new Change());
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
 
 		$moved = $this->service->move(5, 6, 'alice');
 		// after('J') === 'K'
@@ -398,7 +398,7 @@ class StackServiceTest extends TestCase {
 			->willThrowException(new NotPermittedException());
 		$this->db->expects(self::never())->method('beginTransaction');
 		$this->stackMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->move(5, null, 'bob');
@@ -444,7 +444,7 @@ class StackServiceTest extends TestCase {
 		$this->db->expects(self::once())->method('rollBack');
 		$this->db->expects(self::never())->method('commit');
 		$this->stackMapper->expects(self::never())->method('update');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(\OverflowException::class);
 		$this->service->move(5, 6, 'alice');
@@ -462,7 +462,7 @@ class StackServiceTest extends TestCase {
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('rollBack');
 		$this->db->expects(self::never())->method('commit');
-		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
 
 		$this->expectException(\RuntimeException::class);
 		$this->service->move(7, 5, 'alice');

--- a/tests/unit/Service/TrashServiceTest.php
+++ b/tests/unit/Service/TrashServiceTest.php
@@ -12,6 +12,7 @@ use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardContactMapper;
+use OCA\Kanso\Db\CardFieldValueMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardLinkMapper;
 use OCA\Kanso\Db\CardMapper;
@@ -52,6 +53,7 @@ class TrashServiceTest extends TestCase {
 	private ProjectCardMapper&MockObject $projectCardMapper;
 	private CardAttachmentService&MockObject $cardAttachmentService;
 	private CardTimeEntryService&MockObject $cardTimeEntryService;
+	private CardFieldValueMapper&MockObject $cardFieldValueMapper;
 	private TrashService $service;
 
 	protected function setUp(): void {
@@ -73,6 +75,7 @@ class TrashServiceTest extends TestCase {
 		$this->projectCardMapper = $this->createMock(ProjectCardMapper::class);
 		$this->cardAttachmentService = $this->createMock(CardAttachmentService::class);
 		$this->cardTimeEntryService = $this->createMock(CardTimeEntryService::class);
+		$this->cardFieldValueMapper = $this->createMock(CardFieldValueMapper::class);
 		$this->service = new TrashService(
 			$this->cardMapper,
 			$this->boardMapper,
@@ -91,6 +94,7 @@ class TrashServiceTest extends TestCase {
 			$this->projectCardMapper,
 			$this->cardAttachmentService,
 			$this->cardTimeEntryService,
+			$this->cardFieldValueMapper,
 		);
 	}
 
@@ -206,6 +210,8 @@ class TrashServiceTest extends TestCase {
 		$this->cardAttachmentService->expects(self::once())->method('deleteAllForCard')->with(9);
 		// Manual time-tracking entries are cascaded too (#3536).
 		$this->cardTimeEntryService->expects(self::once())->method('deleteAllForCard')->with(9);
+		// Custom-field values are cascaded too (#3537).
+		$this->cardFieldValueMapper->expects(self::once())->method('deleteByCard')->with(9);
 		$this->cardMapper->expects(self::once())->method('delete')->with($card);
 		$this->changeNotifier->expects(self::once())
 			->method('notify')

--- a/tests/unit/Service/TrashServiceTest.php
+++ b/tests/unit/Service/TrashServiceTest.php
@@ -24,6 +24,7 @@ use OCA\Kanso\Db\CommentReactionMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
 use OCA\Kanso\Db\SubscriptionMapper;
 use OCA\Kanso\Service\CardAttachmentService;
+use OCA\Kanso\Service\CardTimeEntryService;
 use OCA\Kanso\Service\ChangeNotifier;
 use OCA\Kanso\Service\InvalidInputException;
 use OCA\Kanso\Service\NotPermittedException;
@@ -50,6 +51,7 @@ class TrashServiceTest extends TestCase {
 	private CardRelationMapper&MockObject $cardRelationMapper;
 	private ProjectCardMapper&MockObject $projectCardMapper;
 	private CardAttachmentService&MockObject $cardAttachmentService;
+	private CardTimeEntryService&MockObject $cardTimeEntryService;
 	private TrashService $service;
 
 	protected function setUp(): void {
@@ -70,6 +72,7 @@ class TrashServiceTest extends TestCase {
 		$this->cardRelationMapper = $this->createMock(CardRelationMapper::class);
 		$this->projectCardMapper = $this->createMock(ProjectCardMapper::class);
 		$this->cardAttachmentService = $this->createMock(CardAttachmentService::class);
+		$this->cardTimeEntryService = $this->createMock(CardTimeEntryService::class);
 		$this->service = new TrashService(
 			$this->cardMapper,
 			$this->boardMapper,
@@ -87,6 +90,7 @@ class TrashServiceTest extends TestCase {
 			$this->cardRelationMapper,
 			$this->projectCardMapper,
 			$this->cardAttachmentService,
+			$this->cardTimeEntryService,
 		);
 	}
 
@@ -200,6 +204,8 @@ class TrashServiceTest extends TestCase {
 		$this->subscriptionMapper->expects(self::once())->method('deleteByCard')->with(9);
 		// Attachments cascade through the service (objects + rows), not a mapper.
 		$this->cardAttachmentService->expects(self::once())->method('deleteAllForCard')->with(9);
+		// Manual time-tracking entries are cascaded too (#3536).
+		$this->cardTimeEntryService->expects(self::once())->method('deleteAllForCard')->with(9);
 		$this->cardMapper->expects(self::once())->method('delete')->with($card);
 		$this->changeNotifier->expects(self::once())
 			->method('notify')


### PR DESCRIPTION
Card-depth features + a batch of card-view UX/perf polish. All on one branch; opened early so CI runs while more polish lands on the same PR.

## Features
- **Review-type stage gating** (#3588) — per-type `stage`; lower stages gate (defer notifications for) higher ones; gated is derived, not stored. Migration V004300. Settings-tab explainer added.
- **Time tracking** (#3536) — manual entries + per-card total; EDIT-gated, IDOR-guarded, purge-cascade. Migration V004400.
- **Custom fields** (#3537) — per-board typed field defs (text/number/date/select) + per-card values; MANAGE defs / EDIT values. Migration V004500.

## Card-view UX/perf
- **Perf:** killed a `user_status` request storm — an invalid `:show-user-status` prop (should be `:hide-status`) fired a request per avatar, in the card modal (#3659) and on board load (#3663, ~8→0).
- **Reactions** — Add-reaction button + chips moved inline into the comment action row; emoji picker no longer clipped.
- **Graceful not-found** (#3662) — 404/403/5xx-aware copy for dead card/board deep-links (inbox/notifications) with back-affordances.
- **Watch control** (#3660, +gap fix) — toggle + caret unified into one flush segmented split-button.
- **Resizable Discussion/Activity pane** (#3661) — drag handle, clamped, persisted per user, keyboard-a11y, mobile-stack.

App version 0.9.25 → 0.9.29. Backend covered by PHPUnit (happy + denial + edge); each UI change has a Playwright spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)