### PR TITLE
feat(estimate): sort & filter by estimate, asc/desc, safe scale change

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Keep BOTH sides' entries when two branches touch the changelog instead of
+# raising a merge conflict. The `union` driver concatenates the conflicting
+# hunks, so parallel PRs each adding lines under `## [Unreleased]` merge cleanly.
+# Order within a section isn't significant, and the only artefact is the rare
+# duplicate `### Added/Changed/Fixed` header — trivially tidied when the
+# `[Unreleased]` block is renamed at release time. GitHub honours this on merge.
+CHANGELOG.md merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,14 @@ jobs:
 
   e2e:
     runs-on: kanso-runners
-    # Boots a full Nextcloud + runs ~170 serial tests (workers:1, retries:1).
+    # Boots a full Nextcloud + runs the serial spec suite (workers:1, retries:1).
     # The self-hosted runner is ~4-5x slower than a dev box (~28s/test observed),
-    # so the serial suite needs ~85 min of test time + ~8 min setup. Cap at 120
-    # to leave comfortable margin (still bounds a hung stack under the 6h default).
-    # If this ever needs to be faster, shard the specs across parallel jobs
-    # rather than raising per-Nextcloud worker count (specs share one instance).
-    timeout-minutes: 120
+    # and the suite keeps growing, so runs were pushing against the old 120-min
+    # cap. Raised to 180 to restore comfortable margin (still bounds a hung stack
+    # well under the 6h default). If this ever needs to be faster, shard the specs
+    # across parallel jobs rather than raising the per-Nextcloud worker count
+    # (specs share one instance).
+    timeout-minutes: 180
     env:
       # Realtime push isn't needed for the UI specs (they poll); skip it so a
       # flaky appstore release can't fail the boot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sort a board by estimate.** The display-sort menu gains an *Estimate* option
+  (shown on boards that have an estimation scale) — cards order by their position
+  in the board's scale (so `13 > 8 > … > 2` and `XL > … > XS`, not string order),
+  with unestimated cards last. View-only, per-user, like the other sorts.
+- **Ascending / descending sort direction.** Every sort (Priority, Due date,
+  Title, Estimate) now has an Ascending/Descending toggle in the sort menu, with a
+  ↑/↓ indicator on the toolbar. Selecting a sort starts in its natural direction
+  (urgent-first, soonest-first, A→Z, biggest-first); missing values (no due date /
+  no estimate) always sort last regardless of direction. Persisted per user.
+- **Filter a board by estimate.** The filter bar gains an *Estimate* facet: pick
+  one or more scale tokens, or *Unestimated*, to narrow the board. Combines with
+  the other filter dimensions and round-trips through the shareable URL and saved
+  views.
+- **"Default (no filter)" entry in the Saved-filters menu.** A one-click way back
+  to the unfiltered board — an easy exit from an applied saved view or any ad-hoc
+  filter.
+
 ### Fixed
 
+- **Sort / view / swimlane menus now show the active option and switch on one
+  click.** The radio menus (Sort, board view mode, Swimlanes) previously rendered
+  nothing as selected when reopened and needed a double click to change — they now
+  highlight the current choice and switch with a single click.
+- **Changing a board's estimation scale no longer strands card estimates.**
+  Switching scales (or turning estimation off) now clears any card estimate that
+  doesn't fit the new scale — previously an off-scale value (e.g. a Fibonacci `8`
+  after a switch to T-shirt) lingered on the card and could neither be re-selected
+  nor cleared. The board settings dialog warns how many cards are affected and
+  asks to confirm before clearing.
 - **My Work pages stay current without a manual reload.** My Tasks, My Reviews
   and Inbox now refresh when you change something (e.g. assign yourself a card),
   when you navigate to them, and on a live poll while the page is open —

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -1025,6 +1025,55 @@ class CardMapper extends QBMapper {
 		return $rows;
 	}
 
+	/**
+	 * Every non-deleted card on a board that carries an estimate, as (id, token)
+	 * pairs. Used by a board scale change to find estimates that no longer fit the
+	 * new scale so they can be cleared {@see self::clearEstimatesByIds()}. NOT
+	 * viewer-scoped and NOT archived/template-filtered on purpose: a scale change
+	 * is a board-wide data-integrity fix that must reach every stranded token, not
+	 * only the ones the acting manager can currently see.
+	 *
+	 * @return list<array{id: int, estimate: string}>
+	 * @throws Exception
+	 */
+	public function findEstimatedCards(int $boardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'estimate')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->isNotNull('estimate'));
+
+		$result = $qb->executeQuery();
+		$rows = [];
+		while (($row = $result->fetch()) !== false) {
+			$rows[] = ['id' => (int)$row['id'], 'estimate' => (string)$row['estimate']];
+		}
+		$result->closeCursor();
+
+		return $rows;
+	}
+
+	/**
+	 * Clears (sets NULL) the estimate of the given cards in one UPDATE and bumps
+	 * their last_modified. No-op for an empty id list. The caller records a
+	 * per-card change row for delta-sync/realtime.
+	 *
+	 * @param list<int> $cardIds
+	 * @throws Exception
+	 */
+	public function clearEstimatesByIds(array $cardIds): void {
+		if ($cardIds === []) {
+			return;
+		}
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			->set('estimate', $qb->createNamedParameter(null))
+			->set('last_modified', $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->in('id', $qb->createNamedParameter($cardIds, IQueryBuilder::PARAM_INT_ARRAY)));
+		$qb->executeStatement();
+	}
+
 	// ── Board-id-set variants (boards-list per-board signal) ──────────────────
 	//
 	// These mirror the single-board aggregates above but group by `board_id` over

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -204,9 +204,16 @@ class BoardService {
 		if ($archived !== null) {
 			$board->setArchived($archived);
 		}
+		// A scale change may strand card estimates that no longer fit the new
+		// scale; capture the transition so we can clear them below (after the
+		// board row is persisted).
+		$scaleChangedTo = null;
 		if ($estimateScale !== null) {
 			if (!EstimateScale::isValidScale($estimateScale)) {
 				throw new InvalidInputException('Unknown estimate scale');
+			}
+			if ($estimateScale !== $board->getEstimateScale()) {
+				$scaleChangedTo = $estimateScale;
 			}
 			$board->setEstimateScale($estimateScale);
 		}
@@ -236,6 +243,33 @@ class BoardService {
 		$now = time();
 		$board->setLastModified($now);
 		$board = $this->boardMapper->update($board);
+
+		// Clear card estimates stranded by a scale change (e.g. fibonacci "8" after
+		// a switch to t-shirt, or every estimate when switching to 'none'). Each
+		// cleared card gets a change row so delta-sync/realtime clients patch their
+		// cache; the single board push below (notify with push=true) covers the
+		// whole batch, so these are recorded WITHOUT their own push.
+		if ($scaleChangedTo !== null) {
+			$staleIds = [];
+			foreach ($this->cardMapper->findEstimatedCards($id) as $row) {
+				if (!EstimateScale::allows($scaleChangedTo, $row['estimate'])) {
+					$staleIds[] = $row['id'];
+				}
+			}
+			if ($staleIds !== []) {
+				$this->cardMapper->clearEstimatesByIds($staleIds);
+				foreach ($staleIds as $cardId) {
+					$this->changeNotifier->recordChange(
+						$id,
+						Change::ENTITY_CARD,
+						$cardId,
+						Change::ACTION_UPDATE,
+						$uid,
+						Change::VERB_UPDATED
+					);
+				}
+			}
+		}
 
 		$this->changeNotifier->notify(
 			$id,

--- a/src/components/BoardFilterBar.vue
+++ b/src/components/BoardFilterBar.vue
@@ -64,6 +64,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:model-value="state.types.has(tp.value)"
 				@update:model-value="toggleSet('types', tp.value)">{{ t('kanso', tp.label) }}</NcActionCheckbox>
 
+			<!-- Estimate (OR within) - scale tokens + the Unestimated sentinel.
+			     Only shown when the board has an estimation scale set. -->
+			<template v-if="estimateTokens.length">
+				<NcActionCaption :name="t('kanso', 'Estimate')" />
+				<NcActionCheckbox
+					:model-value="state.estimates.has(UNESTIMATED)"
+					@update:model-value="toggleSet('estimates', UNESTIMATED)">{{ t('kanso', 'Unestimated') }}</NcActionCheckbox>
+				<NcActionCheckbox
+					v-for="token in estimateTokens"
+					:key="'e-' + token"
+					:model-value="state.estimates.has(token)"
+					@update:model-value="toggleSet('estimates', token)">{{ token }}</NcActionCheckbox>
+			</template>
+
 			<!-- Due (single-select radio; a re-click of the active one clears it) -->
 			<NcActionCaption :name="t('kanso', 'Due date')" />
 			<NcActionRadio
@@ -116,6 +130,21 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				<BookmarkIcon v-if="activeSavedName" :size="20" />
 				<BookmarkOutlineIcon v-else :size="20" />
 			</template>
+
+			<!-- Default view: always present so there's a one-click way back to the
+			     unfiltered board — both out of a saved view and out of any ad-hoc
+			     filter. Highlighted when no filter is active (i.e. we ARE default). -->
+			<NcActionCaption :name="t('kanso', 'Views')" />
+			<NcActionButton
+				class="board-filter-bar__saved-item"
+				:class="{ 'board-filter-bar__saved-item--active': !activeSavedName && count === 0 }"
+				@click="clearAll">
+				<template #icon>
+					<CheckIcon v-if="!activeSavedName && count === 0" :size="20" />
+					<FilterVariantRemoveIcon v-else :size="20" />
+				</template>
+				{{ t('kanso', 'Default (no filter)') }}
+			</NcActionButton>
 
 			<template v-if="savedFilters.length">
 				<NcActionCaption :name="t('kanso', 'Saved filters')" />
@@ -181,8 +210,10 @@ import DeleteOutlineIcon from 'vue-material-design-icons/DeleteOutline.vue'
 import ContentSaveOutlineIcon from 'vue-material-design-icons/ContentSaveOutline.vue'
 import { PRIORITY_LEVELS } from '../composables/usePriority.js'
 import { CARD_TYPES } from '../composables/useCardType.js'
+import { scaleTokens } from '../services/estimateScales.js'
 import {
 	UNASSIGNED,
+	UNESTIMATED,
 	DUE_OPTIONS,
 	DONE_OPTIONS,
 	WAITING_OPTIONS,
@@ -200,6 +231,8 @@ const props = defineProps({
 	savedFilters: { type: Array, default: () => [] },
 	/** Name of the saved view the current filter equals, or '' if none. */
 	activeSavedName: { type: String, default: '' },
+	/** The board's estimation scale key (e.g. 'fibonacci'); 'none' hides the facet. */
+	estimateScale: { type: String, default: 'none' },
 })
 
 const emit = defineEmits(['save', 'apply-saved', 'delete-saved'])
@@ -212,6 +245,9 @@ const priorityLevels = computed(() => PRIORITY_LEVELS.filter((l) => l.value > 0)
 // Built-in card types facet (#3402). "None" is expressed by leaving the type
 // dimension unfiltered - no explicit "None" checkbox (mirrors the priority facet).
 const cardTypes = CARD_TYPES
+
+// Estimate facet tokens for the board's scale (empty ⇒ facet hidden).
+const estimateTokens = computed(() => scaleTokens(props.estimateScale))
 
 const count = useFilterCount(props.state)
 
@@ -235,6 +271,7 @@ function clearAll() {
 	props.state.assignees.clear()
 	props.state.priorities.clear()
 	props.state.types.clear()
+	props.state.estimates.clear()
 	props.state.due = null
 	props.state.done = null
 	props.state.waiting = null

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -1030,6 +1030,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						</label>
 						<select
 							:id="`estimate-scale-${boardId}`"
+							:key="`estimate-scale-${scaleSelectKey}`"
 							class="workflow__select"
 							:disabled="!canManage || estimateScaleSaving"
 							:value="currentEstimateScale"
@@ -2040,6 +2041,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
+import { showConfirmation } from '@nextcloud/dialogs'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
@@ -2078,7 +2080,7 @@ import { useRecurRules } from '../composables/useRecurRules.js'
 import { useAutomationRules } from '../composables/useAutomationRules.js'
 import { cssColor, LABEL_COLOR_PRESETS } from '../services/color.js'
 import { BACKGROUND_PRESETS } from '../services/backgrounds.js'
-import { getScaleOptions } from '../services/estimateScales.js'
+import { getScaleOptions, scaleTokens } from '../services/estimateScales.js'
 import {
 	fetchWebhookConfig,
 	rotateWebhookSecret as apiRotateWebhookSecret,
@@ -2574,14 +2576,56 @@ const currentEstimateScale = computed(
 
 const estimateScaleSaving = ref(false)
 const estimateScaleError = ref('')
+// Bumping this remounts the native <select> so a cancelled change snaps its
+// displayed option back to the persisted scale (a one-way :value bind alone
+// won't reset the DOM when the reactive value is unchanged).
+const scaleSelectKey = ref(0)
+
+/**
+ * How many live cards carry an estimate that the target scale would reject
+ * (and therefore get cleared). Reads the board's card summaries already in
+ * props — no extra request. Switching to 'none' rejects every estimate.
+ * @param {string} newScale
+ * @return {number}
+ */
+function countOffScaleEstimates(newScale) {
+	const allowed = new Set(scaleTokens(newScale))
+	return props.cards.filter(
+		(c) => c && !c.archived && c.estimate && !allowed.has(c.estimate),
+	).length
+}
 
 async function onEstimateScaleChange(newScale) {
 	estimateScaleError.value = ''
+	if (newScale === currentEstimateScale.value) return
+
+	// Warn before a scale change that would strand existing estimates: the
+	// backend clears them, so make the data loss explicit and reversible.
+	const affected = countOffScaleEstimates(newScale)
+	if (affected > 0) {
+		const ok = await showConfirmation({
+			name: t('kanso', 'Change estimation scale?'),
+			text: t(
+				'kanso',
+				'{count} card(s) have an estimate that does not fit the new scale and will be cleared. This cannot be undone.',
+				{ count: affected },
+			),
+			labelConfirm: t('kanso', 'Change and clear'),
+			labelReject: t('kanso', 'Cancel'),
+			severity: 'warning',
+		})
+		if (!ok) {
+			scaleSelectKey.value++ // revert the <select> to the persisted scale
+			return
+		}
+	}
+
 	estimateScaleSaving.value = true
 	try {
 		await updateBoard.mutateAsync({ estimateScale: newScale })
 	} catch (err) {
 		estimateScaleError.value = err?.response?.data?.error || t('kanso', 'Failed to update estimation scale.')
+		scaleSelectKey.value++ // a failed save shouldn't leave the wrong option shown
 	} finally {
 		estimateScaleSaving.value = false
 	}

--- a/src/composables/useBoardFilters.js
+++ b/src/composables/useBoardFilters.js
@@ -18,6 +18,11 @@
  *   - types:       Set<string>  → OR within (built-in card type: bug/feature/
  *                                 task/chore). '' (none) is expressed by leaving
  *                                 the dimension unfiltered (#3402).
+ *   - estimates:   Set<string>  → OR within (raw scale token), plus the sentinel
+ *                                 '__none__' which matches cards with NO estimate.
+ *                                 Tokens are board-scale-dependent, so they are not
+ *                                 validated here — a stale token simply matches
+ *                                 nothing.
  *   - due:         string|null  → one of 'overdue' | 'week' | 'none' | null.
  *   - done:        string|null  → 'done' | 'open' | null (tri-state).
  *   - waiting:     string|null  → 'waiting' | 'not_waiting' | null (tri-state)
@@ -37,6 +42,9 @@ import { reactive, computed } from 'vue'
 
 /** Sentinel assignee id meaning "no assignee". */
 export const UNASSIGNED = '__none__'
+
+/** Sentinel estimate token meaning "no estimate". */
+export const UNESTIMATED = '__none__'
 
 /** Built-in card types selectable as a filter facet (#3402). */
 export const FILTERABLE_TYPES = ['bug', 'feature', 'task', 'chore']
@@ -73,6 +81,7 @@ export function createFilterState() {
 		assignees: new Set(),
 		priorities: new Set(),
 		types: new Set(),
+		estimates: new Set(),
 		due: null,
 		done: null,
 		waiting: null,
@@ -91,6 +100,7 @@ export function serializeFilter(s) {
 	if (s.assignees.size) out.assignees = [...s.assignees].sort()
 	if (s.priorities.size) out.priorities = [...s.priorities].sort((a, b) => a - b)
 	if (s.types.size) out.types = [...s.types].sort()
+	if (s.estimates.size) out.estimates = [...s.estimates].sort()
 	if (s.due) out.due = s.due
 	if (s.done) out.done = s.done
 	if (s.waiting) out.waiting = s.waiting
@@ -109,6 +119,7 @@ export function applyFilter(state, obj) {
 	state.assignees.clear()
 	state.priorities.clear()
 	state.types.clear()
+	state.estimates.clear()
 	state.due = null
 	state.done = null
 	state.waiting = null
@@ -135,6 +146,14 @@ export function applyFilter(state, obj) {
 			if (FILTERABLE_TYPES.includes(tp)) state.types.add(tp)
 		}
 	}
+	if (Array.isArray(obj.estimates)) {
+		// Tokens are board-scale-dependent (validated against the live scale by
+		// the UI, not here); accept any non-empty string, incl. the UNESTIMATED
+		// sentinel. A stale token just matches nothing.
+		for (const tok of obj.estimates) {
+			if (typeof tok === 'string' && tok) state.estimates.add(tok)
+		}
+	}
 	if (DUE_OPTIONS.some((o) => o.value === obj.due)) state.due = obj.due
 	if (DONE_OPTIONS.some((o) => o.value === obj.done)) state.done = obj.done
 	if (WAITING_OPTIONS.some((o) => o.value === obj.waiting)) state.waiting = obj.waiting
@@ -155,6 +174,7 @@ export function filterToQuery(ser) {
 	if (ser.assignees?.length) q.fa = ser.assignees.join(',')
 	if (ser.priorities?.length) q.fp = ser.priorities.join(',')
 	if (ser.types?.length) q.ft = ser.types.join(',')
+	if (ser.estimates?.length) q.fe = ser.estimates.join(',')
 	if (ser.due) q.fd = ser.due
 	if (ser.done) q.fs = ser.done
 	if (ser.waiting) q.fw = ser.waiting
@@ -175,6 +195,7 @@ export function queryToFilter(query) {
 	if (query.fa != null) out.assignees = csv(query.fa)
 	if (query.fp != null) out.priorities = csv(query.fp)
 	if (query.ft != null) out.types = csv(query.ft)
+	if (query.fe != null) out.estimates = csv(query.fe)
 	if (query.fd != null) out.due = String(first(query.fd))
 	if (query.fs != null) out.done = String(first(query.fs))
 	if (query.fw != null) out.waiting = String(first(query.fw))
@@ -190,6 +211,7 @@ export function filterIsEmpty(ser) {
 		&& !ser.assignees?.length
 		&& !ser.priorities?.length
 		&& !ser.types?.length
+		&& !ser.estimates?.length
 		&& !ser.due
 		&& !ser.done
 		&& !ser.waiting
@@ -210,6 +232,7 @@ export function makePredicate(s, now = Date.now()) {
 	const hasAssignees = s.assignees.size > 0
 	const hasPriorities = s.priorities.size > 0
 	const hasTypes = s.types.size > 0
+	const hasEstimates = s.estimates.size > 0
 	const due = s.due
 	const done = s.done
 	const waiting = s.waiting
@@ -241,6 +264,15 @@ export function makePredicate(s, now = Date.now()) {
 		// A typeless card ('') never matches a type facet.
 		if (hasTypes) {
 			if (!s.types.has(card.type ?? '')) return false
+		}
+		// Estimates (OR within): match the card's raw token, or the UNESTIMATED
+		// sentinel for cards with no estimate. An off-scale legacy token still
+		// matches if explicitly selected.
+		if (hasEstimates) {
+			const est = card.estimate ?? ''
+			const matchesToken = est !== '' && s.estimates.has(est)
+			const matchesNone = est === '' && s.estimates.has(UNESTIMATED)
+			if (!matchesToken && !matchesNone) return false
 		}
 		// Due (single-select): overdue / this-week / no-due-date.
 		if (due) {
@@ -281,6 +313,7 @@ export function useFilterCount(s) {
 		+ s.assignees.size
 		+ s.priorities.size
 		+ s.types.size
+		+ s.estimates.size
 		+ (s.due ? 1 : 0)
 		+ (s.done ? 1 : 0)
 		+ (s.waiting ? 1 : 0),

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -43,21 +43,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<ViewColumnIcon v-else :size="20" />
 				</template>
 				<NcActionRadio
-					:model-value="viewMode === 'board'"
+					:model-value="viewMode"
+					value="board"
 					name="kanso-viewmode"
-					@change="setViewMode('board')">
+					@update:model-value="setViewMode">
 					{{ t('kanso', 'Board') }}
 				</NcActionRadio>
 				<NcActionRadio
-					:model-value="viewMode === 'list'"
+					:model-value="viewMode"
+					value="list"
 					name="kanso-viewmode"
-					@change="setViewMode('list')">
+					@update:model-value="setViewMode">
 					{{ t('kanso', 'List') }}
 				</NcActionRadio>
 				<NcActionRadio
-					:model-value="viewMode === 'timeline'"
+					:model-value="viewMode"
+					value="timeline"
 					name="kanso-viewmode"
-					@change="setViewMode('timeline')">
+					@update:model-value="setViewMode">
 					{{ t('kanso', 'Timeline') }}
 				</NcActionRadio>
 			</NcActions>
@@ -66,22 +69,45 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<NcActions
 				v-if="boardData"
 				class="board-view__sort-menu"
-				:menu-name="t('kanso', 'Sort: {mode}', { mode: sortModeLabel })">
+				:menu-name="t('kanso', 'Sort: {mode}', { mode: sortModeMenuName })">
 				<template #icon>
 					<SortIcon :size="20" />
 				</template>
-				<NcActionRadio :model-value="sortMode === 'manual'" name="kanso-sort" @change="setSortMode('manual')">
+				<!-- Radio GROUP idiom: model-value is the group's current value and each
+				     radio carries its own `value` (checked = model === value). This
+				     reflects the active mode when the menu reopens, and switches on a
+				     single click via @update:model-value (a boolean-per-radio +
+				     @change binding shows nothing selected and needs a double click). -->
+				<NcActionRadio :model-value="sortMode" value="manual" name="kanso-sort" @update:model-value="setSortMode">
 					{{ t('kanso', 'Manual') }}
 				</NcActionRadio>
-				<NcActionRadio :model-value="sortMode === 'priority'" name="kanso-sort" @change="setSortMode('priority')">
+				<NcActionRadio :model-value="sortMode" value="priority" name="kanso-sort" @update:model-value="setSortMode">
 					{{ t('kanso', 'Priority') }}
 				</NcActionRadio>
-				<NcActionRadio :model-value="sortMode === 'due'" name="kanso-sort" @change="setSortMode('due')">
+				<NcActionRadio :model-value="sortMode" value="due" name="kanso-sort" @update:model-value="setSortMode">
 					{{ t('kanso', 'Due date') }}
 				</NcActionRadio>
-				<NcActionRadio :model-value="sortMode === 'title'" name="kanso-sort" @change="setSortMode('title')">
+				<NcActionRadio :model-value="sortMode" value="title" name="kanso-sort" @update:model-value="setSortMode">
 					{{ t('kanso', 'Title') }}
 				</NcActionRadio>
+				<NcActionRadio
+					v-if="boardData?.board?.estimateScale && boardData.board.estimateScale !== 'none'"
+					:model-value="sortMode"
+					value="estimate"
+					name="kanso-sort"
+					@update:model-value="setSortMode">
+					{{ t('kanso', 'Estimate') }}
+				</NcActionRadio>
+				<!-- Direction toggle — hidden for Manual (which has no direction). -->
+				<template v-if="sortMode !== 'manual'">
+					<NcActionSeparator />
+					<NcActionRadio :model-value="sortDir" value="asc" name="kanso-sort-dir" @update:model-value="setSortDir">
+						{{ t('kanso', 'Ascending') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="sortDir" value="desc" name="kanso-sort-dir" @update:model-value="setSortDir">
+						{{ t('kanso', 'Descending') }}
+					</NcActionRadio>
+				</template>
 			</NcActions>
 
 			<!-- Compact density toggle (#3415) — a per-user, view-only switch that
@@ -133,6 +159,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:participants="participants.data.value ?? []"
 				:saved-filters="savedFilters"
 				:active-saved-name="activeSavedName"
+				:estimate-scale="boardData?.board?.estimateScale ?? 'none'"
 				@save="handleSaveFilter"
 				@apply-saved="handleApplySavedFilter"
 				@delete-saved="handleDeleteSavedFilter" />
@@ -161,27 +188,31 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				<template v-if="viewMode === 'board'">
 					<NcActionCaption :name="t('kanso', 'Swimlanes')" />
 					<NcActionRadio
-						:model-value="swimlaneMode === 'none'"
+						:model-value="swimlaneMode"
+						value="none"
 						name="kanso-swimlane"
-						@change="setSwimlaneMode('none')">
+						@update:model-value="setSwimlaneMode">
 						{{ t('kanso', 'No swimlanes') }}
 					</NcActionRadio>
 					<NcActionRadio
-						:model-value="swimlaneMode === 'assignee'"
+						:model-value="swimlaneMode"
+						value="assignee"
 						name="kanso-swimlane"
-						@change="setSwimlaneMode('assignee')">
+						@update:model-value="setSwimlaneMode">
 						{{ t('kanso', 'Group by assignee') }}
 					</NcActionRadio>
 					<NcActionRadio
-						:model-value="swimlaneMode === 'label'"
+						:model-value="swimlaneMode"
+						value="label"
 						name="kanso-swimlane"
-						@change="setSwimlaneMode('label')">
+						@update:model-value="setSwimlaneMode">
 						{{ t('kanso', 'Group by label') }}
 					</NcActionRadio>
 					<NcActionRadio
-						:model-value="swimlaneMode === 'priority'"
+						:model-value="swimlaneMode"
+						value="priority"
 						name="kanso-swimlane"
-						@change="setSwimlaneMode('priority')">
+						@update:model-value="setSwimlaneMode">
 						{{ t('kanso', 'Group by priority') }}
 					</NcActionRadio>
 					<NcActionSeparator />
@@ -608,6 +639,7 @@ import { useCardMove } from '../composables/useCardMove.js'
 import { provideAnnouncer } from '../composables/useAnnouncer.js'
 import { useQueryClient } from '@tanstack/vue-query'
 import { cssColor } from '../services/color.js'
+import { scaleTokens } from '../services/estimateScales.js'
 import { backgroundCss } from '../services/backgrounds.js'
 import { initial, between, after, before } from '../services/sortKey.js'
 import { updateCard as apiUpdateCard, moveStack as apiMoveStack, fetchCardTemplates as apiFetchCardTemplates, createCardFromTemplate as apiCreateCardFromTemplate, getSettings, updateSettings } from '../services/api.js'
@@ -652,16 +684,36 @@ const viewModeLabel = computed(() => ({
 // rewrites sort keys; 'manual' is the persisted fractional order. Persisted per
 // board per user. While a non-manual sort is active, card drag-reorder is
 // suppressed (see the card onDrop guard) so manual order is preserved.
-const SORT_MODES = ['manual', 'priority', 'due', 'title']
+const SORT_MODES = ['manual', 'priority', 'due', 'title', 'estimate']
+// Each non-manual mode has a "natural" default direction (the intuitive first
+// orientation): priority urgent-first, due soonest-first, title A→Z, estimate
+// biggest-first. Selecting a mode resets to its natural direction; the user can
+// then flip it. 'manual' has no direction (it IS the persisted fractional order).
+const NATURAL_SORT_DIR = { priority: 'desc', due: 'asc', title: 'asc', estimate: 'desc' }
 const sortMode = ref('manual')
+const sortDir = ref('asc')
 try {
 	const saved = localStorage.getItem(`kanso.sortMode.${props.id}`)
 	if (saved && SORT_MODES.includes(saved)) sortMode.value = saved
 } catch (e) { /* default to manual */ }
+try {
+	const savedDir = localStorage.getItem(`kanso.sortDir.${props.id}`)
+	sortDir.value = (savedDir === 'asc' || savedDir === 'desc')
+		? savedDir
+		: (NATURAL_SORT_DIR[sortMode.value] ?? 'asc')
+} catch (e) { sortDir.value = NATURAL_SORT_DIR[sortMode.value] ?? 'asc' }
 function setSortMode(mode) {
 	sortMode.value = mode
 	try {
 		localStorage.setItem(`kanso.sortMode.${props.id}`, mode)
+	} catch (e) { /* ignore persistence failure */ }
+	// Selecting a mode resets to its natural direction (Title → A→Z, etc.).
+	if (mode !== 'manual') setSortDir(NATURAL_SORT_DIR[mode] ?? 'asc')
+}
+function setSortDir(dir) {
+	sortDir.value = dir
+	try {
+		localStorage.setItem(`kanso.sortDir.${props.id}`, dir)
 	} catch (e) { /* ignore persistence failure */ }
 }
 const sortModeLabel = computed(() => ({
@@ -669,7 +721,13 @@ const sortModeLabel = computed(() => ({
 	priority: t('kanso', 'Priority'),
 	due: t('kanso', 'Due date'),
 	title: t('kanso', 'Title'),
+	estimate: t('kanso', 'Estimate'),
 }[sortMode.value] ?? t('kanso', 'Manual')))
+// Menu-name suffix: an arrow so the active direction is visible on the toolbar
+// without opening the menu. Manual has no direction.
+const sortModeMenuName = computed(() => sortMode.value === 'manual'
+	? sortModeLabel.value
+	: `${sortModeLabel.value} ${sortDir.value === 'asc' ? '↑' : '↓'}`)
 
 // Swimlanes - client-side grouping of the Board view into horizontal lanes by
 // assignee / label / priority (#3406). Purely a view over the board summary
@@ -765,21 +823,55 @@ function expandStack(stackId) {
  */
 function sortCards(cards) {
 	const arr = [...cards]
+	if (sortMode.value === 'manual') return arr.sort(bySortKey)
+
+	// Each mode maps a card to a comparable value, or null when the field is
+	// "missing" (no due date / no estimate). Missing values ALWAYS sort last,
+	// independent of direction; present values flip with sortDir. `compare` is
+	// always ascending — sortDir applies the sign. Ties fall back to the
+	// fractional sort key.
+	let valueOf
+	let compare
 	if (sortMode.value === 'priority') {
-		return arr.sort((a, b) => (Number(b.priority ?? 0) - Number(a.priority ?? 0)) || bySortKey(a, b))
-	}
-	if (sortMode.value === 'due') {
-		const due = (c) => {
-			if (!c.duedate) return Infinity
+		// 0 ("no priority") is a real low value here, not "missing".
+		valueOf = (c) => Number(c.priority ?? 0)
+		compare = (a, b) => a - b
+	} else if (sortMode.value === 'due') {
+		valueOf = (c) => {
+			if (!c.duedate) return null
 			const t2 = new Date(c.duedate).getTime()
-			return Number.isNaN(t2) ? Infinity : t2
+			return Number.isNaN(t2) ? null : t2
 		}
-		return arr.sort((a, b) => (due(a) - due(b)) || bySortKey(a, b))
+		compare = (a, b) => a - b
+	} else if (sortMode.value === 'title') {
+		valueOf = (c) => String(c.title ?? '')
+		compare = (a, b) => a.localeCompare(b)
+	} else if (sortMode.value === 'estimate') {
+		// Rank by ordinal position in the board's scale (NOT string value: "13"
+		// vs "2" mis-orders, and XS…XL has no numeric value). Unestimated /
+		// off-scale tokens are "missing" → sorted last in both directions.
+		const tokens = scaleTokens(boardData.value?.board?.estimateScale ?? 'none')
+		valueOf = (c) => {
+			const i = c.estimate ? tokens.indexOf(c.estimate) : -1
+			return i === -1 ? null : i
+		}
+		compare = (a, b) => a - b
+	} else {
+		return arr.sort(bySortKey)
 	}
-	if (sortMode.value === 'title') {
-		return arr.sort((a, b) => String(a.title).localeCompare(String(b.title)) || bySortKey(a, b))
-	}
-	return arr.sort(bySortKey)
+
+	const mult = sortDir.value === 'asc' ? 1 : -1
+	return arr.sort((a, b) => {
+		const va = valueOf(a)
+		const vb = valueOf(b)
+		const ma = va === null
+		const mb = vb === null
+		if (ma || mb) {
+			if (ma && mb) return bySortKey(a, b)
+			return ma ? 1 : -1 // missing always last, regardless of direction
+		}
+		return (compare(va, vb) * mult) || bySortKey(a, b)
+	})
 }
 const { data: boardData, isLoading, isError, error: boardError, refetch: boardRefetch, createStack, createCard, updateStack, deleteStack, restoreStack } = useBoard(boardId)
 

--- a/tests/e2e/board-filters.spec.js
+++ b/tests/e2e/board-filters.spec.js
@@ -151,4 +151,25 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		await expect(page.locator('.card-tile__title', { hasText: 'Overdue Only Card' })).toHaveCount(0)
 		await expect(page.locator('.card-tile__title', { hasText: 'Plain Card' })).toHaveCount(0)
 	})
+
+	test('the "Default (no filter)" view exits a saved view back to unfiltered', async ({ page }) => {
+		await ncLogin(page)
+		// Land on the board with the saved view active straight from the URL.
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}?fl=${state.labelId}&fd=overdue`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		// Filtered: only the Match Card is shown.
+		await expect(page.locator('.card-tile__title', { hasText: 'Match Card' })).toHaveCount(1)
+		await expect(page.locator('.card-tile__title', { hasText: 'Plain Card' })).toHaveCount(0)
+
+		// Open the Saved menu and pick "Default (no filter)".
+		await page.locator('.board-filter-bar__saved button').first().click()
+		await page.locator('.action-button__text', { hasText: 'Default (no filter)' }).click()
+		await page.keyboard.press('Escape')
+
+		// Back to unfiltered: every card returns and the URL filter params are gone.
+		await expect(page.locator('.card-tile__title', { hasText: 'Plain Card' })).toHaveCount(1)
+		await expect(page.locator('.card-tile__title', { hasText: 'Overdue Only Card' })).toHaveCount(1)
+		await expect.poll(() => page.url()).not.toContain('fl=')
+		expect(page.url()).not.toContain('fd=')
+	})
 })

--- a/tests/e2e/estimations.spec.js
+++ b/tests/e2e/estimations.spec.js
@@ -105,7 +105,11 @@ test.describe('Card estimations (#3443)', () => {
 		await expect(tile.locator('.card-tile__estimate')).toHaveText('8', { timeout: 8_000 })
 	})
 
-	test('the board settings Workflow tab switches the scale', async ({ page }) => {
+	test('switching scale warns and clears estimates that no longer fit', async ({ page }) => {
+		// Deterministic start: fibonacci board with an off-scale-for-tshirt token.
+		await api('PATCH', `/boards/${state.boardId}`, { estimateScale: 'fibonacci' })
+		await api('PATCH', `/cards/${state.cardId}`, { estimate: '8' })
+
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		// Board settings now lives in the consolidated ⋯ More overflow menu.
@@ -117,7 +121,127 @@ test.describe('Card estimations (#3443)', () => {
 		await expect(select).toBeVisible({ timeout: 8_000 })
 		await select.selectOption('tshirt')
 
+		// The confirmation names the affected count; confirm the destructive change.
+		await expect(page.getByText(/does not fit the new scale and will be cleared/i))
+			.toBeVisible({ timeout: 8_000 })
+		await page.getByRole('button', { name: 'Change and clear' }).click()
+
 		await expect.poll(async () => (await api('GET', `/boards/${state.boardId}`)).board.estimateScale, { timeout: 8_000 })
 			.toBe('tshirt')
+		// The off-scale '8' was cleared server-side by the scale change.
+		await expect.poll(async () => (await api('GET', `/cards/${state.cardId}`)).estimate, { timeout: 8_000 })
+			.toBeNull()
+	})
+
+	test('cancelling the scale-change confirmation keeps scale and estimates', async ({ page }) => {
+		// Board is tshirt from the previous test; give the card a valid tshirt token.
+		await api('PATCH', `/boards/${state.boardId}`, { estimateScale: 'tshirt' })
+		await api('PATCH', `/cards/${state.cardId}`, { estimate: 'M' })
+
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /workflow/i }).click()
+
+		const select = page.locator(`#estimate-scale-${state.boardId}`)
+		await expect(select).toBeVisible({ timeout: 8_000 })
+		// 'M' does not fit fibonacci → the confirmation appears; cancel it.
+		await select.selectOption('fibonacci')
+		await expect(page.getByText(/does not fit the new scale and will be cleared/i))
+			.toBeVisible({ timeout: 8_000 })
+		await page.getByRole('button', { name: 'Cancel' }).click()
+
+		// Nothing changed: scale still tshirt, estimate still 'M', select reverted.
+		await expect(select).toHaveValue('tshirt', { timeout: 8_000 })
+		expect((await api('GET', `/boards/${state.boardId}`)).board.estimateScale).toBe('tshirt')
+		expect((await api('GET', `/cards/${state.cardId}`)).estimate).toBe('M')
+	})
+})
+
+test.describe('Estimate sorting & filtering', () => {
+	const state = { boardId: 0, stackId: 0, none: 0, small: 0, big: 0 }
+
+	test.beforeAll(async () => {
+		const stamp = Math.floor(Date.now() / 1000)
+		const board = await api('POST', '/boards', { title: 'EstSortFilter ' + stamp })
+		state.boardId = board.id
+		await api('PATCH', `/boards/${board.id}`, { estimateScale: 'fibonacci' })
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'To do' })).id
+
+		// Create in an order that is NOT the estimate order, so a passing sort
+		// assertion can only come from the estimate ranking (not creation order):
+		// manual order is None → Small(2) → Big(13); estimate-desc is Big → Small → None.
+		state.none = (await api('POST', '/cards', { stackId: state.stackId, title: 'EstNone' })).id
+		state.small = (await api('POST', '/cards', { stackId: state.stackId, title: 'EstSmall' })).id
+		await api('PATCH', `/cards/${state.small}`, { estimate: '2' })
+		state.big = (await api('POST', '/cards', { stackId: state.stackId, title: 'EstBig' })).id
+		await api('PATCH', `/cards/${state.big}`, { estimate: '13' })
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('sort by estimate orders cards high→low with unestimated last', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// Manual (persisted) order first: None, Small, Big.
+		const titlesManual = (await page.locator('.card-tile__title').allTextContents()).map((s) => s.trim())
+		expect(titlesManual.indexOf('EstNone')).toBeLessThan(titlesManual.indexOf('EstSmall'))
+		expect(titlesManual.indexOf('EstSmall')).toBeLessThan(titlesManual.indexOf('EstBig'))
+
+		// Switch the display sort to Estimate (radio only present because the board
+		// has a scale). The estimate ranks by scale position, not string value.
+		await page.locator('.board-view__sort-menu button').first().click()
+		await page.locator('.action-radio__text', { hasText: 'Estimate' }).click()
+		await page.keyboard.press('Escape')
+
+		// Estimate defaults to Descending: Big(13) → Small(2) → None(unestimated, last).
+		await expect.poll(async () => {
+			const t = (await page.locator('.card-tile__title').allTextContents()).map((s) => s.trim())
+			return t.indexOf('EstBig') < t.indexOf('EstSmall') && t.indexOf('EstSmall') < t.indexOf('EstNone')
+		}, { timeout: 8_000 }).toBe(true)
+
+		// Reopening the menu shows the active mode as selected (not blank).
+		await page.locator('.board-view__sort-menu button').first().click()
+		await expect(page.getByRole('menuitemradio', { name: 'Estimate' }))
+			.toHaveAttribute('aria-checked', 'true', { timeout: 8_000 })
+
+		// Flip to Ascending (single click, in the already-open menu): Small(2) →
+		// Big(13), with unestimated STILL last.
+		await page.locator('.action-radio__text', { hasText: 'Ascending' }).click()
+		await page.keyboard.press('Escape')
+		await expect.poll(async () => {
+			const t = (await page.locator('.card-tile__title').allTextContents()).map((s) => s.trim())
+			return t.indexOf('EstSmall') < t.indexOf('EstBig') && t.indexOf('EstBig') < t.indexOf('EstNone')
+		}, { timeout: 8_000 }).toBe(true)
+	})
+
+	test('filter by estimate token, and by "Unestimated"', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// Filter to just the "13" token → only EstBig remains.
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.action-checkbox__text', { hasText: /^13$/ }).click()
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.card-tile__title', { hasText: 'EstBig' })).toHaveCount(1)
+		await expect(page.locator('.card-tile__title', { hasText: 'EstSmall' })).toHaveCount(0)
+		await expect(page.locator('.card-tile__title', { hasText: 'EstNone' })).toHaveCount(0)
+		// The estimate facet round-trips through the URL (shareable).
+		await expect.poll(() => page.url()).toContain('fe=13')
+
+		// Swap to the "Unestimated" facet → only EstNone remains.
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.action-checkbox__text', { hasText: /^13$/ }).click() // uncheck 13
+		await page.locator('.action-checkbox__text', { hasText: 'Unestimated' }).click()
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.card-tile__title', { hasText: 'EstNone' })).toHaveCount(1)
+		await expect(page.locator('.card-tile__title', { hasText: 'EstBig' })).toHaveCount(0)
+		await expect(page.locator('.card-tile__title', { hasText: 'EstSmall' })).toHaveCount(0)
 	})
 })

--- a/tests/unit/Service/BoardServiceTest.php
+++ b/tests/unit/Service/BoardServiceTest.php
@@ -168,6 +168,81 @@ class BoardServiceTest extends TestCase {
 		$this->service->update(1, null, null, null, 'alice', 'made-up-scale');
 	}
 
+	public function testUpdateClearsEstimatesStrandedByScaleChange(): void {
+		$board = $this->board();
+		$board->setEstimateScale('fibonacci');
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->boardMapper->method('update')->willReturnArgument(0);
+
+		// fibonacci -> tshirt: '8' and '2' no longer fit (cleared); 'M' does (kept).
+		$this->cardMapper->expects(self::once())
+			->method('findEstimatedCards')
+			->with(1)
+			->willReturn([
+				['id' => 10, 'estimate' => '8'],
+				['id' => 11, 'estimate' => 'M'],
+				['id' => 12, 'estimate' => '2'],
+			]);
+		$this->cardMapper->expects(self::once())
+			->method('clearEstimatesByIds')
+			->with([10, 12]);
+
+		// One card change row per cleared card, plus the single board change row.
+		$clearedIds = [];
+		$this->changeNotifier->method('recordChange')
+			->willReturnCallback(function (int $boardId, int $type, int $cardId, int $action, ?string $actor, ?int $verb = null) use (&$clearedIds): Change {
+				self::assertSame(1, $boardId);
+				self::assertSame(Change::ENTITY_CARD, $type);
+				self::assertSame(Change::ACTION_UPDATE, $action);
+				self::assertSame('alice', $actor);
+				self::assertSame(Change::VERB_UPDATED, $verb);
+				$clearedIds[] = $cardId;
+				return new Change();
+			});
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_BOARD, 1, Change::ACTION_UPDATE, 'alice')
+			->willReturn(new Change());
+
+		$updated = $this->service->update(1, null, null, null, 'alice', 'tshirt');
+		self::assertSame('tshirt', $updated->getEstimateScale());
+		self::assertSame([10, 12], $clearedIds);
+	}
+
+	public function testUpdateToNoneScaleClearsEveryEstimate(): void {
+		$board = $this->board();
+		$board->setEstimateScale('hours');
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->boardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		$this->cardMapper->method('findEstimatedCards')->with(1)->willReturn([
+			['id' => 7, 'estimate' => '4'],
+			['id' => 8, 'estimate' => '16'],
+		]);
+		// 'none' allows nothing, so every estimated card is cleared.
+		$this->cardMapper->expects(self::once())
+			->method('clearEstimatesByIds')
+			->with([7, 8]);
+
+		$this->service->update(1, null, null, null, 'alice', 'none');
+	}
+
+	public function testUpdateWithUnchangedScaleDoesNotSweepEstimates(): void {
+		$board = $this->board();
+		$board->setEstimateScale('tshirt');
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->boardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('notify')->willReturn(new Change());
+
+		// Re-setting the SAME scale is not a transition: no card sweep at all.
+		$this->cardMapper->expects(self::never())->method('findEstimatedCards');
+		$this->cardMapper->expects(self::never())->method('clearEstimatesByIds');
+
+		$this->service->update(1, null, null, null, 'alice', 'tshirt');
+	}
+
 	public function testUpdateNormalizesPrefix(): void {
 		$board = $this->board();
 		$this->boardMapper->method('find')->with(1)->willReturn($board);


### PR DESCRIPTION
## Context

Estimation was already built end-to-end in Kanso (DB column, per-board scale, card-modal picker, tile chip, board-settings selector, copy/move/import/export, even a velocity/points stats layer) — but **invisible by default**: a board's `estimate_scale` defaults to `none`, and every estimate UI is gated behind `scale !== 'none'`. This makes it discoverable and production-ready, adds the requested sorting/filtering, and fixes a real scale-change data bug.

## What's in this PR

### Added
- **Sort by estimate** — ranked by ordinal position in the board's scale (`13 > 8 > 2`, `XL > XS` — not string order), unestimated last. Only offered when the board has a scale.
- **Ascending / descending direction for every sort** (Priority, Due, Title, Estimate) with a ↑/↓ toolbar indicator. Each sort opens in its natural direction; **missing values always sort last regardless of direction**. Persisted per user.
- **Filter by estimate** — an *Estimate* facet (scale tokens + *Unestimated*) in the filter bar; combines with other dimensions and round-trips through the URL and saved views.
- **"Default (no filter)"** entry in the Saved-filters menu — one click back to unfiltered, out of a saved view or any ad-hoc filter.

### Fixed
- **Safe scale change** — `BoardService::update` now clears card estimates that no longer fit the new scale (backend-authoritative, per-card change rows for realtime); the settings dialog warns with a count and confirms before clearing, and reverts the dropdown on cancel. Previously an off-scale token (e.g. a Fibonacci `8` after a switch to T-shirt) lingered and could neither be re-selected nor cleared.
- **Sort / view-mode / swimlane radio menus** showed nothing selected on reopen and needed a double click to switch — root cause was a boolean-per-radio `:model-value` + `@change` binding (`NcActionRadio` computes `checked = model === value`, so `true === ""` was always false). Switched to the group idiom (`:model-value="mode"` + `value` + `@update:model-value`): single click, reflects state.

### CI
- Raised the `e2e` job cap `120 → 180` min as the serial suite grows.

## Testing
- **PHPUnit**: 3 new `BoardServiceTest` cases (cross-scale clear, `→ none` clears all, unchanged scale skips the sweep). Full `BoardServiceTest` green (29/29). psalm + php-cs-fixer clean.
- **e2e** (local docker stack): estimate sort desc→asc + **selected-on-reopen** + single-click switch, estimate filter by token + *Unestimated*, scale-change **confirm** and **cancel**, and the **Default-view** exit. Verified no regression in display-sort, list-view, timeline-view, swimlanes.
- **build-frontend**: clean.

## Notes
- No custom scales this round (deliberately out of scope). The estimate value stays a plain sizing attribute.
- Changelog updated under `## [Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)