### PR TITLE
chore(release): v0.9.31 follow-ups — release-script fix, changelog cut, tarball install docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ First public release. Targets Nextcloud 30–32 and PHP 8.2+.
   available, with an automatic light polling fallback everywhere else.
 
 [Unreleased]: https://github.com/aktasfatih/kanso/compare/v0.9.31...HEAD
-[0.9.31]: https://github.com/aktasfatih/kanso/releases/tag/v0.9.31
+[0.9.31]: https://github.com/aktasfatih/kanso/compare/v0.9.2...v0.9.31
+[0.9.2]: https://github.com/aktasfatih/kanso/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/aktasfatih/kanso/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/aktasfatih/kanso/releases/tag/v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.31] - 2026-08-08
+
+First tagged beta, published as a pre-built tarball on
+[GitHub Releases](https://github.com/aktasfatih/kanso/releases/tag/v0.9.31).
+
 ### Added
 
 - **Import cards from a CSV / spreadsheet.** The board-list Import menu now has a
@@ -135,8 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0] - 2026-07-30
 
-First public release, published to the Nextcloud App Store. Targets
-Nextcloud 30–32 and PHP 8.2+.
+First public release. Targets Nextcloud 30–32 and PHP 8.2+.
 
 ### Added
 
@@ -183,6 +187,7 @@ Nextcloud 30–32 and PHP 8.2+.
 - **Realtime updates** via `notify_push` (High Performance Backend) when
   available, with an automatic light polling fallback everywhere else.
 
-[Unreleased]: https://github.com/aktasfatih/kanso/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/aktasfatih/kanso/compare/v0.9.31...HEAD
+[0.9.31]: https://github.com/aktasfatih/kanso/releases/tag/v0.9.31
 [0.9.1]: https://github.com/aktasfatih/kanso/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/aktasfatih/kanso/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -103,8 +103,31 @@ your work, on your own Nextcloud, laid out plainly.
 ## Installation
 
 Kanso targets **Nextcloud 30–34** and **PHP 8.2–8.3**. It isn't on the Nextcloud
-App Store yet, so install it from source (you'll need **Node 20+**,
-**Composer**, and shell access to your server):
+App Store yet — until it is, install the pre-built tarball from
+[GitHub Releases](https://github.com/aktasfatih/kanso/releases) (no Node or
+Composer needed on your server):
+
+```sh
+# 1. Download the tarball from the latest release
+curl -fLO https://github.com/aktasfatih/kanso/releases/latest/download/kanso.tar.gz
+
+# 2. Extract into your Nextcloud "custom apps" directory (unpacks as kanso/)
+tar -xzf kanso.tar.gz -C /path/to/nextcloud/custom_apps/
+chown -R www-data:www-data /path/to/nextcloud/custom_apps/kanso
+
+# 3. Enable the app
+cd /path/to/nextcloud
+sudo -u www-data php occ app:enable kanso
+```
+
+The tarball is not (yet) signed by the App Store, so Nextcloud lists Kanso as
+an untested/custom app — that's expected. To upgrade, extract the new tarball
+over the old directory and run `occ upgrade`.
+
+Open **Kanso** from the Nextcloud app menu and create your first board.
+
+<details>
+<summary><b>Install from source</b> (needs Node 20+, Composer, shell access)</summary>
 
 ```sh
 # 1. Clone into your Nextcloud "custom apps" directory
@@ -121,7 +144,7 @@ cd /path/to/nextcloud
 sudo -u www-data php occ app:enable kanso
 ```
 
-Open **Kanso** from the Nextcloud app menu and create your first board.
+</details>
 
 - **Background jobs** (recurring cards, auto-archive, change-log pruning) run
   through Nextcloud's cron. Make sure [system cron](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html)

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -122,7 +122,13 @@ KEY_FILE=""
 CRT_FILE=""
 TMP_KEY=""
 TMP_CRT=""
-cleanup_keys() { [[ -n "$TMP_KEY" ]] && rm -f "$TMP_KEY"; [[ -n "$TMP_CRT" ]] && rm -f "$TMP_CRT"; }
+# Must end with status 0: a failing last command in an EXIT trap overrides the
+# script's exit code under `set -e` (this broke the unsigned path, where the
+# empty-var tests return 1).
+cleanup_keys() {
+	if [[ -n "$TMP_KEY" ]]; then rm -f "$TMP_KEY"; fi
+	if [[ -n "$TMP_CRT" ]]; then rm -f "$TMP_CRT"; fi
+}
 trap cleanup_keys EXIT
 
 if [[ -n "${APP_PRIVATE_KEY_FILE:-}" && -n "${APP_CERTIFICATE_FILE:-}" ]]; then


### PR DESCRIPTION
Follow-ups from cutting the v0.9.31 beta release (https://github.com/aktasfatih/kanso/releases/tag/v0.9.31):

- **Fix `scripts/build-release.sh` exiting 1 on the unsigned path.** The EXIT trap's last command was a failing empty-var test (`[[ -n "$TMP_KEY" ]] && …`), which under `set -e` overrode the script's exit code after a fully successful build. This is what failed the v0.9.31 release workflow run; the tarball was built locally from the tag commit and uploaded manually. Future tag pushes will publish automatically once this merges.
- **Cut CHANGELOG `[Unreleased]` → `[0.9.31] - 2026-08-08`** and drop the incorrect "published to the Nextcloud App Store" claim from the 0.9.0 entry (we're not on the store yet).
- **README: recommend the pre-built tarball** from GitHub Releases as the primary install path (no Node/Composer on the server, addresses #15); source install moves to a collapsible details section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)