### PR TITLE
fix(import): lift card-count limits, stream CSV, fix sort-key overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Importers no longer cap how many cards you can bring in.** The CSV /
+  spreadsheet import row limit is raised from 2,000 to 200,000 and its file-size
+  cap from 5 MiB to 64 MiB; the Deck and Trello whole-board import file-size caps
+  go from 12 MiB to 32 MiB. The CSV importer now streams rows off the file one at
+  a time instead of loading them all into memory, so peak memory tracks the file
+  size rather than the card count. The remaining caps are generous backstops
+  against a pathological upload, not a ceiling on a real board.
+
 ### Fixed
 
 - **My Work pages stay current without a manual reload.** My Tasks, My Reviews
@@ -24,7 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in another tab as the change arrives (near-instant when notify_push is
   available, on the delta poll otherwise), without overwriting an edit you have
   in progress.
-
+- **Large CSV imports no longer fail with a sort-key overflow.** The CSV importer
+  assigned each imported card a sort key by chaining `after()` off the previous
+  one, which grew the key by a character every ~two dozen cards and overflowed the
+  64-character `sort_key` column at roughly 2,000 rows — the hidden reason the row
+  cap sat there. Imported cards now get a single bounded, evenly-spaced key block
+  (new `SortKeyService::appendSequence`), so a block of any realistic size stays
+  well within the column and preserves file order.
 ## [0.9.35] - 2026-08-09
 
 Consolidates the 2026-08-09 sprint. Versions 0.9.32–0.9.34 were internal

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -29,12 +29,18 @@ use OCP\IUserManager;
  *
  * The transactional, all-or-nothing convention mirrors the other importers:
  * every row's card is inserted in ONE DB transaction (any failure rolls the
- * whole import back), the document is byte-capped BEFORE parsing, the row count
- * is capped, and a title too long for the VARCHAR(100) column is truncated
- * rather than failing the import. Unlike the whole-board importers this writes
+ * whole import back), the document is byte-capped BEFORE parsing, and a title
+ * too long for the VARCHAR(100) column is truncated rather than failing the
+ * import. Rows are STREAMED out of the CSV lexer one at a time (never
+ * materialised into one big in-memory array), so peak memory stays proportional
+ * to the document size no matter how many cards it holds; the row count is
+ * capped only as a generous backstop against a pathological upload. Unlike the
+ * whole-board importers this writes
  * into an existing board, so it follows {@see CardService::create}'s conventions
- * for that board: cards APPEND to the stack via {@see SortKeyService::after},
- * each gets a per-board sequence number, an {@see Change::ACTION_CREATE} row is
+ * for that board: cards APPEND to the stack via a single bounded
+ * {@see SortKeyService::appendSequence} block (so a big import never grows the
+ * sort key per card), each gets a per-board sequence number, an
+ * {@see Change::ACTION_CREATE} row is
  * appended to the board's change log, and a single realtime push fires after the
  * commit so the board updates live.
  *
@@ -52,16 +58,19 @@ use OCP\IUserManager;
 class CsvImportService {
 	/**
 	 * Hard ceiling on the accepted CSV size, in bytes, enforced BEFORE parsing to
-	 * bound memory. 5 MiB comfortably fits a large task spreadsheet while stopping
-	 * a pathological upload.
+	 * bound memory. Because rows are streamed (not held all at once) this is the
+	 * dominant memory cost, so it can be generous: 64 MiB fits a very large task
+	 * spreadsheet while still stopping a pathological upload.
 	 */
-	public const MAX_DOCUMENT_BYTES = 5 * 1024 * 1024;
+	public const MAX_DOCUMENT_BYTES = 64 * 1024 * 1024;
 
 	/**
-	 * Hard ceiling on the number of DATA rows (header excluded) turned into cards.
-	 * A file with more rows is rejected up-front rather than silently truncated.
+	 * Backstop on the number of DATA rows (header excluded) turned into cards. The
+	 * point is to import ALL of a real spreadsheet, so this sits far above any
+	 * hand-maintained board; a file past it is rejected up-front (before any DB
+	 * write) rather than silently truncated.
 	 */
-	public const MAX_ROWS = 2000;
+	public const MAX_ROWS = 200000;
 
 	/** Card/label title columns are VARCHAR(100); long values truncate to fit. */
 	private const MAX_TITLE_LENGTH = 100;
@@ -112,30 +121,36 @@ class CsvImportService {
 			throw new InvalidInputException('A title column must be mapped');
 		}
 
-		$rows = $this->parseCsv($rawDocument);
-		if ($hasHeader) {
-			array_shift($rows);
-		}
-		if (count($rows) > self::MAX_ROWS) {
-			throw new InvalidInputException('The CSV has too many rows to import (limit ' . self::MAX_ROWS . ')');
-		}
-
-		// Load + EDIT-gate the target board and stack up-front, before any write,
-		// so a permission denial never leaves a partial import.
-		$board = $this->boardService->find($boardId, $actorUid);
-		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
-		$stack = $this->stackMapper->find($stackId);
-		if ($stack->getBoardId() !== $boardId) {
-			throw new InvalidInputException('That stack does not belong to the chosen board');
-		}
-
-		$this->db->beginTransaction();
+		// The document is lexed into a temp stream once and read row-by-row from it
+		// (twice: a cheap counting pass, then the insert pass), so no full array of
+		// rows is ever held - peak memory tracks the document, not the card count.
+		$handle = $this->openCsv($rawDocument);
 		try {
-			$result = $this->rebuild($rows, $board, $stack, $mapping, $actorUid);
-			$this->db->commit();
-		} catch (\Throwable $e) {
-			$this->db->rollBack();
-			throw $e;
+			$dataRows = $this->countDataRows($handle, $hasHeader);
+			if ($dataRows > self::MAX_ROWS) {
+				throw new InvalidInputException('The CSV has too many rows to import (limit ' . self::MAX_ROWS . ')');
+			}
+
+			// Load + EDIT-gate the target board and stack up-front, before any write,
+			// so a permission denial never leaves a partial import.
+			$board = $this->boardService->find($boardId, $actorUid);
+			$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
+			$stack = $this->stackMapper->find($stackId);
+			if ($stack->getBoardId() !== $boardId) {
+				throw new InvalidInputException('That stack does not belong to the chosen board');
+			}
+
+			rewind($handle);
+			$this->db->beginTransaction();
+			try {
+				$result = $this->rebuild($handle, $hasHeader, $board, $stack, $mapping, $actorUid, $dataRows);
+				$this->db->commit();
+			} catch (\Throwable $e) {
+				$this->db->rollBack();
+				throw $e;
+			}
+		} finally {
+			fclose($handle);
 		}
 
 		// Commit succeeded - broadcast the board change exactly once for the whole
@@ -147,11 +162,17 @@ class CsvImportService {
 	}
 
 	/**
-	 * @param list<list<string>> $rows
+	 * Streams the data rows off $handle (skipping the header when present) and
+	 * inserts one card per titled row. Reads a row at a time via {@see readRow} so
+	 * the whole file is never held in memory at once.
+	 *
+	 * @param resource $handle a rewound CSV stream positioned at the first record
 	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
+	 * @param int $dataRows the number of data rows counted in the pre-pass; sizes
+	 *                      the sort-key block so it never runs short
 	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
 	 */
-	private function rebuild(array $rows, Board $board, Stack $stack, array $mapping, string $actorUid): array {
+	private function rebuild($handle, bool $hasHeader, Board $board, Stack $stack, array $mapping, string $actorUid, int $dataRows): array {
 		$boardId = $board->getId();
 		$stackId = $stack->getId();
 		$now = time();
@@ -164,10 +185,14 @@ class CsvImportService {
 		}
 		$labelsCreated = 0;
 
-		// Append after the current tail of the stack; each new card advances the
-		// sort key so the imported block preserves file order at the bottom.
+		// Append after the current tail of the stack. The whole block's sort keys
+		// are laid out in one shot as a bounded, evenly-spaced sequence past the
+		// tail, so the imported cards preserve file order at the bottom WITHOUT the
+		// key length growing per card (chaining after() would overflow a big
+		// import). Keys are handed out in order to the titled rows that survive.
 		$last = $this->cardMapper->findLastInStack($stackId);
-		$cardKey = $last === null ? null : $last->getSortKey();
+		$sortKeys = $this->sortKeyService->appendSequence($dataRows, $last?->getSortKey());
+		$keyIndex = 0;
 
 		$titleIdx = $mapping['title'];
 		$descIdx = $mapping['description'] ?? null;
@@ -175,9 +200,14 @@ class CsvImportService {
 		$labelsIdx = $mapping['labels'] ?? null;
 		$assigneesIdx = $mapping['assignees'] ?? null;
 
+		// The header row (if any) is consumed and discarded before the data loop.
+		if ($hasHeader) {
+			$this->readRow($handle);
+		}
+
 		$cards = 0;
 		$skipped = 0;
-		foreach ($rows as $row) {
+		while (($row = $this->readRow($handle)) !== null) {
 			$title = $this->title($this->cell($row, $titleIdx));
 			if ($title === '') {
 				// A row with no title cannot become a card - skipped, never fatal.
@@ -191,8 +221,8 @@ class CsvImportService {
 			$card->setTitle($title);
 			$description = $descIdx === null ? '' : trim($this->cell($row, $descIdx));
 			$card->setDescription($description !== '' ? $description : null);
-			$cardKey = $cardKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($cardKey);
-			$card->setSortKey($cardKey);
+			$card->setSortKey($sortKeys[$keyIndex]);
+			$keyIndex++;
 			$card->setBoardSeq($this->cardMapper->nextBoardSeq($boardId));
 			$due = $dueIdx === null ? null : $this->toDate($this->cell($row, $dueIdx));
 			$card->setDuedate($due);
@@ -320,15 +350,15 @@ class CsvImportService {
 	// ── parsing / helpers ────────────────────────────────────────────────────────
 
 	/**
-	 * Parses the raw CSV into rows of string cells. Uses PHP's own CSV lexer
-	 * (via a memory stream) so quoted fields, embedded newlines and escaped
-	 * quotes are handled correctly rather than a naive split. A blank line
-	 * produces an empty row that later title-skipping drops.
+	 * Loads the raw CSV into a rewound temp stream ready to be read record by
+	 * record. Using PHP's own CSV lexer (via the stream) means quoted fields,
+	 * embedded newlines and escaped quotes are handled correctly rather than by a
+	 * naive split. The caller is responsible for fclose()-ing the handle.
 	 *
-	 * @return list<list<string>>
-	 * @throws InvalidInputException if the document is not decodable text
+	 * @return resource
+	 * @throws InvalidInputException if the document cannot be buffered
 	 */
-	private function parseCsv(string $raw): array {
+	private function openCsv(string $raw) {
 		// Strip a UTF-8 BOM so the first header cell is not prefixed with it.
 		if (str_starts_with($raw, "\xEF\xBB\xBF")) {
 			$raw = substr($raw, 3);
@@ -339,12 +369,20 @@ class CsvImportService {
 		}
 		fwrite($handle, $raw);
 		rewind($handle);
+		return $handle;
+	}
 
-		$rows = [];
+	/**
+	 * The next CSV record off $handle as normalised string cells, or null at EOF.
+	 * fgetcsv can yield a non-array on a read error (skipped) or a `[null]` row for
+	 * a blank line; both null cells and that blank row are normalised to '' so
+	 * later mapping never hits a null (a blank row later title-skips itself).
+	 *
+	 * @param resource $handle
+	 * @return list<string>|null
+	 */
+	private function readRow($handle): ?array {
 		while (($cells = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
-			// fgetcsv can yield null (on read error) or a `[null]` row for a blank
-			// line; normalise both to string cells so later mapping never hits a
-			// null.
 			if (!is_array($cells)) {
 				continue;
 			}
@@ -352,10 +390,30 @@ class CsvImportService {
 			foreach ($cells as $cell) {
 				$normalised[] = $cell ?? '';
 			}
-			$rows[] = $normalised;
+			return $normalised;
 		}
-		fclose($handle);
-		return $rows;
+		return null;
+	}
+
+	/**
+	 * Counts the data records on $handle (excluding the header when present) by
+	 * streaming through it, then rewinds it for the caller. Holds no rows in
+	 * memory - it exists so an over-limit file is rejected BEFORE any board load
+	 * or DB write, without materialising the document.
+	 *
+	 * @param resource $handle
+	 */
+	private function countDataRows($handle, bool $hasHeader): int {
+		rewind($handle);
+		if ($hasHeader) {
+			$this->readRow($handle);
+		}
+		$count = 0;
+		while ($this->readRow($handle) !== null) {
+			$count++;
+		}
+		rewind($handle);
+		return $count;
 	}
 
 	/**

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -61,11 +61,14 @@ use OCP\IUserManager;
 class ImportService {
 	/**
 	 * Hard ceiling on the accepted document size, in bytes. A board export is
-	 * plain structured text; anything past this is rejected before parsing to
-	 * bound memory. 12 MiB comfortably fits very large boards while stopping a
-	 * pathological upload.
+	 * plain structured text; anything past this is rejected before parsing. The
+	 * cap exists to bound memory: unlike the CSV importer this decodes the whole
+	 * export with json_decode (the graph must be resolved as a whole to remap ids),
+	 * so the decoded structure - not just the raw bytes - has to fit. The rows are
+	 * then inserted one at a time, so 32 MiB comfortably fits tens of thousands of
+	 * cards while keeping the decode well within a normal PHP memory limit.
 	 */
-	public const MAX_DOCUMENT_BYTES = 12 * 1024 * 1024;
+	public const MAX_DOCUMENT_BYTES = 32 * 1024 * 1024;
 
 	public function __construct(
 		private BoardService $boardService,

--- a/lib/Service/SortKeyService.php
+++ b/lib/Service/SortKeyService.php
@@ -117,6 +117,78 @@ class SortKeyService {
 	}
 
 	/**
+	 * Returns $n short, strictly-increasing keys for appending an ordered BLOCK
+	 * at the tail of a list in one shot - e.g. a bulk CSV import. Every key sorts
+	 * after $after (or from the start of the key space when $after is null).
+	 *
+	 * This exists because calling {@see after} once per item does NOT scale: each
+	 * append can grow the key by a character every ~half-alphabet steps, so a few
+	 * thousand sequential appends overflow MAX_KEY_LENGTH mid-batch. Here the keys
+	 * are instead drawn from a FIXED-WIDTH base-36 grid sized to $n (width w with
+	 * 36^w >= 2*(n+1), so ~log36(n) characters with a gap between neighbours for
+	 * later between()-inserts). When $after is given they are anchored above it by
+	 * a single {@see after} prefix that is strictly greater than $after and shares
+	 * no card's key, so every returned key sorts after the existing tail. The
+	 * result stays well under MAX_KEY_LENGTH for any realistic import.
+	 *
+	 * @param int $n how many keys to produce (>= 0)
+	 * @param string|null $after the current tail key to append past, or null for
+	 *                           an empty list
+	 * @return list<string> $n keys, strictly increasing, each > $after
+	 * @throws InvalidInputException if $n is negative or $after is malformed
+	 * @throws OverflowException if a key would exceed MAX_KEY_LENGTH (the target
+	 *                           list's existing keys are already at the wall and
+	 *                           need a rebalance first)
+	 */
+	public function appendSequence(int $n, ?string $after): array {
+		if ($n < 0) {
+			throw new InvalidInputException('appendSequence() requires n >= 0, got ' . $n);
+		}
+		if ($n === 0) {
+			return [];
+		}
+
+		// Widen the grid until it has at least two slots per item, so consecutive
+		// keys leave a gap (a later between() then fits without extending).
+		$slots = self::BASE;
+		$width = 1;
+		while ($slots < ($n + 1) * 2) {
+			$slots *= self::BASE;
+			$width++;
+		}
+
+		// A single bounded prefix strictly greater than the current tail lifts the
+		// whole block above every existing key at once (empty list needs none).
+		$prefix = $after === null ? '' : $this->after($after);
+
+		$keys = [];
+		for ($i = 0; $i < $n; $i++) {
+			$position = intdiv(($i + 1) * ($slots - 1), $n + 1);
+			$key = $this->encodeFixedWidth($position, $width);
+			if ($key[$width - 1] === '0') {
+				// Never end in '0' (blocks before()); the >=2 slot gap guarantees
+				// position + 1 stays below the next item's slot, so order holds.
+				$key = $this->encodeFixedWidth($position + 1, $width);
+			}
+			$keys[] = $this->guardLength($prefix . $key);
+		}
+		return $keys;
+	}
+
+	/**
+	 * $value as an exactly-$width-digit base-36 string (high digits zero-padded).
+	 * Used to lay out the fixed-width grid in {@see appendSequence}.
+	 */
+	private function encodeFixedWidth(int $value, int $width): string {
+		$out = '';
+		for ($i = 0; $i < $width; $i++) {
+			$out = self::ALPHABET[$value % self::BASE] . $out;
+			$value = intdiv($value, self::BASE);
+		}
+		return $out;
+	}
+
+	/**
 	 * Returns a key k with $a < k < $b (byte comparison).
 	 *
 	 * The result is at most one character longer than the longer input.

--- a/lib/Service/TrelloImportService.php
+++ b/lib/Service/TrelloImportService.php
@@ -43,11 +43,12 @@ use OCP\IDBConnection;
 class TrelloImportService {
 	/**
 	 * Hard ceiling on the accepted document size, in bytes. Trello exports are
-	 * plain JSON; anything past this is rejected before parsing to bound memory.
-	 * 12 MiB comfortably fits very large boards while stopping a pathological
-	 * upload (matches {@see ImportService::MAX_DOCUMENT_BYTES}).
+	 * plain JSON decoded as a whole (json_decode) before the rows are inserted one
+	 * at a time, so the cap bounds the decode's memory rather than a card count.
+	 * 32 MiB comfortably fits very large boards while staying within a normal PHP
+	 * memory limit (matches {@see ImportService::MAX_DOCUMENT_BYTES}).
 	 */
-	public const MAX_DOCUMENT_BYTES = 12 * 1024 * 1024;
+	public const MAX_DOCUMENT_BYTES = 32 * 1024 * 1024;
 
 	/** Fallback label colour when Trello's colour is blank/unknown. */
 	private const DEFAULT_LABEL_COLOR = 'b3b3b3';

--- a/tests/unit/Service/CsvImportServiceTest.php
+++ b/tests/unit/Service/CsvImportServiceTest.php
@@ -176,6 +176,30 @@ class CsvImportServiceTest extends TestCase {
 		self::assertTrue($cards[0]->getSortKey() < $cards[1]->getSortKey());
 	}
 
+	public function testImportsFarBeyondOldRowCap(): void {
+		// Guards the "import ALL the cards" contract: a spreadsheet with many more
+		// rows than the old 2000 hard cap imports every titled row, streamed off the
+		// handle rather than capped or held in one big array.
+		$this->primeTarget();
+		$this->db->method('beginTransaction');
+		$this->db->method('commit');
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+
+		$count = 0;
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$count): Card {
+			$c->setId(1000 + $count);
+			$count++;
+			return $c;
+		});
+
+		$rowCount = 5000;
+		$csv = "title\n" . str_repeat("Task\n", $rowCount);
+		$result = $this->service->import($csv, self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+
+		self::assertSame($rowCount, $result['cards']);
+		self::assertSame($rowCount, $count);
+	}
+
 	public function testTruncatesLongTitles(): void {
 		$this->primeTarget();
 		$this->db->method('beginTransaction');

--- a/tests/unit/Service/SortKeyServiceTest.php
+++ b/tests/unit/Service/SortKeyServiceTest.php
@@ -195,6 +195,67 @@ class SortKeyServiceTest extends TestCase {
 		self::assertLessThan(0, strcmp($keys[count($keys) - 1], $tail));
 	}
 
+	// ---- appendSequence (bulk tail append, e.g. CSV import) ---------------
+
+	public function testAppendSequenceZeroReturnsEmpty(): void {
+		self::assertSame([], $this->service->appendSequence(0, null));
+		self::assertSame([], $this->service->appendSequence(0, 'I'));
+	}
+
+	public function testAppendSequenceRejectsNegative(): void {
+		$this->expectException(InvalidInputException::class);
+		$this->service->appendSequence(-1, null);
+	}
+
+	/**
+	 * The core scaling guarantee: even far past the ~2000-append wall where
+	 * chaining after() overflows a 64-char key, a block stays short, strictly
+	 * increasing, valid, and (when anchored) entirely above the existing tail.
+	 */
+	public function testAppendSequenceScalesToLargeBlocks(): void {
+		foreach ([1, 2, 50, 2000, 50000] as $n) {
+			foreach ([null, 'I', 'ZZ'] as $after) {
+				$keys = $this->service->appendSequence($n, $after);
+				self::assertCount($n, $keys);
+				for ($i = 0; $i < $n; $i++) {
+					self::assertMatchesRegularExpression('/^[0-9A-Z]+$/', $keys[$i]);
+					self::assertStringEndsNotWith('0', $keys[$i]);
+					self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($keys[$i]));
+					if ($after !== null) {
+						self::assertLessThan(
+							0,
+							strcmp($after, $keys[$i]),
+							"appendSequence($n, $after) key #$i must sort after the tail"
+						);
+					}
+					if ($i > 0) {
+						self::assertLessThan(
+							0,
+							strcmp($keys[$i - 1], $keys[$i]),
+							"appendSequence($n, " . var_export($after, true) . ") not strictly increasing at $i"
+						);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * A block appended after an existing tail must slot in AFTER it and still
+	 * leave room to insert between the fresh keys.
+	 */
+	public function testAppendSequenceAnchorsAboveTailAndLeavesGaps(): void {
+		$tail = $this->service->initial();
+		$keys = $this->service->appendSequence(200, $tail);
+		self::assertLessThan(0, strcmp($tail, $keys[0]));
+		for ($i = 1; $i < count($keys); $i++) {
+			$mid = $this->service->between($keys[$i - 1], $keys[$i]);
+			self::assertLessThan(0, strcmp($keys[$i - 1], $mid));
+			self::assertLessThan(0, strcmp($mid, $keys[$i]));
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($mid));
+		}
+	}
+
 	/**
 	 * A stack that has hit the overflow wall (colliding/at-capacity long keys)
 	 * is rescued: the rewritten keys are short and a subsequent between() no


### PR DESCRIPTION
## Why

The importers should bring in **every** card, not a capped subset. Auditing them, the CSV importer was the only one with a real ceiling (2,000 rows) — and raising it surfaced a latent bug.

## What the limits were

- **CSV**: hard `MAX_ROWS = 2000` (threw), `MAX_DOCUMENT_BYTES = 5 MiB`.
- **Deck / Trello / Kanso-export**: no card-count limits — just 12 MiB file-size backstops. (Deck reads Deck's DB tables directly and imports every card; its only cap is a legitimate per-file 100 MiB attachment guard, left as-is.)

## The buried bug

The CSV importer assigned each card's sort key by chaining `SortKeyService::after()` off the previous one. That grows the key by a character every ~two dozen cards and overflows the 64-char `sort_key` column at **~2,000 rows** — almost certainly *why* `MAX_ROWS` was 2,000. Raising the cap alone would have turned a clean rejection into a mid-import crash that rolls the whole thing back. A 5,000-row import test reproduced it (`OverflowException: Sort key would exceed 64 characters`).

## Changes

- **`SortKeyService::appendSequence(n, after)`** (new) — lays out a whole ordered key block in one shot from a fixed-width base-36 grid sized to `n`, anchored above the tail by a single bounded `after()` prefix. Length stays ~log₃₆(n) instead of growing per card. `evenlySpaced`/rebalance deliberately untouched (their 2-/3-char length disjointness is load-bearing).
- **CSV importer** — streams rows off the file one at a time (peak memory tracks file size, not card count), uses `appendSequence` for keys, and raises caps: **2,000 → 200,000 rows**, **5 MiB → 64 MiB**. All-or-nothing transaction preserved.
- **Deck / Trello / Kanso-export** — file-size cap **12 MiB → 32 MiB**. These `json_decode` the whole document (the memory floor) and already insert row-by-row, so no rewrite was warranted.
- Tests for `appendSequence` scaling (50k keys, strictly increasing, under 64 chars, anchored above tail) and a 5,000-row CSV import.

## Note on chunking

Kept each import in a **single** DB transaction rather than chunking commits — the importers' documented contract is all-or-nothing, and chunking would let a failure leave a half-imported board. The streaming refactor is what bounds PHP memory; transaction size is a DB concern Postgres handles fine.

## Verification

- `cs-check`: clean · `psalm`: no errors · full unit suite: **1053 tests OK** (2 pre-existing PHP 8.5 runtime deprecations, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)