### PR TITLE
feat: board parity + release-quality UX sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Import cards from a CSV / spreadsheet.** The board-list Import menu now has a
+  working "CSV file" entry (#3678): upload or paste a CSV, map its columns
+  (title required; optional description, due date, comma-separated labels and
+  assignees) with sensible header auto-detection, then add the rows as cards to a
+  board and column you choose. Labels are matched-or-created on the target board;
+  assignees are matched-or-dropped, filtered by READ so an import never
+  references someone who cannot see the board. The whole import is a single
+  all-or-nothing transaction (byte-capped before parsing, row-capped, long titles
+  truncated), EDIT on the target board is required, and the cards append to the
+  chosen stack with a single realtime push. This is the "add my spreadsheet of
+  tasks to an existing board" case only — creating a whole new board from a CSV
+  is out of scope (the Deck/Trello importers cover whole-board creation).
 - **iCal / ICS calendar feed of card due dates.** A board manager can now expose
   a read-only calendar feed of the board's card due dates (Board settings →
   Automation → Calendar feed), subscribable in any calendar client (Nextcloud

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.29</version>
+	<version>0.9.30</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.30</version>
+	<version>0.9.31</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -69,6 +69,9 @@ return [
 		// Trello board JSON import → a fresh Kanso board owned by the importer.
 		// A distinct literal POST path, alongside boardPortability#import above.
 		['name' => 'trelloImport#import', 'url' => '/api/trello-import', 'verb' => 'POST'],
+		// CSV import → append rows as cards into an EXISTING board's stack (the
+		// caller must have EDIT on that board). A distinct literal POST path.
+		['name' => 'csvImport#import', 'url' => '/api/csv-import', 'verb' => 'POST'],
 		// Delta-sync read (#3675): board changes since the client's cursor, so a
 		// single edit patches the client cache instead of a whole-board refetch.
 		// Declared BEFORE board#show so the router never captures "changes" as a

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -121,6 +121,7 @@ return [
 		['name' => 'card#destroy', 'url' => '/api/cards/{id}', 'verb' => 'DELETE'],
 		['name' => 'card#move', 'url' => '/api/cards/{id}/move', 'verb' => 'POST'],
 		['name' => 'card#copy', 'url' => '/api/cards/{id}/copy', 'verb' => 'POST'],
+		['name' => 'card#moveToBoard', 'url' => '/api/cards/{id}/move-to-board', 'verb' => 'POST'],
 		// Per-board card templates (#3409). Flag/unflag a card as a template
 		// (EDIT-gated), and create a new live card pre-filled from a template.
 		['name' => 'card#setTemplate', 'url' => '/api/cards/{id}/template', 'verb' => 'PUT'],

--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -242,6 +242,25 @@ class CardController extends Controller {
 	}
 
 	/**
+	 * MOVES the card to $targetStackId on ANOTHER board (#3679): the card is
+	 * re-created on the target board and REMOVED from the source, in one
+	 * transaction. Requires EDIT on BOTH boards. Content, checklist, and
+	 * title/status/dates cross over; labels map by title+color or drop; assignees
+	 * and watchers are KEPT only for uids that can READ the target board (dropped
+	 * otherwise). The KAN-id is re-issued on the target. Returns the full detail
+	 * payload of the moved card. A sort-key overflow surfaces as
+	 * 409 {"error": "rebalance_required"} via ApiErrorTrait.
+	 */
+	#[NoAdminRequired]
+	public function moveToBoard(int $id, int $targetStackId = 0): JSONResponse {
+		return $this->respond(function () use ($id, $targetStackId): JSONResponse {
+			$uid = $this->currentUserId();
+			$card = $this->cardService->moveToBoard($id, $targetStackId, $uid);
+			return new JSONResponse($this->detailPayload($card, $uid));
+		});
+	}
+
+	/**
 	 * Per-board template picker (#3409): summaries of the board's template cards
 	 * (the complement of the live board render, which excludes them). Requires
 	 * READ on the board (same gate as the board payload). Returns a flat list of

--- a/lib/Controller/CsvImportController.php
+++ b/lib/Controller/CsvImportController.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Controller;
+
+use OCA\Kanso\Service\CsvImportService;
+use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\NotPermittedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * CSV import: append the rows of an uploaded/pasted CSV as cards into an
+ * EXISTING board's chosen stack. The caller must have EDIT on that board (the
+ * gate lives in {@see CsvImportService}). The raw document text is passed
+ * straight through so the size cap + parsing in the service stay meaningful.
+ */
+class CsvImportController extends Controller {
+	use ApiErrorTrait;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private CsvImportService $importService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Imports CSV rows as cards into $boardId / $stackId.
+	 *
+	 * @param string $document raw CSV text (uploaded file or pasted)
+	 * @param array<string, mixed> $mapping field name → 0-based source column index
+	 * @param bool $hasHeader whether the first row is a header row to skip
+	 */
+	#[NoAdminRequired]
+	public function import(
+		string $document = '',
+		int $boardId = 0,
+		int $stackId = 0,
+		array $mapping = [],
+		bool $hasHeader = true,
+	): JSONResponse {
+		return $this->respond(function () use ($document, $boardId, $stackId, $mapping, $hasHeader): JSONResponse {
+			return new JSONResponse(
+				$this->importService->import(
+					$document,
+					$boardId,
+					$stackId,
+					$this->normaliseMapping($mapping),
+					$hasHeader,
+					$this->currentUserId(),
+				)
+			);
+		});
+	}
+
+	/**
+	 * Coerces the wire mapping into the service's shape: `title` is required and
+	 * an integer, every other field is an optional integer column index (a
+	 * missing / non-numeric value drops that field).
+	 *
+	 * @param array<string, mixed> $mapping
+	 * @return array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int}
+	 * @throws InvalidInputException if no usable title column was supplied
+	 */
+	private function normaliseMapping(array $mapping): array {
+		if (!isset($mapping['title']) || !is_numeric($mapping['title'])) {
+			throw new InvalidInputException('A title column must be mapped');
+		}
+		$out = ['title' => (int)$mapping['title']];
+		foreach (['description', 'duedate', 'labels', 'assignees'] as $field) {
+			if (isset($mapping[$field]) && is_numeric($mapping[$field])) {
+				$out[$field] = (int)$mapping[$field];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * @throws NotPermittedException if there is no user session
+	 */
+	private function currentUserId(): string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No authenticated user');
+		}
+		return $user->getUID();
+	}
+}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -27,8 +27,16 @@ class SettingsController extends Controller {
 	// Collapsed board-folder ids (#3529): a JSON list of the folder ids the user
 	// has collapsed in the nav / boards page. A pure per-user view preference.
 	private const KEY_COLLAPSED_GROUPS = 'collapsed_board_groups';
+	// Dismissed one-time onboarding hints (#3413): a JSON list of hint ids the
+	// user has dismissed (e.g. the "press ? for shortcuts" nudge). Server-side so
+	// a hint that is dismissed on one device stays dismissed everywhere.
+	private const KEY_DISMISSED_HINTS = 'dismissed_hints';
 	// Bound the value so a scripted client can't bloat the user-config row.
 	private const MAX_COLLAPSED = 200;
+	// Hint ids are shape-restricted (short slug) and capped, so the row can't be
+	// abused as arbitrary per-user storage. This is a shape guard, not an
+	// enumerated id allow-list — the frontend owns the concrete hint ids.
+	private const MAX_HINTS = 50;
 
 	public function __construct(
 		string $appName,
@@ -50,6 +58,7 @@ class SettingsController extends Controller {
 			return new JSONResponse([
 				'defaultBoardId' => $raw === '' ? null : (int)$raw,
 				'collapsedBoardGroups' => $this->readCollapsedGroups($uid),
+				'dismissedHints' => $this->readDismissedHints($uid),
 			]);
 		});
 	}
@@ -62,11 +71,15 @@ class SettingsController extends Controller {
 	 * `collapsedBoardGroups`, when provided, replaces the set of nav folders the
 	 * user has collapsed (#3529); omitting it leaves that preference untouched.
 	 *
+	 * `dismissedHints`, when provided, replaces the set of dismissed one-time
+	 * onboarding hints (#3413); omitting it leaves that preference untouched.
+	 *
 	 * @param ?int[] $collapsedBoardGroups
+	 * @param ?string[] $dismissedHints
 	 */
 	#[NoAdminRequired]
-	public function update(?int $defaultBoardId = null, ?array $collapsedBoardGroups = null): JSONResponse {
-		return $this->respond(function () use ($defaultBoardId, $collapsedBoardGroups): JSONResponse {
+	public function update(?int $defaultBoardId = null, ?array $collapsedBoardGroups = null, ?array $dismissedHints = null): JSONResponse {
+		return $this->respond(function () use ($defaultBoardId, $collapsedBoardGroups, $dismissedHints): JSONResponse {
 			$uid = $this->currentUserId();
 			$value = ($defaultBoardId === null || $defaultBoardId <= 0) ? '' : (string)$defaultBoardId;
 			$this->config->setUserValue($uid, 'kanso', self::KEY_DEFAULT_BOARD, $value);
@@ -75,9 +88,14 @@ class SettingsController extends Controller {
 				$this->writeCollapsedGroups($uid, $collapsedBoardGroups);
 			}
 
+			if ($dismissedHints !== null) {
+				$this->writeDismissedHints($uid, $dismissedHints);
+			}
+
 			return new JSONResponse([
 				'defaultBoardId' => $value === '' ? null : (int)$value,
 				'collapsedBoardGroups' => $this->readCollapsedGroups($uid),
+				'dismissedHints' => $this->readDismissedHints($uid),
 			]);
 		});
 	}
@@ -108,6 +126,58 @@ class SettingsController extends Controller {
 			$clean = array_slice($clean, 0, self::MAX_COLLAPSED);
 		}
 		$this->config->setUserValue($uid, 'kanso', self::KEY_COLLAPSED_GROUPS, json_encode($clean) ?: '[]');
+	}
+
+	/**
+	 * The user's dismissed one-time hint ids, tolerating a corrupt/legacy value.
+	 *
+	 * @return string[]
+	 */
+	private function readDismissedHints(string $uid): array {
+		$raw = $this->config->getUserValue($uid, 'kanso', self::KEY_DISMISSED_HINTS, '');
+		if ($raw === '') {
+			return [];
+		}
+		$decoded = json_decode($raw, true);
+		if (!is_array($decoded)) {
+			return [];
+		}
+		return $this->cleanHintIds($decoded);
+	}
+
+	/**
+	 * @param string[] $ids
+	 */
+	private function writeDismissedHints(string $uid, array $ids): void {
+		$clean = $this->cleanHintIds($ids);
+		$this->config->setUserValue($uid, 'kanso', self::KEY_DISMISSED_HINTS, json_encode($clean) ?: '[]');
+	}
+
+	/**
+	 * Normalise a list of hint ids: strings only, trimmed, de-duped, short slug
+	 * shape enforced, and capped so the value can't be abused as free storage.
+	 *
+	 * @param array<mixed> $ids
+	 * @return string[]
+	 */
+	private function cleanHintIds(array $ids): array {
+		$clean = [];
+		foreach ($ids as $id) {
+			if (!is_string($id)) {
+				continue;
+			}
+			$id = trim($id);
+			// Accept only short slug-shaped ids (a-z, 0-9, '-', '_').
+			if ($id === '' || strlen($id) > 64 || preg_match('/^[a-z0-9_-]+$/', $id) !== 1) {
+				continue;
+			}
+			$clean[$id] = true;
+		}
+		$out = array_keys($clean);
+		if (count($out) > self::MAX_HINTS) {
+			$out = array_slice($out, 0, self::MAX_HINTS);
+		}
+		return $out;
 	}
 
 	/**

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -11,16 +11,20 @@ use OCA\Kanso\Db\Board;
 use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\BoardPrefix;
 use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CardReviewMapper;
 use OCA\Kanso\Db\Change;
+use OCA\Kanso\Db\ChecklistItem;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\EstimateScale;
 use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
+use OCA\Kanso\Db\Subscription;
+use OCA\Kanso\Db\SubscriptionMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IDBConnection;
 
@@ -54,6 +58,8 @@ class CardService {
 		private LabelMapper $labelMapper,
 		private CardLabelMapper $cardLabelMapper,
 		private ChecklistItemMapper $checklistItemMapper,
+		private CardAssigneeMapper $cardAssigneeMapper,
+		private SubscriptionMapper $subscriptionMapper,
 	) {
 	}
 
@@ -330,6 +336,290 @@ class CardService {
 		$this->cloneContentInto($source, $copy, $sourceBoard, $targetBoard, $uid);
 
 		return $copy;
+	}
+
+	/**
+	 * MOVES a single card to a stack on ANOTHER board (#3679): the card is
+	 * re-created on the target board and REMOVED from the source, in ONE enclosing
+	 * transaction. Unlike {@see self::copy()} (a standalone duplicate that drops
+	 * assignees/watchers) this is a true relocation - the card leaves the source
+	 * board and lands on the target with as much of its context as the target
+	 * board's ACL permits.
+	 *
+	 * What crosses over:
+	 *   - content: title (unchanged, no " (copy)" suffix), description, priority,
+	 *     type, status timestamps, due/start dates, cover colour, and estimate
+	 *     (dropped when the target board's scale rejects the token);
+	 *   - labels: mapped by title+color to the target board (unmatched drop),
+	 *     exactly like {@see self::copyLabels()} - labels are never auto-created;
+	 *   - checklist items, in order, with their done state;
+	 *   - assignees AND watchers/subscriptions: KEPT only for uids that can READ
+	 *     the target board; any uid that cannot is DROPPED (the leak guard - a move
+	 *     must never carry a card reference to someone who cannot access it).
+	 *
+	 * What does NOT cross over (mirrors copy / the charter non-goals): comments,
+	 * activity/history, relations/back-links, and parent/children links (a moved
+	 * card is detached from its source-board hierarchy). The human KAN-id is
+	 * RE-ISSUED on the target board (a fresh per-board sequence) - the reference
+	 * changes, as it does for a copy.
+	 *
+	 * The whole thing runs in a single begin/commit/rollBack: the target INSERT +
+	 * its label/checklist/assignee/subscription rows + the source soft-delete +
+	 * BOTH boards' `kanso_changes` rows commit together, so a permission or DB
+	 * failure never leaves the card half-moved (created on the target but still on
+	 * the source, or vice versa). Both boards are pushed AFTER commit so realtime /
+	 * ETag advance on each.
+	 *
+	 * @throws DoesNotExistException if the source card, either board or the target stack does not exist or is deleted
+	 * @throws NotPermittedException if the actor lacks EDIT on the source OR the target board
+	 * @throws InvalidInputException if the target stack is on the SAME board (use move() for an in-board move)
+	 * @throws \OverflowException if the appended sort key or the board sequence keeps colliding after retries
+	 */
+	public function moveToBoard(int $id, int $targetStackId, string $uid): Card {
+		// Load the source with its description and gate EDIT on its board up-front.
+		$source = $this->loadCard($id);
+		$sourceBoard = $this->loadBoard($source->getBoardId());
+		$this->permissionService->assertPermission($sourceBoard, $uid, PermissionService::PERMISSION_EDIT);
+
+		$targetStack = $this->loadStack($targetStackId);
+		$targetBoard = $this->loadBoard($targetStack->getBoardId());
+		// EDIT on the target too - asserted up-front so a denial never soft-deletes
+		// the source before the target write is even attempted.
+		$this->permissionService->assertPermission($targetBoard, $uid, PermissionService::PERMISSION_EDIT);
+
+		// A same-board "move to board" is meaningless (and would try to soft-delete
+		// then re-create on one board): route in-board moves through move() instead.
+		if ($targetBoard->getId() === $sourceBoard->getId()) {
+			throw new InvalidInputException('Use the in-board move for a card staying on the same board');
+		}
+
+		// Snapshot the source's carried context ONCE, before the transaction, so a
+		// retry re-reads only the sort-key/sequence neighbours (which can shift
+		// under concurrency), never the whole card graph.
+		$sourceLabelIds = $this->cardLabelMapper->findLabelIdsByCard($id);
+		$sourceItems = $this->checklistItemMapper->findByCard($id);
+		// Assignees / watchers that may cross the boundary: only uids that can READ
+		// the TARGET board. Dropping the rest is the leak guard - a move must never
+		// carry the card to someone who cannot access where it landed.
+		$targetLabelByKey = $this->targetLabelIndex($sourceLabelIds, $targetBoard);
+		// De-duplicate the uid lists after the READ filter: the target rows are
+		// fresh, so the only way a per-uid insert could hit a unique violation is a
+		// duplicate uid in the source - which the retry loop would otherwise
+		// misread as a sort-key/board_seq collision. array_unique keeps that from
+		// happening (and documents that one row per uid is intended).
+		$carriedAssignees = array_values(array_unique($this->filterReadableOnTarget(
+			$this->cardAssigneeMapper->findUserIdsByCard($id),
+			$targetBoard,
+		)));
+		$carriedWatchers = array_values(array_unique($this->filterReadableOnTarget(
+			$this->subscriptionMapper->findCardSubscriberUids($id),
+			$targetBoard,
+		)));
+
+		$title = $this->validateTitle($source->getTitle());
+
+		for ($attempt = 0; ; $attempt++) {
+			$this->db->beginTransaction();
+			try {
+				// Fresh shell on the target: append to the bottom of the target stack
+				// and re-issue the per-board KAN-id (MAX+1 guarded by the unique
+				// (board_id, board_seq) index, like create()).
+				$lastCard = $this->cardMapper->findLastInStack($targetStackId);
+				$sortKey = $lastCard === null
+					? $this->sortKeyService->initial()
+					: $this->sortKeyService->after($lastCard->getSortKey());
+				$boardSeq = $this->cardMapper->nextBoardSeq($targetBoard->getId());
+
+				$now = time();
+				$moved = $this->buildMovedCard($source, $targetBoard, $targetStackId, $sortKey, $boardSeq, $now);
+				$moved = $this->cardMapper->insert($moved);
+				$newId = $moved->getId();
+
+				// Labels: assign the mapped twins directly (no self-committing service
+				// call inside our transaction).
+				foreach ($sourceLabelIds as $labelId) {
+					$twinId = $targetLabelByKey[$labelId] ?? null;
+					if ($twinId !== null) {
+						$this->cardLabelMapper->insertAssignment($newId, $twinId);
+					}
+				}
+
+				// Checklist items, in display order, carrying their done state.
+				$itemKey = $this->sortKeyService->initial();
+				foreach ($sourceItems as $index => $item) {
+					if ($index > 0) {
+						$itemKey = $this->sortKeyService->after($itemKey);
+					}
+					$clone = new ChecklistItem();
+					$clone->setCardId($newId);
+					$clone->setTitle($item->getTitle());
+					$clone->setDone($item->getDone());
+					$clone->setSortKey($itemKey);
+					$clone->setCreatedAt($now);
+					$this->checklistItemMapper->insert($clone);
+				}
+
+				// Assignees / watchers that survived the READ filter.
+				foreach ($carriedAssignees as $assigneeUid) {
+					$this->cardAssigneeMapper->insertAssignment($newId, $assigneeUid);
+				}
+				foreach ($carriedWatchers as $watcherUid) {
+					$sub = new Subscription();
+					$sub->setSubscriber($watcherUid);
+					$sub->setCardId($newId);
+					$sub->setCommentThreadId(SubscriptionMapper::THREAD_CARD);
+					$sub->setState(Subscription::STATE_SUBSCRIBED);
+					$sub->setCreatedAt($now);
+					$this->subscriptionMapper->insert($sub);
+				}
+
+				// Remove the card from the SOURCE: detach its children (same
+				// self-healing as delete()) then soft-delete it.
+				foreach ($this->cardMapper->findChildren($id) as $child) {
+					$child->setParentCardId(null);
+					$child->setLastModified($now);
+					$this->cardMapper->update($child);
+				}
+				$source->setDeletedAt($now);
+				$source->setLastModified($now);
+				$this->cardMapper->update($source);
+
+				// A change row on BOTH boards so delta-sync/ETag advance on each: a
+				// CREATE on the target, a DELETE on the source.
+				$this->changeNotifier->recordChange(
+					$targetBoard->getId(),
+					Change::ENTITY_CARD,
+					$newId,
+					Change::ACTION_CREATE,
+					$uid,
+					Change::VERB_CREATED,
+				);
+				$this->changeNotifier->recordChange(
+					$sourceBoard->getId(),
+					Change::ENTITY_CARD,
+					$id,
+					Change::ACTION_DELETE,
+					$uid,
+					Change::VERB_DELETED,
+				);
+
+				$this->db->commit();
+
+				// Commit succeeded - broadcast BOTH boards and surface the move in the
+				// Activity stream (best-effort, on the target where the card now lives).
+				$this->changeNotifier->pushBoardChanged($targetBoard->getId());
+				$this->changeNotifier->pushBoardChanged($sourceBoard->getId());
+				$this->changeNotifier->publishCardActivity(
+					$targetBoard->getId(),
+					'card_moved',
+					$newId,
+					(string)$moved->getTitle(),
+					$uid,
+				);
+
+				return $moved;
+			} catch (\OCP\DB\Exception $e) {
+				$this->db->rollBack();
+				if ($e->getReason() !== \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
+				// A sort-key or board_seq collision on the target: re-derive both and
+				// retry a few times before surfacing a retryable 409.
+				if ($attempt >= self::MAX_CREATE_ATTEMPTS - 1) {
+					throw new \OverflowException('card move key conflict (sort key or board_seq) after retries', 0, $e);
+				}
+			} catch (\Throwable $e) {
+				$this->db->rollBack();
+				throw $e;
+			}
+		}
+	}
+
+	/**
+	 * Builds the target-board card entity for a cross-board move from the source's
+	 * carried content. Estimate is board-scoped (dropped when the target scale
+	 * rejects the token); the title crosses UNCHANGED (a move is not a copy, so no
+	 * " (copy)" suffix). Never a template - a moved card is always an ordinary live
+	 * card.
+	 */
+	private function buildMovedCard(Card $source, Board $targetBoard, int $targetStackId, string $sortKey, int $boardSeq, int $now): Card {
+		$card = new Card();
+		$card->setBoardId($targetBoard->getId());
+		$card->setStackId($targetStackId);
+		$card->setTitle($this->validateTitle($source->getTitle()));
+		$card->setSortKey($sortKey);
+		$card->setBoardSeq($boardSeq);
+		$card->setDescription($source->getDescription());
+		$card->setPriority($source->getPriority());
+		$card->setType($source->getType());
+		$card->setStartedAt($source->getStartedAt());
+		$card->setDoneAt($source->getDoneAt());
+		$card->setDuedate($source->getDuedate());
+		$card->setStartDate($source->getStartDate());
+		$card->setAllDay($source->getAllDay());
+		$card->setCoverColor($source->getCoverColor());
+		$estimate = $source->getEstimate();
+		if ($estimate !== null && EstimateScale::allows($targetBoard->getEstimateScale(), $estimate)) {
+			$card->setEstimate($estimate);
+		}
+		$card->setArchived($source->getArchived());
+		$card->setOwner($source->getOwner());
+		$card->setCreatedAt($now);
+		$card->setLastModified($now);
+		$card->setDeletedAt(0);
+		$card->setIsTemplate(false);
+		return $card;
+	}
+
+	/**
+	 * Maps each of $sourceLabelIds to a target-board label id sharing the SAME
+	 * title (case-insensitive, trimmed) AND color - the same title+color rule as
+	 * {@see self::copyLabels()}. Source labels with no twin are simply absent from
+	 * the map (they drop). Returns a source-label-id => target-label-id map.
+	 *
+	 * @param int[] $sourceLabelIds
+	 * @return array<int,int>
+	 */
+	private function targetLabelIndex(array $sourceLabelIds, Board $targetBoard): array {
+		if ($sourceLabelIds === []) {
+			return [];
+		}
+		$targetByKey = [];
+		foreach ($this->labelMapper->findByBoard($targetBoard->getId()) as $targetLabel) {
+			$targetByKey[$this->labelKey($targetLabel)] ??= $targetLabel->getId();
+		}
+		$map = [];
+		foreach ($sourceLabelIds as $labelId) {
+			try {
+				$sourceLabel = $this->labelMapper->find($labelId);
+			} catch (DoesNotExistException) {
+				continue;
+			}
+			$twinId = $targetByKey[$this->labelKey($sourceLabel)] ?? null;
+			if ($twinId !== null) {
+				$map[$labelId] = $twinId;
+			}
+		}
+		return $map;
+	}
+
+	/**
+	 * Keeps only the uids that can READ the target board - the leak guard for a
+	 * cross-board move's assignees and watchers. A uid with no permission (or an
+	 * unknown uid) is dropped so the moved card never references someone who cannot
+	 * see where it landed. Mirrors the importer/participant read rule.
+	 *
+	 * @param string[] $uids
+	 * @return string[]
+	 */
+	private function filterReadableOnTarget(array $uids, Board $targetBoard): array {
+		$kept = [];
+		foreach ($uids as $candidate) {
+			if (($this->permissionService->getPermissions($targetBoard, $candidate) & PermissionService::PERMISSION_READ) !== 0) {
+				$kept[] = $candidate;
+			}
+		}
+		return $kept;
 	}
 
 	/**

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardAssigneeMapper;
+use OCA\Kanso\Db\CardLabelMapper;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Db\Label;
+use OCA\Kanso\Db\LabelMapper;
+use OCA\Kanso\Db\Stack;
+use OCA\Kanso\Db\StackMapper;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+
+/**
+ * Imports rows of a CSV / spreadsheet as cards into an EXISTING board's chosen
+ * stack - the "I have a spreadsheet of tasks, add them to my board" case. This
+ * is deliberately NOT a whole-board importer (that lane is covered by
+ * {@see DeckImportService} / {@see TrelloImportService}); it only appends cards
+ * to a stack the caller can EDIT.
+ *
+ * The transactional, all-or-nothing convention mirrors the other importers:
+ * every row's card is inserted in ONE DB transaction (any failure rolls the
+ * whole import back), the document is byte-capped BEFORE parsing, the row count
+ * is capped, and a title too long for the VARCHAR(100) column is truncated
+ * rather than failing the import. Unlike the whole-board importers this writes
+ * into an existing board, so it follows {@see CardService::create}'s conventions
+ * for that board: cards APPEND to the stack via {@see SortKeyService::after},
+ * each gets a per-board sequence number, an {@see Change::ACTION_CREATE} row is
+ * appended to the board's change log, and a single realtime push fires after the
+ * commit so the board updates live.
+ *
+ * Column mapping (0-based source column indexes chosen by the caller):
+ *   - title       REQUIRED. A row with a blank title is skipped, not fatal.
+ *   - description optional.
+ *   - duedate     optional; a spreadsheet date/datetime → the card due date.
+ *   - labels      optional; comma-separated names, match-or-CREATE on the board
+ *                 (mirrors the whole-board importers, which create the labels
+ *                 they reference rather than dropping them).
+ *   - assignees   optional; comma-separated uids, match-or-DROP filtered by READ
+ *                 on the target board (mirrors the Deck importer's assignee rule
+ *                 and never leaks a uid onto a board they cannot see).
+ */
+class CsvImportService {
+	/**
+	 * Hard ceiling on the accepted CSV size, in bytes, enforced BEFORE parsing to
+	 * bound memory. 5 MiB comfortably fits a large task spreadsheet while stopping
+	 * a pathological upload.
+	 */
+	public const MAX_DOCUMENT_BYTES = 5 * 1024 * 1024;
+
+	/**
+	 * Hard ceiling on the number of DATA rows (header excluded) turned into cards.
+	 * A file with more rows is rejected up-front rather than silently truncated.
+	 */
+	public const MAX_ROWS = 2000;
+
+	/** Card/label title columns are VARCHAR(100); long values truncate to fit. */
+	private const MAX_TITLE_LENGTH = 100;
+
+	/** Colour given to a label auto-created during import (neutral grey). */
+	private const DEFAULT_LABEL_COLOR = 'b3b3b3';
+
+	public function __construct(
+		private BoardService $boardService,
+		private StackMapper $stackMapper,
+		private CardMapper $cardMapper,
+		private LabelMapper $labelMapper,
+		private CardLabelMapper $cardLabelMapper,
+		private CardAssigneeMapper $cardAssigneeMapper,
+		private SortKeyService $sortKeyService,
+		private ChangeNotifier $changeNotifier,
+		private PermissionService $permissionService,
+		private IUserManager $userManager,
+		private IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * Imports the CSV rows as cards appended to $stackId (which must belong to
+	 * $boardId). EDIT on the board is required.
+	 *
+	 * $mapping maps a field name to the 0-based source column index (or null when
+	 * that field is not mapped); `title` MUST be mapped. When $hasHeader is true
+	 * the first parsed row is treated as headers and skipped.
+	 *
+	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
+	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
+	 * @throws InvalidInputException on an oversized/malformed CSV, a missing title mapping, or too many rows
+	 * @throws NotPermittedException if the actor lacks EDIT on the board
+	 */
+	public function import(
+		string $rawDocument,
+		int $boardId,
+		int $stackId,
+		array $mapping,
+		bool $hasHeader,
+		string $actorUid,
+	): array {
+		if (strlen($rawDocument) > self::MAX_DOCUMENT_BYTES) {
+			throw new InvalidInputException('The CSV file is too large to import');
+		}
+		if (!isset($mapping['title'])) {
+			throw new InvalidInputException('A title column must be mapped');
+		}
+
+		$rows = $this->parseCsv($rawDocument);
+		if ($hasHeader) {
+			array_shift($rows);
+		}
+		if (count($rows) > self::MAX_ROWS) {
+			throw new InvalidInputException('The CSV has too many rows to import (limit ' . self::MAX_ROWS . ')');
+		}
+
+		// Load + EDIT-gate the target board and stack up-front, before any write,
+		// so a permission denial never leaves a partial import.
+		$board = $this->boardService->find($boardId, $actorUid);
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
+		$stack = $this->stackMapper->find($stackId);
+		if ($stack->getBoardId() !== $boardId) {
+			throw new InvalidInputException('That stack does not belong to the chosen board');
+		}
+
+		$this->db->beginTransaction();
+		try {
+			$result = $this->rebuild($rows, $board, $stack, $mapping, $actorUid);
+			$this->db->commit();
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+
+		// Commit succeeded - broadcast the board change exactly once for the whole
+		// batch (not per card), mirroring the importers' single push.
+		if ($result['cards'] > 0) {
+			$this->changeNotifier->pushBoardChanged($boardId);
+		}
+		return $result;
+	}
+
+	/**
+	 * @param list<list<string>> $rows
+	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
+	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
+	 */
+	private function rebuild(array $rows, Board $board, Stack $stack, array $mapping, string $actorUid): array {
+		$boardId = $board->getId();
+		$stackId = $stack->getId();
+		$now = time();
+
+		// Existing labels on the board, indexed case-insensitively by title, so a
+		// name that already exists is REUSED rather than duplicated.
+		$labelIdByName = [];
+		foreach ($this->labelMapper->findByBoard($boardId) as $label) {
+			$labelIdByName[$this->labelKey((string)$label->getTitle())] = $label->getId();
+		}
+		$labelsCreated = 0;
+
+		// Append after the current tail of the stack; each new card advances the
+		// sort key so the imported block preserves file order at the bottom.
+		$last = $this->cardMapper->findLastInStack($stackId);
+		$cardKey = $last === null ? null : $last->getSortKey();
+
+		$titleIdx = $mapping['title'];
+		$descIdx = $mapping['description'] ?? null;
+		$dueIdx = $mapping['duedate'] ?? null;
+		$labelsIdx = $mapping['labels'] ?? null;
+		$assigneesIdx = $mapping['assignees'] ?? null;
+
+		$cards = 0;
+		$skipped = 0;
+		foreach ($rows as $row) {
+			$title = $this->title($this->cell($row, $titleIdx));
+			if ($title === '') {
+				// A row with no title cannot become a card - skipped, never fatal.
+				$skipped++;
+				continue;
+			}
+
+			$card = new Card();
+			$card->setBoardId($boardId);
+			$card->setStackId($stackId);
+			$card->setTitle($title);
+			$description = $descIdx === null ? '' : trim($this->cell($row, $descIdx));
+			$card->setDescription($description !== '' ? $description : null);
+			$cardKey = $cardKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($cardKey);
+			$card->setSortKey($cardKey);
+			$card->setBoardSeq($this->cardMapper->nextBoardSeq($boardId));
+			$due = $dueIdx === null ? null : $this->toDate($this->cell($row, $dueIdx));
+			$card->setDuedate($due);
+			// A date-only value (no time component) is an all-day due date, so the
+			// pill hides the midnight time - matching the composer's date tokens.
+			if ($due !== null) {
+				$card->setAllDay($this->isDateOnly($this->cell($row, $dueIdx)));
+			}
+			$card->setDoneAt($stack->getRole() === Stack::ROLE_DONE ? $now : 0);
+			$card->setStartedAt(
+				in_array($stack->getRole(), [Stack::ROLE_IN_PROGRESS, Stack::ROLE_REVIEW], true) ? $now : 0,
+			);
+			$card->setArchived(false);
+			$card->setOwner($actorUid);
+			$card->setCreatedAt($now);
+			$card->setLastModified($now);
+			$card->setDeletedAt(0);
+			$card->setParentCardId(null);
+			$card->setPriority(0);
+			$card->setIsTemplate(false);
+			$newCardId = $this->cardMapper->insert($card)->getId();
+
+			// The card and its CREATE change row are written inside the SAME
+			// transaction as the rest of the import (all-or-nothing), so delta
+			// sync / ETag stay correct for every imported card.
+			$this->changeNotifier->recordChange(
+				$boardId,
+				Change::ENTITY_CARD,
+				$newCardId,
+				Change::ACTION_CREATE,
+				$actorUid,
+				Change::VERB_CREATED,
+			);
+
+			if ($labelsIdx !== null) {
+				$labelsCreated += $this->attachLabels(
+					$this->splitList($this->cell($row, $labelsIdx)),
+					$newCardId,
+					$boardId,
+					$labelIdByName,
+				);
+			}
+			if ($assigneesIdx !== null) {
+				$this->attachAssignees(
+					$this->splitList($this->cell($row, $assigneesIdx)),
+					$newCardId,
+					$board,
+				);
+			}
+
+			$cards++;
+		}
+
+		return [
+			'boardId' => $boardId,
+			'stackId' => $stackId,
+			'cards' => $cards,
+			'skipped' => $skipped,
+			'labelsCreated' => $labelsCreated,
+		];
+	}
+
+	/**
+	 * Match-or-create each label name on the board: a name that already exists
+	 * (case-insensitively) is reused, an unseen one is created once and cached so
+	 * repeated names across rows share one label. Mirrors the whole-board
+	 * importers, which create the labels they reference.
+	 *
+	 * @param string[] $names
+	 * @param array<string, int> $labelIdByName label key → id, updated by reference
+	 * @return int the number of labels newly created
+	 */
+	private function attachLabels(array $names, int $cardId, int $boardId, array &$labelIdByName): int {
+		$created = 0;
+		$seen = [];
+		foreach ($names as $name) {
+			$name = $this->title($name);
+			if ($name === '') {
+				continue;
+			}
+			$key = $this->labelKey($name);
+			$labelId = $labelIdByName[$key] ?? null;
+			if ($labelId === null) {
+				$label = new Label();
+				$label->setBoardId($boardId);
+				$label->setTitle($name);
+				$label->setColor(self::DEFAULT_LABEL_COLOR);
+				$labelId = $this->labelMapper->insert($label)->getId();
+				$labelIdByName[$key] = $labelId;
+				$created++;
+			}
+			if (!isset($seen[$labelId])) {
+				$this->cardLabelMapper->insertAssignment($cardId, $labelId);
+				$seen[$labelId] = true;
+			}
+		}
+		return $created;
+	}
+
+	/**
+	 * Assign each uid that (a) exists and (b) can READ the target board. A uid
+	 * that fails either check is DROPPED, never assigned - the leak guard that
+	 * stops an imported card referencing someone who cannot see the board.
+	 *
+	 * @param string[] $uids
+	 */
+	private function attachAssignees(array $uids, int $cardId, Board $board): void {
+		$seen = [];
+		foreach ($uids as $uid) {
+			$uid = trim($uid);
+			if ($uid === '' || isset($seen[$uid])) {
+				continue;
+			}
+			$seen[$uid] = true;
+			if (!$this->userManager->userExists($uid)) {
+				continue;
+			}
+			if (($this->permissionService->getPermissions($board, $uid) & PermissionService::PERMISSION_READ) === 0) {
+				continue;
+			}
+			$this->cardAssigneeMapper->insertAssignment($cardId, $uid);
+		}
+	}
+
+	// ── parsing / helpers ────────────────────────────────────────────────────────
+
+	/**
+	 * Parses the raw CSV into rows of string cells. Uses PHP's own CSV lexer
+	 * (via a memory stream) so quoted fields, embedded newlines and escaped
+	 * quotes are handled correctly rather than a naive split. A blank line
+	 * produces an empty row that later title-skipping drops.
+	 *
+	 * @return list<list<string>>
+	 * @throws InvalidInputException if the document is not decodable text
+	 */
+	private function parseCsv(string $raw): array {
+		// Strip a UTF-8 BOM so the first header cell is not prefixed with it.
+		if (str_starts_with($raw, "\xEF\xBB\xBF")) {
+			$raw = substr($raw, 3);
+		}
+		$handle = fopen('php://temp', 'r+');
+		if ($handle === false) {
+			throw new InvalidInputException('The CSV file could not be read');
+		}
+		fwrite($handle, $raw);
+		rewind($handle);
+
+		$rows = [];
+		while (($cells = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
+			// fgetcsv can yield null (on read error) or a `[null]` row for a blank
+			// line; normalise both to string cells so later mapping never hits a
+			// null.
+			if (!is_array($cells)) {
+				continue;
+			}
+			$normalised = [];
+			foreach ($cells as $cell) {
+				$normalised[] = $cell ?? '';
+			}
+			$rows[] = $normalised;
+		}
+		fclose($handle);
+		return $rows;
+	}
+
+	/**
+	 * A cell at $index, or '' when the row is shorter than the mapped column (a
+	 * ragged row never throws).
+	 *
+	 * @param list<string> $row
+	 */
+	private function cell(array $row, ?int $index): string {
+		if ($index === null || $index < 0 || !isset($row[$index])) {
+			return '';
+		}
+		return $row[$index];
+	}
+
+	/**
+	 * A comma-separated cell → its trimmed, non-empty values.
+	 *
+	 * @return string[]
+	 */
+	private function splitList(string $cell): array {
+		$out = [];
+		foreach (explode(',', $cell) as $part) {
+			$part = trim($part);
+			if ($part !== '') {
+				$out[] = $part;
+			}
+		}
+		return $out;
+	}
+
+	/** Fits an external value into the VARCHAR(100) title columns (trimmed first). */
+	private function title(string $value): string {
+		return mb_substr(trim($value), 0, self::MAX_TITLE_LENGTH);
+	}
+
+	/** Case-insensitive key for matching an existing label by title. */
+	private function labelKey(string $title): string {
+		return mb_strtolower(trim($title));
+	}
+
+	/**
+	 * A spreadsheet date/datetime cell → a UTC \DateTime, or null when blank or
+	 * unparseable (an unrecognised date is dropped, never fatal to the import).
+	 */
+	private function toDate(string $value): ?\DateTime {
+		$value = trim($value);
+		if ($value === '') {
+			return null;
+		}
+		$ts = strtotime($value);
+		if ($ts === false) {
+			return null;
+		}
+		return (new \DateTime('@' . $ts))->setTimezone(new \DateTimeZone('UTC'));
+	}
+
+	/** Whether a due-date cell carries no time component (a date-only value). */
+	private function isDateOnly(string $value): bool {
+		return preg_match('/\d[:h]\d|\d\s*(am|pm)/i', $value) !== 1;
+	}
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -280,3 +280,24 @@ const { tasksCount, reviewsCount, inboxCount } = useMyWorkBadges()
 	font-style: italic;
 }
 </style>
+
+<!--
+	App-wide reduced-motion guard (#3415). A single global rule (deliberately
+	UNSCOPED) that respects the OS "reduce motion" setting across the whole Kanso
+	app at once: it neutralizes every transition, animation (incl. the shimmer
+	skeletons), and smooth-scroll. This is the canonical place for the app's
+	motion policy — a later a11y card references it, so it is kept clean and
+	global rather than per-component. Individual components no longer need their
+	own reduced-motion guards.
+-->
+<style>
+@media (prefers-reduced-motion: reduce) {
+	*,
+	::before,
+	::after {
+		transition-duration: 0.01ms !important;
+		animation: none !important;
+		scroll-behavior: auto !important;
+	}
+}
+</style>

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -321,6 +321,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<NcActionButton
 								v-if="canEdit"
 								:close-after-click="true"
+								@click="openMovePicker">
+								<template #icon>
+									<DragIcon :size="20" />
+								</template>
+								{{ t('kanso', 'Move card…') }}
+							</NcActionButton>
+							<NcActionButton
+								v-if="canEdit"
+								:close-after-click="true"
 								@click="openCopyDialog">
 								<template #icon>
 									<ContentDuplicateIcon :size="20" />
@@ -1815,6 +1824,61 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</div>
 		</div>
 	</NcModal>
+
+	<!-- Keyboard / screen-reader "Move card…" picker: the non-pointer
+	     alternative to drag-and-drop. Pick a column + position; confirm funnels
+	     through the shared optimistic move path (useCardMove). -->
+	<NcModal
+		v-if="showMovePicker"
+		size="small"
+		:name="t('kanso', 'Move card')"
+		@close="showMovePicker = false">
+		<div class="card-modal__copy-dialog">
+			<h2 class="card-modal__copy-title">{{ t('kanso', 'Move card') }}</h2>
+			<label class="card-modal__copy-field">
+				<span class="card-modal__copy-label">{{ t('kanso', 'Column') }}</span>
+				<select v-model="movePickerStackId" class="card-modal__relation-target">
+					<option v-for="s in moveTargetStacks" :key="s.id" :value="s.id">{{ s.title }}</option>
+				</select>
+			</label>
+			<fieldset class="card-modal__move-position">
+				<legend class="card-modal__copy-label">{{ t('kanso', 'Position') }}</legend>
+				<label class="card-modal__move-radio">
+					<input v-model="movePickerPosition" type="radio" value="top">
+					<span>{{ t('kanso', 'Top of the column') }}</span>
+				</label>
+				<label class="card-modal__move-radio">
+					<input v-model="movePickerPosition" type="radio" value="bottom">
+					<span>{{ t('kanso', 'Bottom of the column') }}</span>
+				</label>
+				<label class="card-modal__move-radio" :class="{ 'card-modal__move-radio--disabled': movePickerAfterOptions.length === 0 }">
+					<input
+						v-model="movePickerPosition"
+						type="radio"
+						value="after"
+						:disabled="movePickerAfterOptions.length === 0">
+					<span>{{ t('kanso', 'After a specific card') }}</span>
+				</label>
+				<select
+					v-if="movePickerPosition === 'after'"
+					v-model="movePickerAfterCardId"
+					class="card-modal__relation-target"
+					:disabled="movePickerAfterOptions.length === 0">
+					<option v-for="c in movePickerAfterOptions" :key="c.id" :value="c.id">{{ c.title }}</option>
+				</select>
+			</fieldset>
+			<span v-if="moveError" class="card-modal__save-error">{{ moveError }}</span>
+			<div class="card-modal__copy-actions">
+				<NcButton @click="showMovePicker = false">{{ t('kanso', 'Cancel') }}</NcButton>
+				<NcButton
+					type="primary"
+					:disabled="movePickerStackId == null"
+					@click="confirmMovePicker">
+					{{ t('kanso', 'Move') }}
+				</NcButton>
+			</div>
+		</div>
+	</NcModal>
 </template>
 
 <script setup>
@@ -1907,13 +1971,16 @@ import { useComments, buildCommentTree, REACTION_EMOJI } from '../composables/us
 import { buildCardPrompt } from '../utils/cardPrompt.js'
 import { useCardHierarchy } from '../composables/useCardHierarchy.js'
 import { boardQueryKey } from '../composables/queryKeys.js'
+import { useCardMove } from '../composables/useCardMove.js'
+import { useAnnouncer } from '../composables/useAnnouncer.js'
+import { initial, between, after, before } from '../services/sortKey.js'
 import { useSubscription } from '../composables/useSubscription.js'
 import { useCardLinks, branchName } from '../composables/useCardLinks.js'
 import { useCardAttachments } from '../composables/useCardAttachments.js'
 import { useCardTimeEntries } from '../composables/useCardTimeEntries.js'
 import { useImagePaste } from '../composables/useImagePaste.js'
 import { cardAttachmentUrl, cardAttachmentInlineUrl } from '../services/api.js'
-import { addCardRelation as apiAddCardRelation, removeCardRelation as apiRemoveCardRelation, moveCard as apiMoveCard, getCardActivity as apiGetCardActivity, copyCard as apiCopyCard, moveCardToBoard as apiMoveCardToBoard, fetchBoard as apiFetchBoard, resolveCardRef as apiResolveCardRef, setCardTemplate as apiSetCardTemplate } from '../services/api.js'
+import { addCardRelation as apiAddCardRelation, removeCardRelation as apiRemoveCardRelation, getCardActivity as apiGetCardActivity, copyCard as apiCopyCard, moveCardToBoard as apiMoveCardToBoard, fetchBoard as apiFetchBoard, resolveCardRef as apiResolveCardRef, setCardTemplate as apiSetCardTemplate } from '../services/api.js'
 import { useBoards } from '../composables/useBoards.js'
 import { useCardFields } from '../composables/useCardFields.js'
 import { cssColor, LABEL_COLOR_PRESETS, readableColor } from '../services/color.js'
@@ -2119,6 +2186,9 @@ async function handleToggleLabel(label) {
 			labelId: label.id,
 			assign,
 		})
+		announceMove(assign
+			? t('kanso', 'Label {label} added', { label: label.title })
+			: t('kanso', 'Label {label} removed', { label: label.title }))
 	} catch (err) {
 		labelToggleError.value = err?.response?.data?.error || t('kanso', 'Failed to update label.')
 	}
@@ -2200,6 +2270,10 @@ async function handleToggleAssignee(uid, assign) {
 			userId: uid,
 			assign,
 		})
+		const who = participantName(uid)
+		announceMove(assign
+			? t('kanso', '{user} assigned', { user: who })
+			: t('kanso', '{user} unassigned', { user: who }))
 	} catch (err) {
 		assigneeError.value = err?.response?.data?.error || t('kanso', 'Failed to update assignee.')
 	}
@@ -3862,33 +3936,143 @@ watch(discussionTab, (tab) => {
 }, { immediate: true })
 onBeforeUnmount(stopActivityCacheSyncFn)
 
-// ── Move to top / bottom of the current column (⋯ menu) ──────────────────────
-// Reuses the existing move endpoint: afterCardId=null → top; afterCardId=last
-// card in the stack → bottom. A menu action (not a drag), so we just refetch the
-// board rather than run the DnD optimistic machinery.
+// ── Same-board move (⋯ menu "Move to top/bottom" + keyboard "Move card…") ─────
+// Both the edge shortcuts and the keyboard/SR position picker funnel through the
+// ONE optimistic move path (useCardMove.enqueueMove) — the same code DnD uses —
+// so there is never a second move implementation to keep in sync.
 const moveError = ref('')
-async function moveToEdge(toTop) {
+const { enqueueMove, lastError: enqueueMoveError } = useCardMove(boardId)
+const { announce: announceMove } = useAnnouncer()
+
+/** Non-archived cards in a stack, self excluded, sorted by fractional key. */
+function stackCardsSorted(stackId) {
+	const selfId = Number(props.cardId)
+	return (boardData.value?.cards ?? [])
+		.filter((c) => c.stackId === stackId && !c.archived && c.id !== selfId)
+		.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0))
+}
+
+/**
+ * Move this card within the board via the shared optimistic queue. afterCardId
+ * null → top of the target stack; otherwise land right after that card. Computes
+ * the same optimistic fractional key BoardView derives for a drop, so the card
+ * appears in the right spot before the server responds. Announces to SR.
+ *
+ * @param {number} targetStackId
+ * @param {?number} afterCardId  card to land after, or null for top
+ */
+function moveWithinBoard(targetStackId, afterCardId) {
 	moveError.value = ''
+	const selfId = Number(props.cardId)
+	const inStack = stackCardsSorted(targetStackId)
+
+	// Derive optimisticKey mirroring BoardView's drop math.
+	let optimisticKey
+	try {
+		if (afterCardId == null) {
+			// Top: before the first card, or the only card in an empty stack.
+			const first = inStack[0]
+			optimisticKey = first ? before(first.sortKey) : initial()
+		} else {
+			const idx = inStack.findIndex((c) => c.id === afterCardId)
+			const anchor = inStack[idx]
+			const next = idx >= 0 ? inStack[idx + 1] : null
+			optimisticKey = next ? between(anchor.sortKey, next.sortKey) : after(anchor.sortKey)
+		}
+	} catch {
+		// Keys too close/overflow → let the server truth win on reconcile.
+		optimisticKey = afterCardId == null
+			? (inStack[0]?.sortKey ?? initial())
+			: (inStack.find((c) => c.id === afterCardId)?.sortKey ?? initial())
+	}
+
+	enqueueMove({ cardId: selfId, targetStackId, afterCardId: afterCardId ?? null, optimisticKey })
+	queryClient.invalidateQueries({ queryKey: ['card', props.cardId] })
+
+	const stackTitle = (boardData.value?.stacks ?? []).find((s) => s.id === targetStackId)?.title ?? ''
+	announceMove(t('kanso', '{card} moved to {stack}', {
+		card: cardData.value?.title || t('kanso', 'Card'),
+		stack: stackTitle,
+	}))
+}
+
+// afterCardId=null → top; last card in the stack → bottom.
+function moveToEdge(toTop) {
 	const stackId = cardData.value?.stackId
 	if (stackId == null) return
-	const selfId = Number(props.cardId)
-	let afterCardId = null
-	if (!toTop) {
-		// Bottom: land after the last non-archived card in this stack (by sortKey).
-		const inStack = (boardData.value?.cards ?? [])
-			.filter((c) => c.stackId === stackId && !c.archived && c.id !== selfId)
-			.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0))
-		if (inStack.length === 0) return // alone in the stack → already top and bottom
-		afterCardId = inStack[inStack.length - 1].id
-	}
-	try {
-		await apiMoveCard(selfId, { targetStackId: stackId, afterCardId })
-		queryClient.invalidateQueries({ queryKey: boardQueryKey(boardId.value) })
-		queryClient.invalidateQueries({ queryKey: ['card', props.cardId] })
-	} catch (err) {
-		moveError.value = err?.response?.data?.error || t('kanso', 'Failed to move card.')
+	const inStack = stackCardsSorted(stackId)
+	if (toTop) {
+		if (inStack.length === 0) return // already the only card → top & bottom
+		moveWithinBoard(stackId, null)
+	} else {
+		if (inStack.length === 0) return
+		moveWithinBoard(stackId, inStack[inStack.length - 1].id)
 	}
 }
+
+// ── Keyboard / SR "Move card…" picker (a11y alternative to drag-and-drop) ─────
+// Reviewers require a non-pointer way to move a card. Pick a target stack and a
+// position (top, bottom, or after a specific card); confirm funnels through
+// moveWithinBoard → enqueueMove (same path as DnD).
+const showMovePicker = ref(false)
+const movePickerStackId = ref(null)
+// 'top' | 'bottom' | 'after'
+const movePickerPosition = ref('bottom')
+const movePickerAfterCardId = ref(null)
+
+/** Editable, non-archived stacks on this board (the move targets). */
+const moveTargetStacks = computed(() =>
+	(boardData.value?.stacks ?? [])
+		.filter((s) => !s.archived)
+		.slice()
+		.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0)),
+)
+
+/** Cards in the chosen target stack the user can position after (self excluded). */
+const movePickerAfterOptions = computed(() =>
+	movePickerStackId.value == null ? [] : stackCardsSorted(movePickerStackId.value),
+)
+
+function openMovePicker() {
+	moveError.value = ''
+	movePickerStackId.value = cardData.value?.stackId ?? moveTargetStacks.value[0]?.id ?? null
+	movePickerPosition.value = 'bottom'
+	movePickerAfterCardId.value = null
+	showMovePicker.value = true
+}
+
+// Reset the "after" selection whenever the target stack changes so a stale card
+// id from the previous stack can't leak into the move contract.
+watch(movePickerStackId, () => {
+	movePickerAfterCardId.value = movePickerAfterOptions.value[0]?.id ?? null
+})
+
+function confirmMovePicker() {
+	const stackId = movePickerStackId.value
+	if (stackId == null) return
+	let afterCardId = null
+	if (movePickerPosition.value === 'top') {
+		afterCardId = null
+	} else if (movePickerPosition.value === 'bottom') {
+		const cards = stackCardsSorted(stackId)
+		afterCardId = cards.length ? cards[cards.length - 1].id : null
+	} else {
+		// 'after' a specific card. Guard against a stale/empty selection: an empty
+		// target stack or a missing pick degrades to top — never an invalid move.
+		afterCardId = movePickerAfterCardId.value ?? null
+		if (afterCardId != null && !stackCardsSorted(stackId).some((c) => c.id === afterCardId)) {
+			afterCardId = null
+		}
+	}
+	moveWithinBoard(stackId, afterCardId)
+	showMovePicker.value = false
+}
+
+// Surface a queued-move failure (403 review gate / 409 rebalance / generic) in
+// the modal's move-error slot, same as the edge shortcuts.
+watch(enqueueMoveError, (msg) => {
+	if (msg) moveError.value = msg
+})
 
 // The four relation groups from card detail
 const relations = computed(() => cardData.value?.relations ?? { blocks: [], blockedBy: [], duplicates: [], relates: [] })
@@ -4314,6 +4498,27 @@ async function handleToggleProject(projectId) {
 	justify-content: flex-end;
 	gap: 8px;
 	margin-top: 4px;
+}
+
+.card-modal__move-position {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	border: none;
+	margin: 0;
+	padding: 0;
+}
+
+.card-modal__move-radio {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	cursor: pointer;
+}
+
+.card-modal__move-radio--disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 /* ── Modal shell ─────────────────────────────────────────────────────────── */

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -330,6 +330,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<NcActionButton
 								v-if="canEdit"
 								:close-after-click="true"
+								@click="openMoveToBoardDialog">
+								<template #icon>
+									<TransferIcon :size="20" />
+								</template>
+								{{ t('kanso', 'Move to board…') }}
+							</NcActionButton>
+							<NcActionButton
+								v-if="canEdit"
+								:close-after-click="true"
 								:disabled="templatePending"
 								@click="handleTemplateToggle">
 								<template #icon>
@@ -1761,16 +1770,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		</div>
 	</NcModal>
 
-	<!-- Copy to… : pick a target board + stack (same or another board the user can edit). -->
+	<!-- Copy to… / Move to board… : pick a target board + stack (a board the user can edit). -->
 	<NcModal
 		v-if="showCopyDialog"
 		size="small"
-		:name="t('kanso', 'Copy card to…')"
+		:name="copyDialogIsMove ? t('kanso', 'Move card to board…') : t('kanso', 'Copy card to…')"
 		@close="showCopyDialog = false">
 		<div class="card-modal__copy-dialog">
-			<h2 class="card-modal__copy-title">{{ t('kanso', 'Copy card to…') }}</h2>
+			<h2 class="card-modal__copy-title">{{ copyDialogIsMove ? t('kanso', 'Move card to board…') : t('kanso', 'Copy card to…') }}</h2>
 			<p class="card-modal__copy-hint">
-				{{ t('kanso', 'Duplicates the title, description, labels, checklist, estimate, priority and status. Comments, activity and assignees are not copied.') }}
+				{{ copyDialogIsMove
+					? t('kanso', 'Moves the card to another board and removes it from here. Assignees and watchers are kept only if they can access the target board.')
+					: t('kanso', 'Duplicates the title, description, labels, checklist, estimate, priority and status. Comments, activity and assignees are not copied.') }}
 			</p>
 			<label class="card-modal__copy-field">
 				<span class="card-modal__copy-label">{{ t('kanso', 'Board') }}</span>
@@ -1796,8 +1807,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				<NcButton
 					type="primary"
 					:disabled="copyPending || !copyTargetStackId"
-					@click="confirmCopy">
-					{{ copyPending ? t('kanso', 'Copying…') : t('kanso', 'Copy') }}
+					@click="copyDialogIsMove ? confirmMoveToBoard() : confirmCopy()">
+					{{ copyDialogIsMove
+						? (copyPending ? t('kanso', 'Moving…') : t('kanso', 'Move'))
+						: (copyPending ? t('kanso', 'Copying…') : t('kanso', 'Copy')) }}
 				</NcButton>
 			</div>
 		</div>
@@ -1824,6 +1837,7 @@ import CloseIcon from 'vue-material-design-icons/Close.vue'
 import GithubIcon from 'vue-material-design-icons/Github.vue'
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
 import ContentDuplicateIcon from 'vue-material-design-icons/ContentDuplicate.vue'
+import TransferIcon from 'vue-material-design-icons/Transfer.vue'
 import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
 import AccountBoxIcon from 'vue-material-design-icons/AccountBox.vue'
 import AccountPlusIcon from 'vue-material-design-icons/AccountPlus.vue'
@@ -1899,7 +1913,7 @@ import { useCardAttachments } from '../composables/useCardAttachments.js'
 import { useCardTimeEntries } from '../composables/useCardTimeEntries.js'
 import { useImagePaste } from '../composables/useImagePaste.js'
 import { cardAttachmentUrl, cardAttachmentInlineUrl } from '../services/api.js'
-import { addCardRelation as apiAddCardRelation, removeCardRelation as apiRemoveCardRelation, moveCard as apiMoveCard, getCardActivity as apiGetCardActivity, copyCard as apiCopyCard, fetchBoard as apiFetchBoard, resolveCardRef as apiResolveCardRef, setCardTemplate as apiSetCardTemplate } from '../services/api.js'
+import { addCardRelation as apiAddCardRelation, removeCardRelation as apiRemoveCardRelation, moveCard as apiMoveCard, getCardActivity as apiGetCardActivity, copyCard as apiCopyCard, moveCardToBoard as apiMoveCardToBoard, fetchBoard as apiFetchBoard, resolveCardRef as apiResolveCardRef, setCardTemplate as apiSetCardTemplate } from '../services/api.js'
 import { useBoards } from '../composables/useBoards.js'
 import { useCardFields } from '../composables/useCardFields.js'
 import { cssColor, LABEL_COLOR_PRESETS, readableColor } from '../services/color.js'
@@ -3138,8 +3152,12 @@ async function copyAsPrompt() {
 	}
 }
 
-// ── Copy to… (duplicate card into a target board/stack) ──────────────────────
+// ── Copy to… / Move to board… (relocate card into a target board/stack) ──────
+// The same picker UI serves both: 'copy' duplicates the card, 'move' relocates
+// it (server-side single-card cross-board move, #3679).
 const showCopyDialog = ref(false)
+const copyDialogMode = ref('copy')
+const copyDialogIsMove = computed(() => copyDialogMode.value === 'move')
 const copyTargetBoardId = ref(null)
 const copyTargetStackId = ref('')
 const copyStackOptions = ref([])
@@ -3147,11 +3165,15 @@ const copyStacksLoading = ref(false)
 const copyPending = ref(false)
 const copyError = ref('')
 
-// All boards the user can see - the picker offers every board; a copy into one
-// the user cannot EDIT is rejected server-side and surfaced as copyError.
+// All boards the user can see - the picker offers every board; a copy/move into
+// one the user cannot EDIT is rejected server-side and surfaced as copyError.
+// Move mode excludes the card's current board (a same-board "move to board" is
+// meaningless - the server rejects it too).
 const { data: allBoardsData } = useBoards()
 const copyBoardOptions = computed(() =>
-	(allBoardsData.value ?? []).filter((b) => !b.archived),
+	(allBoardsData.value ?? [])
+		.filter((b) => !b.archived)
+		.filter((b) => !copyDialogIsMove.value || Number(b.id) !== Number(boardId.value)),
 )
 
 const copyIsCrossBoard = computed(() =>
@@ -3159,6 +3181,7 @@ const copyIsCrossBoard = computed(() =>
 )
 
 async function openCopyDialog() {
+	copyDialogMode.value = 'copy'
 	copyError.value = ''
 	copyTargetStackId.value = ''
 	// Default the target to the card's current board so the common case (copy
@@ -3166,6 +3189,23 @@ async function openCopyDialog() {
 	copyTargetBoardId.value = Number(boardId.value)
 	showCopyDialog.value = true
 	await loadCopyStacks(Number(boardId.value))
+}
+
+async function openMoveToBoardDialog() {
+	copyDialogMode.value = 'move'
+	copyError.value = ''
+	copyTargetStackId.value = ''
+	// Move targets another board; default to the first eligible one (the current
+	// board is excluded from the options). No default when none exist.
+	const first = copyBoardOptions.value[0]
+	copyTargetBoardId.value = first ? Number(first.id) : null
+	showCopyDialog.value = true
+	if (copyTargetBoardId.value != null) {
+		await loadCopyStacks(copyTargetBoardId.value)
+	} else {
+		copyStackOptions.value = []
+		copyError.value = t('kanso', 'There is no other board you can move this card to.')
+	}
 }
 
 function onCopyBoardChange() {
@@ -3226,6 +3266,31 @@ async function confirmCopy() {
 		}
 	} catch (err) {
 		copyError.value = err?.response?.data?.error || t('kanso', 'Failed to copy card.')
+	} finally {
+		copyPending.value = false
+	}
+}
+
+async function confirmMoveToBoard() {
+	const targetStackId = Number(copyTargetStackId.value)
+	if (!targetStackId || copyPending.value) return
+	copyError.value = ''
+	copyPending.value = true
+	try {
+		const targetBoard = Number(copyTargetBoardId.value)
+		await apiMoveCardToBoard(Number(props.cardId), targetStackId)
+		// The card left this board and landed on the target: refresh BOTH boards
+		// (source loses it, target gains it) and the boards list (per-board counts).
+		queryClient.invalidateQueries({ queryKey: boardQueryKey(targetBoard) })
+		queryClient.invalidateQueries({ queryKey: boardQueryKey(boardId.value) })
+		queryClient.invalidateQueries({ queryKey: ['boards'] })
+		showCopyDialog.value = false
+		showSuccess(t('kanso', 'Card moved.'))
+		// The card no longer exists on this board (its id changed on the target),
+		// so close the modal rather than leave a stale/404 detail open.
+		closeModal()
+	} catch (err) {
+		copyError.value = err?.response?.data?.error || t('kanso', 'Failed to move card.')
 	} finally {
 		copyPending.value = false
 	}

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -605,10 +605,12 @@ const extraAssigneeCount = computed(() => {
 	display: inline-flex;
 	align-items: center;
 }
-.card-tile__type--bug { color: #e74c3c; }
-.card-tile__type--feature { color: #27ae60; }
+/* Type icons use theme tokens so they keep WCAG contrast in both light and dark
+   themes (bare #e74c3c/#27ae60/#7f8c8d fail contrast on the dark surface). */
+.card-tile__type--bug { color: var(--color-error, #e74c3c); }
+.card-tile__type--feature { color: var(--color-success, #27ae60); }
 .card-tile__type--task { color: var(--color-primary-element, #0082c9); }
-.card-tile__type--chore { color: #7f8c8d; }
+.card-tile__type--chore { color: var(--color-text-maxcontrast, #7f8c8d); }
 
 /* Priority indicator badge */
 .card-tile__priority {
@@ -622,10 +624,10 @@ const extraAssigneeCount = computed(() => {
 	border: 1px solid currentColor;
 }
 
-/* Low: grey */
+/* Low: grey — token keeps contrast on the dark surface where #888 fails. */
 .card-tile__priority--1 {
-	color: #888;
-	border-color: #888;
+	color: var(--color-text-maxcontrast, #767676);
+	border-color: var(--color-text-maxcontrast, #767676);
 	background: rgba(136, 136, 136, 0.1);
 }
 
@@ -636,10 +638,11 @@ const extraAssigneeCount = computed(() => {
 	background: rgba(0, 130, 201, 0.1);
 }
 
-/* High: orange */
+/* High: orange — --color-warning adapts per theme and keeps ≥4.5:1 text
+   contrast; stays distinct from Urgent's --color-error red. */
 .card-tile__priority--3 {
-	color: #e07b00;
-	border-color: #e07b00;
+	color: var(--color-warning, #e07b00);
+	border-color: var(--color-warning, #e07b00);
 	background: rgba(224, 123, 0, 0.1);
 }
 

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<button
 			ref="el"
 			class="card-tile"
-			:class="{ 'card-tile--done': isDone, 'card-tile--selected': selected }"
+			:class="{ 'card-tile--done': isDone, 'card-tile--selected': selected, 'card-tile--compact': compact }"
 			:data-card-id="card.id"
 			@click="onTileClick"
 			@mouseenter="$emit('hover', card.id)"
@@ -146,7 +146,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						v-for="uid in visibleAssigneeIds"
 						:key="uid"
 						:user="uid"
-						:size="24"
+						:size="compact ? 20 : 24"
 						:hide-status="true"
 						:disable-tooltip="false"
 						class="card-tile__avatar" />
@@ -223,6 +223,15 @@ const props = defineProps({
 	},
 	/** Whether this tile is currently in the multi-select selection. */
 	selected: {
+		type: Boolean,
+		default: false,
+	},
+	/**
+	 * Compact density (#3415): a per-user, view-only toggle that tightens the
+	 * tile — smaller padding, a single-line title, smaller chips — so more cards
+	 * fit on screen. Purely presentational; no card-data change.
+	 */
+	compact: {
 		type: Boolean,
 		default: false,
 	},
@@ -435,7 +444,11 @@ const extraAssigneeCount = computed(() => {
 	overflow: hidden;
 }
 
-/* Meta row - all badges on a single flex line; assignees pushed right */
+/* Meta row - all badges on a single flex line; assignees pushed right.
+ * A min-height reserves the row's vertical space so late-loading chips /
+ * avatars (which render after the summary paint) don't shift the tile height
+ * and jolt the virtualizer's measured rows (#3415). 24px == the avatar height,
+ * the tallest inline meta item. */
 .card-tile__meta {
 	display: flex;
 	flex-wrap: wrap;
@@ -443,6 +456,7 @@ const extraAssigneeCount = computed(() => {
 	gap: 4px;
 	width: 100%;
 	margin-top: 2px;
+	min-height: 24px;
 }
 
 .card-tile__inprogress {
@@ -728,5 +742,71 @@ const extraAssigneeCount = computed(() => {
 	font-size: 0.65rem;
 	font-weight: 700;
 	margin-left: -6px;
+}
+
+/* ── Compact density (#3415) ───────────────────────────────────────────────────
+ * A per-user, view-only toggle that tightens every tile so more cards fit on
+ * screen: less padding, a single-line title, a shorter meta row, and smaller
+ * chips / avatars. Purely presentational — the tile keeps every badge, it just
+ * renders denser. The compact tile is measurably shorter, so StackColumn feeds
+ * the virtualizer a smaller estimateSize and forces a re-measure when density
+ * flips (see StackColumn.vue). */
+.card-tile--compact {
+	gap: 3px;
+	padding: 6px 8px;
+}
+
+.card-tile--compact .card-tile__cover {
+	height: 5px;
+	width: calc(100% + 16px);
+	margin: -6px -8px 1px;
+}
+
+.card-tile--compact .card-tile__title {
+	font-size: 0.83rem;
+	line-height: 1.3;
+	-webkit-line-clamp: 1;
+}
+
+.card-tile--compact .card-tile__labels {
+	margin-bottom: 0;
+}
+
+/* Compact chips read one tick smaller with tighter padding. */
+.card-tile--compact .card-tile__label-chip {
+	font-size: 0.66rem;
+	padding: 2px 6px;
+}
+
+/* A shorter reserved meta row in compact mode; still tall enough for the
+ * (smaller) avatars so late-loading chips don't shift the row. */
+.card-tile--compact .card-tile__meta {
+	margin-top: 0;
+	min-height: 20px;
+}
+
+.card-tile--compact .card-tile__due,
+.card-tile--compact .card-tile__checklist,
+.card-tile--compact .card-tile__children,
+.card-tile--compact .card-tile__comments,
+.card-tile--compact .card-tile__priority,
+.card-tile--compact .card-tile__estimate,
+.card-tile--compact .card-tile__review,
+.card-tile--compact .card-tile__inprogress,
+.card-tile--compact .card-tile__blocked {
+	font-size: 0.68rem;
+	padding: 0 5px;
+}
+
+.card-tile--compact .card-tile__ref {
+	font-size: 0.64rem;
+}
+
+/* Smaller overflow badge to match the 20px compact avatars (NcAvatar itself is
+ * sized via its :size prop above). */
+.card-tile--compact .card-tile__avatar-overflow {
+	width: 20px;
+	height: 20px;
+	font-size: 0.6rem;
 }
 </style>

--- a/src/components/CsvImportModal.vue
+++ b/src/components/CsvImportModal.vue
@@ -1,0 +1,361 @@
+<!--
+SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcModal size="normal" @close="$emit('close')">
+		<div class="csv-import" data-test="csv-import">
+			<h2 class="csv-import__title">{{ t('kanso', 'Import cards from CSV') }}</h2>
+
+			<!-- Step 1: pick a source (upload or paste). -->
+			<template v-if="step === 'source'">
+				<p class="csv-import__hint">
+					{{ t('kanso', 'Upload or paste a CSV of tasks. The rows are added as cards to a board and column you choose. The first row is treated as headers.') }}
+				</p>
+
+				<div class="csv-import__source">
+					<NcButton @click="fileInput?.click()">
+						<template #icon>
+							<UploadIcon :size="20" />
+						</template>
+						{{ t('kanso', 'Choose a CSV file') }}
+					</NcButton>
+					<span class="csv-import__or">{{ t('kanso', 'or paste below') }}</span>
+				</div>
+				<input
+					ref="fileInput"
+					type="file"
+					accept="text/csv,.csv"
+					class="csv-import__file"
+					data-test="csv-import-file"
+					@change="onFileChange">
+
+				<textarea
+					v-model="rawText"
+					class="csv-import__paste"
+					rows="6"
+					data-test="csv-import-paste"
+					:placeholder="t('kanso', 'title,description,due date,labels,assignees\nDesign login,Wireframe the flow,2026-02-01,ux,alice')" />
+
+				<p v-if="parseError" class="csv-import__error" data-test="csv-import-error">{{ parseError }}</p>
+
+				<div class="csv-import__actions">
+					<NcButton type="primary" :disabled="!rawText.trim()" data-test="csv-import-next" @click="toMapping">
+						{{ t('kanso', 'Next') }}
+					</NcButton>
+				</div>
+			</template>
+
+			<!-- Step 2: choose board + stack, map columns, confirm. -->
+			<template v-else>
+				<div class="csv-import__grid">
+					<label class="csv-import__field">
+						<span>{{ t('kanso', 'Board') }}</span>
+						<select v-model="targetBoardId" data-test="csv-import-board" @change="onBoardChange">
+							<option :value="null" disabled>{{ t('kanso', 'Choose a board…') }}</option>
+							<option v-for="b in editableBoards" :key="b.id" :value="b.id">{{ b.title }}</option>
+						</select>
+					</label>
+					<label class="csv-import__field">
+						<span>{{ t('kanso', 'Column (stack)') }}</span>
+						<select v-model="targetStackId" data-test="csv-import-stack" :disabled="stacksLoading || stacks.length === 0">
+							<option :value="null" disabled>{{ stacksLoading ? t('kanso', 'Loading…') : t('kanso', 'Choose a column…') }}</option>
+							<option v-for="s in stacks" :key="s.id" :value="s.id">{{ s.title }}</option>
+						</select>
+					</label>
+				</div>
+
+				<h3 class="csv-import__subtitle">{{ t('kanso', 'Map columns') }}</h3>
+				<div class="csv-import__grid">
+					<label v-for="field in fields" :key="field.key" class="csv-import__field">
+						<span>{{ field.label }}<em v-if="field.required"> *</em></span>
+						<select v-model="mapping[field.key]" :data-test="'csv-map-' + field.key">
+							<option :value="null">{{ field.required ? t('kanso', 'Choose a column…') : t('kanso', '— none —') }}</option>
+							<option v-for="(h, i) in headers" :key="i" :value="i">{{ h || t('kanso', 'Column {n}', { n: i + 1 }) }}</option>
+						</select>
+					</label>
+				</div>
+
+				<p class="csv-import__count">
+					{{ n('kanso', '%n data row detected', '%n data rows detected', dataRowCount) }}
+				</p>
+				<p v-if="parseError" class="csv-import__error" data-test="csv-import-error">{{ parseError }}</p>
+
+				<div class="csv-import__actions">
+					<NcButton :disabled="importing" @click="step = 'source'">{{ t('kanso', 'Back') }}</NcButton>
+					<NcButton
+						type="primary"
+						:disabled="!canImport"
+						data-test="csv-import-submit"
+						@click="doImport">
+						{{ importing ? t('kanso', 'Importing…') : t('kanso', 'Import cards') }}
+					</NcButton>
+				</div>
+			</template>
+		</div>
+	</NcModal>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import NcModal from '@nextcloud/vue/components/NcModal'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import UploadIcon from 'vue-material-design-icons/Upload.vue'
+import { fetchBoards, fetchBoard, importCsvCards } from '../services/api.js'
+
+const emit = defineEmits(['close', 'imported'])
+
+const step = ref('source')
+const rawText = ref('')
+const parseError = ref('')
+const fileInput = ref(null)
+
+// Parsed CSV state.
+const headers = ref([])
+const dataRowCount = ref(0)
+
+// Target + mapping.
+const boards = ref([])
+const targetBoardId = ref(null)
+const stacks = ref([])
+const stacksLoading = ref(false)
+const targetStackId = ref(null)
+const importing = ref(false)
+
+const mapping = ref({
+	title: null,
+	description: null,
+	duedate: null,
+	labels: null,
+	assignees: null,
+})
+
+const fields = [
+	{ key: 'title', label: t('kanso', 'Title'), required: true },
+	{ key: 'description', label: t('kanso', 'Description'), required: false },
+	{ key: 'duedate', label: t('kanso', 'Due date'), required: false },
+	{ key: 'labels', label: t('kanso', 'Labels (comma-separated)'), required: false },
+	{ key: 'assignees', label: t('kanso', 'Assignees (uids, comma-separated)'), required: false },
+]
+
+// The boards-list payload is summary-only (no per-board permission bits), so we
+// list every non-archived board; EDIT is authoritatively enforced server-side
+// and a READ-only choice is surfaced as a clear error on import.
+const editableBoards = computed(() =>
+	boards.value.filter((b) => !b.archived),
+)
+
+const canImport = computed(() =>
+	!importing.value
+	&& targetBoardId.value !== null
+	&& targetStackId.value !== null
+	&& mapping.value.title !== null
+	&& dataRowCount.value > 0,
+)
+
+// A minimal CSV lexer good enough to preview headers + count rows in the browser
+// (quoted fields, escaped quotes, embedded newlines). The authoritative parse
+// happens server-side; this is only for the mapping UI.
+function parseCsv(text) {
+	const rows = []
+	let row = []
+	let field = ''
+	let inQuotes = false
+	for (let i = 0; i < text.length; i++) {
+		const c = text[i]
+		if (inQuotes) {
+			if (c === '"') {
+				if (text[i + 1] === '"') { field += '"'; i++ } else { inQuotes = false }
+			} else { field += c }
+		} else if (c === '"') {
+			inQuotes = true
+		} else if (c === ',') {
+			row.push(field); field = ''
+		} else if (c === '\n' || c === '\r') {
+			if (c === '\r' && text[i + 1] === '\n') i++
+			row.push(field); field = ''
+			rows.push(row); row = []
+		} else {
+			field += c
+		}
+	}
+	if (field !== '' || row.length > 0) { row.push(field); rows.push(row) }
+	// Drop trailing fully-empty rows.
+	return rows.filter((r) => !(r.length === 1 && r[0].trim() === ''))
+}
+
+function autoDetect() {
+	// Header-name → field key auto-detection (case-insensitive contains).
+	const norm = headers.value.map((h) => (h || '').toLowerCase().trim())
+	const pick = (matchers) => {
+		for (let i = 0; i < norm.length; i++) {
+			if (matchers.some((m) => norm[i] === m || norm[i].includes(m))) return i
+		}
+		return null
+	}
+	mapping.value.title = pick(['title', 'name', 'task', 'summary']) ?? 0
+	mapping.value.description = pick(['description', 'desc', 'notes', 'body'])
+	mapping.value.duedate = pick(['due date', 'due', 'deadline', 'duedate'])
+	mapping.value.labels = pick(['labels', 'label', 'tags', 'tag'])
+	mapping.value.assignees = pick(['assignees', 'assignee', 'owner', 'assigned to'])
+}
+
+async function onFileChange(event) {
+	const file = event.target.files?.[0]
+	event.target.value = ''
+	if (!file) return
+	rawText.value = await file.text()
+	toMapping()
+}
+
+function toMapping() {
+	parseError.value = ''
+	const rows = parseCsv(rawText.value)
+	if (rows.length < 2) {
+		parseError.value = t('kanso', 'The CSV needs a header row and at least one data row.')
+		return
+	}
+	headers.value = rows[0]
+	dataRowCount.value = rows.length - 1
+	autoDetect()
+	if (boards.value.length === 0) loadBoards()
+	step.value = 'mapping'
+}
+
+async function loadBoards() {
+	try {
+		boards.value = await fetchBoards()
+	} catch {
+		parseError.value = t('kanso', 'Could not load your boards.')
+	}
+}
+
+async function onBoardChange() {
+	targetStackId.value = null
+	stacks.value = []
+	if (targetBoardId.value === null) return
+	stacksLoading.value = true
+	try {
+		const board = await fetchBoard(targetBoardId.value)
+		stacks.value = (board.stacks ?? []).filter((s) => !s.archived)
+	} catch {
+		parseError.value = t('kanso', 'Could not load that board’s columns.')
+	} finally {
+		stacksLoading.value = false
+	}
+}
+
+async function doImport() {
+	if (!canImport.value) return
+	parseError.value = ''
+	importing.value = true
+	// Only send the fields the user actually mapped (title is always present).
+	const sent = { title: mapping.value.title }
+	for (const key of ['description', 'duedate', 'labels', 'assignees']) {
+		if (mapping.value[key] !== null) sent[key] = mapping.value[key]
+	}
+	try {
+		const res = await importCsvCards(targetBoardId.value, targetStackId.value, rawText.value, sent, true)
+		emit('imported', { boardId: targetBoardId.value, ...res })
+	} catch (err) {
+		parseError.value = err?.response?.data?.error || t('kanso', 'Could not import that CSV.')
+	} finally {
+		importing.value = false
+	}
+}
+</script>
+
+<style scoped>
+.csv-import {
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.csv-import__title {
+	font-size: 1.25rem;
+	font-weight: 700;
+	margin: 0;
+}
+
+.csv-import__subtitle {
+	font-size: 1rem;
+	font-weight: 600;
+	margin: 4px 0 0;
+}
+
+.csv-import__hint {
+	color: var(--color-text-maxcontrast);
+	margin: 0;
+}
+
+.csv-import__source {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.csv-import__or {
+	color: var(--color-text-maxcontrast);
+	font-size: 0.9em;
+}
+
+.csv-import__file {
+	display: none;
+}
+
+.csv-import__paste {
+	width: 100%;
+	box-sizing: border-box;
+	font-family: monospace;
+	font-size: 0.85rem;
+	resize: vertical;
+}
+
+.csv-import__grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+	gap: 10px 16px;
+}
+
+.csv-import__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 0.85rem;
+}
+
+.csv-import__field span {
+	color: var(--color-text-maxcontrast);
+}
+
+.csv-import__field em {
+	color: var(--color-error);
+	font-style: normal;
+}
+
+.csv-import__field select {
+	height: 34px;
+}
+
+.csv-import__count {
+	color: var(--color-text-maxcontrast);
+	font-size: 0.85rem;
+	margin: 0;
+}
+
+.csv-import__error {
+	color: var(--color-error);
+	font-size: 0.85rem;
+	margin: 0;
+}
+
+.csv-import__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 4px;
+}
+</style>

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -260,7 +260,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				container keeps its height during the 0→1 card transition and the
 				virtualizer never loses its scrollRect.
 			-->
-			<div v-if="cards.length === 0" class="stack-column__empty-placeholder" />
+			<div v-if="cards.length === 0" class="stack-column__empty-placeholder">
+				<span v-if="!collapsed" class="stack-column__empty-hint">
+					{{ t('kanso', 'Drop cards here · press n') }}
+				</span>
+			</div>
 
 			<!--
 				Virtualized list: always in the DOM (no v-if guard) so that the
@@ -1240,8 +1244,29 @@ async function createFromTemplate(templateId) {
 }
 
 .stack-column__empty-placeholder {
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
 	min-height: 48px;
+	padding: 12px 8px;
 	border-radius: var(--border-radius);
+}
+
+/* Subtle onboarding nudge (#3413): shown only while the stack is empty. Faint
+   so it reads as a placeholder, and it strengthens when the column is a drop
+   target (the parent gets --drop-over). */
+.stack-column__empty-hint {
+	color: var(--color-text-maxcontrast);
+	font-size: 0.8rem;
+	opacity: 0.7;
+	text-align: center;
+	pointer-events: none;
+	user-select: none;
+}
+
+.stack-column__cards--drop-over .stack-column__empty-hint {
+	opacity: 1;
+	color: var(--color-primary-element);
 }
 
 /* Role chip - pushed to the right edge of the header row (mockup 1a). */

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -939,10 +939,18 @@ async function createFromTemplate(templateId) {
 .stack-column--collapsed {
 	width: 48px;
 	min-width: 48px;
+	/* Fill the board height so every collapsed rail is the same length,
+	   regardless of how many cards its (hidden) list holds — otherwise a
+	   1-card column collapses to a stub while a full one stays tall. Matches
+	   the expanded column's max-height cap. */
+	height: calc(100vh - 140px);
 	padding: 0;
 	gap: 0;
 	overflow: hidden;
 	cursor: pointer;
+}
+.stack-column--collapsed:hover {
+	background: var(--color-background-hover);
 }
 .stack-column--collapsed .stack-column__cards {
 	/* Keep a sized box for the drop target, but hide the cards behind the rail. */
@@ -966,13 +974,13 @@ async function createFromTemplate(templateId) {
 	gap: 8px;
 	padding: 10px 0;
 	border: none;
-	border-radius: var(--border-radius-large);
-	background: var(--color-main-background);
+	/* No own background/border-radius: the parent .stack-column already draws
+	   the card (bg + border + radius) and clips via overflow:hidden, so a
+	   second rounded rect here just produced mismatched corners. The rail is a
+	   transparent overlay that only holds the chevron/count/title + click. */
+	background: transparent;
 	color: var(--color-main-text);
 	cursor: pointer;
-}
-.stack-column__rail:hover {
-	background: var(--color-background-hover);
 }
 .stack-column__rail:focus-visible {
 	outline: 2px solid var(--color-primary-element);

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -289,6 +289,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						:labels-by-id="labelsById"
 						:board-prefix="boardPrefix"
 						:lane-key="laneKey"
+						:compact="compact"
 						:selection-mode="selectionMode"
 						:selected="selectedIds.has(cards[vRow.index].id)"
 						@click="openCard(cards[vRow.index].id)"
@@ -496,6 +497,17 @@ const props = defineProps({
 		type: Function,
 		default: null,
 	},
+	/**
+	 * Compact density (#3415): a per-user, view-only toggle owned by BoardView.
+	 * Threaded down to each CardTile (which renders denser) and used here to feed
+	 * the virtualizer a smaller pre-measure estimateSize. When it flips, a watch
+	 * re-measures the mounted rows so the size cache doesn't hold stale heights
+	 * (which would jump the scroll position on a long, scrolled stack).
+	 */
+	compact: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 const router = useRouter()
@@ -655,7 +667,10 @@ const virtualizerOptions = computed(() => ({
 	// the computed (and re-run the virtualizer's internal watch on getScrollElement)
 	// when cardListRef changes from null → DOM element after mount.
 	getScrollElement: () => cardListRef.value,
-	estimateSize: () => 90,
+	// Pre-measure estimate only — real heights are measured per-row via
+	// measureElement below. Compact tiles are meaningfully shorter, so seed a
+	// smaller estimate so the first paint doesn't over-allocate slots (#3415).
+	estimateSize: () => (props.compact ? 62 : 90),
 	overscan: 6,
 	gap: 8,
 	// Key the size cache by card id, not index: on a same-length reorder an
@@ -671,6 +686,20 @@ const virtualizer = useVirtualizer(virtualizerOptions)
 // after the virtualizer's internal watch fires).
 watch(cardListRef, (el) => {
 	if (el) virtualizer.value._willUpdate()
+})
+
+// Density flip (#3415): the compact ↔ comfortable toggle changes every tile's
+// height, but the virtualizer caches measured heights by card id — those cached
+// heights are now stale, and estimateSize only governs not-yet-measured rows.
+// Force a full re-measure so the total size + row offsets recompute from the new
+// tile heights; without this a long, scrolled stack keeps the old slot heights
+// until each row re-measures lazily, jumping the scroll position. nextTick lets
+// the CardTiles apply their compact class first so measureElement reads the new
+// height. measure() clears the size cache and re-measures the mounted rows.
+watch(() => props.compact, () => {
+	nextTick(() => {
+		virtualizer.value.measure()
+	})
 })
 
 /**

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -3,18 +3,52 @@ SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div ref="columnRef" class="stack-column" :class="{ 'stack-column--dragging': isStackDragging }">
+	<div
+		ref="columnRef"
+		class="stack-column"
+		:class="{ 'stack-column--dragging': isStackDragging, 'stack-column--collapsed': collapsed }">
 		<!-- Left / right stack drop indicators - same visual language as the card tile drop line -->
 		<div v-if="stackDropEdge === 'left'" class="stack-column__drop-line stack-column__drop-line--left" />
 		<div v-if="stackDropEdge === 'right'" class="stack-column__drop-line stack-column__drop-line--right" />
 
+		<!-- Collapsed rail (#3677): a slim vertical strip showing the (rotated)
+		     column title + card count. Clicking anywhere on it expands the column.
+		     Rendered ALONGSIDE the full column (which is hidden via v-show below)
+		     so the virtualizer and drop targets stay mounted the whole time. -->
+		<button
+			v-if="collapsed"
+			type="button"
+			class="stack-column__rail"
+			:aria-label="t('kanso', 'Expand column {name}', { name: stack.title })"
+			:title="t('kanso', 'Expand column')"
+			@click="handleToggleCollapsed">
+			<ChevronRightIcon class="stack-column__rail-chevron" :size="18" />
+			<span class="stack-column__rail-count">{{ props.cards.length }}</span>
+			<span class="stack-column__rail-title">{{ stack.title }}</span>
+		</button>
+
 		<!-- Column header - drag handle for stack reordering -->
 		<div
 			ref="headerRef"
+			v-show="!collapsed"
 			class="stack-column__header"
 			:class="{ 'stack-column__header--colored': !!stack.color }"
 			:style="stack.color ? { '--stack-color': cssColor(stack.color) } : {}">
 			<div class="stack-column__header-row">
+				<!-- Collapse toggle (#3677). A real button that stops propagation so a
+				     click folds the column instead of starting the header drag. -->
+				<button
+					v-if="onToggleCollapsed"
+					type="button"
+					class="stack-column__collapse-btn"
+					:aria-label="t('kanso', 'Collapse column')"
+					:aria-expanded="!collapsed"
+					:title="t('kanso', 'Collapse column')"
+					@click.stop="handleToggleCollapsed"
+					@pointerdown.stop
+					@keydown.enter.stop>
+					<ChevronLeftIcon :size="18" />
+				</button>
 				<input
 					v-if="editingTitle"
 					ref="titleInputRef"
@@ -154,7 +188,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		</div>
 
 		<!-- Inline card composer at TOP - signature rapid-entry UX -->
-		<div class="card-composer-wrap">
+		<div v-show="!collapsed" class="card-composer-wrap">
 			<form class="card-composer" @submit.prevent="submitCard">
 				<input
 					ref="composerInputRef"
@@ -208,7 +242,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</template>
 			</NcActions>
 		</div>
-		<p v-if="composerError" class="card-composer__error">{{ composerError }}</p>
+		<p v-if="composerError && !collapsed" class="card-composer__error">{{ composerError }}</p>
 
 		<!--
 			Card list - own scrollable element.
@@ -281,6 +315,7 @@ import NcActionText from '@nextcloud/vue/components/NcActionText'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
 import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
 import CogOutlineIcon from 'vue-material-design-icons/CogOutline.vue'
 import CardTile from './CardTile.vue'
@@ -440,6 +475,24 @@ const props = defineProps({
 	 * emits 'select' in multi-select mode.
 	 */
 	onCardSelect: {
+		type: Function,
+		default: null,
+	},
+	/**
+	 * Whether this column is collapsed to a narrow rail (#3677). Per-user,
+	 * view-only state owned by BoardView. When true the card list is hidden
+	 * (via v-show + a CSS class — NOT v-if, so the virtualizer and drop targets
+	 * stay mounted and the rail remains a valid drop target).
+	 */
+	collapsed: {
+		type: Boolean,
+		default: false,
+	},
+	/**
+	 * (stackId) → void — toggle this column's collapsed state. When provided a
+	 * collapse/expand button appears in the header; omit to disable collapsing.
+	 */
+	onToggleCollapsed: {
 		type: Function,
 		default: null,
 	},
@@ -727,6 +780,11 @@ async function handleDeleteStack() {
 	}
 }
 
+/** Toggle this column's collapsed state (#3677). */
+function handleToggleCollapsed() {
+	props.onToggleCollapsed?.(props.stack.id)
+}
+
 defineExpose({ scrollToIndex, focusComposer })
 
 /**
@@ -837,6 +895,109 @@ async function createFromTemplate(templateId) {
 
 .stack-column--dragging {
 	opacity: 0.4;
+}
+
+/* ── Collapsed column / rail (#3677) ──────────────────────────────────────────
+   Collapsed = a narrow rail. The full column body (header, composer, card list)
+   stays mounted so the virtualizer + drop targets survive; it's just hidden/
+   shrunk. The card list keeps a box (so cardListRef remains a valid drop target)
+   but its contents are visually hidden behind the rail overlay. Width animates
+   ≤150ms. */
+.stack-column--collapsed {
+	width: 48px;
+	min-width: 48px;
+	padding: 0;
+	gap: 0;
+	overflow: hidden;
+	cursor: pointer;
+}
+.stack-column--collapsed .stack-column__cards {
+	/* Keep a sized box for the drop target, but hide the cards behind the rail. */
+	visibility: hidden;
+	overflow: hidden;
+}
+@media (prefers-reduced-motion: no-preference) {
+	.stack-column {
+		transition: width 0.15s ease, min-width 0.15s ease;
+	}
+}
+
+/* The rail overlay: a full-height button covering the collapsed column. */
+.stack-column__rail {
+	position: absolute;
+	inset: 0;
+	z-index: 5;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 0;
+	border: none;
+	border-radius: var(--border-radius-large);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+	cursor: pointer;
+}
+.stack-column__rail:hover {
+	background: var(--color-background-hover);
+}
+.stack-column__rail:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -2px;
+}
+.stack-column__rail-chevron {
+	flex-shrink: 0;
+	color: var(--color-text-maxcontrast);
+}
+.stack-column__rail-count {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 20px;
+	height: 20px;
+	padding: 0 6px;
+	border-radius: 10px;
+	background: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+	font-size: 0.75rem;
+	font-weight: 600;
+}
+/* Vertical (bottom-to-top) column title filling the rail. */
+.stack-column__rail-title {
+	writing-mode: vertical-rl;
+	transform: rotate(180deg);
+	font-weight: 600;
+	font-size: 0.85rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-height: 100%;
+}
+
+/* Collapse toggle button in the expanded header. */
+.stack-column__collapse-btn {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	margin: -2px 0 -2px -4px;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--color-text-maxcontrast);
+	cursor: pointer;
+}
+.stack-column__collapse-btn:hover {
+	background: var(--color-background-hover);
+	color: var(--color-main-text);
+}
+.stack-column__collapse-btn:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -1px;
 }
 
 /* Stack drop indicators - same visual language as .card-tile__drop-line */

--- a/src/components/SwimlaneRow.vue
+++ b/src/components/SwimlaneRow.vue
@@ -28,6 +28,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:labels-by-id="labelsById"
 				:board-prefix="boardPrefix"
 				:lane-key="lane.key"
+				:compact="compact"
 				:on-create-card="onCreateCard"
 				:on-card-focus="onCardFocus"
 				:on-card-hover="onCardHover"
@@ -92,6 +93,11 @@ const props = defineProps({
 	onToggleCollapsed: {
 		type: Function,
 		default: null,
+	},
+	/** Compact density (#3415) — threaded down to each lane's StackColumn → CardTile. */
+	compact: {
+		type: Boolean,
+		default: false,
 	},
 })
 

--- a/src/components/SwimlaneRow.vue
+++ b/src/components/SwimlaneRow.vue
@@ -30,7 +30,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:lane-key="lane.key"
 				:on-create-card="onCreateCard"
 				:on-card-focus="onCardFocus"
-				:on-card-hover="onCardHover" />
+				:on-card-hover="onCardHover"
+				:collapsed="collapsedStacks.has(stack.id)"
+				:on-toggle-collapsed="onToggleCollapsed" />
 		</div>
 	</section>
 </template>
@@ -74,6 +76,20 @@ const props = defineProps({
 		default: null,
 	},
 	onCardHover: {
+		type: Function,
+		default: null,
+	},
+	/**
+	 * Set<stackId> of per-user collapsed columns (#3677). Collapse is shared
+	 * across lanes (a stack is one board column rendered once per lane), so the
+	 * same Set drives every lane's copy of the column.
+	 */
+	collapsedStacks: {
+		type: Set,
+		default: () => new Set(),
+	},
+	/** (stackId) → void — toggle a column's collapsed state. */
+	onToggleCollapsed: {
 		type: Function,
 		default: null,
 	},

--- a/src/composables/useAnnouncer.js
+++ b/src/composables/useAnnouncer.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { ref, provide, inject } from 'vue'
+
+/**
+ * Screen-reader announcer for the board. A single visually-hidden
+ * aria-live="polite" region is rendered once by the board host (BoardView);
+ * this composable owns its text and exposes announce(msg).
+ *
+ * The message is cleared then set on the next microtask so that repeating the
+ * same string (e.g. moving a card back and forth) still fires an assistive-tech
+ * announcement — some screen readers suppress an aria-live update whose text is
+ * identical to the current content.
+ */
+const ANNOUNCER_KEY = Symbol('kanso:announcer')
+
+/**
+ * Create the announcer (call in the host that renders the live region).
+ * @return {{ message: import('vue').Ref<string>, announce: (msg: string) => void }}
+ */
+export function provideAnnouncer() {
+	const message = ref('')
+	function announce(msg) {
+		if (!msg) return
+		message.value = ''
+		// Re-set on the next frame so identical consecutive messages re-announce.
+		requestAnimationFrame(() => { message.value = String(msg) })
+	}
+	const api = { message, announce }
+	provide(ANNOUNCER_KEY, api)
+	return api
+}
+
+/**
+ * Consume the announcer from a descendant (e.g. CardModal). Returns a no-op
+ * announce() when no host provided one, so callers never need to null-check.
+ * @return {{ announce: (msg: string) => void }}
+ */
+export function useAnnouncer() {
+	return inject(ANNOUNCER_KEY, { announce: () => {} })
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -358,6 +358,15 @@ export const duplicateBoard = (boardId, withCards) =>
 export const importTrelloBoard = (document) =>
 	axios.post(url('/api/trello-import'), { document }).then((r) => r.data)
 
+// CSV import → append rows as cards into an EXISTING board's stack. `document`
+// is the raw CSV text; `mapping` is { title, description?, duedate?, labels?,
+// assignees? } of 0-based source column indexes (title required). The caller
+// must have EDIT on the target board (enforced server-side).
+export const importCsvCards = (boardId, stackId, document, mapping, hasHeader = true) =>
+	axios
+		.post(url('/api/csv-import'), { boardId, stackId, document, mapping, hasHeader })
+		.then((r) => r.data)
+
 // GitHub webhook config (board-level, MANAGE)
 export const fetchWebhookConfig = (boardId) =>
 	axios.get(url(`/api/boards/${boardId}/webhook`)).then((r) => r.data)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -76,6 +76,9 @@ export const moveCard = (id, data) =>
 export const copyCard = (id, targetStackId) =>
 	axios.post(url(`/api/cards/${id}/copy`), { targetStackId }).then((r) => r.data)
 
+export const moveCardToBoard = (id, targetStackId) =>
+	axios.post(url(`/api/cards/${id}/move-to-board`), { targetStackId }).then((r) => r.data)
+
 // Per-board card templates (#3409). A template is an ordinary card flagged as a
 // reusable content blueprint for its own board; it is excluded from the live
 // board render and offered in a small picker.

--- a/src/views/BoardList.vue
+++ b/src/views/BoardList.vue
@@ -210,15 +210,40 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				<p>{{ t('kanso', 'Failed to load boards. Please try again.') }}</p>
 			</div>
 
-			<!-- Empty state (no boards at all) -->
+			<!-- Empty state (no boards at all) — first-run onboarding (#3413):
+			     a primary "Create your first board" CTA plus an optional
+			     "Start with a template" action that seeds a starter board. -->
 			<template v-else-if="!boards || boards.length === 0">
 				<NcEmptyContent
 					:name="t('kanso', 'No boards yet')"
-					:description="t('kanso', 'Create your first board to get started.')">
+					:description="t('kanso', 'Create your first board to get started — or start from a ready-made template.')">
 					<template #icon>
 						<ViewColumnIcon :size="64" />
 					</template>
+					<template #action>
+						<NcButton
+							type="primary"
+							data-test="empty-create-board"
+							@click="showCreate = true">
+							<template #icon>
+								<PlusIcon :size="20" />
+							</template>
+							{{ t('kanso', 'Create your first board') }}
+						</NcButton>
+						<NcButton
+							:disabled="seedingTemplate"
+							data-test="empty-start-template"
+							@click="seedStarterBoard">
+							<template #icon>
+								<ViewDashboardOutlineIcon :size="20" />
+							</template>
+							{{ seedingTemplate ? t('kanso', 'Setting up…') : t('kanso', 'Start with a template') }}
+						</NcButton>
+					</template>
 				</NcEmptyContent>
+				<p v-if="seedError" class="board-list__import-error" data-test="empty-template-error">
+					{{ seedError }}
+				</p>
 			</template>
 
 			<template v-else>
@@ -439,7 +464,7 @@ import BoardTileMenu from '../components/BoardTileMenu.vue'
 import CsvImportModal from '../components/CsvImportModal.vue'
 import { useBoards } from '../composables/useBoards.js'
 import { useBoardGroups } from '../composables/useBoardGroups.js'
-import { getSettings, updateSettings } from '../services/api.js'
+import { getSettings, updateSettings, createStack, createCard } from '../services/api.js'
 import { fetchDeckImportBoards, importDeckBoard, importBoard, importTrelloBoard } from '../services/api.js'
 
 const router = useRouter()
@@ -605,6 +630,59 @@ async function submitNewBoard() {
 	} catch (err) {
 		createError.value =
 			err?.response?.data?.error || t('kanso', 'Failed to create board.')
+	}
+}
+
+// ── Starter board template (#3413) ────────────────────────────────────────────
+// First-run onboarding: seed a small "To do / Doing / Done" board with a few
+// sample cards that explain the app. Reuses the plain create APIs (no template
+// gallery — the seeded board is an ordinary board the user can delete). The
+// cards deliberately say they are safe to delete.
+const seedingTemplate = ref(false)
+const seedError = ref('')
+
+async function seedStarterBoard() {
+	if (seedingTemplate.value) return
+	seedingTemplate.value = true
+	seedError.value = ''
+	// Track the board once created: if a later stack/card call fails, the board
+	// itself is still usable, so we navigate to it rather than stranding the user
+	// on an error message that the empty state (now non-empty) would unmount.
+	let boardId = null
+	try {
+		// createBoard.mutateAsync invalidates the ['boards'] query on settle, so
+		// no separate invalidation is needed here.
+		const board = await createBoard.mutateAsync({ title: t('kanso', 'My first board') })
+		boardId = board.id
+
+		// Create the three classic stacks in order.
+		const todo = await createStack({ boardId, title: t('kanso', 'To do') })
+		const doing = await createStack({ boardId, title: t('kanso', 'Doing') })
+		const done = await createStack({ boardId, title: t('kanso', 'Done') })
+
+		// A few friendly sample cards. Kept short; each notes it is deletable.
+		const samples = [
+			{ stackId: todo.id, title: t('kanso', '👋 Welcome to Kanso!') },
+			{ stackId: todo.id, title: t('kanso', 'Drag a card between columns — try it') },
+			{ stackId: todo.id, title: t('kanso', 'Press "n" in a column to add a card') },
+			{ stackId: doing.id, title: t('kanso', 'Press "?" to see keyboard shortcuts') },
+			{ stackId: done.id, title: t('kanso', 'Delete these sample cards whenever you like') },
+		]
+		for (const c of samples) {
+			await createCard(c)
+		}
+
+		router.push({ name: 'board', params: { id: boardId } })
+	} catch (err) {
+		if (boardId !== null) {
+			// The board exists and is usable — take the user to it despite the
+			// partial-seed failure, rather than showing an unreachable error.
+			router.push({ name: 'board', params: { id: boardId } })
+		} else {
+			seedError.value = err?.response?.data?.error || t('kanso', 'Could not set up the starter board.')
+		}
+	} finally {
+		seedingTemplate.value = false
 	}
 }
 

--- a/src/views/BoardList.vue
+++ b/src/views/BoardList.vue
@@ -62,11 +62,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</template>
 					{{ t('kanso', 'Trello (.json)') }}
 				</NcActionButton>
-				<NcActionButton :disabled="true">
-					{{ t('kanso', 'GitHub Projects (coming soon)') }}
+				<NcActionButton close-after-click @click="showCsvImport = true">
+					<template #icon>
+						<TableLargeIcon :size="20" />
+					</template>
+					{{ t('kanso', 'CSV file') }}
 				</NcActionButton>
 				<NcActionButton :disabled="true">
-					{{ t('kanso', 'CSV file (coming soon)') }}
+					{{ t('kanso', 'GitHub Projects (coming soon)') }}
 				</NcActionButton>
 			</NcActions>
 
@@ -149,6 +152,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</NcButton>
 			<p v-if="createError" class="new-board-form__error">{{ createError }}</p>
 		</form>
+
+		<!-- Import cards from CSV into an existing board/stack (#3678) -->
+		<CsvImportModal
+			v-if="showCsvImport"
+			@close="showCsvImport = false"
+			@imported="onCsvImported" />
 
 		<!-- Import-from-Deck modal -->
 		<NcModal v-if="showImport" size="normal" @close="showImport = false">
@@ -416,6 +425,7 @@ import ViewColumnIcon from 'vue-material-design-icons/ViewColumn.vue'
 import ViewDashboardOutlineIcon from 'vue-material-design-icons/ViewDashboardOutline.vue'
 import ImportIcon from 'vue-material-design-icons/Import.vue'
 import CodeJsonIcon from 'vue-material-design-icons/CodeJson.vue'
+import TableLargeIcon from 'vue-material-design-icons/TableLarge.vue'
 import MagnifyIcon from 'vue-material-design-icons/Magnify.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import ArchiveArrowUpIcon from 'vue-material-design-icons/ArchiveArrowUp.vue'
@@ -426,6 +436,7 @@ import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import BoardTileContent from '../components/BoardTileContent.vue'
 import BoardTileMenu from '../components/BoardTileMenu.vue'
+import CsvImportModal from '../components/CsvImportModal.vue'
 import { useBoards } from '../composables/useBoards.js'
 import { useBoardGroups } from '../composables/useBoardGroups.js'
 import { getSettings, updateSettings } from '../services/api.js'
@@ -697,6 +708,17 @@ async function onTrelloImportChange(event) {
 		trelloImportError.value =
 			err?.response?.data?.error || t('kanso', 'Could not import that Trello file.')
 	}
+}
+
+// ── Import cards from CSV into an existing board/stack (#3678) ─────────────────
+const showCsvImport = ref(false)
+
+async function onCsvImported({ boardId }) {
+	showCsvImport.value = false
+	// The imported cards land on an existing board; refresh the list stats and
+	// jump the user to the board they just populated.
+	await queryClient.invalidateQueries({ queryKey: ['boards'] })
+	if (boardId) router.push({ name: 'board', params: { id: boardId } })
 }
 </script>
 

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -310,7 +310,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:on-card-hover="(cardId) => { hoveredCardId = cardId }"
 					:selection-mode="bulk.selectionMode.value"
 					:selected-ids="bulk.selected.value"
-					:on-card-select="handleCardSelect" />
+					:on-card-select="handleCardSelect"
+					:collapsed="isStackCollapsed(stack.id)"
+					:on-toggle-collapsed="toggleStackCollapsed" />
 
 				<!-- Add stack inline input -->
 				<div class="add-stack">
@@ -345,7 +347,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:register-column-ref="registerLaneColumnRef"
 					:on-create-card="handleCreateCard"
 					:on-card-focus="(cardId) => { focusedCardId = cardId }"
-					:on-card-hover="(cardId) => { hoveredCardId = cardId }" />
+					:on-card-hover="(cardId) => { hoveredCardId = cardId }"
+					:collapsed-stacks="collapsedStacks"
+					:on-toggle-collapsed="toggleStackCollapsed" />
 				<p v-if="lanes.length === 0" class="board-view__swimlanes-empty">
 					{{ t('kanso', 'No cards to group.') }}
 				</p>
@@ -603,6 +607,50 @@ function setSwimlaneMode(mode) {
 	try {
 		localStorage.setItem(`kanso.swimlaneMode.${props.id}`, mode)
 	} catch (e) { /* ignore persistence failure */ }
+}
+
+// Per-user collapsed columns (#3677). A collapsed stack renders as a narrow
+// rail (title + card count) instead of its full card list. Purely presentational
+// and view-only: no card-data / board-schema change. Persisted per board per user
+// as a Set<stackId>, mirroring the List/Timeline group-collapse convention
+// (kanso.listCollapsed / kanso.timelineCollapsed). Collapse is applied with a CSS
+// class + v-show (never v-if) so each StackColumn keeps its virtualizer and drop
+// targets mounted — a collapsed rail stays a valid card/stack drop target.
+const collapsedStackKey = computed(() => `kanso.stackCollapsed.${props.id}`)
+function loadCollapsedStacks() {
+	try {
+		const saved = localStorage.getItem(collapsedStackKey.value)
+		if (saved) return new Set(JSON.parse(saved))
+	} catch (e) { /* localStorage unavailable - default to all expanded */ }
+	return new Set()
+}
+const collapsedStacks = ref(loadCollapsedStacks())
+// Reload persisted state when the board changes (component is reused across boards).
+watch(() => props.id, () => { collapsedStacks.value = loadCollapsedStacks() })
+
+function isStackCollapsed(stackId) {
+	return collapsedStacks.value.has(stackId)
+}
+
+function toggleStackCollapsed(stackId) {
+	const next = new Set(collapsedStacks.value)
+	if (next.has(stackId)) next.delete(stackId)
+	else next.add(stackId)
+	collapsedStacks.value = next
+	try {
+		localStorage.setItem(collapsedStackKey.value, JSON.stringify([...next]))
+	} catch (e) { /* localStorage unavailable - collapse is in-memory only */ }
+}
+
+/** Expand a collapsed stack (used when a card is dropped onto its rail). */
+function expandStack(stackId) {
+	if (!collapsedStacks.value.has(stackId)) return
+	const next = new Set(collapsedStacks.value)
+	next.delete(stackId)
+	collapsedStacks.value = next
+	try {
+		localStorage.setItem(collapsedStackKey.value, JSON.stringify([...next]))
+	} catch (e) { /* localStorage unavailable - collapse is in-memory only */ }
 }
 /**
  * View-only comparator for the active display sort. Every non-manual mode falls
@@ -1343,6 +1391,11 @@ onMounted(() => {
 					const currentAfterCardId = cardBefore?.id ?? null
 					if (currentAfterCardId === afterCardId) return // already in this position
 				}
+
+				// A card dropped onto a collapsed column's rail lands at the end of
+				// that stack (columnTarget branch above); expand it so the moved card
+				// is visible rather than silently disappearing into a collapsed rail.
+				expandStack(targetStackId)
 
 				enqueueMove({ cardId, targetStackId, afterCardId, optimisticKey })
 			},

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -273,6 +273,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			@edit="openTemplateForEdit"
 			@close="showManageTemplates = false" />
 
+		<!-- Screen-reader live region: announces the user's own card moves and
+		     label/assignee changes (drag-and-drop has no visible SR feedback). -->
+		<div class="board-view__sr-only" aria-live="polite" role="status">
+			{{ announceMessage }}
+		</div>
+
 		<!-- DnD / shortcut error banner -->
 		<div v-if="moveError || shortcutError" class="board-view__move-error">
 			{{ moveError || shortcutError }}
@@ -551,6 +557,7 @@ import { useBoardSubscription } from '../composables/useBoardSubscription.js'
 import { boardQueryKey } from '../composables/queryKeys.js'
 import { useAssignees } from '../composables/useAssignees.js'
 import { useCardMove } from '../composables/useCardMove.js'
+import { provideAnnouncer } from '../composables/useAnnouncer.js'
 import { useQueryClient } from '@tanstack/vue-query'
 import { cssColor } from '../services/color.js'
 import { backgroundCss } from '../services/backgrounds.js'
@@ -745,6 +752,15 @@ const boardErrorMessage = computed(() => {
 	return t('kanso', 'Couldn\'t load this board. Please try again.')
 })
 const { enqueueMove, lastError: moveError, dismissError: dismissMoveError } = useCardMove(boardId)
+
+// Screen-reader announcer (aria-live="polite"). Provided here so descendants
+// (CardModal via router-view) can announce their own actions through one region.
+const { message: announceMessage, announce } = provideAnnouncer()
+
+/** Human title of a stack by id, for announcements. */
+function stackTitleById(stackId) {
+	return sortedStacks.value.find((s) => s.id === stackId)?.title ?? ''
+}
 const { toggle: boardWatchToggle } = useBoardSubscription(boardId)
 // The chosen background preset resolved to its CSS gradient (null = none). The
 // key → CSS mapping lives client-side; an unknown key resolves to null.
@@ -1450,6 +1466,16 @@ onMounted(() => {
 				expandStack(targetStackId)
 
 				enqueueMove({ cardId, targetStackId, afterCardId, optimisticKey })
+
+				// Announce the user's own move to assistive tech.
+				const movedTitle = (cardsByStack.value.get(targetStackId) ?? [])
+					.find((c) => c.id === cardId)?.title
+					|| allVisibleCards.value.find((c) => c.id === cardId)?.title
+					|| t('kanso', 'Card')
+				announce(t('kanso', '{card} moved to {stack}', {
+					card: movedTitle,
+					stack: stackTitleById(targetStackId),
+				}))
 			},
 		}),
 		// Stack reordering: header-dragged columns dropped on another column's
@@ -1696,6 +1722,20 @@ const onBulkDelete = () => runBulkAction('delete', {})
 </script>
 
 <style scoped>
+/* Visually hidden but readable by screen readers (aria-live region). */
+.board-view__sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
+}
+
 .board-view {
 	display: flex;
 	flex-direction: column;

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -84,6 +84,25 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</NcActionRadio>
 			</NcActions>
 
+			<!-- Compact density toggle (#3415) — a per-user, view-only switch that
+			     tightens every card tile so more cards fit on screen. Persisted per
+			     board per user. A pressed icon button sits with the other view
+			     controls; aria-pressed reflects the state for assistive tech. -->
+			<NcButton
+				v-if="boardData"
+				class="board-view__density-toggle"
+				type="tertiary"
+				:pressed="isCompact"
+				:aria-pressed="isCompact ? 'true' : 'false'"
+				:aria-label="isCompact ? t('kanso', 'Switch to comfortable density') : t('kanso', 'Switch to compact density')"
+				:title="isCompact ? t('kanso', 'Comfortable density') : t('kanso', 'Compact density')"
+				@click="toggleDensity">
+				<template #icon>
+					<ViewCompactIcon v-if="isCompact" :size="20" />
+					<ViewAgendaIcon v-else :size="20" />
+				</template>
+			</NcButton>
+
 			<!-- Composable filter bar (#3407) — labels / assignees / due / done /
 			     priority, AND across dimensions & OR within, plus saved named views
 			     (per-user NC config) and URL-query sharing. Generalizes the old
@@ -312,7 +331,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:selected-ids="bulk.selected.value"
 					:on-card-select="handleCardSelect"
 					:collapsed="isStackCollapsed(stack.id)"
-					:on-toggle-collapsed="toggleStackCollapsed" />
+					:on-toggle-collapsed="toggleStackCollapsed"
+					:compact="isCompact" />
 
 				<!-- Add stack inline input -->
 				<div class="add-stack">
@@ -349,7 +369,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:on-card-focus="(cardId) => { focusedCardId = cardId }"
 					:on-card-hover="(cardId) => { hoveredCardId = cardId }"
 					:collapsed-stacks="collapsedStacks"
-					:on-toggle-collapsed="toggleStackCollapsed" />
+					:on-toggle-collapsed="toggleStackCollapsed"
+					:compact="isCompact" />
 				<p v-if="lanes.length === 0" class="board-view__swimlanes-empty">
 					{{ t('kanso', 'No cards to group.') }}
 				</p>
@@ -493,6 +514,8 @@ import EyeOffOutlineIcon from 'vue-material-design-icons/EyeOffOutline.vue'
 import ViewColumnIcon from 'vue-material-design-icons/ViewColumn.vue'
 import FormatListBulletedIcon from 'vue-material-design-icons/FormatListBulleted.vue'
 import SortIcon from 'vue-material-design-icons/Sort.vue'
+import ViewCompactIcon from 'vue-material-design-icons/ViewCompact.vue'
+import ViewAgendaIcon from 'vue-material-design-icons/ViewAgenda.vue'
 import ChartTimelineIcon from 'vue-material-design-icons/ChartTimeline.vue'
 import ChartBarIcon from 'vue-material-design-icons/ChartBar.vue'
 import SelectMultipleIcon from 'vue-material-design-icons/SelectMultiple.vue'
@@ -608,6 +631,35 @@ function setSwimlaneMode(mode) {
 		localStorage.setItem(`kanso.swimlaneMode.${props.id}`, mode)
 	} catch (e) { /* ignore persistence failure */ }
 }
+
+// Compact density (#3415): a per-user, view-only boolean that tightens every
+// card tile (smaller padding, single-line title, smaller chips) so more cards
+// fit on screen. Purely presentational — no card-data / board-schema change.
+// Persisted per board per user, mirroring viewMode / sortMode / swimlaneMode.
+// Threaded down to StackColumn (which feeds the virtualizer a smaller estimate
+// and re-measures on flip) → CardTile.
+const density = ref('comfortable')
+try {
+	const saved = localStorage.getItem(`kanso.density.${props.id}`)
+	if (saved === 'compact' || saved === 'comfortable') density.value = saved
+} catch (e) { /* default to comfortable */ }
+const isCompact = computed(() => density.value === 'compact')
+function setDensity(mode) {
+	density.value = mode
+	try {
+		localStorage.setItem(`kanso.density.${props.id}`, mode)
+	} catch (e) { /* ignore persistence failure */ }
+}
+function toggleDensity() {
+	setDensity(isCompact.value ? 'comfortable' : 'compact')
+}
+// Reload persisted density when the board changes (component is reused).
+watch(() => props.id, () => {
+	try {
+		const saved = localStorage.getItem(`kanso.density.${props.id}`)
+		density.value = (saved === 'compact' || saved === 'comfortable') ? saved : 'comfortable'
+	} catch (e) { density.value = 'comfortable' }
+})
 
 // Per-user collapsed columns (#3677). A collapsed stack renders as a narrow
 // rail (title + card count) instead of its full card list. Purely presentational
@@ -1715,6 +1767,11 @@ const onBulkDelete = () => runBulkAction('delete', {})
 /* Search box - pushed to the right edge of the title area via margin-left: auto */
 .board-view__search {
 	margin-left: auto;
+	flex-shrink: 0;
+}
+
+/* Compact density toggle (#3415) — an icon button among the view controls. */
+.board-view__density-toggle {
 	flex-shrink: 0;
 }
 

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -342,6 +342,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 				<!-- Add stack inline input -->
 				<div class="add-stack">
+					<!-- Empty-board onboarding hint (#3413): when the board has no
+					     stacks yet, point the user at this composer. -->
+					<p
+						v-if="sortedStacks.length === 0"
+						class="add-stack__hint"
+						data-test="empty-board-hint">
+						{{ t('kanso', 'Start by adding a column, e.g. “To do”.') }}
+					</p>
 					<form @submit.prevent="submitNewStack">
 						<input
 							v-model="newStackTitle"
@@ -495,6 +503,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			@archive="onBulkArchive"
 			@delete="onBulkDelete"
 			@close="bulk.exitMode()" />
+
+		<!-- One-time keyboard-shortcut discoverability hint (#3413): a subtle,
+		     dismissible nudge shown once after the user first opens a board.
+		     Dismissal is persisted per user (settings key), so it stays hidden. -->
+		<div
+			v-if="showShortcutsHint && boardData"
+			class="board-view__shortcuts-hint"
+			data-test="shortcuts-hint"
+			role="status">
+			<button
+				class="board-view__shortcuts-hint-open"
+				data-test="shortcuts-hint-open"
+				@click="openShortcutsFromHint">
+				{{ t('kanso', 'Tip: press ? for keyboard shortcuts') }}
+			</button>
+			<button
+				class="board-view__shortcuts-hint-dismiss"
+				:aria-label="t('kanso', 'Dismiss')"
+				data-test="shortcuts-hint-dismiss"
+				@click="dismissShortcutsHint">×</button>
+		</div>
 	</div>
 </template>
 
@@ -562,7 +591,7 @@ import { useQueryClient } from '@tanstack/vue-query'
 import { cssColor } from '../services/color.js'
 import { backgroundCss } from '../services/backgrounds.js'
 import { initial, between, after, before } from '../services/sortKey.js'
-import { updateCard as apiUpdateCard, moveStack as apiMoveStack, fetchCardTemplates as apiFetchCardTemplates, createCardFromTemplate as apiCreateCardFromTemplate } from '../services/api.js'
+import { updateCard as apiUpdateCard, moveStack as apiMoveStack, fetchCardTemplates as apiFetchCardTemplates, createCardFromTemplate as apiCreateCardFromTemplate, getSettings, updateSettings } from '../services/api.js'
 import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
 import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element'
@@ -820,6 +849,44 @@ const showCommandPalette = ref(false)
 // ── Keyboard shortcuts overlay ────────────────────────────────────────────────
 const showShortcuts = ref(false)
 const shortcutError = ref('')
+
+// ── One-time "press ? for shortcuts" discoverability hint (#3413) ─────────────
+// A subtle, dismissible nudge shown once after the user first opens a board.
+// Whether it has been dismissed is persisted PER USER via NC config (the shared
+// `dismissed_hints` settings key), so it never re-appears on any device.
+const SHORTCUTS_HINT_ID = 'shortcuts-discoverability'
+const showShortcutsHint = ref(false)
+
+async function loadShortcutsHint() {
+	try {
+		const s = await getSettings()
+		const dismissed = Array.isArray(s?.dismissedHints) ? s.dismissedHints : []
+		if (!dismissed.includes(SHORTCUTS_HINT_ID)) {
+			showShortcutsHint.value = true
+		}
+	} catch {
+		// Non-fatal: just don't show the hint if settings can't be read.
+	}
+}
+
+async function dismissShortcutsHint() {
+	showShortcutsHint.value = false
+	try {
+		const s = await getSettings()
+		const dismissed = Array.isArray(s?.dismissedHints) ? s.dismissedHints : []
+		if (!dismissed.includes(SHORTCUTS_HINT_ID)) {
+			await updateSettings({ dismissedHints: [...dismissed, SHORTCUTS_HINT_ID] })
+		}
+	} catch {
+		// Non-fatal: it will re-appear next load, which is acceptable.
+	}
+}
+
+// Opening the overlay from the hint both shows it and permanently dismisses the hint.
+function openShortcutsFromHint() {
+	showShortcuts.value = true
+	dismissShortcutsHint()
+}
 
 // ── Search box ref (for programmatic focus via '/' shortcut) ─────────────────
 const searchBoxRef = ref(null)
@@ -1355,6 +1422,9 @@ function publishToolbarHeight() {
 onMounted(() => {
 	// Apply any filter params already in the URL (a shared link opened cold).
 	applyUrlToFilter()
+
+	// First-run keyboard-shortcut discoverability nudge (#3413).
+	loadShortcutsHint()
 
 	document.addEventListener('keydown', handleKeydown)
 
@@ -1989,6 +2059,66 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	color: var(--color-error);
 	font-size: 0.8rem;
 	margin: 4px 0 0;
+}
+
+/* Empty-board onboarding hint (#3413): sits above the "Add stack" composer when
+   the board has no columns yet. */
+.add-stack__hint {
+	color: var(--color-text-maxcontrast);
+	font-size: 0.85rem;
+	margin: 0 0 8px;
+}
+
+/* One-time keyboard-shortcut discoverability hint (#3413): a small, unobtrusive
+   pill anchored bottom-left, out of the way of the bulk action bar (centered). */
+.board-view__shortcuts-hint {
+	position: fixed;
+	right: 16px;
+	bottom: 16px;
+	/* Above the app content and the NC left nav so its trigger is clickable. */
+	z-index: 2000;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 4px 4px 12px;
+	background: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-pill, 100px);
+	box-shadow: var(--shadow-card-hover, 0 1px 4px rgba(0, 0, 0, 0.2));
+	font-size: 0.85rem;
+}
+
+.board-view__shortcuts-hint-open {
+	border: none;
+	background: transparent;
+	color: var(--color-main-text);
+	font-size: 0.85rem;
+	cursor: pointer;
+	padding: 2px 0;
+}
+
+.board-view__shortcuts-hint-open:hover {
+	color: var(--color-primary-element);
+}
+
+.board-view__shortcuts-hint-dismiss {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border: none;
+	border-radius: 50%;
+	background: transparent;
+	color: var(--color-text-maxcontrast);
+	font-size: 1.1rem;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.board-view__shortcuts-hint-dismiss:hover {
+	background: var(--color-background-hover);
+	color: var(--color-main-text);
 }
 
 /* Keyboard shortcuts modal */

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// #3412 — one accessibility smoke over the board + open card modal. Uses
+// Playwright's built-in accessibility snapshot (no extra dependency): asserts
+// the board exposes a landmark/heading tree and the card modal opens as a
+// focusable dialog with an accessible name and the aria-live region present.
+test.describe('Accessibility smoke', () => {
+	const state = { boardId: 0, stackId: 0, cardId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'A11y Smoke E2E' })
+		state.boardId = board.id
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })).id
+		state.cardId = (await api('POST', '/cards', { stackId: state.stackId, title: 'Accessible card' })).id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${state.cardId}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('board + card modal expose an accessible tree with an aria-live region', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view', { timeout: 10_000 })
+
+		// The single polite aria-live region for own-action announcements exists.
+		await expect(page.locator('.board-view [aria-live="polite"]')).toHaveCount(1)
+
+		// Playwright's native accessibility snapshot (aria tree) must be
+		// non-trivial and surface the card by its accessible name.
+		const boardSnapshot = await page.locator('.board-view').ariaSnapshot()
+		expect(boardSnapshot).toBeTruthy()
+		expect(boardSnapshot).toContain('Accessible card')
+
+		// Open the card modal → it must be a dialog with an accessible name.
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+		const dialog = page.getByRole('dialog').first()
+		await expect(dialog).toBeVisible()
+		const modalSnapshot = await dialog.ariaSnapshot()
+		expect(modalSnapshot).toContain('Accessible card')
+	})
+})

--- a/tests/e2e/card-move-picker.spec.js
+++ b/tests/e2e/card-move-picker.spec.js
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+async function stackOrder(boardId, stackId) {
+	const board = await api('GET', `/boards/${boardId}`)
+	return board.cards
+		.filter((c) => c.stackId === stackId && !c.archived)
+		.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0))
+		.map((c) => c.title)
+}
+
+async function cardStackId(boardId, cardId) {
+	const board = await api('GET', `/boards/${boardId}`)
+	return board.cards.find((c) => c.id === cardId)?.stackId
+}
+
+// #3412 — the keyboard / screen-reader "Move card…" picker: a non-pointer
+// alternative to drag-and-drop. It must funnel through the SAME optimistic move
+// path (useCardMove) as DnD, and must never produce an invalid position.
+test.describe('Move card… picker (keyboard / SR DnD alternative)', () => {
+	const state = { boardId: 0, todoId: 0, doingId: 0, aId: 0, bId: 0, cId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Move-Picker E2E' })
+		state.boardId = board.id
+		state.todoId = (await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })).id
+		state.doingId = (await api('POST', '/stacks', { boardId: board.id, title: 'Doing' })).id
+		// To Do: A (top), B (middle), C (bottom).
+		state.aId = (await api('POST', '/cards', { stackId: state.todoId, title: 'Card A' })).id
+		state.bId = (await api('POST', '/cards', { stackId: state.todoId, title: 'Card B' })).id
+		state.cId = (await api('POST', '/cards', { stackId: state.todoId, title: 'Card C' })).id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${state.bId}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('moves the card to another column at a chosen position, and to an empty column', async ({ page }) => {
+		expect(await stackOrder(state.boardId, state.todoId)).toEqual(['Card A', 'Card B', 'Card C'])
+
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// Open ⋯ → "Move card…" picker.
+		await page.locator('.card-modal__actions-menu button').first().click()
+		await page.getByRole('menuitem', { name: 'Move card…' }).click()
+		await page.waitForSelector('.card-modal__move-position', { timeout: 5_000 })
+
+		// Pick target column "Doing" and "After a specific card" is disabled there
+		// (empty stack) — the picker must degrade to top, never an invalid move.
+		// Move Card B to the empty "Doing" column at the top.
+		await page.locator('.card-modal__copy-dialog select').first().selectOption({ label: 'Doing' })
+		await page.getByText('Top of the column').click()
+		await page.getByRole('button', { name: 'Move', exact: true }).click()
+
+		// Card B landed in Doing (moved via the shared queue → server reflects it).
+		await expect
+			.poll(() => cardStackId(state.boardId, state.bId), { timeout: 8_000 })
+			.toBe(state.doingId)
+		expect(await stackOrder(state.boardId, state.todoId)).toEqual(['Card A', 'Card C'])
+		expect(await stackOrder(state.boardId, state.doingId)).toEqual(['Card B'])
+	})
+
+	test('positions the card after a specific card in the same/other column', async ({ page }) => {
+		// Fresh state: Card C in To Do; move it to Doing AFTER Card B.
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${state.cId}`)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		await page.locator('.card-modal__actions-menu button').first().click()
+		await page.getByRole('menuitem', { name: 'Move card…' }).click()
+		await page.waitForSelector('.card-modal__move-position', { timeout: 5_000 })
+
+		await page.locator('.card-modal__copy-dialog select').first().selectOption({ label: 'Doing' })
+		await page.getByText('After a specific card').click()
+		// The "after" card select now lists Card B (the only card in Doing).
+		await page.locator('.card-modal__copy-dialog select').nth(1).selectOption({ label: 'Card B' })
+		await page.getByRole('button', { name: 'Move', exact: true }).click()
+
+		await expect
+			.poll(() => stackOrder(state.boardId, state.doingId), { timeout: 8_000 })
+			.toEqual(['Card B', 'Card C'])
+	})
+})

--- a/tests/e2e/card-move-to-board.spec.js
+++ b/tests/e2e/card-move-to-board.spec.js
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// Live (non-archived) cards in a stack, top-to-bottom, from the board payload.
+async function stackTitles(boardId, stackId) {
+	const board = await api('GET', `/boards/${boardId}`)
+	return board.cards
+		.filter((c) => c.stackId === stackId && !c.archived)
+		.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0))
+		.map((c) => c.title)
+}
+
+// #3679 — "Move to board…" from the card ⋯ menu: relocate a single card to
+// another board (created on the target, removed from the source).
+test.describe('Move card to another board (card ⋯ menu)', () => {
+	const state = { srcBoardId: 0, dstBoardId: 0, srcStackId: 0, dstStackId: 0, labelId: 0, srcId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const src = await api('POST', '/boards', { title: 'Move-Src E2E' })
+		state.srcBoardId = src.id
+		state.srcStackId = (await api('POST', '/stacks', { boardId: src.id, title: 'Source Column' })).id
+
+		const dst = await api('POST', '/boards', { title: 'Move-Dst E2E' })
+		state.dstBoardId = dst.id
+		state.dstStackId = (await api('POST', '/stacks', { boardId: dst.id, title: 'Landing Column' })).id
+		// A matching label (same name + color) on BOTH boards so the map-over keeps it.
+		await api('POST', '/labels', { boardId: src.id, title: 'Important', color: 'e01e01' })
+		const dstLabel = await api('POST', '/labels', { boardId: dst.id, title: 'Important', color: 'e01e01' })
+		state.labelId = dstLabel.id
+
+		const card = await api('POST', '/cards', { stackId: state.srcStackId, title: 'Relocatable card' })
+		state.srcId = card.id
+		await api('PATCH', `/cards/${card.id}`, { description: 'travels with me', priority: 3 })
+		const srcLabels = await api('GET', `/boards/${src.id}`)
+		const srcLabelId = srcLabels.labels.find((l) => l.title === 'Important').id
+		await api('PUT', `/cards/${card.id}/labels/${srcLabelId}`)
+		await api('POST', `/cards/${card.id}/checklist`, { title: 'carry me too' })
+
+		state.cardUrl = `${BASE}/index.php/apps/kanso/#/board/${src.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.srcBoardId) await api('DELETE', `/boards/${state.srcBoardId}`).catch(() => {})
+		if (state.dstBoardId) await api('DELETE', `/boards/${state.dstBoardId}`).catch(() => {})
+	})
+
+	test('moves the card off the source board and onto the target', async ({ page }) => {
+		// Preconditions: source has the card, target is empty.
+		expect(await stackTitles(state.srcBoardId, state.srcStackId)).toEqual(['Relocatable card'])
+		expect(await stackTitles(state.dstBoardId, state.dstStackId)).toEqual([])
+
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// Open the ⋯ menu and click "Move to board…".
+		await page.locator('.card-modal__actions-menu button').first().click()
+		await page.getByRole('menuitem', { name: 'Move to board…' }).click()
+
+		// The move dialog opens (reuses the copy picker); pick the target board+column.
+		await page.waitForSelector('.card-modal__copy-dialog', { timeout: 8_000 })
+		await page.locator('.card-modal__copy-field select').first()
+			.selectOption({ label: 'Move-Dst E2E' })
+		await page.locator('.card-modal__copy-field select').nth(1)
+			.selectOption({ label: 'Landing Column' })
+		await page.getByRole('button', { name: 'Move', exact: true }).click()
+
+		// The card LEFT the source board...
+		await expect
+			.poll(() => stackTitles(state.srcBoardId, state.srcStackId), { timeout: 8_000 })
+			.toEqual([])
+		// ...and APPEARS on the target board.
+		await expect
+			.poll(() => stackTitles(state.dstBoardId, state.dstStackId), { timeout: 8_000 })
+			.toEqual(['Relocatable card'])
+
+		// The relocated card is a NEW card (fresh id) carrying the content + mapped label.
+		const dstBoard = await api('GET', `/boards/${state.dstBoardId}`)
+		const moved = dstBoard.cards.find((c) => c.stackId === state.dstStackId && !c.archived)
+		expect(moved).toBeTruthy()
+		expect(moved.id).not.toBe(state.srcId)
+
+		const detail = await api('GET', `/cards/${moved.id}`)
+		expect(detail.description).toBe('travels with me')
+		expect(detail.priority).toBe(3)
+		expect(detail.labelIds).toContain(state.labelId)
+		expect(detail.checklistItems.map((i) => i.title)).toEqual(['carry me too'])
+
+		// The original id is gone (soft-deleted on the source): its detail 404s.
+		const r = await fetch(`${API}/cards/${state.srcId}`, {
+			headers: { ...HEADERS, Authorization: AUTH },
+		})
+		expect(r.status).toBe(404)
+	})
+})

--- a/tests/e2e/column-collapse.spec.js
+++ b/tests/e2e/column-collapse.spec.js
@@ -92,3 +92,46 @@ test.describe('Column collapse (#3677)', () => {
 		await expect(page.locator('.card-composer__input').first()).toBeVisible({ timeout: 6_000 })
 	})
 })
+
+// Regression (#3677): a collapsed rail's height must not follow its (hidden)
+// card count — a 1-card column and a full column collapse to the SAME
+// full-height rail. Previously the rail filled a content-height column, so
+// short stacks collapsed to stubs while a full stack stayed tall.
+test.describe('Column collapse — equal-height rails (#3677)', () => {
+	const state = { boardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await apiSend('POST', '/boards', { title: 'Collapse Height E2E' })
+		state.boardId = board.id
+		const long = await apiSend('POST', '/stacks', { boardId: board.id, title: 'Long Stack' })
+		const a = await apiSend('POST', '/stacks', { boardId: board.id, title: 'One A' })
+		const b = await apiSend('POST', '/stacks', { boardId: board.id, title: 'One B' })
+		for (let i = 0; i < 25; i++) await apiSend('POST', '/cards', { stackId: long.id, title: `Card ${i}` })
+		await apiSend('POST', '/cards', { stackId: a.id, title: 'Only A' })
+		await apiSend('POST', '/cards', { stackId: b.id, title: 'Only B' })
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await apiSend('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('a full stack and a 1-card stack collapse to equal-height rails', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.stack-column', { timeout: 20_000 })
+		await page.waitForTimeout(600)
+
+		// Collapse all three (always the leftmost still-expanded column).
+		for (let i = 0; i < 3; i++) {
+			await page.locator('.stack-column:not(.stack-column--collapsed) .stack-column__collapse-btn').first().click()
+			await page.waitForTimeout(300)
+		}
+
+		const heights = await page.$$eval('.stack-column--collapsed',
+			els => els.map(e => Math.round(e.getBoundingClientRect().height)))
+		expect(heights.length).toBe(3)
+		// All rails the same height (full board height), not card-count-driven stubs.
+		expect(Math.max(...heights) - Math.min(...heights)).toBeLessThanOrEqual(2)
+		expect(Math.min(...heights)).toBeGreaterThan(300)
+	})
+})

--- a/tests/e2e/column-collapse.spec.js
+++ b/tests/e2e/column-collapse.spec.js
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiSend(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Column collapse / fold to a rail (#3677)
+//
+// Per-user, view-only collapse: a collapsed column shrinks to a slim rail that
+// shows its title + card count, hiding the cards. State persists across reload
+// (localStorage). Verifies the full lifecycle: collapse → cards hidden + rail
+// count → reload still collapsed → expand → cards back.
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Column collapse (#3677)', () => {
+	const state = { boardId: 0, stackId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await apiSend('POST', '/boards', { title: 'Column Collapse E2E' })
+		state.boardId = board.id
+		const stack = await apiSend('POST', '/stacks', { boardId: board.id, title: 'Foldable' })
+		state.stackId = stack.id
+		// Two cards so we can assert the count on the rail and that they hide.
+		await apiSend('POST', '/cards', { stackId: stack.id, title: 'Alpha card' })
+		await apiSend('POST', '/cards', { stackId: stack.id, title: 'Beta card' })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) {
+			await apiSend('DELETE', `/boards/${state.boardId}`).catch(() => {})
+		}
+	})
+
+	test('collapse hides cards + shows rail count, persists across reload, expands back', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.stack-column__header', { timeout: 15_000 })
+
+		// Cards visible in the expanded state.
+		await expect(page.locator('.card-tile', { hasText: 'Alpha card' })).toBeVisible({ timeout: 8_000 })
+
+		// Collapse via the header toggle button.
+		await page.locator('.stack-column__collapse-btn').first().click()
+
+		// The rail appears with the column title + card count; cards are hidden.
+		const rail = page.locator('.stack-column__rail')
+		await expect(rail).toBeVisible({ timeout: 6_000 })
+		await expect(rail.locator('.stack-column__rail-title')).toHaveText('Foldable')
+		await expect(rail.locator('.stack-column__rail-count')).toHaveText('2')
+		await expect(page.locator('.card-tile', { hasText: 'Alpha card' })).toBeHidden({ timeout: 6_000 })
+		// Full header (with composer) is hidden while collapsed.
+		await expect(page.locator('.card-composer__input')).toBeHidden({ timeout: 6_000 })
+
+		// Persisted per user: reload → still collapsed.
+		await page.reload()
+		await page.waitForSelector('.stack-column__rail', { timeout: 15_000 })
+		await expect(page.locator('.stack-column__rail')).toBeVisible({ timeout: 6_000 })
+		await expect(page.locator('.card-tile', { hasText: 'Alpha card' })).toBeHidden({ timeout: 6_000 })
+
+		// Expand by clicking the rail → cards come back, rail gone.
+		await page.locator('.stack-column__rail').click()
+		await expect(page.locator('.stack-column__rail')).toHaveCount(0, { timeout: 6_000 })
+		await expect(page.locator('.card-tile', { hasText: 'Alpha card' })).toBeVisible({ timeout: 8_000 })
+		await expect(page.locator('.card-composer__input').first()).toBeVisible({ timeout: 6_000 })
+	})
+})

--- a/tests/e2e/csv-import.spec.js
+++ b/tests/e2e/csv-import.spec.js
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// #3678 — Import cards from a CSV into an EXISTING board's stack via the
+// board-list Import menu, then assert the mapped cards landed on that stack.
+test.describe('Import cards from CSV', () => {
+	const stamp = Math.floor(Date.now() / 1000)
+	const state = {}
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'CSV Target ' + stamp })
+		state.boardId = board.id
+		state.boardTitle = board.title
+		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'Inbox' })
+		state.stackId = stack.id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('pastes a CSV, maps columns, and creates the cards in the chosen stack', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/`)
+		await page.waitForSelector('.board-list-view', { timeout: 15_000 })
+
+		// Open the Import menu and pick "CSV file".
+		await page.getByRole('button', { name: 'Import' }).click()
+		await page.getByText('CSV file', { exact: true }).click()
+
+		// Step 1: paste a small CSV (header + three data rows) and continue.
+		const csv = [
+			'title,description,due date,labels',
+			'Design login,Wireframe the flow,2026-02-01,ux',
+			'Build API,,,backend',
+			'Ship it,Final polish,,',
+		].join('\n')
+		await page.locator('[data-test="csv-import-paste"]').fill(csv)
+		await page.locator('[data-test="csv-import-next"]').click()
+
+		// Step 2: choose the target board + its stack. (Auto-detection already
+		// mapped title/description/due/labels from the header row.)
+		await page.locator('[data-test="csv-import-board"]').selectOption({ label: state.boardTitle })
+		await page.locator('[data-test="csv-import-stack"]').selectOption({ label: 'Inbox' })
+
+		await page.locator('[data-test="csv-import-submit"]').click()
+
+		// The FE navigates to the populated board once the import returns.
+		await page.waitForURL(new RegExp(`#/board/${state.boardId}\\b`), { timeout: 20_000 })
+
+		// Assert the three cards landed on the Inbox stack, in file order, with the
+		// mapped description + match-or-created labels.
+		const payload = await api('GET', `/boards/${state.boardId}`)
+		const cards = payload.cards
+			.filter((c) => c.stackId === state.stackId)
+			.slice()
+			.sort((a, b) => (a.sortKey < b.sortKey ? -1 : 1))
+		expect(cards.map((c) => c.title)).toEqual(['Design login', 'Build API', 'Ship it'])
+
+		const byTitle = Object.fromEntries(cards.map((c) => [c.title, c]))
+		// The labels column auto-created "ux" + "backend" on the board.
+		const labelByTitle = Object.fromEntries(payload.labels.map((l) => [l.title, l.id]))
+		expect(labelByTitle.ux).toBeTruthy()
+		expect(labelByTitle.backend).toBeTruthy()
+		expect(byTitle['Design login'].labelIds).toContain(labelByTitle.ux)
+		expect(byTitle['Build API'].labelIds).toContain(labelByTitle.backend)
+
+		// The mapped description + due date came across for the first card.
+		const detail = await api('GET', `/cards/${byTitle['Design login'].id}`)
+		expect(detail.description).toBe('Wireframe the flow')
+		expect(byTitle['Design login'].duedate).toBeTruthy()
+	})
+})

--- a/tests/e2e/density.spec.js
+++ b/tests/e2e/density.spec.js
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiSend(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Compact density mode (#3415)
+//
+// A per-user, view-only toggle that tightens every card tile (smaller padding,
+// single-line title, smaller chips) so more cards fit on screen. Persisted per
+// board per user via localStorage (kanso.density.<id>). Threaded down to each
+// CardTile (which gets the .card-tile--compact class) and to the per-column
+// virtualizer, which must re-measure on the flip so a long, scrolled stack
+// doesn't jump.
+//
+// Coverage:
+//  1. Toggle → tiles become compact (class + measurably shorter height).
+//  2. Persists across a reload.
+//  3. On a long, SCROLLED stack the toggle keeps the virtualizer honest — tiles
+//     render, are compact, and the scroll position stays put (no jump to top).
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Compact density (#3415)', () => {
+	const TOTAL_CARDS = 40
+	const state = { boardId: 0, stackId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await apiSend('POST', '/boards', { title: 'Density E2E' })
+		state.boardId = board.id
+		const stack = await apiSend('POST', '/stacks', { boardId: board.id, title: 'Dense Stack' })
+		state.stackId = stack.id
+		for (let i = 1; i <= TOTAL_CARDS; i++) {
+			await apiSend('POST', '/cards', { stackId: stack.id, title: `Density card ${i}` })
+		}
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) {
+			await apiSend('DELETE', `/boards/${state.boardId}`).catch(() => {})
+		}
+	})
+
+	test('toggle makes tiles compact + shorter, and persists across reload', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.card-tile', { timeout: 15_000 })
+
+		const firstTile = page.locator('.card-tile').first()
+		await expect(firstTile).toBeVisible({ timeout: 8_000 })
+
+		// Comfortable (default): no compact class.
+		await expect(firstTile).not.toHaveClass(/card-tile--compact/)
+		const comfortableHeight = (await firstTile.boundingBox()).height
+
+		// Flip to compact via the header toggle.
+		const toggle = page.locator('.board-view__density-toggle')
+		await expect(toggle).toBeVisible({ timeout: 6_000 })
+		await toggle.click()
+
+		// Tiles gain the compact class and become measurably shorter.
+		await expect(firstTile).toHaveClass(/card-tile--compact/, { timeout: 6_000 })
+		const compactHeight = (await firstTile.boundingBox()).height
+		expect(compactHeight).toBeLessThan(comfortableHeight)
+
+		// Persisted per user: reload → still compact.
+		await page.reload()
+		await page.waitForSelector('.card-tile', { timeout: 15_000 })
+		await expect(page.locator('.card-tile').first()).toHaveClass(/card-tile--compact/, { timeout: 8_000 })
+
+		// Flip back to comfortable and confirm it also persists.
+		await page.locator('.board-view__density-toggle').click()
+		await expect(page.locator('.card-tile').first()).not.toHaveClass(/card-tile--compact/, { timeout: 6_000 })
+		await page.reload()
+		await page.waitForSelector('.card-tile', { timeout: 15_000 })
+		await expect(page.locator('.card-tile').first()).not.toHaveClass(/card-tile--compact/, { timeout: 8_000 })
+	})
+
+	test('toggling on a scrolled long stack does not jump or break virtualization', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.card-tile', { timeout: 15_000 })
+
+		const cardList = page.locator('.stack-column__cards').first()
+		await expect(cardList).toBeVisible({ timeout: 8_000 })
+
+		// Scroll the column well down so we're inside the virtualized window
+		// (not at the top). A stale estimate/size-cache on the flip would jump
+		// the scroll back toward 0 or mis-measure rows.
+		await cardList.evaluate((el) => { el.scrollTop = 600 })
+		await page.waitForTimeout(300)
+		const scrollBefore = await cardList.evaluate((el) => el.scrollTop)
+		expect(scrollBefore).toBeGreaterThan(200)
+
+		// Virtualization proof before the flip: fewer tiles in the DOM than total.
+		const beforeCount = await page.locator('.card-tile-wrap').count()
+		expect(beforeCount).toBeLessThan(TOTAL_CARDS)
+		expect(beforeCount).toBeGreaterThan(0)
+
+		// Flip to compact — the virtualizer must re-measure, not jump to the top.
+		await page.locator('.board-view__density-toggle').click()
+		await expect(page.locator('.card-tile').first()).toHaveClass(/card-tile--compact/, { timeout: 6_000 })
+		await page.waitForTimeout(400)
+
+		// Still virtualized, tiles still rendered, and we did NOT jump back to the
+		// top (a stale 90px slot cache would have collapsed scrollTop toward 0).
+		const afterCount = await page.locator('.card-tile-wrap').count()
+		expect(afterCount).toBeLessThan(TOTAL_CARDS)
+		expect(afterCount).toBeGreaterThan(0)
+		await expect(page.locator('.card-tile-wrap').first()).toBeVisible({ timeout: 6_000 })
+
+		const scrollAfter = await cardList.evaluate((el) => el.scrollTop)
+		// The compact re-measure shrinks total height, so scrollTop can settle a
+		// bit lower, but it must stay in the same neighbourhood — not reset to 0.
+		expect(scrollAfter).toBeGreaterThan(100)
+	})
+})

--- a/tests/e2e/onboarding.spec.js
+++ b/tests/e2e/onboarding.spec.js
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #3413 — Empty states and first-run onboarding.
+// A fresh user (no boards) sees the enriched empty state: a primary
+// "Create your first board" CTA plus a "Start with a template" action that
+// seeds a To do / Doing / Done starter board with a few sample cards. Opening a
+// board surfaces a one-time "press ? for shortcuts" hint whose dismissal is
+// persisted PER USER via the shared `dismissed_hints` settings key, so it stays
+// hidden after a reload.
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const ADMIN = 'admin'
+const ADMIN_PASS = 'admin'
+const ADMIN_AUTH = 'Basic ' + Buffer.from(ADMIN + ':' + ADMIN_PASS).toString('base64')
+
+// A hermetic, throwaway user so the board list is genuinely empty.
+const UID = 'kanso-onboard-' + Math.floor(Date.now() / 1000)
+const PASS = 'onboard-pass-123'
+
+const OCS = BASE + '/ocs/v2.php/cloud'
+const OCS_HEADERS = { 'OCS-APIREQUEST': 'true', Accept: 'application/json' }
+
+async function provisionUser(uid, password) {
+	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: ADMIN_AUTH } }).catch(() => {})
+	const body = new URLSearchParams({ userid: uid, password })
+	const r = await fetch(`${OCS}/users`, {
+		method: 'POST',
+		headers: { ...OCS_HEADERS, Authorization: ADMIN_AUTH, 'Content-Type': 'application/x-www-form-urlencoded' },
+		body,
+	})
+	if (!r.ok) throw new Error(`provision ${uid} → ${r.status}: ${await r.text()}`)
+}
+
+async function deleteUser(uid) {
+	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: ADMIN_AUTH } }).catch(() => {})
+}
+
+async function loginAs(page, user, pass) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', user)
+	await page.fill('#password', pass)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('First-run onboarding (#3413)', () => {
+	test.beforeAll(async () => {
+		await provisionUser(UID, PASS)
+	})
+
+	test.afterAll(async () => {
+		await deleteUser(UID)
+	})
+
+	test('empty state seeds a starter board and the shortcut hint stays dismissed', async ({ page }) => {
+		await loginAs(page, UID, PASS)
+		await page.goto(`${BASE}/index.php/apps/kanso#/`)
+		await page.waitForSelector('.board-list-view', { timeout: 15_000 })
+
+		// Empty state: both onboarding actions are present.
+		const createCta = page.locator('[data-test="empty-create-board"]')
+		const templateCta = page.locator('[data-test="empty-start-template"]')
+		await expect(createCta).toBeVisible({ timeout: 10_000 })
+		await expect(templateCta).toBeVisible()
+
+		// "Start with a template" seeds the starter board and navigates to it.
+		await templateCta.click()
+		await page.waitForSelector('.board-view__stacks-wrap', { timeout: 20_000 })
+
+		// The three classic stacks are present.
+		for (const col of ['To do', 'Doing', 'Done']) {
+			await expect(page.locator('.stack-column', { hasText: col }).first())
+				.toBeVisible({ timeout: 10_000 })
+		}
+
+		// A couple of the sample cards seeded across the stacks.
+		await expect(page.getByText('👋 Welcome to Kanso!').first()).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByText('Delete these sample cards whenever you like').first()).toBeVisible()
+
+		// The one-time shortcut discoverability hint appears on the board.
+		const hint = page.locator('[data-test="shortcuts-hint"]')
+		await expect(hint).toBeVisible({ timeout: 10_000 })
+
+		// Dismiss it — it hides, and the dismissal is persisted server-side. Wait
+		// for the settings PUT so the assertion below doesn't race the write.
+		const putDone = page.waitForResponse(
+			(r) => r.url().includes('/apps/kanso/api/settings') && r.request().method() === 'PUT' && r.ok(),
+			{ timeout: 10_000 },
+		)
+		await page.locator('[data-test="shortcuts-hint-dismiss"]').click()
+		await putDone
+		await expect(hint).toHaveCount(0)
+
+		// The settings API reflects the persisted dismissal for this user.
+		const settings = await page.evaluate(async (base) => {
+			const r = await fetch(base + '/index.php/apps/kanso/api/settings', {
+				headers: { 'OCS-APIREQUEST': 'true' },
+			})
+			return r.json()
+		}, BASE)
+		expect(Array.isArray(settings.dismissedHints)).toBe(true)
+		expect(settings.dismissedHints).toContain('shortcuts-discoverability')
+
+		// Reload the board: the hint must STAY hidden (persisted via settings).
+		await page.reload()
+		await page.waitForSelector('.board-view__stacks-wrap', { timeout: 20_000 })
+		await expect(page.locator('[data-test="shortcuts-hint"]')).toHaveCount(0)
+	})
+})

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -46,7 +46,7 @@ class SettingsControllerTest extends TestCase {
 		$this->stubGetUserValue(['default_board' => '42']);
 
 		self::assertSame(
-			['defaultBoardId' => 42, 'collapsedBoardGroups' => []],
+			['defaultBoardId' => 42, 'collapsedBoardGroups' => [], 'dismissedHints' => []],
 			$this->controller->index()->getData()
 		);
 	}
@@ -55,7 +55,7 @@ class SettingsControllerTest extends TestCase {
 		$this->stubGetUserValue([]);
 
 		self::assertSame(
-			['defaultBoardId' => null, 'collapsedBoardGroups' => []],
+			['defaultBoardId' => null, 'collapsedBoardGroups' => [], 'dismissedHints' => []],
 			$this->controller->index()->getData()
 		);
 	}
@@ -68,7 +68,7 @@ class SettingsControllerTest extends TestCase {
 
 		// Deduped and int-cast.
 		self::assertSame(
-			['defaultBoardId' => null, 'collapsedBoardGroups' => [3, 7]],
+			['defaultBoardId' => null, 'collapsedBoardGroups' => [3, 7], 'dismissedHints' => []],
 			$this->controller->index()->getData()
 		);
 	}
@@ -80,7 +80,7 @@ class SettingsControllerTest extends TestCase {
 			->with('alice', 'kanso', 'default_board', '7');
 
 		self::assertSame(
-			['defaultBoardId' => 7, 'collapsedBoardGroups' => []],
+			['defaultBoardId' => 7, 'collapsedBoardGroups' => [], 'dismissedHints' => []],
 			$this->controller->update(7)->getData()
 		);
 	}
@@ -92,7 +92,7 @@ class SettingsControllerTest extends TestCase {
 			->with('alice', 'kanso', 'default_board', '');
 
 		self::assertSame(
-			['defaultBoardId' => null, 'collapsedBoardGroups' => []],
+			['defaultBoardId' => null, 'collapsedBoardGroups' => [], 'dismissedHints' => []],
 			$this->controller->update(null)->getData()
 		);
 	}
@@ -104,7 +104,7 @@ class SettingsControllerTest extends TestCase {
 			->with('alice', 'kanso', 'default_board', '');
 
 		self::assertSame(
-			['defaultBoardId' => null, 'collapsedBoardGroups' => []],
+			['defaultBoardId' => null, 'collapsedBoardGroups' => [], 'dismissedHints' => []],
 			$this->controller->update(0)->getData()
 		);
 	}
@@ -135,5 +135,33 @@ class SettingsControllerTest extends TestCase {
 
 		$result = $this->controller->update(3)->getData();
 		self::assertSame([1, 2], $result['collapsedBoardGroups']);
+	}
+
+	public function testUpdatePersistsDismissedHints(): void {
+		$stored = [];
+		$this->config->method('getUserValue')
+			->willReturnCallback(static function (string $uid, string $app, string $key, string $default) use (&$stored): string {
+				return $stored[$key] ?? $default;
+			});
+		$this->config->method('setUserValue')
+			->willReturnCallback(static function (string $uid, string $app, string $key, string $value) use (&$stored): void {
+				$stored[$key] = $value;
+			});
+
+		// Dupes are collapsed and malformed/invalid ids are dropped by the shape guard.
+		$result = $this->controller->update(null, null, ['shortcuts', 'shortcuts', 'BAD ID', 'starter-board'])->getData();
+		self::assertSame(['shortcuts', 'starter-board'], $result['dismissedHints']);
+		self::assertSame('["shortcuts","starter-board"]', $stored['dismissed_hints']);
+	}
+
+	public function testUpdateLeavesDismissedHintsUntouchedWhenOmitted(): void {
+		$this->stubGetUserValue(['dismissed_hints' => '["shortcuts"]']);
+		// Only the default_board key is written; dismissed hints are not touched.
+		$this->config->expects(self::once())
+			->method('setUserValue')
+			->with('alice', 'kanso', 'default_board', '3');
+
+		$result = $this->controller->update(3)->getData();
+		self::assertSame(['shortcuts'], $result['dismissedHints']);
 	}
 }

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -44,6 +44,8 @@ class CardServiceTest extends TestCase {
 	private \OCA\Kanso\Db\LabelMapper&MockObject $labelMapper;
 	private \OCA\Kanso\Db\CardLabelMapper&MockObject $cardLabelMapper;
 	private \OCA\Kanso\Db\ChecklistItemMapper&MockObject $checklistItemMapper;
+	private \OCA\Kanso\Db\CardAssigneeMapper&MockObject $cardAssigneeMapper;
+	private \OCA\Kanso\Db\SubscriptionMapper&MockObject $subscriptionMapper;
 	private CardService $service;
 
 	protected function setUp(): void {
@@ -63,6 +65,8 @@ class CardServiceTest extends TestCase {
 		$this->labelMapper = $this->createMock(\OCA\Kanso\Db\LabelMapper::class);
 		$this->cardLabelMapper = $this->createMock(\OCA\Kanso\Db\CardLabelMapper::class);
 		$this->checklistItemMapper = $this->createMock(\OCA\Kanso\Db\ChecklistItemMapper::class);
+		$this->cardAssigneeMapper = $this->createMock(\OCA\Kanso\Db\CardAssigneeMapper::class);
+		$this->subscriptionMapper = $this->createMock(\OCA\Kanso\Db\SubscriptionMapper::class);
 		$this->service = new CardService(
 			$this->cardMapper,
 			$this->stackMapper,
@@ -79,7 +83,9 @@ class CardServiceTest extends TestCase {
 			$this->checklistService,
 			$this->labelMapper,
 			$this->cardLabelMapper,
-			$this->checklistItemMapper
+			$this->checklistItemMapper,
+			$this->cardAssigneeMapper,
+			$this->subscriptionMapper
 		);
 	}
 
@@ -2109,6 +2115,226 @@ class CardServiceTest extends TestCase {
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->copy(9, 7, 'bob');
+	}
+
+	// ---- moveToBoard (#3679) ----------------------------------------------
+
+	/**
+	 * Cross-board MOVE happy path: the card is re-created on the target board
+	 * (content + checklist carried), assignees/watchers that can READ the target
+	 * cross over, the source is soft-deleted, and a change row lands on BOTH
+	 * boards (CREATE on target, DELETE on source).
+	 */
+	public function testMoveToBoardRecreatesOnTargetAndSoftDeletesSource(): void {
+		$sourceBoard = $this->board(1);
+		$targetBoard = $this->board(2);
+		$targetBoard->setEstimateScale('fibonacci');
+		$targetStack = $this->stack(7, 2);
+
+		$source = $this->card(9, 5, 1);
+		$source->setTitle('Ship it');
+		$source->setDescription('the spec');
+		$source->setPriority(Card::PRIORITY_URGENT);
+		$source->setEstimate('3');
+
+		$this->cardMapper->method('find')->willReturnMap([[9, $source]]);
+		$this->stackMapper->method('find')->with(7)->willReturn($targetStack);
+		$this->boardMapper->method('find')->willReturnMap([[1, $sourceBoard], [2, $targetBoard]]);
+		$this->cardMapper->method('findLastInStack')->with(7)->willReturn(null);
+		$this->cardMapper->method('nextBoardSeq')->with(2)->willReturn(88);
+		$this->cardMapper->method('findChildren')->with(9)->willReturn([]);
+
+		// Everyone can read the target board here (READ bit set for any uid).
+		$this->permissionService->method('getPermissions')->willReturn(PermissionService::PERMISSION_ALL);
+
+		// Source carries no labels, one checklist item, one assignee, one watcher.
+		$this->cardLabelMapper->method('findLabelIdsByCard')->with(9)->willReturn([]);
+		$this->checklistItemMapper->method('findByCard')->with(9)->willReturn([
+			$this->checklistItem(1, 9, 'Step one', true),
+		]);
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->with(9)->willReturn(['bob']);
+		$this->subscriptionMapper->method('findCardSubscriberUids')->with(9)->willReturn(['carol']);
+
+		$inserted = null;
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$inserted): Card {
+			$c->setId(42);
+			$inserted = $c;
+			return $c;
+		});
+		$softDeleted = null;
+		$this->cardMapper->method('update')->willReturnCallback(function (Card $c) use (&$softDeleted): Card {
+			if ($c->getId() === 9) {
+				$softDeleted = $c;
+			}
+			return $c;
+		});
+
+		$assignedTo = [];
+		$this->cardAssigneeMapper->method('insertAssignment')->willReturnCallback(function (int $cardId, string $uid) use (&$assignedTo): \OCA\Kanso\Db\CardAssignee {
+			$assignedTo[] = [$cardId, $uid];
+			return new \OCA\Kanso\Db\CardAssignee();
+		});
+		$watchedBy = [];
+		$this->subscriptionMapper->method('insert')->willReturnCallback(function (\OCA\Kanso\Db\Subscription $s) use (&$watchedBy): \OCA\Kanso\Db\Subscription {
+			$watchedBy[] = $s->getSubscriber();
+			return $s;
+		});
+		$items = [];
+		$this->checklistItemMapper->method('insert')->willReturnCallback(function (\OCA\Kanso\Db\ChecklistItem $i) use (&$items): \OCA\Kanso\Db\ChecklistItem {
+			$items[] = [$i->getTitle(), $i->getDone()];
+			return $i;
+		});
+
+		// A change row on BOTH boards (target CREATE + source DELETE).
+		$changeBoards = [];
+		$this->changeNotifier->method('recordChange')->willReturnCallback(function (int $boardId, int $entity, int $cardId, int $action) use (&$changeBoards): Change {
+			$changeBoards[] = [$boardId, $action];
+			return new Change();
+		});
+		// Both boards pushed after commit.
+		$pushed = [];
+		$this->changeNotifier->method('pushBoardChanged')->willReturnCallback(function (int $boardId) use (&$pushed): void {
+			$pushed[] = $boardId;
+		});
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+
+		$moved = $this->service->moveToBoard(9, 7, 'alice');
+
+		self::assertSame(42, $moved->getId());
+		self::assertSame(2, $moved->getBoardId());
+		self::assertSame(7, $moved->getStackId());
+		self::assertSame('Ship it', $moved->getTitle(), 'move keeps the title (no " (copy)" suffix)');
+		self::assertSame('the spec', $moved->getDescription());
+		self::assertSame(88, $moved->getBoardSeq(), 'the KAN-id is re-issued on the target board');
+		self::assertSame('3', $moved->getEstimate());
+		self::assertSame([[42, 'bob']], $assignedTo, 'the readable assignee crosses over');
+		self::assertSame(['carol'], $watchedBy, 'the readable watcher crosses over');
+		self::assertSame([['Step one', true]], $items);
+		self::assertNotNull($softDeleted, 'the source card is soft-deleted');
+		self::assertGreaterThan(0, $softDeleted->getDeletedAt());
+		self::assertSame(
+			[[2, Change::ACTION_CREATE], [1, Change::ACTION_DELETE]],
+			$changeBoards,
+			'a CREATE on the target board and a DELETE on the source board',
+		);
+		self::assertSame([2, 1], $pushed, 'both boards are pushed after commit');
+	}
+
+	/**
+	 * moveToBoard needs EDIT on the TARGET board: a viewer with EDIT on the source
+	 * but not the target is rejected, and the source is NOT soft-deleted (no
+	 * half-move).
+	 */
+	public function testMoveToBoardAssertsEditOnTargetBoard(): void {
+		$sourceBoard = $this->board(1);
+		$targetBoard = $this->board(2);
+		$targetStack = $this->stack(7, 2);
+		$source = $this->card(9, 5, 1);
+
+		$this->cardMapper->method('find')->willReturnMap([[9, $source]]);
+		$this->stackMapper->method('find')->with(7)->willReturn($targetStack);
+		$this->boardMapper->method('find')->willReturnMap([[1, $sourceBoard], [2, $targetBoard]]);
+
+		$this->permissionService->method('assertPermission')
+			->willReturnCallback(static function (Board $board, string $uid, int $perm): void {
+				if ($board->getId() === 2) {
+					throw new NotPermittedException();
+				}
+			});
+
+		$this->cardMapper->expects(self::never())->method('insert');
+		$this->cardMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->moveToBoard(9, 7, 'bob');
+	}
+
+	/**
+	 * A "move to board" whose target stack is on the SAME board is rejected (the
+	 * in-board move() is the right tool) - and nothing is written.
+	 */
+	public function testMoveToBoardRejectsSameBoardTarget(): void {
+		$board = $this->board(1);
+		$targetStack = $this->stack(7, 1);
+		$source = $this->card(9, 5, 1);
+
+		$this->cardMapper->method('find')->willReturnMap([[9, $source]]);
+		$this->stackMapper->method('find')->with(7)->willReturn($targetStack);
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+
+		$this->cardMapper->expects(self::never())->method('insert');
+		$this->cardMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->moveToBoard(9, 7, 'alice');
+	}
+
+	/**
+	 * Cross-board move maps labels by title+color to the target board (unmatched
+	 * drop) and DROPS any assignee/watcher who cannot READ the target board - the
+	 * leak guard. Here 'bob' can read the target, 'mallory' cannot.
+	 */
+	public function testMoveToBoardMapsLabelsAndDropsUnreadableParticipants(): void {
+		$sourceBoard = $this->board(1);
+		$targetBoard = $this->board(2);
+		$targetStack = $this->stack(7, 2);
+		$source = $this->card(9, 5, 1);
+		$source->setTitle('Cross move');
+
+		$this->cardMapper->method('find')->willReturnMap([[9, $source]]);
+		$this->stackMapper->method('find')->with(7)->willReturn($targetStack);
+		$this->boardMapper->method('find')->willReturnMap([[1, $sourceBoard], [2, $targetBoard]]);
+		$this->cardMapper->method('findLastInStack')->with(7)->willReturn(null);
+		$this->cardMapper->method('nextBoardSeq')->with(2)->willReturn(5);
+		$this->cardMapper->method('findChildren')->with(9)->willReturn([]);
+		$this->cardMapper->method('insert')->willReturnCallback(static function (Card $c): Card {
+			$c->setId(42);
+			return $c;
+		});
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+		$this->checklistItemMapper->method('findByCard')->with(9)->willReturn([]);
+
+		// 'bob' can read the target; 'mallory' cannot (no permission bits).
+		$this->permissionService->method('getPermissions')
+			->willReturnCallback(static fn (Board $b, string $uid): int => $uid === 'mallory' ? 0 : PermissionService::PERMISSION_ALL);
+
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->with(9)->willReturn(['bob', 'mallory']);
+		$this->subscriptionMapper->method('findCardSubscriberUids')->with(9)->willReturn(['bob', 'mallory']);
+
+		// Source labels 11 (Bug/e01) + 12 (Secret/abc); target has only the Bug twin.
+		$this->cardLabelMapper->method('findLabelIdsByCard')->with(9)->willReturn([11, 12]);
+		$this->labelMapper->method('find')->willReturnMap([
+			[11, $this->label(11, 1, 'Bug', 'e01e01')],
+			[12, $this->label(12, 1, 'Secret', 'abcabc')],
+		]);
+		$this->labelMapper->method('findByBoard')->with(2)->willReturn([
+			$this->label(71, 2, 'Bug', 'e01e01'),
+		]);
+
+		$labelAssignments = [];
+		$this->cardLabelMapper->method('insertAssignment')->willReturnCallback(function (int $cardId, int $labelId) use (&$labelAssignments): \OCA\Kanso\Db\CardLabel {
+			$labelAssignments[] = $labelId;
+			return new \OCA\Kanso\Db\CardLabel();
+		});
+		$assignees = [];
+		$this->cardAssigneeMapper->method('insertAssignment')->willReturnCallback(function (int $cardId, string $uid) use (&$assignees): \OCA\Kanso\Db\CardAssignee {
+			$assignees[] = $uid;
+			return new \OCA\Kanso\Db\CardAssignee();
+		});
+		$watchers = [];
+		$this->subscriptionMapper->method('insert')->willReturnCallback(function (\OCA\Kanso\Db\Subscription $s) use (&$watchers): \OCA\Kanso\Db\Subscription {
+			$watchers[] = $s->getSubscriber();
+			return $s;
+		});
+
+		$this->service->moveToBoard(9, 7, 'alice');
+
+		self::assertSame([71], $labelAssignments, 'only the title+color twin is mapped; the unmatched label drops');
+		self::assertSame(['bob'], $assignees, 'the unreadable assignee is dropped (leak guard)');
+		self::assertSame(['bob'], $watchers, 'the unreadable watcher is dropped (leak guard)');
 	}
 
 	// ---- templates (#3409) ------------------------------------------------

--- a/tests/unit/Service/CsvImportServiceTest.php
+++ b/tests/unit/Service/CsvImportServiceTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardAssignee;
+use OCA\Kanso\Db\CardAssigneeMapper;
+use OCA\Kanso\Db\CardLabel;
+use OCA\Kanso\Db\CardLabelMapper;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Label;
+use OCA\Kanso\Db\LabelMapper;
+use OCA\Kanso\Db\Stack;
+use OCA\Kanso\Db\StackMapper;
+use OCA\Kanso\Service\BoardService;
+use OCA\Kanso\Service\ChangeNotifier;
+use OCA\Kanso\Service\CsvImportService;
+use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\PermissionService;
+use OCA\Kanso\Service\SortKeyService;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CsvImportServiceTest extends TestCase {
+	private BoardService&MockObject $boardService;
+	private StackMapper&MockObject $stackMapper;
+	private CardMapper&MockObject $cardMapper;
+	private LabelMapper&MockObject $labelMapper;
+	private CardLabelMapper&MockObject $cardLabelMapper;
+	private CardAssigneeMapper&MockObject $cardAssigneeMapper;
+	private ChangeNotifier&MockObject $changeNotifier;
+	private PermissionService&MockObject $permissionService;
+	private IUserManager&MockObject $userManager;
+	private IDBConnection&MockObject $db;
+	private CsvImportService $service;
+
+	private const BOARD_ID = 900;
+	private const STACK_ID = 30;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->boardService = $this->createMock(BoardService::class);
+		$this->stackMapper = $this->createMock(StackMapper::class);
+		$this->cardMapper = $this->createMock(CardMapper::class);
+		$this->labelMapper = $this->createMock(LabelMapper::class);
+		$this->cardLabelMapper = $this->createMock(CardLabelMapper::class);
+		$this->cardAssigneeMapper = $this->createMock(CardAssigneeMapper::class);
+		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->db = $this->createMock(IDBConnection::class);
+
+		$this->service = new CsvImportService(
+			$this->boardService,
+			$this->stackMapper,
+			$this->cardMapper,
+			$this->labelMapper,
+			$this->cardLabelMapper,
+			$this->cardAssigneeMapper,
+			new SortKeyService(),
+			$this->changeNotifier,
+			$this->permissionService,
+			$this->userManager,
+			$this->db,
+		);
+	}
+
+	private function board(): Board {
+		$b = new Board();
+		$b->setId(self::BOARD_ID);
+		$b->setTitle('Target');
+		return $b;
+	}
+
+	private function stack(int $role = Stack::ROLE_NONE): Stack {
+		$s = new Stack();
+		$s->setId(self::STACK_ID);
+		$s->setBoardId(self::BOARD_ID);
+		$s->setTitle('Todo');
+		$s->setRole($role);
+		return $s;
+	}
+
+	/** Wires up the common happy-path expectations (board/stack found + EDIT ok). */
+	private function primeTarget(): void {
+		$this->boardService->method('find')->with(self::BOARD_ID, 'alice')->willReturn($this->board());
+		$this->stackMapper->method('find')->with(self::STACK_ID)->willReturn($this->stack());
+		$this->permissionService->method('assertPermission');
+		$this->cardMapper->method('nextBoardSeq')->willReturnCallback(function (): int {
+			static $n = 0;
+			return ++$n;
+		});
+		$this->cardMapper->method('findLastInStack')->willReturn(null);
+	}
+
+	private function mapping(): array {
+		return ['title' => 0, 'description' => 1, 'duedate' => 2, 'labels' => 3, 'assignees' => 4];
+	}
+
+	// ── rejection cases ────────────────────────────────────────────────────────
+
+	public function testRejectsOversizedDocument(): void {
+		$this->expectException(InvalidInputException::class);
+		$huge = str_repeat('x', CsvImportService::MAX_DOCUMENT_BYTES + 1);
+		$this->service->import($huge, self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+	}
+
+	public function testRejectsMissingTitleMapping(): void {
+		$this->expectException(InvalidInputException::class);
+		$this->service->import("a,b\n1,2\n", self::BOARD_ID, self::STACK_ID, ['description' => 1], true, 'alice');
+	}
+
+	public function testRejectsTooManyRows(): void {
+		$this->expectException(InvalidInputException::class);
+		$rows = "title\n" . str_repeat("x\n", CsvImportService::MAX_ROWS + 1);
+		$this->service->import($rows, self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+	}
+
+	public function testDeniesWithoutEdit(): void {
+		$this->boardService->method('find')->willReturn($this->board());
+		$this->permissionService->method('assertPermission')
+			->willThrowException(new NotPermittedException('nope'));
+		$this->expectException(NotPermittedException::class);
+		$this->service->import("title\nBuy milk\n", self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+	}
+
+	// ── happy path ──────────────────────────────────────────────────────────────
+
+	public function testImportsRowsAsCardsAppendedInOrder(): void {
+		$this->primeTarget();
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(self::BOARD_ID);
+		// One CREATE change row per imported card (2 titled rows).
+		$this->changeNotifier->expects(self::exactly(2))->method('recordChange');
+
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+
+		$cards = [];
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$cards): Card {
+			$c->setId(100 + count($cards));
+			$cards[] = $c;
+			return $c;
+		});
+
+		$csv = "title,description,due date,labels,assignees\n"
+			. "Design login,Wireframe the flow,2026-02-01,,\n"
+			. ",no title so skipped,,,\n"
+			. "Ship it,,,,\n";
+
+		$result = $this->service->import($csv, self::BOARD_ID, self::STACK_ID, $this->mapping(), true, 'alice');
+
+		self::assertSame(2, $result['cards']);
+		self::assertSame(1, $result['skipped']);
+		self::assertSame(self::BOARD_ID, $result['boardId']);
+		self::assertSame(self::STACK_ID, $result['stackId']);
+
+		self::assertCount(2, $cards);
+		self::assertSame('Design login', $cards[0]->getTitle());
+		self::assertSame('Wireframe the flow', $cards[0]->getDescription());
+		self::assertSame(self::STACK_ID, $cards[0]->getStackId());
+		self::assertSame('alice', $cards[0]->getOwner());
+		self::assertNotNull($cards[0]->getDuedate());
+		// Second titled row keeps file order via a strictly-increasing sort key.
+		self::assertSame('Ship it', $cards[1]->getTitle());
+		self::assertNull($cards[1]->getDescription());
+		self::assertTrue($cards[0]->getSortKey() < $cards[1]->getSortKey());
+	}
+
+	public function testTruncatesLongTitles(): void {
+		$this->primeTarget();
+		$this->db->method('beginTransaction');
+		$this->db->method('commit');
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+
+		$captured = null;
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$captured): Card {
+			$c->setId(100);
+			$captured = $c;
+			return $c;
+		});
+
+		$long = str_repeat('x', 250);
+		$this->service->import("title\n$long\n", self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+		self::assertSame(100, mb_strlen($captured->getTitle()));
+	}
+
+	// ── labels: match-or-create ─────────────────────────────────────────────────
+
+	public function testLabelsMatchExistingOrAreCreated(): void {
+		$this->primeTarget();
+		$this->db->method('beginTransaction');
+		$this->db->method('commit');
+
+		// An existing "Bug" label on the board (matched case-insensitively).
+		$existing = new Label();
+		$existing->setId(7);
+		$existing->setTitle('Bug');
+		$existing->setColor('eb5a46');
+		$this->labelMapper->method('findByBoard')->willReturn([$existing]);
+
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c): Card {
+			static $id = 100;
+			$c->setId($id++);
+			return $c;
+		});
+
+		$createdLabels = [];
+		$this->labelMapper->method('insert')->willReturnCallback(function (Label $l) use (&$createdLabels): Label {
+			$l->setId(50 + count($createdLabels));
+			$createdLabels[] = $l;
+			return $l;
+		});
+
+		$assignments = [];
+		$this->cardLabelMapper->method('insertAssignment')->willReturnCallback(function (int $cardId, int $labelId) use (&$assignments): CardLabel {
+			$assignments[] = [$cardId, $labelId];
+			return new CardLabel();
+		});
+
+		// Row 1 references the existing "bug" (different case) + a new "urgent";
+		// row 2 references "urgent" again → it must be created ONCE and reused.
+		$csv = "title,labels\n"
+			. "A,\"bug, urgent\"\n"
+			. "B,urgent\n";
+		$result = $this->service->import($csv, self::BOARD_ID, self::STACK_ID, ['title' => 0, 'labels' => 1], true, 'alice');
+
+		self::assertSame(1, $result['labelsCreated']);
+		self::assertCount(1, $createdLabels);
+		self::assertSame('urgent', $createdLabels[0]->getTitle());
+
+		// Card A got both the existing (7) and the new label; card B reused the new
+		// label id (never a second create).
+		$newLabelId = $createdLabels[0]->getId();
+		$forA = array_values(array_filter($assignments, fn ($a) => $a[0] === 100));
+		$forB = array_values(array_filter($assignments, fn ($a) => $a[0] === 101));
+		$aIds = array_map(fn ($a) => $a[1], $forA);
+		sort($aIds);
+		self::assertSame([7, $newLabelId], $aIds);
+		self::assertSame([[101, $newLabelId]], $forB);
+	}
+
+	// ── assignees: match-or-drop, READ-filtered ─────────────────────────────────
+
+	public function testAssigneesMatchOrDropByReadPermission(): void {
+		$this->primeTarget();
+		$this->db->method('beginTransaction');
+		$this->db->method('commit');
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c): Card {
+			$c->setId(100);
+			return $c;
+		});
+
+		// alice exists + can READ; bob does not exist; carol exists but cannot READ.
+		$this->userManager->method('userExists')->willReturnCallback(
+			fn (string $uid): bool => in_array($uid, ['alice', 'carol'], true),
+		);
+		$this->permissionService->method('getPermissions')->willReturnCallback(
+			fn (Board $b, string $uid): int => $uid === 'alice' ? PermissionService::PERMISSION_READ : 0,
+		);
+
+		$assigned = [];
+		$this->cardAssigneeMapper->method('insertAssignment')->willReturnCallback(function (int $cardId, string $uid) use (&$assigned): CardAssignee {
+			$assigned[] = $uid;
+			return new CardAssignee();
+		});
+
+		$csv = "title,assignees\nTask,\"alice, bob, carol\"\n";
+		$this->service->import($csv, self::BOARD_ID, self::STACK_ID, ['title' => 0, 'assignees' => 1], true, 'alice');
+
+		// Only alice survives (bob missing, carol unreadable) - no leak.
+		self::assertSame(['alice'], $assigned);
+	}
+
+	public function testRollsBackOnFailure(): void {
+		$this->primeTarget();
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('rollBack');
+		$this->db->expects(self::never())->method('commit');
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardMapper->method('insert')->willThrowException(new \RuntimeException('boom'));
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->import("title\nX\n", self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+	}
+}


### PR DESCRIPTION
Accumulating sprint branch (like PR #12) — CI validates during dev; **no auto-merge**, merge when green. 6 commits, all locally validated (build + per-card e2e on the dev NC34 stack; psalm + php-cs-fixer clean where PHP was touched).

## Board parity (Deck/Trello parity + adoption)
- **#3677 Collapse a column to a rail** (`3904bfd`) — per-user, persisted; `v-show` keeps each column's virtualizer + drop targets mounted; collapsed rail is a valid drop target that auto-expands. +`column-collapse.spec`.
- **#3679 Move a card to another board** (`8123727`) — transactional `CardService::moveToBoard()`: EDIT-gates both boards, KAN-id reissue + label map-or-drop, assignees/watchers carried **only if READ on target** (leak guard), `kanso_changes` + push on **both** boards. PHPUnit 1037 incl. denial/leak cases. +`card-move-to-board.spec`.
- **#3678 Import cards from CSV** (`e5789c6`) — into an existing board/stack; `CsvImportService` mirrors the Trello importer (single tx, byte-cap-before-parse, 2000-row cap, truncation); labels match-or-create, assignees match-or-drop by READ. PHPUnit 1046. +`csv-import.spec`.

## Release-quality UX polish
- **#3415 Compact density + motion polish** (`ed8fda7`) — per-user compact toggle (`kanso.density.<id>`) with tighter tiles; virtualizer `estimateSize` lowered + `measure()` re-run on toggle (no scroll jump); one **app-wide `prefers-reduced-motion` guard** in App.vue. +`density.spec`.
- **#3412 Accessibility** (`585db17`) — keyboard/SR **"Move card…"** stack+position picker routed through `useCardMove` (no second move path; also fixed `moveToEdge` bypassing the optimistic queue); a single `aria-live` region announcing moves + label/assignee changes; contrast fixes (hardcoded badge hex → theme tokens, light/dark); one a11y smoke test. +`card-move-picker.spec` + `accessibility.spec`.
- **#3413 Empty states + first-run onboarding** (`60a7b5c`) — enriched board-list empty state ("Create your first board" + "Start with a template" seeding a To do/Doing/Done demo board via existing create APIs); empty-stack + empty-board hints; one-time "press ? for shortcuts" nudge; dismissals persisted server-side via a new `dismissed_hints` settings key (mirrors `collapsed_board_groups`). +`onboarding.spec`.

App version 0.9.29 → 0.9.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)