### PR TITLE
chore: add GitHub Sponsors button (FUNDING.yml)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Shows a "Sponsor" button on the repo and enables Sponsor links in PRs.
+# Only GitHub Sponsors is set up for now; add other platforms here if enabled.
+github: aktasfatih


### PR DESCRIPTION
Adds `.github/FUNDING.yml` pointing at the now-live `github.com/sponsors/aktasfatih`, which renders the **Sponsor** button on the repo header and enables sponsor links in the PR sidebar.

Config-only, single file. Note: GitHub only renders the button once this lands on the default branch (`main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)