### PR TITLE
fix: My Work staleness + realtime freshness for card modal and cross-board pages

### DIFF
--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -2095,7 +2095,7 @@ import { useChecklist } from '../composables/useChecklist.js'
 import { useComments, buildCommentTree, REACTION_EMOJI } from '../composables/useComments.js'
 import { buildCardPrompt } from '../utils/cardPrompt.js'
 import { useCardHierarchy } from '../composables/useCardHierarchy.js'
-import { boardQueryKey } from '../composables/queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from '../composables/queryKeys.js'
 import { useCardMove } from '../composables/useCardMove.js'
 import { useAnnouncer } from '../composables/useAnnouncer.js'
 import { initial, between, after, before } from '../services/sortKey.js'
@@ -3584,6 +3584,9 @@ async function confirmMoveToBoard() {
 		queryClient.invalidateQueries({ queryKey: boardQueryKey(targetBoard) })
 		queryClient.invalidateQueries({ queryKey: boardQueryKey(boardId.value) })
 		queryClient.invalidateQueries({ queryKey: ['boards'] })
+		// A cross-board move changes the board context the My Work feeds render,
+		// and can drop the card from a feed entirely (#3766).
+		invalidateMyWork(queryClient)
 		showCopyDialog.value = false
 		showSuccess(t('kanso', 'Card moved.'))
 		// The card no longer exists on this board (its id changed on the target),

--- a/src/composables/queryKeys.js
+++ b/src/composables/queryKeys.js
@@ -29,3 +29,35 @@ export function boardQueryKey(id) {
 	}
 	return ['board', String(value)]
 }
+
+/**
+ * Key family for the cross-board "My Work" feeds (My Tasks / My Reviews /
+ * Inbox). These queries live outside the per-board cache, so board-scoped
+ * invalidation and delta sync never touch them (#3766).
+ *
+ * @type {Array<[string]>}
+ */
+export const MY_WORK_QUERY_KEYS = [['my-cards'], ['my-reviews'], ['inbox']]
+
+/**
+ * Invalidate every cross-board My Work feed (#3766).
+ *
+ * Call this from the settle phase of any mutation that can change membership
+ * of a My Work set: card assign/unassign, review request/withdraw/verdict,
+ * watch/unwatch, card done/archive/delete/restore, move-to-board, and bulk
+ * apply. The nav badges (useMyWorkBadges) keep these three queries mounted for
+ * the app's lifetime, so invalidating here refetches them immediately and the
+ * feeds are already fresh when the user navigates to a My Work page.
+ *
+ * Never call this from onMutate - the settle phase only - so it can never
+ * interfere with optimistic patches or their rollback. The feeds are small,
+ * per-user, server-filtered lists (three cheap GETs), so refetching all three
+ * on a membership-changing user action is deliberate and proportionate.
+ *
+ * @param {import('@tanstack/vue-query').QueryClient} queryClient
+ */
+export function invalidateMyWork(queryClient) {
+	for (const queryKey of MY_WORK_QUERY_KEYS) {
+		queryClient.invalidateQueries({ queryKey })
+	}
+}

--- a/src/composables/queryKeys.js
+++ b/src/composables/queryKeys.js
@@ -40,6 +40,24 @@ export function boardQueryKey(id) {
 export const MY_WORK_QUERY_KEYS = [['my-cards'], ['my-reviews'], ['inbox']]
 
 /**
+ * Visible-tab polling cadence for the My Work feeds (#3768).
+ *
+ * The feeds are cross-board, so no board delta poll ever covers them - while
+ * the user sits on My Tasks / My Reviews / Inbox, this interval IS the delta
+ * mechanism for other users' changes (their own mutations and navigation are
+ * already covered by invalidateMyWork + refetchOnMount 'always', #3766).
+ *
+ * 60s matches the board query's full-refetch safety net, not the 5s/30s delta
+ * poll: these queries are full list reads (small, per-user, server-filtered),
+ * so they align with the board's full-read cadence. TanStack's default
+ * refetchIntervalInBackground=false skips interval ticks while the tab is
+ * hidden/unfocused, so background tabs generate no traffic.
+ *
+ * @type {number}
+ */
+export const MY_WORK_POLL_INTERVAL = 60_000
+
+/**
  * Invalidate every cross-board My Work feed (#3766).
  *
  * Call this from the settle phase of any mutation that can change membership

--- a/src/composables/useAssignees.js
+++ b/src/composables/useAssignees.js
@@ -8,6 +8,7 @@ import {
 	unassignUser as apiUnassignUser,
 } from '../services/api.js'
 import { boardQueryKey } from './useBoard.js'
+import { invalidateMyWork } from './queryKeys.js'
 
 /**
  * Resolve a boardId argument that may be a plain value, a Vue ref (.value),
@@ -98,6 +99,8 @@ export function useAssignees(boardId) {
 			// Sync card detail query and board query with server truth
 			queryClient.invalidateQueries({ queryKey: ['card', String(cardId)] })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Assign/unassign changes My Tasks membership (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 

--- a/src/composables/useBoardDelta.js
+++ b/src/composables/useBoardDelta.js
@@ -22,6 +22,22 @@ import { boardQueryKey } from './queryKeys.js'
  * Mid-drag safety: never patch while a move is pending for the board - a patch
  * (like a refetch) would clobber the optimistic move placement. The move queue's
  * drain invalidate (useCardMove) is the post-drag reconciliation point.
+ *
+ * Open-card freshness (#3767): the board delta only patches the board SUMMARY
+ * cache. The card modal composes separate per-card detail queries (description,
+ * comments, checklist, links, attachments, time entries, activity) that a
+ * summary patch never touches - so an open modal in another tab went stale
+ * until closed and reopened. Every card-scoped mutation (comments, checklist,
+ * reviews, labels, relations included) records an ENTITY_CARD change row, so a
+ * delta upsert/remove for a card id is exactly the "this card's details may
+ * have changed" signal: when one arrives we invalidate that card's detail
+ * queries. Only ACTIVE queries refetch (an open modal); everything else is just
+ * marked stale for its next mount, so this is O(open modals), not O(cards).
+ *
+ * Draft safety: the modal's title/description editors copy into local draft
+ * refs when editing starts, so a detail refetch can never clobber a dirty
+ * editor. Optimistic in-flight mutations ARE clobberable, so the invalidation
+ * defers while any mutation is in flight (see flushCardDetailInvalidation).
  */
 
 // Module-level cursor registry, keyed by String(boardId) (mirrors
@@ -29,6 +45,111 @@ import { boardQueryKey } from './queryKeys.js'
 // cache (the useBoard poll and the main.js push handler) so they advance the
 // same cursor.
 const cursorByBoard = new Map()
+
+// First segment of every per-card detail query key the modal (and the tile
+// quick-preview) composes. Board-level keys ('board', 'board-stats', ...) are
+// deliberately absent - the delta patch / board invalidate already covers them.
+const CARD_DETAIL_KEY_PREFIXES = new Set([
+	'card',
+	'comments',
+	'checklist',
+	'card-links',
+	'card-attachments',
+	'card-time-entries',
+	'card-activity',
+])
+
+// "Changes arrived" client signal (#3767): listeners are notified after a
+// delta has been applied (or a resync/error forced a full refetch), with the
+// card ids the window touched. Kept deliberately tiny - consumers that need
+// finer-than-board realtime (open modal freshness today, presence/toasts
+// tomorrow) subscribe here instead of growing new polling loops.
+const changesAppliedListeners = new Set()
+
+/**
+ * Subscribe to applied board changes. The listener receives
+ * `{ boardId: string, cardIds: number[], resync: boolean }` - on a resync the
+ * touched ids are unknown, so `cardIds` is empty and `resync` is true.
+ *
+ * @param {(event: {boardId: string, cardIds: number[], resync: boolean}) => void} listener
+ * @return {() => void} unsubscribe
+ */
+export function onBoardChangesApplied(listener) {
+	changesAppliedListeners.add(listener)
+	return () => changesAppliedListeners.delete(listener)
+}
+
+/**
+ * @param {{boardId: string, cardIds: number[], resync: boolean}} event
+ */
+function emitBoardChangesApplied(event) {
+	for (const listener of changesAppliedListeners) {
+		try {
+			listener(event)
+		} catch {
+			// A listener must never be able to break delta sync itself.
+		}
+	}
+}
+
+// Pending detail invalidation (#3767). Invalidation is deferred while ANY
+// mutation is in flight: an invalidate-triggered refetch racing an optimistic
+// patch (comment add, checklist toggle) could momentarily resurrect the
+// pre-mutation server state - the exact clobbering the onMutate cancelQueries
+// convention exists to prevent. The ids are remembered (not dropped) and
+// flushed by the next syncBoardDelta tick; the mutation's own onSettled
+// invalidation covers its card in the meantime. `all` is the resync/error
+// case where the touched ids are unknown.
+const pendingDetailInvalidation = { all: false, ids: new Set() }
+
+/**
+ * Queue (and, when safe, immediately apply) an invalidation of the per-card
+ * detail queries for the given card ids - or for every cached card when
+ * `cardIds` is null (resync/error: the touched ids are unknown).
+ *
+ * @param {import('@tanstack/vue-query').QueryClient} queryClient
+ * @param {Array<number>|null} cardIds
+ */
+function invalidateCardDetailQueries(queryClient, cardIds) {
+	if (cardIds === null) {
+		pendingDetailInvalidation.all = true
+	} else {
+		for (const id of cardIds) {
+			pendingDetailInvalidation.ids.add(String(id))
+		}
+	}
+	flushCardDetailInvalidation(queryClient)
+}
+
+/**
+ * Apply any queued detail invalidation, unless a mutation is in flight (the
+ * queue is kept and retried on the next delta tick). Matching is by predicate
+ * so both String- and Number-typed detail keys (['card', '7'] from the route
+ * param, ['card', 7] from a tile preview) are caught.
+ *
+ * @param {import('@tanstack/vue-query').QueryClient} queryClient
+ */
+function flushCardDetailInvalidation(queryClient) {
+	if (!pendingDetailInvalidation.all && pendingDetailInvalidation.ids.size === 0) {
+		return
+	}
+	if (queryClient.isMutating() > 0) {
+		return
+	}
+	const all = pendingDetailInvalidation.all
+	const ids = new Set(pendingDetailInvalidation.ids)
+	pendingDetailInvalidation.all = false
+	pendingDetailInvalidation.ids.clear()
+	queryClient.invalidateQueries({
+		predicate: (query) => {
+			const [prefix, id] = query.queryKey
+			if (!CARD_DETAIL_KEY_PREFIXES.has(prefix)) {
+				return false
+			}
+			return all || ids.has(String(id))
+		},
+	})
+}
 
 function keyOf(boardId) {
 	const value = typeof boardId === 'object' && boardId !== null && boardId.value !== undefined
@@ -98,6 +219,11 @@ function applyDelta(list, delta) {
  * @return {Promise<void>}
  */
 export async function syncBoardDelta(queryClient, boardId) {
+	// Retry any detail invalidation a previous tick deferred (mutation was in
+	// flight). Runs even when the delta below turns out empty or unfetchable -
+	// the queue must drain, not depend on new changes arriving.
+	flushCardDetailInvalidation(queryClient)
+
 	if (isBoardMovePending(boardId)) {
 		return
 	}
@@ -115,14 +241,24 @@ export async function syncBoardDelta(queryClient, boardId) {
 	} catch {
 		// A failed delta read must never leave the client silently stale: drop the
 		// cursor and fall back to a full refetch (which re-seeds the cursor).
+		// The full board refetch only heals the SUMMARY cache; the rows we may
+		// have missed could carry open-card detail changes, so invalidate the
+		// detail queries too (ids unknown → all).
 		dropCursor(boardId)
 		queryClient.invalidateQueries({ queryKey: boardKey })
+		invalidateCardDetailQueries(queryClient, null)
+		emitBoardChangesApplied({ boardId: key, cardIds: [], resync: true })
 		return
 	}
 
 	if (delta?.resync) {
+		// Same reasoning as the error path: a resync window (saturated, pruned
+		// tail, or an unmodeled entity kind) may hide ENTITY_CARD rows for the
+		// open card - never let it stay stale.
 		dropCursor(boardId)
 		queryClient.invalidateQueries({ queryKey: boardKey })
+		invalidateCardDetailQueries(queryClient, null)
+		emitBoardChangesApplied({ boardId: key, cardIds: [], resync: true })
 		return
 	}
 
@@ -132,11 +268,30 @@ export async function syncBoardDelta(queryClient, boardId) {
 		return
 	}
 
+	// The card ids this window touched: upserts (edited/created, incl. every
+	// card-scoped sub-entity change - comments, checklist, reviews, labels -
+	// which all record an ENTITY_CARD row) plus removes (deleted/hidden).
+	const touchedCardIds = [
+		...(delta.cards?.upsert ?? []).map((card) => card.id),
+		...(delta.cards?.remove ?? []),
+	]
+	// An empty delta (most poll ticks) is not a change event - don't spam
+	// listeners with it.
+	const hasChanges = touchedCardIds.length > 0
+		|| (delta.stacks?.upsert?.length ?? 0) > 0
+		|| (delta.stacks?.remove?.length ?? 0) > 0
+
 	const existing = queryClient.getQueryData(boardKey)
 	if (!existing) {
 		// Nothing cached to patch (board not loaded / evicted): just record the
 		// advanced cursor; a future full fetch re-seeds from the payload anyway.
+		// The rows are consumed here (the cursor moves past them), so the detail
+		// invalidation must still happen or an open modal misses the change.
+		invalidateCardDetailQueries(queryClient, touchedCardIds)
 		cursorByBoard.set(key, delta.cursor)
+		if (hasChanges) {
+			emitBoardChangesApplied({ boardId: key, cardIds: touchedCardIds, resync: false })
+		}
 		return
 	}
 
@@ -149,6 +304,13 @@ export async function syncBoardDelta(queryClient, boardId) {
 		}
 	})
 
+	// Open-card freshness (#3767): a change row for a card means its DETAIL
+	// data may have changed too - refetch the open modal's queries.
+	invalidateCardDetailQueries(queryClient, touchedCardIds)
+
 	// Advance the cursor only after a successful patch.
 	cursorByBoard.set(key, delta.cursor)
+	if (hasChanges) {
+		emitBoardChangesApplied({ boardId: key, cardIds: touchedCardIds, resync: false })
+	}
 }

--- a/src/composables/useBulkSelect.js
+++ b/src/composables/useBulkSelect.js
@@ -3,7 +3,7 @@
 
 import { ref, computed } from 'vue'
 import { bulkApplyCards } from '../services/api.js'
-import { boardQueryKey } from './queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from './queryKeys.js'
 
 /**
  * Resolve a value that may be a plain primitive, a Vue ref, or a getter fn.
@@ -118,6 +118,8 @@ export function useBulkSelect(boardId, queryClient) {
 			const result = await bulkApplyCards([...selected.value], action, params)
 			lastResult.value = result
 			await queryClient.invalidateQueries({ queryKey: boardQueryKey(resolve(boardId)) })
+			// Bulk assign/archive/delete/move can change My Work membership (#3766).
+			invalidateMyWork(queryClient)
 			clear()
 			return result
 		} finally {

--- a/src/composables/useCard.js
+++ b/src/composables/useCard.js
@@ -4,7 +4,7 @@
 import { computed } from 'vue'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { fetchCard, updateCard as apiUpdateCard } from '../services/api.js'
-import { boardQueryKey } from './queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from './queryKeys.js'
 
 export function useCard(id, enabled) {
 	const queryClient = useQueryClient()
@@ -41,6 +41,9 @@ export function useCard(id, enabled) {
 				// Invalidate all board queries as a fallback
 				queryClient.invalidateQueries({ queryKey: ['board'] })
 			}
+			// Card updates can change My Work membership (done) or the card
+			// context the feeds render (title, due date) (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 

--- a/src/composables/useCardActions.js
+++ b/src/composables/useCardActions.js
@@ -18,7 +18,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { updateCard as apiUpdateCard, deleteCard as apiDeleteCard, restoreCard as apiRestoreCard } from '../services/api.js'
-import { boardQueryKey } from './queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from './queryKeys.js'
 
 /**
  * Resolve a value that may be a plain primitive, a Vue ref, or a getter fn.
@@ -95,6 +95,8 @@ export function useCardActions(boardId, cardId) {
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: getCardKey() })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Archiving removes the card from the My Work feeds (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 
@@ -137,6 +139,8 @@ export function useCardActions(boardId, cardId) {
 		onSettled: () => {
 			// Board is the only remaining relevant cache; card detail was removed.
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Deleting removes the card from the My Work feeds (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 
@@ -147,6 +151,8 @@ export function useCardActions(boardId, cardId) {
 		mutationFn: () => apiRestoreCard(resolve(cardId)),
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Restoring can return the card to the My Work feeds (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 

--- a/src/composables/useInbox.js
+++ b/src/composables/useInbox.js
@@ -3,6 +3,7 @@
 
 import { useQuery } from '@tanstack/vue-query'
 import { getInbox as apiGetInbox } from '../services/api.js'
+import { MY_WORK_POLL_INTERVAL } from './queryKeys.js'
 
 /**
  * Composable for the Inbox feed - recent comments on cards the current user
@@ -19,6 +20,10 @@ export function useInbox() {
 		// mount refetch is suppressed within staleTime - 'always' makes every
 		// navigation to the Inbox revalidate against the server.
 		refetchOnMount: 'always',
+		// #3768: other people's comments must appear while the user sits on the
+		// Inbox - polling is the only channel for this cross-board feed.
+		// Paused on hidden tabs (TanStack default refetchIntervalInBackground).
+		refetchInterval: MY_WORK_POLL_INTERVAL,
 	})
 
 	return query

--- a/src/composables/useInbox.js
+++ b/src/composables/useInbox.js
@@ -15,6 +15,10 @@ export function useInbox() {
 	const query = useQuery({
 		queryKey: ['inbox'],
 		queryFn: apiGetInbox,
+		// #3766: the nav badges keep this query permanently mounted, so a default
+		// mount refetch is suppressed within staleTime - 'always' makes every
+		// navigation to the Inbox revalidate against the server.
+		refetchOnMount: 'always',
 	})
 
 	return query

--- a/src/composables/useMyCards.js
+++ b/src/composables/useMyCards.js
@@ -8,11 +8,18 @@ import { getMyCards as apiGetMyCards } from '../services/api.js'
  * Composable for the "My tasks" feed - all open cards assigned to the current
  * user, across every board they can read. Refetches on window focus so the
  * panel stays current without a dedicated realtime channel.
+ *
+ * refetchOnMount 'always' (#3766): the nav badges keep this query mounted for
+ * the app's lifetime, so it is often within the global staleTime when the user
+ * navigates to My Tasks - a default mount refetch would be suppressed and the
+ * page would render pre-mutation data. 'always' makes every view mount (i.e.
+ * client-side navigation) revalidate against the server.
  */
 export function useMyCards() {
 	return useQuery({
 		queryKey: ['my-cards'],
 		queryFn: apiGetMyCards,
 		refetchOnWindowFocus: true,
+		refetchOnMount: 'always',
 	})
 }

--- a/src/composables/useMyCards.js
+++ b/src/composables/useMyCards.js
@@ -3,6 +3,7 @@
 
 import { useQuery } from '@tanstack/vue-query'
 import { getMyCards as apiGetMyCards } from '../services/api.js'
+import { MY_WORK_POLL_INTERVAL } from './queryKeys.js'
 
 /**
  * Composable for the "My tasks" feed - all open cards assigned to the current
@@ -14,6 +15,11 @@ import { getMyCards as apiGetMyCards } from '../services/api.js'
  * navigates to My Tasks - a default mount refetch would be suppressed and the
  * page would render pre-mutation data. 'always' makes every view mount (i.e.
  * client-side navigation) revalidate against the server.
+ *
+ * refetchInterval (#3768): other users' changes while the user SITS on the
+ * page (no navigation, no focus change) only arrive by polling - the feed is
+ * cross-board, so no board delta poll covers it. The same interval keeps the
+ * nav badge live from any view. Paused on hidden tabs (TanStack default).
  */
 export function useMyCards() {
 	return useQuery({
@@ -21,5 +27,6 @@ export function useMyCards() {
 		queryFn: apiGetMyCards,
 		refetchOnWindowFocus: true,
 		refetchOnMount: 'always',
+		refetchInterval: MY_WORK_POLL_INTERVAL,
 	})
 }

--- a/src/composables/useMyReviews.js
+++ b/src/composables/useMyReviews.js
@@ -3,7 +3,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { getMyReviews as apiGetMyReviews, setReviewState as apiSetReviewState } from '../services/api.js'
-import { boardQueryKey } from './queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from './queryKeys.js'
 
 /**
  * Composable for the "My Reviews" feed - all review requests assigned to the
@@ -15,6 +15,10 @@ export function useMyReviews() {
 	const query = useQuery({
 		queryKey: ['my-reviews'],
 		queryFn: apiGetMyReviews,
+		// #3766: the nav badges keep this query permanently mounted, so a default
+		// mount refetch is suppressed within staleTime - 'always' makes every
+		// navigation to My Reviews revalidate against the server.
+		refetchOnMount: 'always',
 	})
 
 	/**
@@ -44,7 +48,9 @@ export function useMyReviews() {
 		},
 
 		onSettled: (_data, _err, { cardId, boardId }) => {
-			queryClient.invalidateQueries({ queryKey: ['my-reviews'] })
+			// A verdict changes My Reviews membership (pending → answered), and the
+			// other feeds render card context too - refresh the whole family (#3766).
+			invalidateMyWork(queryClient)
 			// Best-effort invalidation of related board/card caches
 			if (cardId) {
 				queryClient.invalidateQueries({ queryKey: ['card', String(cardId)] })

--- a/src/composables/useMyReviews.js
+++ b/src/composables/useMyReviews.js
@@ -3,7 +3,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { getMyReviews as apiGetMyReviews, setReviewState as apiSetReviewState } from '../services/api.js'
-import { boardQueryKey, invalidateMyWork } from './queryKeys.js'
+import { boardQueryKey, invalidateMyWork, MY_WORK_POLL_INTERVAL } from './queryKeys.js'
 
 /**
  * Composable for the "My Reviews" feed - all review requests assigned to the
@@ -19,6 +19,10 @@ export function useMyReviews() {
 		// mount refetch is suppressed within staleTime - 'always' makes every
 		// navigation to My Reviews revalidate against the server.
 		refetchOnMount: 'always',
+		// #3768: other users' review requests must appear while the user sits on
+		// the page - polling is the only channel for this cross-board feed.
+		// Paused on hidden tabs (TanStack default refetchIntervalInBackground).
+		refetchInterval: MY_WORK_POLL_INTERVAL,
 	})
 
 	/**

--- a/src/composables/useMyWorkBadges.js
+++ b/src/composables/useMyWorkBadges.js
@@ -47,9 +47,11 @@ export function markInboxSeen(newestCreatedAt) {
  * Lightweight badge counts for the My Tasks / My Reviews / Inbox nav items.
  *
  * Reuses the existing feed queries (`useMyCards`, `useMyReviews`, `useInbox`)
- * from the shared query cache — no extra endpoints or polling. The nav mounts
- * once for the app's lifetime, so these queries are warmed here and shared with
- * the views themselves (TanStack Query dedupes by key).
+ * from the shared query cache — no extra endpoints, no badge-specific polling.
+ * The nav mounts once for the app's lifetime, so these queries are warmed here
+ * and shared with the views themselves (TanStack Query dedupes by key). The
+ * queries' own visible-tab interval (MY_WORK_POLL_INTERVAL, #3768) is what
+ * keeps both these badges and the My Work pages live for other users' changes.
  *
  * - tasks:   count of open cards assigned to me (useMyCards already returns
  *            open-only, so no extra filtering is applied here).

--- a/src/composables/useReviews.js
+++ b/src/composables/useReviews.js
@@ -8,6 +8,7 @@ import {
 	setReviewState as apiSetReviewState,
 } from '../services/api.js'
 import { boardQueryKey } from './useBoard.js'
+import { invalidateMyWork } from './queryKeys.js'
 
 /**
  * Resolve a boardId argument that may be a plain value, a Vue ref (.value),
@@ -120,6 +121,9 @@ export function useReviews(boardId) {
 		onSettled: (_data, _err, { cardId }) => {
 			queryClient.invalidateQueries({ queryKey: ['card', String(cardId)] })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Requesting/withdrawing a review changes My Reviews membership for the
+			// target reviewer - refresh the actor's own feeds too (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 
@@ -164,6 +168,9 @@ export function useReviews(boardId) {
 		onSettled: (_data, _err, { cardId }) => {
 			queryClient.invalidateQueries({ queryKey: ['card', String(cardId)] })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Requesting/withdrawing a review changes My Reviews membership for the
+			// target reviewer - refresh the actor's own feeds too (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 
@@ -225,6 +232,8 @@ export function useReviews(boardId) {
 			// so refresh the discussion thread too - otherwise it only appears after
 			// a full reload.
 			queryClient.invalidateQueries({ queryKey: ['comments', String(cardId)] })
+			// A verdict changes My Reviews membership (pending → answered) (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 

--- a/src/composables/useSubscription.js
+++ b/src/composables/useSubscription.js
@@ -29,6 +29,7 @@ import {
 	subscribeWatcher as apiSubscribeWatcher,
 	unsubscribeWatcher as apiUnsubscribeWatcher,
 } from '../services/api.js'
+import { invalidateMyWork } from './queryKeys.js'
 
 /**
  * Resolve a value that may be a plain primitive, a Vue ref, or a getter fn.
@@ -106,6 +107,9 @@ export function useSubscription(cardId) {
 
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: getCardKey() })
+			// Watching/unwatching changes which comments the Inbox feed surfaces
+			// for the affected watcher (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 
@@ -157,6 +161,9 @@ export function useSubscription(cardId) {
 
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: getCardKey() })
+			// Watching/unwatching changes which comments the Inbox feed surfaces
+			// for the affected watcher (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 

--- a/src/composables/useTrash.js
+++ b/src/composables/useTrash.js
@@ -21,7 +21,7 @@
 import { computed } from 'vue'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { fetchTrash, restoreCard, purgeCard } from '../services/api.js'
-import { boardQueryKey } from './queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from './queryKeys.js'
 
 /**
  * @param {import('vue').Ref<string|number>} boardId  - reactive board id
@@ -72,6 +72,8 @@ export function useTrash(boardId, enabled) {
 			// board cache so the restored card appears in the stack column.
 			queryClient.invalidateQueries({ queryKey: trashKey.value })
 			queryClient.invalidateQueries({ queryKey: boardQueryKey(boardId.value) })
+			// Restoring can return the card to the My Work feeds (#3766).
+			invalidateMyWork(queryClient)
 		},
 	})
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,8 @@ import App from './App.vue'
 import { router } from './router/index.js'
 import { initRealtime } from './services/realtime.js'
 import { isBoardMovePending } from './composables/useCardMove.js'
-import { syncBoardDelta } from './composables/useBoardDelta.js'
+import { syncBoardDelta, onBoardChangesApplied } from './composables/useBoardDelta.js'
+import { invalidateMyWork } from './composables/queryKeys.js'
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -60,6 +61,43 @@ if (openCard) {
 	})
 }
 
+// My Work live-updates, fast path (#3768). The PRIMARY freshness mechanism for
+// the cross-board feeds (My Tasks / My Reviews / Inbox) is their own 60s
+// visible-tab refetchInterval (MY_WORK_POLL_INTERVAL) - it works everywhere,
+// including a user parked on a My Work page with no board mounted. This funnel
+// is the free upgrade on top: a push event ("a board you participate in
+// changed") or an applied board delta is exactly a "my feeds may have changed"
+// signal, so we invalidate the always-mounted feed queries and the change shows
+// up near-instantly instead of at the next 60s tick.
+//
+// Guards (both mirror the delta machinery's own conventions):
+//  - throttle: board deltas can arrive every few seconds on a busy board; the
+//    feeds are refreshed at most once per 30s (global staleTime) - the 60s
+//    interval is the backstop for anything a throttled window skipped.
+//  - isMutating: never race an optimistic my-work patch (review verdict) with
+//    a refetch; the mutation's own settle-phase invalidateMyWork covers it.
+//  - hidden tab: push events still arrive there, and invalidateQueries
+//    refetches active queries regardless of focus (the feeds' own interval is
+//    focus-gated by TanStack) - skip, and let refetchOnWindowFocus +
+//    refetchOnMount 'always' catch the tab up when it returns.
+const MY_WORK_SIGNAL_THROTTLE = 30_000
+let lastMyWorkSignal = 0
+function invalidateMyWorkThrottled() {
+	if (document.visibilityState === 'hidden') {
+		return
+	}
+	const now = Date.now()
+	if (now - lastMyWorkSignal < MY_WORK_SIGNAL_THROTTLE) {
+		return
+	}
+	if (queryClient.isMutating() > 0) {
+		return
+	}
+	lastMyWorkSignal = now
+	invalidateMyWork(queryClient)
+}
+onBoardChangesApplied(invalidateMyWorkThrottled)
+
 // Realtime: a push event means someone changed the board - delta-sync it (#3675)
 // instead of re-downloading the whole board. syncBoardDelta fetches only the
 // changes since our cursor and PATCHES the cache (O(delta), not O(boardSize));
@@ -67,6 +105,10 @@ if (openCard) {
 // re-checks the move-pending guard internally so it never clobbers an optimistic
 // move (the move queue's drain invalidate reconciles afterwards).
 initRealtime((boardId) => {
+	// The push body names a board, but the my-work feeds are cross-board and
+	// need no cursor: refresh them even when the board itself was never opened
+	// this session (syncBoardDelta would early-return without a cursor) (#3768).
+	invalidateMyWorkThrottled()
 	if (isBoardMovePending(boardId)) {
 		return
 	}

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -602,7 +602,7 @@ import CommandPalette from '../components/CommandPalette.vue'
 import CardPreview from '../components/CardPreview.vue'
 import { useBoard } from '../composables/useBoard.js'
 import { useBoardSubscription } from '../composables/useBoardSubscription.js'
-import { boardQueryKey } from '../composables/queryKeys.js'
+import { boardQueryKey, invalidateMyWork } from '../composables/queryKeys.js'
 import { useAssignees } from '../composables/useAssignees.js'
 import { useCardMove } from '../composables/useCardMove.js'
 import { provideAnnouncer } from '../composables/useAnnouncer.js'
@@ -1410,6 +1410,8 @@ function handleKeydown(e) {
 			})
 			.finally(() => {
 				queryClient.invalidateQueries({ queryKey: boardQueryKey(props.id) })
+				// Done-state changes My Tasks membership (#3766).
+				invalidateMyWork(queryClient)
 			})
 		return
 	}

--- a/tests/e2e/my-work-freshness.spec.js
+++ b/tests/e2e/my-work-freshness.spec.js
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #3766 — My Work surfaces must not serve stale cache. The cross-board feeds
+// (My Tasks / My Reviews / Inbox) are separate TanStack Query caches from the
+// per-board cache, and the nav badges keep them mounted for the app's lifetime.
+// Before the fix, membership-changing mutations never invalidated them and the
+// global staleTime suppressed the mount refetch on navigation — so a
+// self-assignment didn't show up in My Tasks until a manual browser reload.
+//
+// These tests drive the exact reported repro through the UI and assert that
+// NO full page reload happens (a window marker survives every navigation):
+//  1. self-assign on a board → client-side navigate to My Tasks → card is
+//     there; unassign → it disappears again.
+//  2. request a review → client-side navigate to My Reviews → request is there.
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+/**
+ * Same-document (hash-only) navigation — vue-router handles it client-side,
+ * exactly like clicking a nav link. Never triggers a page reload, which is the
+ * whole point of this spec.
+ */
+async function gotoHash(page, hash) {
+	await page.evaluate((h) => { window.location.hash = h }, hash)
+}
+
+test.describe('My Work freshness (#3766)', () => {
+	const ts = Date.now()
+	const TASK_TITLE = `Fresh SelfAssign ${ts}`
+	const REVIEW_TITLE = `Fresh ReviewReq ${ts}`
+	const state = { boardId: 0, stackId: 0, taskCardId: 0, reviewCardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: `MyWork Fresh E2E ${ts}` })
+		state.boardId = board.id
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'To do' })).id
+		// Both cards start UNASSIGNED / review-free — the tests mutate via the UI.
+		state.taskCardId = (await api('POST', '/cards', { stackId: state.stackId, title: TASK_TITLE })).id
+		state.reviewCardId = (await api('POST', '/cards', { stackId: state.stackId, title: REVIEW_TITLE })).id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('self-assign shows in My Tasks after client-side navigation; unassign removes it (exact repro)', async ({ page }) => {
+		await ncLogin(page)
+
+		// Prime the My Tasks cache first — this is what made the bug bite: the
+		// feed was fetched once here and then served stale after the mutation.
+		await page.goto(`${BASE}/index.php/apps/kanso#/my-tasks`)
+		await expect(page.locator('.my-cards-view')).toBeVisible({ timeout: 15_000 })
+		const row = page.locator('.my-cards-view__row', { hasText: TASK_TITLE })
+		await expect(row).toBeHidden()
+
+		// Marker that only survives if NO full page reload happens from here on.
+		await page.evaluate(() => { window.__kansoNoReload = true })
+
+		// Client-side navigate to the card and self-assign via the UI.
+		await gotoHash(page, `#/board/${state.boardId}/card/${state.taskCardId}`)
+		await page.waitForSelector('.card-modal__content', { timeout: 15_000 })
+		await page.locator('.card-modal__pill--dashed', { hasText: 'Assign' }).first().click()
+
+		// The settle-phase invalidation must refetch the my-cards feed on its own
+		// (the nav badges keep it mounted) — no navigation, no reload.
+		const feedRefetch = page.waitForResponse(
+			(r) => r.url().includes('/api/my-cards') && r.ok(),
+			{ timeout: 10_000 },
+		)
+		await page.locator('.card-modal__popover .card-modal__assign-option').first().click()
+		await expect(page.locator('.card-modal__assignee-pill', { hasText: USER })).toBeVisible({ timeout: 8000 })
+		await feedRefetch
+
+		// Client-side navigation to My Tasks — the new assignment is there.
+		await gotoHash(page, '#/my-tasks')
+		await expect(row).toBeVisible({ timeout: 10_000 })
+		expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+
+		// Unassign from the modal (opened from the feed row) — the card must
+		// leave My Tasks on returning, again without a reload.
+		await row.click()
+		await page.waitForSelector('.card-modal__content', { timeout: 15_000 })
+		const unassignDone = page.waitForResponse(
+			(r) => r.url().includes(`/api/cards/${state.taskCardId}/assignees/`) && r.request().method() === 'DELETE',
+			{ timeout: 10_000 },
+		)
+		await page.locator('.card-modal__assignee-pill', { hasText: USER })
+			.locator('.card-modal__pill-x').first().click()
+		await unassignDone
+
+		await page.keyboard.press('Escape') // close-to-origin returns to My Tasks
+		await expect(page).toHaveURL(/#\/my-tasks/, { timeout: 10_000 })
+		await expect(row).toBeHidden({ timeout: 10_000 })
+		expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+	})
+
+	test('review request shows in My Reviews after client-side navigation (second surface)', async ({ page }) => {
+		await ncLogin(page)
+
+		// Prime the My Reviews cache.
+		await page.goto(`${BASE}/index.php/apps/kanso#/reviews`)
+		await expect(page.locator('.my-reviews-view')).toBeVisible({ timeout: 15_000 })
+		const row = page.locator('.review-row', { hasText: REVIEW_TITLE })
+		await expect(row).toBeHidden()
+
+		await page.evaluate(() => { window.__kansoNoReload = true })
+
+		// Client-side navigate to the card and request a review from the owner
+		// (a valid single-user path — the owner holds READ on their own board).
+		await gotoHash(page, `#/board/${state.boardId}/card/${state.reviewCardId}`)
+		await page.waitForSelector('.card-modal__content', { timeout: 15_000 })
+		await page.locator('.card-modal__pill--dashed', { hasText: 'Request' }).first().click()
+
+		const feedRefetch = page.waitForResponse(
+			(r) => r.url().includes('/api/reviews/mine') && r.ok(),
+			{ timeout: 10_000 },
+		)
+		await page.locator('.card-modal__popover .card-modal__assign-option').first().click()
+		await expect(page.locator('.card-modal__review-pill--pending')).toBeVisible({ timeout: 8000 })
+		await feedRefetch
+
+		// Client-side navigation to My Reviews — the new request is there.
+		await gotoHash(page, '#/reviews')
+		await expect(row).toBeVisible({ timeout: 10_000 })
+		expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+	})
+})

--- a/tests/e2e/my-work-live.spec.js
+++ b/tests/e2e/my-work-live.spec.js
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #3768 — My Work surfaces live-update while OPEN. #3766 made My Tasks /
+// My Reviews / Inbox fresh on the user's own mutations and on client-side
+// navigation; the remaining gap was OTHER users' changes while the user just
+// sits on the page (no navigation, no focus change, no reload). The fix is a
+// 60s visible-tab refetchInterval on the three cross-board feed queries
+// (MY_WORK_POLL_INTERVAL — the interval IS the delta mechanism there, since no
+// board delta poll runs on those pages), plus a throttled push/delta-driven
+// invalidation fast path when notify_push is available.
+//
+// These tests drive the exact acceptance scenario with two users: the tester
+// parks on a My Work page and never touches it again, while the admin (a
+// plain API client — a different "user in another browser") makes a change
+// that concerns the tester. The entry must appear on its own:
+// near-instantly via push on a push-enabled stack (dev/setup.sh), or within
+// the 60s polling interval otherwise (CI sets KANSO_SKIP_NOTIFY_PUSH=1) —
+// the 90s expectation budget covers either, and a no-reload marker plus a
+// hash check prove no reload/navigation "helped".
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const ADMIN_AUTH = 'Basic ' + Buffer.from('admin:admin').toString('base64')
+
+const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page, user, pass) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', user)
+	await page.fill('#password', pass)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('My Work live updates (#3768)', () => {
+	const ts = Date.now()
+	const REVIEW_TITLE = `Live ReviewReq ${ts}`
+	const TASK_TITLE = `Live Assign ${ts}`
+	const state = { boardId: 0, reviewCardId: 0, taskCardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: `MyWork Live E2E ${ts}` })
+		state.boardId = board.id
+		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To do' })
+		state.reviewCardId = (await api('POST', '/cards', { stackId: stack.id, title: REVIEW_TITLE })).id
+		state.taskCardId = (await api('POST', '/cards', { stackId: stack.id, title: TASK_TITLE })).id
+		// Share with tester (READ|EDIT = 3) so the admin's review request /
+		// assignment lands in the tester's cross-board feeds.
+		await api('POST', `/boards/${board.id}/acl`, {
+			participant: TESTER.user,
+			participantType: 'user',
+			permission: 3,
+		})
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('a review requested by another user appears in the open My Reviews view by itself', async ({ browser }) => {
+		// Polling budget (60s interval + slow-CI headroom) on top of the default.
+		test.setTimeout(180_000)
+		const ctx = await browser.newContext()
+		try {
+			const page = await ctx.newPage()
+			await ncLogin(page, TESTER.user, TESTER.pass)
+
+			// Tester parks on My Reviews — from here on: no navigation, no focus
+			// change, no reload. The marker survives only if that holds.
+			await page.goto(`${BASE}/index.php/apps/kanso#/reviews`)
+			await expect(page.locator('.my-reviews-view')).toBeVisible({ timeout: 15_000 })
+			const row = page.locator('.review-row', { hasText: REVIEW_TITLE })
+			await expect(row).toBeHidden()
+			await page.evaluate(() => { window.__kansoNoReload = true })
+
+			// The admin — another user, no browser — requests a review FROM the tester.
+			await api('PUT', `/cards/${state.reviewCardId}/reviews/${TESTER.user}`)
+
+			// Push: near-instant. Poll-only (CI): within the 60s interval.
+			await expect(row).toBeVisible({ timeout: 90_000 })
+			expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+			expect(new URL(page.url()).hash).toBe('#/reviews')
+		} finally {
+			await ctx.close()
+		}
+	})
+
+	test('a card assigned by another user appears in the open My Tasks view by itself', async ({ browser }) => {
+		test.setTimeout(180_000)
+		const ctx = await browser.newContext()
+		try {
+			const page = await ctx.newPage()
+			await ncLogin(page, TESTER.user, TESTER.pass)
+
+			await page.goto(`${BASE}/index.php/apps/kanso#/my-tasks`)
+			await expect(page.locator('.my-cards-view')).toBeVisible({ timeout: 15_000 })
+			const row = page.locator('.my-cards-view__row', { hasText: TASK_TITLE })
+			await expect(row).toBeHidden()
+			await page.evaluate(() => { window.__kansoNoReload = true })
+
+			// The admin assigns the tester to the card.
+			await api('PUT', `/cards/${state.taskCardId}/assignees/${TESTER.user}`)
+
+			await expect(row).toBeVisible({ timeout: 90_000 })
+			expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+			expect(new URL(page.url()).hash).toBe('#/my-tasks')
+		} finally {
+			await ctx.close()
+		}
+	})
+})

--- a/tests/e2e/realtime-card-modal.spec.js
+++ b/tests/e2e/realtime-card-modal.spec.js
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #3767 — open-card-modal realtime freshness. The board delta only patched the
+// board SUMMARY cache, so a card modal open in another tab/browser went stale:
+// title, description and comment changes never appeared until close/reopen.
+// The fix invalidates the open card's DETAIL queries when a delta change row
+// for that card arrives. This suite drives two browser contexts (admin mutates
+// via API, tester watches an open modal) and works with notify_push (near-
+// instant) or the 5s delta-poll fallback — both under the 15s budgets used
+// here, matching realtime.spec.js.
+//
+// Draft safety is asserted too: the modal's editors copy into local draft refs
+// on edit-start, so a remote refresh must never clobber a dirty editor.
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const ADMIN_AUTH = 'Basic ' + Buffer.from('admin:admin').toString('base64')
+
+const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: ADMIN_AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+	return r.json()
+}
+
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiPatch(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PATCH',
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`PATCH ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page, user, pass) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return // Already logged in
+
+	await page.fill('#user', user)
+	await page.fill('#password', pass)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Realtime card modal freshness', () => {
+	const state = { boardId: 0, cardId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === 'Realtime Modal Board') {
+				await apiDelete(`/boards/${b.id}`)
+			}
+		}
+		const board = await apiPost('/boards', { title: 'Realtime Modal Board' })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'S1' })
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'Modal card v1' })
+		state.cardId = card.id
+		// Share with tester (READ|EDIT = 3)
+		await apiPost(`/boards/${board.id}/acl`, {
+			participant: TESTER.user,
+			participantType: 'user',
+			permission: 3,
+		})
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) {
+			await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+		}
+	})
+
+	test('open modal picks up remote title, description and comment without reload', async ({ browser }) => {
+		const testerCtx = await browser.newContext()
+		try {
+			const page = await testerCtx.newPage()
+			await ncLogin(page, TESTER.user, TESTER.pass)
+
+			// Tester opens the card modal and keeps it open — no further navigation.
+			await page.goto(state.cardUrl)
+			await expect(page.locator('.card-modal__title')).toHaveText('Modal card v1', { timeout: 15_000 })
+
+			// Admin (other "tab") edits title + description and adds a comment.
+			await apiPatch(`/cards/${state.cardId}`, { title: 'Modal card v2' })
+			await apiPatch(`/cards/${state.cardId}`, { description: 'remote description v1' })
+			await apiPost(`/cards/${state.cardId}/comments`, { body: 'remote comment v1' })
+
+			// All three must land in the OPEN modal: push is near-instant, the
+			// delta-poll fallback fires every 5s — 15s is generous for either.
+			await expect(page.locator('.card-modal__title')).toHaveText('Modal card v2', { timeout: 15_000 })
+			await expect(page.locator('.card-modal__desc-rendered')).toContainText('remote description v1', { timeout: 15_000 })
+			await expect(
+				page.locator('.card-modal__comment-body').filter({ hasText: 'remote comment v1' }),
+			).toBeVisible({ timeout: 15_000 })
+		} finally {
+			await testerCtx.close()
+		}
+	})
+
+	test('a remote change never clobbers a dirty description draft', async ({ browser }) => {
+		const testerCtx = await browser.newContext()
+		try {
+			const page = await testerCtx.newPage()
+			await ncLogin(page, TESTER.user, TESTER.pass)
+
+			await page.goto(state.cardUrl)
+			await expect(page.locator('.card-modal__desc-rendered')).toContainText('remote description v1', { timeout: 15_000 })
+
+			// Tester starts editing the description — the editor seeds a LOCAL
+			// draft from the current text; from here on it must be untouchable.
+			await page.locator('.card-modal__desc-view').click()
+			const textarea = page.locator('.card-modal__desc-textarea')
+			await expect(textarea).toBeVisible()
+			await textarea.fill('my precious local draft')
+
+			// Admin edits BOTH the title and the description remotely.
+			await apiPatch(`/cards/${state.cardId}`, { title: 'Modal card v3' })
+			await apiPatch(`/cards/${state.cardId}`, { description: 'remote description v2' })
+
+			// The title updating proves the remote change reached the open modal
+			// (card detail refetched) while the editor was dirty...
+			await expect(page.locator('.card-modal__title')).toHaveText('Modal card v3', { timeout: 15_000 })
+
+			// ...and the dirty draft survived it, byte for byte.
+			await expect(textarea).toBeVisible()
+			await expect(textarea).toHaveValue('my precious local draft')
+
+			// The tester's save then wins (deliberate last-writer-wins, same as any
+			// two-user edit): the draft is what gets persisted and rendered.
+			await page.locator('.card-modal__desc-actions button', { hasText: 'Save' }).click()
+			await expect(page.locator('.card-modal__desc-rendered')).toContainText('my precious local draft', { timeout: 15_000 })
+		} finally {
+			await testerCtx.close()
+		}
+	})
+})


### PR DESCRIPTION
Fixes the user-reported freshness bugs: stale My Tasks after self-assignment, card edits not propagating to other open tabs, and My Work pages not updating while open.

## What was wrong
- **My Cards / My Reviews / Inbox** are separate TanStack Query caches from the per-board cache. No membership-changing mutation ever invalidated them, and the app-wide nav badges keep the queries permanently active, so the global 30s staleTime suppressed the refetch on navigation — assign yourself, open My Tasks, see pre-assignment data until a hard reload.
- **The card modal's detail queries** (description, comments, checklist, links, attachments, time entries, activity) were never invalidated by the delta/push sync — board tiles updated, an open modal in another tab did not.
- Nothing revalidated the my-work pages **while sitting on them** when other users acted.

## The fix (frontend only — reuses the existing delta/notify_push plumbing, no new server machinery)
- `MY_WORK_QUERY_KEYS` family + `invalidateMyWork()` helper, wired into the settle phase of every membership-changing mutation (assign/unassign, review request/withdraw/verdict, watch/unwatch, done/archive/delete/restore, move-to-board, bulk apply); `refetchOnMount: 'always'` on the three page queries.
- After each applied board delta, the touched cards' detail queries are invalidated (active-only, O(open modals)); resync paths invalidate all card-detail queries. Dirty-editor protection: local draft refs are untouched by refetches, and invalidation defers while any mutation is in flight. New `onBoardChangesApplied` signal exported for reuse.
- 60s visible-tab polling on the three my-work queries (matches the board safety-net cadence; zero traffic when hidden) + a throttled push/delta fast path with visibility and in-flight-mutation guards.

## Tests
Three new Playwright specs (two-context realtime modal incl. draft-survives-remote-edit; my-work freshness on navigation; my-work live-update with the push path AND the pure polling path — the latter is what CI exercises), plus a 100+-test regression sweep across my-work/realtime/delta/board specs, all green. `npm run build` clean; no PHP touched.

Board cards: #3766, #3767, #3768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)