### PR TITLE
ci: run the full matrix on pushes to main (repo-page status)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,15 @@
 name: CI
 
 on:
-  # Every change lands via a PR, and the pull_request run is the merge gate — so we
-  # deliberately do NOT re-run CI on main after a merge. That post-merge run would
-  # just repeat the ~1.5h suite the PR already passed, on the slow serial runners.
-  # Push only builds release tags; feature branches are covered by pull_request.
+  # Changes land via PRs (the pull_request run is the merge gate). We ALSO run the
+  # full suite on pushes to main so the repo page shows main's status: each merge
+  # to main re-runs the matrix and stamps that commit green. Feature-branch pushes
+  # are NOT matched here (only main + release tags), so a PR still fires exactly
+  # one run via pull_request — no double-runs. This does repeat the ~1.5h suite the
+  # PR already passed; that is the deliberate cost of an always-visible green
+  # status on main.
   push:
+    branches: [main]
     tags: ['v*']
   pull_request:
 


### PR DESCRIPTION
## What
Re-add `push: branches: [main]` to the CI workflow so a merge to `main` re-runs the full matrix and stamps main's HEAD commit green. The repo page and commit list currently show **no status on main** because CI only ran on `pull_request` + release tags.

## Why this form is safe (no double-runs)
Feature-branch pushes are **not** matched (only `main` + `tags: v*`), so a PR still fires exactly one run via `pull_request` — this preserves the earlier trigger-dedup fix. Only pushes to `main` (i.e. merges) additionally trigger a run.

## Tradeoff (chosen deliberately)
This repeats the ~1.5h suite the PR already passed, on the serial self-hosted runner. That's the accepted cost of an always-visible green status on `main`. (Alternatives considered: a merge queue, or a fast-only main run skipping e2e.)

## Effect
The moment this merges, the merge commit to `main` carries the new trigger, so it will itself kick off the first full main run → main gets its green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)