### PR TITLE
feat(board): rename, add-column relocation, Display toolbar & filter fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"Default (no filter)" entry in the Saved-filters menu.** A one-click way back
   to the unfiltered board — an easy exit from an applied saved view or any ad-hoc
   filter.
+- **Rename a board from its header.** Click the board title to edit it inline
+  (Enter saves, Esc cancels); the app-navigation sidebar, command palette and
+  boards grid update live. Editors only.
+- **"Add column" moved into the ⋯ More menu.** The board no longer carries a
+  persistent "Add stack" text box taking up a column of space; adding a column is
+  now an action in the ⋯ menu that reveals a focused composer on demand (a
+  brand-new empty board still shows an inline first-column prompt). The composer
+  and the menu action are shown to editors only.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The board toolbar adapts to narrow / mobile widths.** When the header is too
+  narrow for the full toolbar (small screens, or a wide screen with the navigation
+  sidebar open), the View / Sort / Density controls fold into the ⋯ menu and the
+  back and filter buttons become icon-only, so no toolbar control is ever pushed
+  off-screen. It reacts to the header's actual width, so it also kicks in when the
+  sidebar opens — not just on true mobile.
 - **Importers no longer cap how many cards you can bring in.** The CSV /
   spreadsheet import row limit is raised from 2,000 to 200,000 and its file-size
   cap from 5 MiB to 64 MiB; the Deck and Trello whole-board import file-size caps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **"Default (no filter)" entry in the Saved-filters menu.** A one-click way back
   to the unfiltered board — an easy exit from an applied saved view or any ad-hoc
   filter.
-- **Rename a board from its header.** Click the board title to edit it inline
-  (Enter saves, Esc cancels); the app-navigation sidebar, command palette and
-  boards grid update live. Editors only.
+- **Rename a board.** Board Settings → General now has a *Board name* field
+  (managers only); saving updates the header, the app-navigation sidebar, the
+  command palette and the boards grid live.
 - **"Add column" moved into the ⋯ More menu.** The board no longer carries a
   persistent "Add stack" text box taking up a column of space; adding a column is
   now an action in the ⋯ menu that reveals a focused composer on demand (a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The board toolbar adapts to narrow / mobile widths.** When the header is too
-  narrow for the full toolbar (small screens, or a wide screen with the navigation
-  sidebar open), the View / Sort / Density controls fold into the ⋯ menu and the
-  back and filter buttons become icon-only, so no toolbar control is ever pushed
-  off-screen. It reacts to the header's actual width, so it also kicks in when the
-  sidebar opens — not just on true mobile.
+- **Board toolbar consolidated behind a "Display" control.** How the board is
+  arranged — view (Board / List / Timeline), Group by (swimlanes), Sort (+
+  direction) and Density — now lives in a single *Display* popover instead of
+  several separate toolbar menus (Linear-style). This declutters the header and
+  makes it fit narrow / mobile widths without pushing controls off-screen; on a
+  narrow header the back, Display and ⋯ buttons go icon-only and the search box
+  collapses to a magnifier.
 - **Importers no longer cap how many cards you can bring in.** The CSV /
   spreadsheet import row limit is raised from 2,000 to 200,000 and its file-size
   cap from 5 MiB to 64 MiB; the Deck and Trello whole-board import file-size caps

--- a/src/components/BoardFilterBar.vue
+++ b/src/components/BoardFilterBar.vue
@@ -80,33 +80,54 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					@update:model-value="toggleSet('estimates', token)">{{ token }}</NcActionCheckbox>
 			</template>
 
-			<!-- Due (single-select radio; a re-click of the active one clears it) -->
+			<!-- Due (single-select). Radio GROUP idiom (model-value = the selected
+			     value, each radio carries its own `value`) so the selected indicator
+			     actually renders — a boolean-per-radio binding shows nothing checked.
+			     An explicit "Any" (value '') is the clear. -->
 			<NcActionCaption :name="t('kanso', 'Due date')" />
+			<NcActionRadio
+				:model-value="state.due ?? ''"
+				value=""
+				name="kanso-filter-due"
+				@update:model-value="(v) => setSingleRadio('due', v)">{{ t('kanso', 'Any') }}</NcActionRadio>
 			<NcActionRadio
 				v-for="opt in DUE_OPTIONS"
 				:key="'d-' + opt.value"
-				:model-value="state.due === opt.value"
+				:model-value="state.due ?? ''"
+				:value="opt.value"
 				name="kanso-filter-due"
-				@update:model-value="setSingle('due', opt.value)">{{ t('kanso', opt.label) }}</NcActionRadio>
+				@update:model-value="(v) => setSingleRadio('due', v)">{{ t('kanso', opt.label) }}</NcActionRadio>
 
-			<!-- Done state (tri-state via radios) -->
+			<!-- Done state (single-select + Any) -->
 			<NcActionCaption :name="t('kanso', 'Status')" />
+			<NcActionRadio
+				:model-value="state.done ?? ''"
+				value=""
+				name="kanso-filter-done"
+				@update:model-value="(v) => setSingleRadio('done', v)">{{ t('kanso', 'Any') }}</NcActionRadio>
 			<NcActionRadio
 				v-for="opt in DONE_OPTIONS"
 				:key="'s-' + opt.value"
-				:model-value="state.done === opt.value"
+				:model-value="state.done ?? ''"
+				:value="opt.value"
 				name="kanso-filter-done"
-				@update:model-value="setSingle('done', opt.value)">{{ t('kanso', opt.label) }}</NcActionRadio>
+				@update:model-value="(v) => setSingleRadio('done', v)">{{ t('kanso', opt.label) }}</NcActionRadio>
 
-			<!-- Waiting on client (#3746, tri-state via radios) - reads the derived
-			     waitingOnExternal summary flag, no extra request -->
+			<!-- Waiting on client (#3746) - reads the derived waitingOnExternal
+			     summary flag, no extra request. Single-select + Any. -->
 			<NcActionCaption :name="t('kanso', 'Client status')" />
+			<NcActionRadio
+				:model-value="state.waiting ?? ''"
+				value=""
+				name="kanso-filter-waiting"
+				@update:model-value="(v) => setSingleRadio('waiting', v)">{{ t('kanso', 'Any') }}</NcActionRadio>
 			<NcActionRadio
 				v-for="opt in WAITING_OPTIONS"
 				:key="'w-' + opt.value"
-				:model-value="state.waiting === opt.value"
+				:model-value="state.waiting ?? ''"
+				:value="opt.value"
 				name="kanso-filter-waiting"
-				@update:model-value="setSingle('waiting', opt.value)">{{ t('kanso', opt.label) }}</NcActionRadio>
+				@update:model-value="(v) => setSingleRadio('waiting', v)">{{ t('kanso', opt.label) }}</NcActionRadio>
 
 			<!-- Clear (only when something is active) -->
 			<template v-if="count > 0">
@@ -265,10 +286,10 @@ function toggleSet(dim, value) {
 	else set.add(value)
 }
 
-// Radio dimensions are single-select but re-selecting the active option clears
-// it (tri-state feel): NcActionRadio only emits true on select, so we compare.
-function setSingle(dim, value) {
-	props.state[dim] = props.state[dim] === value ? null : value
+// Single-select radio dimensions (due / done / waiting). The group's value is the
+// selected token, with '' meaning "Any" → stored as null (the empty state).
+function setSingleRadio(dim, value) {
+	props.state[dim] = value || null
 }
 
 function clearAll() {

--- a/src/components/BoardFilterBar.vue
+++ b/src/components/BoardFilterBar.vue
@@ -10,10 +10,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		     the predicate. Mirrors the old label/priority dropdown, generalised. -->
 		<NcActions
 			class="board-filter-bar__filter"
-			:aria-label="t('kanso', 'Filter cards')"
-			:menu-name="count > 0
-				? t('kanso', 'Filter · {count}', { count })
-				: t('kanso', 'Filter')"
+			:aria-label="count > 0 ? t('kanso', 'Filter · {count}', { count }) : t('kanso', 'Filter cards')"
+			:menu-name="compact
+				? undefined
+				: (count > 0
+					? t('kanso', 'Filter · {count}', { count })
+					: t('kanso', 'Filter'))"
 			:primary="count > 0">
 			<template #icon>
 				<FilterVariantIcon :size="20" />
@@ -123,6 +125,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		     saved view, or delete one. Bookmark icon; highlighted when the active
 		     filter matches a saved view. -->
 		<NcActions
+			v-if="!compact"
 			class="board-filter-bar__saved"
 			:aria-label="t('kanso', 'Saved filters')"
 			:menu-name="activeSavedName || t('kanso', 'Saved')">
@@ -233,6 +236,8 @@ const props = defineProps({
 	activeSavedName: { type: String, default: '' },
 	/** The board's estimation scale key (e.g. 'fibonacci'); 'none' hides the facet. */
 	estimateScale: { type: String, default: 'none' },
+	/** Compact (narrow header): icon-only filter trigger, and hide the Saved menu. */
+	compact: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['save', 'apply-saved', 'delete-saved'])

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -81,6 +81,29 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						role="tabpanel"
 						aria-labelledby="bs-rail-tab-general">
 					<div class="board-settings__general">
+							<template v-if="canManage">
+								<label class="board-settings__prefix-label" for="bs-board-name">
+									{{ t('kanso', 'Board name') }}
+								</label>
+								<div class="board-settings__prefix-row">
+									<input
+										id="bs-board-name"
+										v-model="nameDraft"
+										class="board-settings__prefix-input board-settings__name-input"
+										type="text"
+										maxlength="100"
+										:disabled="nameSaving"
+										:placeholder="t('kanso', 'Board name')"
+										@keydown.enter.prevent="saveName">
+									<NcButton
+										:disabled="nameSaving || !nameDirty"
+										@click="saveName">
+										{{ t('kanso', 'Save') }}
+									</NcButton>
+								</div>
+								<span v-if="nameError" class="label-settings__error">{{ nameError }}</span>
+							</template>
+
 						<NcCheckboxRadioSwitch
 							:model-value="isDefaultBoard"
 							:disabled="settingsBusy"
@@ -2672,6 +2695,35 @@ async function applyBackground(key) {
 		backgroundError.value = err?.response?.data?.error || t('kanso', 'Failed to update background.')
 	} finally {
 		backgroundSaving.value = false
+	}
+}
+
+// ── Board name (rename) ──────────────────────────────────────────────────────
+// Renaming lives here (not inline in the board header) so it's always reachable
+// regardless of how cramped the header is. The draft mirrors the cache value and
+// is re-seeded whenever the board payload changes (a save invalidates + refetches,
+// and the ['boards'] list too, so the sidebar/command palette update live).
+const boardTitle = computed(() => boardQueryData.value?.board?.title || '')
+const nameDraft = ref('')
+const nameSaving = ref(false)
+const nameError = ref('')
+watch(boardTitle, (val) => { nameDraft.value = val }, { immediate: true })
+// Dirty when the trimmed draft is non-empty and differs from the stored title
+// (an empty title is rejected server-side).
+const nameDirty = computed(() => {
+	const draft = nameDraft.value.trim()
+	return draft !== '' && draft !== boardTitle.value
+})
+async function saveName() {
+	if (!nameDirty.value) return
+	nameSaving.value = true
+	nameError.value = ''
+	try {
+		await updateBoard.mutateAsync({ title: nameDraft.value.trim() })
+	} catch (err) {
+		nameError.value = err?.response?.data?.error || t('kanso', 'Failed to rename board.')
+	} finally {
+		nameSaving.value = false
 	}
 }
 

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -3,9 +3,12 @@ SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="search-box" role="search">
+	<div
+		class="search-box"
+		:class="{ 'search-box--compact': compact, 'search-box--has-term': term.length > 0 }"
+		role="search">
 		<!-- Input row with magnify icon -->
-		<div class="search-box__input-wrap">
+		<div class="search-box__input-wrap" @click="focusInput">
 			<MagnifyIcon class="search-box__magnify" :size="18" aria-hidden="true" />
 			<input
 				ref="inputRef"
@@ -113,6 +116,11 @@ const props = defineProps({
 		type: [String, Number],
 		required: true,
 	},
+	/** Compact (narrow header): collapse to a magnify icon until focused/non-empty. */
+	compact: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 const emit = defineEmits(['open-card'])
@@ -123,6 +131,12 @@ const router = useRouter()
 const term = ref('')
 const activeIndex = ref(-1)
 const inputRef = ref(null)
+
+// Focus the input when the (collapsed) compact box is clicked, so tapping the
+// magnify icon expands it (via :focus-within) and lets you type immediately.
+function focusInput() {
+	inputRef.value?.focus()
+}
 const dropdownRef = ref(null)
 
 // ── Search composable ──────────────────────────────────────────────────────────
@@ -241,6 +255,35 @@ defineExpose({ focus: () => inputRef.value?.focus() })
 .search-box {
 	position: relative;
 	flex-shrink: 0;
+}
+
+/* Compact (narrow header): collapse to just the magnify icon to reclaim space,
+   then expand on focus or while a query is present. Pure CSS — the input stays
+   mounted so focus/typing keeps working; only its box width animates. */
+.search-box--compact {
+	flex-shrink: 1;
+	min-width: 0;
+}
+
+.search-box--compact .search-box__input-wrap {
+	min-width: 0;
+	width: 40px;
+	transition: width 0.15s ease;
+}
+
+.search-box--compact .search-box__input {
+	/* Hide the text field until expanded so a stray click lands on the icon. */
+	opacity: 0;
+}
+
+.search-box--compact:focus-within .search-box__input-wrap,
+.search-box--compact.search-box--has-term .search-box__input-wrap {
+	width: min(240px, 60vw);
+}
+
+.search-box--compact:focus-within .search-box__input,
+.search-box--compact.search-box--has-term .search-box__input {
+	opacity: 1;
 }
 
 .search-box__input-wrap {

--- a/src/composables/useBoard.js
+++ b/src/composables/useBoard.js
@@ -96,7 +96,13 @@ export function useBoard(id) {
 
 	const updateBoard = useMutation({
 		mutationFn: (data) => apiUpdateBoard(typeof id === 'object' ? id.value : id, data),
-		onSettled: () => queryClient.invalidateQueries({ queryKey: boardKey.value }),
+		// Invalidate BOTH the single-board query and the boards list: a board-level
+		// edit (rename, colour, …) must also refresh the app-navigation sidebar,
+		// command palette and boards grid, which all read the ['boards'] list.
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: boardKey.value })
+			queryClient.invalidateQueries({ queryKey: ['boards'] })
+		},
 	})
 
 	return {

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -33,52 +33,47 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:board-id="props.id"
 				:compact="isNarrow" />
 
-			<!-- View switch - Board (columns) vs List (table). Persisted per board. -->
+			<!-- Display: one popover for HOW the board is arranged - view type,
+			     grouping (swimlanes), sort and density (Linear-style). Replaces the
+			     separate view/sort/density controls and the swimlanes section that used
+			     to live in the more menu. Icon-only on a narrow header. -->
 			<NcActions
-				v-if="boardData && !isNarrow"
-				class="board-view__view-menu"
-				:menu-name="viewModeLabel">
+				v-if="boardData"
+				class="board-view__display-menu"
+				:menu-name="isNarrow ? undefined : t('kanso', 'Display')"
+				:aria-label="t('kanso', 'Display options')">
 				<template #icon>
-					<ChartTimelineIcon v-if="viewMode === 'timeline'" :size="20" />
-					<FormatListBulletedIcon v-else-if="viewMode === 'list'" :size="20" />
-					<ViewColumnIcon v-else :size="20" />
+					<TuneVariantIcon :size="20" />
 				</template>
-				<NcActionRadio
-					:model-value="viewMode"
-					value="board"
-					name="kanso-viewmode"
-					@update:model-value="setViewMode">
+
+				<NcActionCaption :name="t('kanso', 'View')" />
+				<NcActionRadio :model-value="viewMode" value="board" name="kanso-viewmode" @update:model-value="setViewMode">
 					{{ t('kanso', 'Board') }}
 				</NcActionRadio>
-				<NcActionRadio
-					:model-value="viewMode"
-					value="list"
-					name="kanso-viewmode"
-					@update:model-value="setViewMode">
+				<NcActionRadio :model-value="viewMode" value="list" name="kanso-viewmode" @update:model-value="setViewMode">
 					{{ t('kanso', 'List') }}
 				</NcActionRadio>
-				<NcActionRadio
-					:model-value="viewMode"
-					value="timeline"
-					name="kanso-viewmode"
-					@update:model-value="setViewMode">
+				<NcActionRadio :model-value="viewMode" value="timeline" name="kanso-viewmode" @update:model-value="setViewMode">
 					{{ t('kanso', 'Timeline') }}
 				</NcActionRadio>
-			</NcActions>
 
-			<!-- Display sort - a view-only reorder within each stack (Board + List). -->
-			<NcActions
-				v-if="boardData && !isNarrow"
-				class="board-view__sort-menu"
-				:menu-name="t('kanso', 'Sort: {mode}', { mode: sortModeMenuName })">
-				<template #icon>
-					<SortIcon :size="20" />
+				<template v-if="viewMode === 'board'">
+					<NcActionCaption :name="t('kanso', 'Group by')" />
+					<NcActionRadio :model-value="swimlaneMode" value="none" name="kanso-swimlane" @update:model-value="setSwimlaneMode">
+						{{ t('kanso', 'None') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="swimlaneMode" value="assignee" name="kanso-swimlane" @update:model-value="setSwimlaneMode">
+						{{ t('kanso', 'Assignee') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="swimlaneMode" value="label" name="kanso-swimlane" @update:model-value="setSwimlaneMode">
+						{{ t('kanso', 'Label') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="swimlaneMode" value="priority" name="kanso-swimlane" @update:model-value="setSwimlaneMode">
+						{{ t('kanso', 'Priority') }}
+					</NcActionRadio>
 				</template>
-				<!-- Radio GROUP idiom: model-value is the group's current value and each
-				     radio carries its own `value` (checked = model === value). This
-				     reflects the active mode when the menu reopens, and switches on a
-				     single click via @update:model-value (a boolean-per-radio +
-				     @change binding shows nothing selected and needs a double click). -->
+
+				<NcActionCaption :name="t('kanso', 'Sort')" />
 				<NcActionRadio :model-value="sortMode" value="manual" name="kanso-sort" @update:model-value="setSortMode">
 					{{ t('kanso', 'Manual') }}
 				</NcActionRadio>
@@ -99,9 +94,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					@update:model-value="setSortMode">
 					{{ t('kanso', 'Estimate') }}
 				</NcActionRadio>
-				<!-- Direction toggle — hidden for Manual (which has no direction). -->
 				<template v-if="sortMode !== 'manual'">
-					<NcActionSeparator />
 					<NcActionRadio :model-value="sortDir" value="asc" name="kanso-sort-dir" @update:model-value="setSortDir">
 						{{ t('kanso', 'Ascending') }}
 					</NcActionRadio>
@@ -109,26 +102,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						{{ t('kanso', 'Descending') }}
 					</NcActionRadio>
 				</template>
+
+				<NcActionCaption :name="t('kanso', 'Density')" />
+				<NcActionRadio :model-value="density" value="comfortable" name="kanso-density" @update:model-value="setDensity">
+					{{ t('kanso', 'Comfortable') }}
+				</NcActionRadio>
+				<NcActionRadio :model-value="density" value="compact" name="kanso-density" @update:model-value="setDensity">
+					{{ t('kanso', 'Compact') }}
+				</NcActionRadio>
 			</NcActions>
 
-			<!-- Compact density toggle (#3415) — a per-user, view-only switch that
-			     tightens every card tile so more cards fit on screen. Persisted per
-			     board per user. A pressed icon button sits with the other view
-			     controls; aria-pressed reflects the state for assistive tech. -->
-			<NcButton
-				v-if="boardData && !isNarrow"
-				class="board-view__density-toggle"
-				type="tertiary"
-				:pressed="isCompact"
-				:aria-pressed="isCompact ? 'true' : 'false'"
-				:aria-label="isCompact ? t('kanso', 'Switch to comfortable density') : t('kanso', 'Switch to compact density')"
-				:title="isCompact ? t('kanso', 'Comfortable density') : t('kanso', 'Compact density')"
-				@click="toggleDensity">
-				<template #icon>
-					<ViewCompactIcon v-if="isCompact" :size="20" />
-					<ViewAgendaIcon v-else :size="20" />
-				</template>
-			</NcButton>
+
 
 			<!-- Project chat (#3748): a plain deep link (typically a Talk room)
 			     set in board settings (MANAGE); visible to every member when set.
@@ -188,61 +172,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				     Clicking reveals an on-demand composer at the end of the board and
 				     focuses it (a text INPUT here would strip the menu's role=menuitem
 				     semantics, so this stays a plain action button). -->
-				<!-- Responsive consolidation (#mobile): when the header is too narrow
-				     for the full toolbar, the view / sort / density controls collapse
-				     in here so nothing is pushed off-screen. Same handlers/state as the
-				     toolbar versions; distinct radio-group names avoid any overlap. -->
-				<template v-if="isNarrow">
-					<NcActionCaption :name="t('kanso', 'View')" />
-					<NcActionRadio :model-value="viewMode" value="board" name="kanso-viewmode-m" @update:model-value="setViewMode">
-						{{ t('kanso', 'Board') }}
-					</NcActionRadio>
-					<NcActionRadio :model-value="viewMode" value="list" name="kanso-viewmode-m" @update:model-value="setViewMode">
-						{{ t('kanso', 'List') }}
-					</NcActionRadio>
-					<NcActionRadio :model-value="viewMode" value="timeline" name="kanso-viewmode-m" @update:model-value="setViewMode">
-						{{ t('kanso', 'Timeline') }}
-					</NcActionRadio>
-
-					<NcActionCaption :name="t('kanso', 'Sort')" />
-					<NcActionRadio :model-value="sortMode" value="manual" name="kanso-sort-m" @update:model-value="setSortMode">
-						{{ t('kanso', 'Manual') }}
-					</NcActionRadio>
-					<NcActionRadio :model-value="sortMode" value="priority" name="kanso-sort-m" @update:model-value="setSortMode">
-						{{ t('kanso', 'Priority') }}
-					</NcActionRadio>
-					<NcActionRadio :model-value="sortMode" value="due" name="kanso-sort-m" @update:model-value="setSortMode">
-						{{ t('kanso', 'Due date') }}
-					</NcActionRadio>
-					<NcActionRadio :model-value="sortMode" value="title" name="kanso-sort-m" @update:model-value="setSortMode">
-						{{ t('kanso', 'Title') }}
-					</NcActionRadio>
-					<NcActionRadio
-						v-if="boardData?.board?.estimateScale && boardData.board.estimateScale !== 'none'"
-						:model-value="sortMode"
-						value="estimate"
-						name="kanso-sort-m"
-						@update:model-value="setSortMode">
-						{{ t('kanso', 'Estimate') }}
-					</NcActionRadio>
-					<template v-if="sortMode !== 'manual'">
-						<NcActionRadio :model-value="sortDir" value="asc" name="kanso-sort-dir-m" @update:model-value="setSortDir">
-							{{ t('kanso', 'Ascending') }}
-						</NcActionRadio>
-						<NcActionRadio :model-value="sortDir" value="desc" name="kanso-sort-dir-m" @update:model-value="setSortDir">
-							{{ t('kanso', 'Descending') }}
-						</NcActionRadio>
-					</template>
-
-					<NcActionButton :aria-pressed="isCompact ? 'true' : 'false'" @click="toggleDensity">
-						<template #icon>
-							<ViewCompactIcon v-if="isCompact" :size="20" />
-							<ViewAgendaIcon v-else :size="20" />
-						</template>
-						{{ isCompact ? t('kanso', 'Comfortable density') : t('kanso', 'Compact density') }}
-					</NcActionButton>
-					<NcActionSeparator />
-				</template>
 
 				<template v-if="canEditBoard">
 					<NcActionButton
@@ -257,42 +186,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<NcActionSeparator />
 				</template>
 
-				<!-- Swimlanes - client-side grouping of the Board view into
-				     horizontal lanes by assignee / label / priority. View-only over
-				     the summary payload; persisted per board per user. Only shown in
-				     Board view. -->
-				<template v-if="viewMode === 'board'">
-					<NcActionCaption :name="t('kanso', 'Swimlanes')" />
-					<NcActionRadio
-						:model-value="swimlaneMode"
-						value="none"
-						name="kanso-swimlane"
-						@update:model-value="setSwimlaneMode">
-						{{ t('kanso', 'No swimlanes') }}
-					</NcActionRadio>
-					<NcActionRadio
-						:model-value="swimlaneMode"
-						value="assignee"
-						name="kanso-swimlane"
-						@update:model-value="setSwimlaneMode">
-						{{ t('kanso', 'Group by assignee') }}
-					</NcActionRadio>
-					<NcActionRadio
-						:model-value="swimlaneMode"
-						value="label"
-						name="kanso-swimlane"
-						@update:model-value="setSwimlaneMode">
-						{{ t('kanso', 'Group by label') }}
-					</NcActionRadio>
-					<NcActionRadio
-						:model-value="swimlaneMode"
-						value="priority"
-						name="kanso-swimlane"
-						@update:model-value="setSwimlaneMode">
-						{{ t('kanso', 'Group by priority') }}
-					</NcActionRadio>
-					<NcActionSeparator />
-				</template>
 
 				<!-- Archived cards page - only offered when ≥1 archived card. The
 				     visible label already carries the count, so no separate aria-label
@@ -670,6 +563,7 @@ import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import TuneVariantIcon from 'vue-material-design-icons/TuneVariant.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
 import ArchiveIcon from 'vue-material-design-icons/Archive.vue'

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -30,7 +30,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				v-if="boardData"
 				ref="searchBoxRef"
 				class="board-view__search"
-				:board-id="props.id" />
+				:board-id="props.id"
+				:compact="isNarrow" />
 
 			<!-- View switch - Board (columns) vs List (table). Persisted per board. -->
 			<NcActions
@@ -176,7 +177,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				v-if="boardData"
 				v-model:open="moreMenuOpen"
 				class="board-view__more-menu"
-				:menu-name="t('kanso', 'More')"
+				:menu-name="isNarrow ? undefined : t('kanso', 'More')"
 				:aria-label="t('kanso', 'More board actions')">
 				<template #icon>
 					<DotsHorizontalIcon :size="20" />

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -15,31 +15,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</template>
 				{{ t('kanso', 'All boards') }}
 			</NcButton>
-			<h1 v-if="boardData" class="board-view__title" :class="{ 'board-view__title--editing': editingBoardTitle }">
+			<h1 v-if="boardData" class="board-view__title">
 				<span
 					v-if="boardData.board.color"
 					class="board-view__color-dot"
 					:style="{ background: boardData.board.color }" />
-				<input
-					v-if="editingBoardTitle"
-					ref="boardTitleInputRef"
-					v-model="boardTitleDraft"
-					class="board-view__title-input"
-					type="text"
-					maxlength="100"
-					:aria-label="t('kanso', 'Board name')"
-					@keydown.enter.prevent="saveBoardTitle"
-					@keydown.esc.prevent="cancelEditBoardTitle"
-					@blur="onBoardTitleBlur">
-				<span
-					v-else
-					class="board-view__title-text"
-					:class="{ 'board-view__title-text--editable': canEditBoard }"
-					:role="canEditBoard ? 'button' : null"
-					:tabindex="canEditBoard ? 0 : null"
-					:title="canEditBoard ? t('kanso', 'Rename board') : null"
-					@click="startEditBoardTitle"
-					@keydown.enter="startEditBoardTitle">{{ boardData.board.title }}</span>
+				<span class="board-view__title-text">{{ boardData.board.title }}</span>
 			</h1>
 			<div v-else-if="isLoading" class="board-view__title-skeleton skeleton-text" />
 
@@ -621,7 +602,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
-import { showSuccess, showWarning, showError } from '@nextcloud/dialogs'
+import { showSuccess, showWarning } from '@nextcloud/dialogs'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -915,7 +896,7 @@ function sortCards(cards) {
 		return (compare(va, vb) * mult) || bySortKey(a, b)
 	})
 }
-const { data: boardData, isLoading, isError, error: boardError, refetch: boardRefetch, createStack, createCard, updateStack, updateBoard, deleteStack, restoreStack } = useBoard(boardId)
+const { data: boardData, isLoading, isError, error: boardError, refetch: boardRefetch, createStack, createCard, updateStack, deleteStack, restoreStack } = useBoard(boardId)
 
 // Status-aware board error copy (#3662). A dead deep-link/notification to a
 // deleted board 404s; a revoked share 403s. Both should read as an explanatory
@@ -985,52 +966,6 @@ const showManageTemplates = ref(false)
 
 /** Whether the current user may EDIT this board (bit 2). Gates template mutations. */
 const canEditBoard = computed(() => ((boardData.value?.permissions ?? 0) & 2) !== 0)
-
-// ── Inline board rename (#header) ─────────────────────────────────────────────
-// Click the board title to edit it in place (Enter saves, Esc cancels, blur
-// saves). Mirrors the column-title editor in StackColumn, including the blur
-// guard that swallows the spurious blur a closing menu / focus-trap can fire.
-const editingBoardTitle = ref(false)
-const boardTitleDraft = ref('')
-const boardTitleInputRef = ref(null)
-const boardTitleEditReady = ref(false)
-
-function startEditBoardTitle() {
-	if (!canEditBoard.value) return
-	boardTitleDraft.value = boardData.value?.board?.title ?? ''
-	editingBoardTitle.value = true
-	boardTitleEditReady.value = false
-	nextTick(() => {
-		boardTitleInputRef.value?.focus()
-		boardTitleInputRef.value?.select()
-		setTimeout(() => { boardTitleEditReady.value = true }, 200)
-	})
-}
-
-function onBoardTitleBlur() {
-	if (!boardTitleEditReady.value) {
-		nextTick(() => boardTitleInputRef.value?.focus())
-		return
-	}
-	saveBoardTitle()
-}
-
-function cancelEditBoardTitle() {
-	boardTitleEditReady.value = true
-	editingBoardTitle.value = false
-}
-
-async function saveBoardTitle() {
-	if (!editingBoardTitle.value) return
-	editingBoardTitle.value = false
-	const next = boardTitleDraft.value.trim()
-	if (next === '' || next === boardData.value?.board?.title) return
-	try {
-		await updateBoard.mutateAsync({ title: next })
-	} catch (err) {
-		showError(err?.response?.data?.error || t('kanso', 'Failed to rename board.'))
-	}
-}
 
 /** First (sorted, non-archived) stack id — hosts a freshly created blank template. */
 const firstStackId = computed(() => sortedStacks.value[0]?.id ?? null)
@@ -2104,58 +2039,11 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	border-radius: 50%;
 }
 
-/* Inline-editable board title: the display span reads as clickable when the
-   viewer can edit. The parent h1 already handles nowrap/ellipsis clipping, so the
-   span must NOT set overflow/min-width itself (that collapsed it to ~0 width in
-   the flex header and hid the title). */
 .board-view__title-text {
-	border-radius: 4px;
-}
-
-.board-view__title-text--editable {
-	cursor: text;
-	padding: 2px 4px;
-	margin: -2px -4px;
-}
-
-.board-view__title-text--editable:hover {
-	background: var(--color-background-hover);
-}
-
-/* While editing, the title box overlays the full header width so the input can
-   actually be large. A flex approach can't achieve this: the toolbar packs the
-   header and the search's margin-left:auto eats any slack, leaving the title only
-   a sliver. The toolbar isn't interactive mid-rename, so absolutely positioning
-   the editing title across the header (left = header padding-left, right = padding-
-   right) and letting the input fill it is the reliable way to "cover the space". */
-.board-view__title--editing {
-	position: absolute;
-	left: 52px;
-	right: 20px;
-	top: 6px;
-	bottom: 6px;
-	/* Above the toolbar buttons (each NcActions makes its own stacking context, so
-	   a small z-index isn't enough) — an opaque strip that cleanly covers them. */
-	z-index: 100;
-	background: var(--color-main-background);
-}
-
-.board-view__title-input {
-	flex: 1 1 auto;
-	width: 100%;
 	min-width: 0;
-	font-size: inherit;
-	font-weight: inherit;
-	color: var(--color-main-text);
-	background: var(--color-main-background);
-	border: 2px solid var(--color-primary-element);
-	border-radius: var(--border-radius);
-	padding: 2px 6px;
-	margin: -2px 0;
-}
-
-.board-view__title-input:focus {
-	outline: none;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .board-view__title-skeleton {

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -9,11 +9,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		:style="boardBackground ? { '--board-background': boardBackground } : {}">
 		<!-- Header -->
 		<div ref="headerRef" class="board-view__header">
-			<NcButton class="board-view__back" @click="goBack">
+			<NcButton class="board-view__back" :aria-label="t('kanso', 'All boards')" @click="goBack">
 				<template #icon>
 					<ArrowLeftIcon :size="20" />
 				</template>
-				{{ t('kanso', 'All boards') }}
+				<template v-if="!isNarrow">{{ t('kanso', 'All boards') }}</template>
 			</NcButton>
 			<h1 v-if="boardData" class="board-view__title">
 				<span
@@ -34,7 +34,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 			<!-- View switch - Board (columns) vs List (table). Persisted per board. -->
 			<NcActions
-				v-if="boardData"
+				v-if="boardData && !isNarrow"
 				class="board-view__view-menu"
 				:menu-name="viewModeLabel">
 				<template #icon>
@@ -67,7 +67,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 			<!-- Display sort - a view-only reorder within each stack (Board + List). -->
 			<NcActions
-				v-if="boardData"
+				v-if="boardData && !isNarrow"
 				class="board-view__sort-menu"
 				:menu-name="t('kanso', 'Sort: {mode}', { mode: sortModeMenuName })">
 				<template #icon>
@@ -115,7 +115,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			     board per user. A pressed icon button sits with the other view
 			     controls; aria-pressed reflects the state for assistive tech. -->
 			<NcButton
-				v-if="boardData"
+				v-if="boardData && !isNarrow"
 				class="board-view__density-toggle"
 				type="tertiary"
 				:pressed="isCompact"
@@ -160,6 +160,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:saved-filters="savedFilters"
 				:active-saved-name="activeSavedName"
 				:estimate-scale="boardData?.board?.estimateScale ?? 'none'"
+				:compact="isNarrow"
 				@save="handleSaveFilter"
 				@apply-saved="handleApplySavedFilter"
 				@delete-saved="handleDeleteSavedFilter" />
@@ -186,6 +187,62 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				     Clicking reveals an on-demand composer at the end of the board and
 				     focuses it (a text INPUT here would strip the menu's role=menuitem
 				     semantics, so this stays a plain action button). -->
+				<!-- Responsive consolidation (#mobile): when the header is too narrow
+				     for the full toolbar, the view / sort / density controls collapse
+				     in here so nothing is pushed off-screen. Same handlers/state as the
+				     toolbar versions; distinct radio-group names avoid any overlap. -->
+				<template v-if="isNarrow">
+					<NcActionCaption :name="t('kanso', 'View')" />
+					<NcActionRadio :model-value="viewMode" value="board" name="kanso-viewmode-m" @update:model-value="setViewMode">
+						{{ t('kanso', 'Board') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="viewMode" value="list" name="kanso-viewmode-m" @update:model-value="setViewMode">
+						{{ t('kanso', 'List') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="viewMode" value="timeline" name="kanso-viewmode-m" @update:model-value="setViewMode">
+						{{ t('kanso', 'Timeline') }}
+					</NcActionRadio>
+
+					<NcActionCaption :name="t('kanso', 'Sort')" />
+					<NcActionRadio :model-value="sortMode" value="manual" name="kanso-sort-m" @update:model-value="setSortMode">
+						{{ t('kanso', 'Manual') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="sortMode" value="priority" name="kanso-sort-m" @update:model-value="setSortMode">
+						{{ t('kanso', 'Priority') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="sortMode" value="due" name="kanso-sort-m" @update:model-value="setSortMode">
+						{{ t('kanso', 'Due date') }}
+					</NcActionRadio>
+					<NcActionRadio :model-value="sortMode" value="title" name="kanso-sort-m" @update:model-value="setSortMode">
+						{{ t('kanso', 'Title') }}
+					</NcActionRadio>
+					<NcActionRadio
+						v-if="boardData?.board?.estimateScale && boardData.board.estimateScale !== 'none'"
+						:model-value="sortMode"
+						value="estimate"
+						name="kanso-sort-m"
+						@update:model-value="setSortMode">
+						{{ t('kanso', 'Estimate') }}
+					</NcActionRadio>
+					<template v-if="sortMode !== 'manual'">
+						<NcActionRadio :model-value="sortDir" value="asc" name="kanso-sort-dir-m" @update:model-value="setSortDir">
+							{{ t('kanso', 'Ascending') }}
+						</NcActionRadio>
+						<NcActionRadio :model-value="sortDir" value="desc" name="kanso-sort-dir-m" @update:model-value="setSortDir">
+							{{ t('kanso', 'Descending') }}
+						</NcActionRadio>
+					</template>
+
+					<NcActionButton :aria-pressed="isCompact ? 'true' : 'false'" @click="toggleDensity">
+						<template #icon>
+							<ViewCompactIcon v-if="isCompact" :size="20" />
+							<ViewAgendaIcon v-else :size="20" />
+						</template>
+						{{ isCompact ? t('kanso', 'Comfortable density') : t('kanso', 'Compact density') }}
+					</NcActionButton>
+					<NcActionSeparator />
+				</template>
+
 				<template v-if="canEditBoard">
 					<NcActionButton
 						class="board-view__add-column-btn"
@@ -1029,6 +1086,15 @@ function openShortcutsFromHint() {
 const searchBoxRef = ref(null)
 const headerRef = ref(null)
 
+// Responsive header (#mobile). When the header is too narrow to hold the full
+// toolbar with labels, the secondary controls (view mode, sort, density) collapse
+// into the ⋯ More menu and the back button + filter go icon-only, so nothing is
+// ever pushed off-screen. Driven by the header's OWN width (a ResizeObserver, see
+// onHeaderResize) — not a viewport media query — because the available width also
+// changes when the app-navigation sidebar opens/closes, not just on real mobile.
+const NARROW_HEADER_PX = 860
+const isNarrow = ref(false)
+
 function dismissActionError() {
 	dismissMoveError()
 	shortcutError.value = ''
@@ -1553,9 +1619,12 @@ function handleKeydown(e) {
 // dock BELOW the toolbar instead of over it — otherwise the panel covers the gear
 // button and a second gear click can't toggle it closed.
 let toolbarResizeObserver = null
-function publishToolbarHeight() {
-	const h = headerRef.value ? headerRef.value.offsetHeight : 0
-	document.documentElement.style.setProperty('--kanso-board-toolbar-height', `${h}px`)
+function onHeaderResize() {
+	if (!headerRef.value) return
+	document.documentElement.style.setProperty('--kanso-board-toolbar-height', `${headerRef.value.offsetHeight}px`)
+	// Header width is parent-driven (flex-shrink:0), so toggling isNarrow doesn't
+	// change it — no observer feedback loop.
+	isNarrow.value = headerRef.value.offsetWidth < NARROW_HEADER_PX
 }
 
 onMounted(() => {
@@ -1568,10 +1637,10 @@ onMounted(() => {
 	document.addEventListener('keydown', handleKeydown)
 
 	if (headerRef.value && typeof ResizeObserver !== 'undefined') {
-		toolbarResizeObserver = new ResizeObserver(publishToolbarHeight)
+		toolbarResizeObserver = new ResizeObserver(onHeaderResize)
 		toolbarResizeObserver.observe(headerRef.value)
 	}
-	publishToolbarHeight()
+	onHeaderResize()
 
 	const cleanups = [
 		monitorForElements({

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -15,12 +15,31 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</template>
 				{{ t('kanso', 'All boards') }}
 			</NcButton>
-			<h1 v-if="boardData" class="board-view__title">
+			<h1 v-if="boardData" class="board-view__title" :class="{ 'board-view__title--editing': editingBoardTitle }">
 				<span
 					v-if="boardData.board.color"
 					class="board-view__color-dot"
 					:style="{ background: boardData.board.color }" />
-				{{ boardData.board.title }}
+				<input
+					v-if="editingBoardTitle"
+					ref="boardTitleInputRef"
+					v-model="boardTitleDraft"
+					class="board-view__title-input"
+					type="text"
+					maxlength="100"
+					:aria-label="t('kanso', 'Board name')"
+					@keydown.enter.prevent="saveBoardTitle"
+					@keydown.esc.prevent="cancelEditBoardTitle"
+					@blur="onBoardTitleBlur">
+				<span
+					v-else
+					class="board-view__title-text"
+					:class="{ 'board-view__title-text--editable': canEditBoard }"
+					:role="canEditBoard ? 'button' : null"
+					:tabindex="canEditBoard ? 0 : null"
+					:title="canEditBoard ? t('kanso', 'Rename board') : null"
+					@click="startEditBoardTitle"
+					@keydown.enter="startEditBoardTitle">{{ boardData.board.title }}</span>
 			</h1>
 			<div v-else-if="isLoading" class="board-view__title-skeleton skeleton-text" />
 
@@ -179,6 +198,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:aria-label="t('kanso', 'More board actions')">
 				<template #icon>
 					<DotsHorizontalIcon :size="20" />
+				</template>
+
+				<!-- Add column — moved off the board (was a persistent trailing input)
+				     into this menu so the board stays uncluttered. Editors only.
+				     Clicking reveals an on-demand composer at the end of the board and
+				     focuses it (a text INPUT here would strip the menu's role=menuitem
+				     semantics, so this stays a plain action button). -->
+				<template v-if="canEditBoard">
+					<NcActionButton
+						class="board-view__add-column-btn"
+						:close-after-click="true"
+						@click="revealAddColumn">
+						<template #icon>
+							<PlusIcon :size="20" />
+						</template>
+						{{ t('kanso', 'Add column') }}
+					</NcActionButton>
+					<NcActionSeparator />
 				</template>
 
 				<!-- Swimlanes - client-side grouping of the Board view into
@@ -389,24 +426,28 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:on-toggle-collapsed="toggleStackCollapsed"
 					:compact="isCompact" />
 
-				<!-- Add stack inline input -->
-				<div class="add-stack">
-					<!-- Empty-board onboarding hint (#3413): when the board has no
-					     stacks yet, point the user at this composer. -->
-					<p
-						v-if="sortedStacks.length === 0"
-						class="add-stack__hint"
-						data-test="empty-board-hint">
+				<!-- Column composer (#3413). No longer a PERSISTENT trailing input: it
+				     appears only when revealed from the ⋯ More menu ("Add column"), or
+				     as onboarding on a brand-new empty board so a fresh board isn't a
+				     dead end. Editors only. Esc or an empty blur collapses it again. -->
+				<div
+					v-if="canEditBoard && (showAddColumn || sortedStacks.length === 0)"
+					class="add-stack add-stack--empty">
+					<p v-if="sortedStacks.length === 0" class="add-stack__hint" data-test="empty-board-hint">
 						{{ t('kanso', 'Start by adding a column, e.g. “To do”.') }}
 					</p>
 					<form @submit.prevent="submitNewStack">
 						<input
+							ref="addColumnInputRef"
 							v-model="newStackTitle"
 							class="add-stack__input"
 							type="text"
-							:placeholder="t('kanso', 'Add stack…')"
+							maxlength="100"
+							:placeholder="t('kanso', 'Add column…')"
 							:disabled="createStack.isPending.value"
-							@keydown.enter.prevent="submitNewStack" />
+							@keydown.enter.prevent="submitNewStack"
+							@keydown.esc.prevent="collapseAddColumn"
+							@blur="onAddColumnBlur" />
 						<p v-if="stackError" class="add-stack__error">{{ stackError }}</p>
 					</form>
 				</div>
@@ -580,7 +621,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
-import { showSuccess, showWarning } from '@nextcloud/dialogs'
+import { showSuccess, showWarning, showError } from '@nextcloud/dialogs'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -590,6 +631,7 @@ import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
 import ArchiveIcon from 'vue-material-design-icons/Archive.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
@@ -873,7 +915,7 @@ function sortCards(cards) {
 		return (compare(va, vb) * mult) || bySortKey(a, b)
 	})
 }
-const { data: boardData, isLoading, isError, error: boardError, refetch: boardRefetch, createStack, createCard, updateStack, deleteStack, restoreStack } = useBoard(boardId)
+const { data: boardData, isLoading, isError, error: boardError, refetch: boardRefetch, createStack, createCard, updateStack, updateBoard, deleteStack, restoreStack } = useBoard(boardId)
 
 // Status-aware board error copy (#3662). A dead deep-link/notification to a
 // deleted board 404s; a revoked share 403s. Both should read as an explanatory
@@ -943,6 +985,52 @@ const showManageTemplates = ref(false)
 
 /** Whether the current user may EDIT this board (bit 2). Gates template mutations. */
 const canEditBoard = computed(() => ((boardData.value?.permissions ?? 0) & 2) !== 0)
+
+// ── Inline board rename (#header) ─────────────────────────────────────────────
+// Click the board title to edit it in place (Enter saves, Esc cancels, blur
+// saves). Mirrors the column-title editor in StackColumn, including the blur
+// guard that swallows the spurious blur a closing menu / focus-trap can fire.
+const editingBoardTitle = ref(false)
+const boardTitleDraft = ref('')
+const boardTitleInputRef = ref(null)
+const boardTitleEditReady = ref(false)
+
+function startEditBoardTitle() {
+	if (!canEditBoard.value) return
+	boardTitleDraft.value = boardData.value?.board?.title ?? ''
+	editingBoardTitle.value = true
+	boardTitleEditReady.value = false
+	nextTick(() => {
+		boardTitleInputRef.value?.focus()
+		boardTitleInputRef.value?.select()
+		setTimeout(() => { boardTitleEditReady.value = true }, 200)
+	})
+}
+
+function onBoardTitleBlur() {
+	if (!boardTitleEditReady.value) {
+		nextTick(() => boardTitleInputRef.value?.focus())
+		return
+	}
+	saveBoardTitle()
+}
+
+function cancelEditBoardTitle() {
+	boardTitleEditReady.value = true
+	editingBoardTitle.value = false
+}
+
+async function saveBoardTitle() {
+	if (!editingBoardTitle.value) return
+	editingBoardTitle.value = false
+	const next = boardTitleDraft.value.trim()
+	if (next === '' || next === boardData.value?.board?.title) return
+	try {
+		await updateBoard.mutateAsync({ title: next })
+	} catch (err) {
+		showError(err?.response?.data?.error || t('kanso', 'Failed to rename board.'))
+	}
+}
 
 /** First (sorted, non-archived) stack id — hosts a freshly created blank template. */
 const firstStackId = computed(() => sortedStacks.value[0]?.id ?? null)
@@ -1808,6 +1896,38 @@ async function submitNewStack() {
 	}
 }
 
+// On-demand column composer revealed from the ⋯ More menu. Kept off the board by
+// default (was a persistent trailing input); shown when revealed here or when the
+// board is empty (onboarding). Esc / empty-blur collapses it.
+const showAddColumn = ref(false)
+const addColumnInputRef = ref(null)
+
+function revealAddColumn() {
+	stackError.value = ''
+	showAddColumn.value = true
+	nextTick(() => {
+		// Scroll the composer into view (it sits at the far right of the columns row)
+		// and focus it so the user can type immediately.
+		addColumnInputRef.value?.scrollIntoView?.({ inline: 'end', block: 'nearest' })
+		addColumnInputRef.value?.focus()
+	})
+}
+
+function collapseAddColumn() {
+	showAddColumn.value = false
+	newStackTitle.value = ''
+	stackError.value = ''
+}
+
+// Blur collapses the on-demand composer only when it's empty; a non-empty draft
+// stays open (mirrors the card composer) so a stray blur doesn't lose typing. The
+// empty-board onboarding composer never collapses (there's nothing to collapse to).
+function onAddColumnBlur() {
+	if (showAddColumn.value && newStackTitle.value.trim() === '') {
+		showAddColumn.value = false
+	}
+}
+
 async function handleCreateCard(stackId, title, duedate = null, allDay = false) {
 	// Only carry a due date when a natural-date token resolved to one (#3416);
 	// a plain create stays the exact same payload as before (back-compat).
@@ -1984,6 +2104,60 @@ const onBulkDelete = () => runBulkAction('delete', {})
 	border-radius: 50%;
 }
 
+/* Inline-editable board title: the display span reads as clickable when the
+   viewer can edit. The parent h1 already handles nowrap/ellipsis clipping, so the
+   span must NOT set overflow/min-width itself (that collapsed it to ~0 width in
+   the flex header and hid the title). */
+.board-view__title-text {
+	border-radius: 4px;
+}
+
+.board-view__title-text--editable {
+	cursor: text;
+	padding: 2px 4px;
+	margin: -2px -4px;
+}
+
+.board-view__title-text--editable:hover {
+	background: var(--color-background-hover);
+}
+
+/* While editing, the title box overlays the full header width so the input can
+   actually be large. A flex approach can't achieve this: the toolbar packs the
+   header and the search's margin-left:auto eats any slack, leaving the title only
+   a sliver. The toolbar isn't interactive mid-rename, so absolutely positioning
+   the editing title across the header (left = header padding-left, right = padding-
+   right) and letting the input fill it is the reliable way to "cover the space". */
+.board-view__title--editing {
+	position: absolute;
+	left: 52px;
+	right: 20px;
+	top: 6px;
+	bottom: 6px;
+	/* Above the toolbar buttons (each NcActions makes its own stacking context, so
+	   a small z-index isn't enough) — an opaque strip that cleanly covers them. */
+	z-index: 100;
+	background: var(--color-main-background);
+}
+
+.board-view__title-input {
+	flex: 1 1 auto;
+	width: 100%;
+	min-width: 0;
+	font-size: inherit;
+	font-weight: inherit;
+	color: var(--color-main-text);
+	background: var(--color-main-background);
+	border: 2px solid var(--color-primary-element);
+	border-radius: var(--border-radius);
+	padding: 2px 6px;
+	margin: -2px 0;
+}
+
+.board-view__title-input:focus {
+	outline: none;
+}
+
 .board-view__title-skeleton {
 	width: 200px;
 	height: 20px;
@@ -2151,6 +2325,12 @@ const onBulkDelete = () => runBulkAction('delete', {})
 .add-stack {
 	flex-shrink: 0;
 	width: 240px;
+}
+
+/* Empty-board first-column composer: a little breathing room so a fresh board
+   reads as an intentional prompt rather than a stray input. */
+.add-stack--empty {
+	padding-top: 8px;
 }
 
 .add-stack__input {

--- a/tests/e2e/board-rename-add-column.spec.js
+++ b/tests/e2e/board-rename-add-column.spec.js
@@ -49,32 +49,29 @@ test.describe('Board rename + Add column', () => {
 		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('rename the board inline from the header', async ({ page }) => {
+	test('rename the board from Board settings → General', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		const titleText = page.locator('.board-view__title-text')
-		await expect(titleText).toBeVisible({ timeout: 8_000 })
+		// Open Board settings (in the ⋯ More menu) and the General tab.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /general/i }).click()
 
-		// Esc cancels: open the editor, type, press Escape → title unchanged.
-		await titleText.click()
-		let input = page.locator('.board-view__title-input')
-		await expect(input).toBeFocused({ timeout: 5_000 })
-		await input.fill('Should not stick')
-		await input.press('Escape')
-		await expect(page.locator('.board-view__title-text')).toContainText('Rename me', { timeout: 6_000 })
+		const nameInput = page.locator('#bs-board-name')
+		await expect(nameInput).toBeVisible({ timeout: 8_000 })
 
-		// Enter saves: rename to a new title → header + server both reflect it.
 		const newTitle = 'Renamed board ' + Math.floor(Date.now() / 1000)
-		await page.locator('.board-view__title-text').click()
-		input = page.locator('.board-view__title-input')
-		await input.fill(newTitle)
-		await input.press('Enter')
+		await nameInput.fill(newTitle)
+		await nameInput.press('Enter')
 
-		await expect(page.locator('.board-view__title-text')).toContainText(newTitle, { timeout: 8_000 })
+		// Server reflects the rename…
 		await expect.poll(async () => (await api('GET', `/boards/${state.boardId}`)).board.title, { timeout: 8_000 })
 			.toBe(newTitle)
+		// …and so does the header once the modal is dismissed.
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.board-view__title-text')).toContainText(newTitle, { timeout: 8_000 })
 	})
 
 	test('add a column from the ⋯ More menu; no persistent trailing input remains', async ({ page }) => {
@@ -117,13 +114,17 @@ test.describe('Board rename + Add column', () => {
 		const navLink = (title) => page.locator('.app-navigation .app-navigation-entry-link', { hasText: title })
 		await expect(navLink(before)).toBeVisible({ timeout: 8_000 })
 
-		// Rename from the header.
+		// Rename via Board settings → General.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /general/i }).click()
 		const after = 'Sidebar rename ' + Math.floor(Date.now() / 1000)
-		await page.locator('.board-view__title-text').click()
-		const input = page.locator('.board-view__title-input')
-		await input.fill(after)
-		await input.press('Enter')
-		await expect(page.locator('.board-view__title-text')).toContainText(after, { timeout: 8_000 })
+		const nameInput = page.locator('#bs-board-name')
+		await expect(nameInput).toBeVisible({ timeout: 8_000 })
+		await nameInput.fill(after)
+		await nameInput.press('Enter')
+		await expect.poll(async () => (await api('GET', `/boards/${state.boardId}`)).board.title, { timeout: 8_000 })
+			.toBe(after)
 
 		// The sidebar reflects the new name and drops the old one — no manual reload.
 		await expect(navLink(after)).toBeVisible({ timeout: 8_000 })

--- a/tests/e2e/board-rename-add-column.spec.js
+++ b/tests/e2e/board-rename-add-column.spec.js
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Board rename + Add column', () => {
+	// A roomy header so the (ellipsised) board title isn't squeezed to zero width
+	// behind the toolbar when the app-navigation sidebar is open.
+	test.use({ viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, stackId: 0 }
+
+	test.beforeAll(async () => {
+		const stamp = Math.floor(Date.now() / 1000)
+		const board = await api('POST', '/boards', { title: 'Rename me ' + stamp })
+		state.boardId = board.id
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'To do' })).id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('rename the board inline from the header', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		const titleText = page.locator('.board-view__title-text')
+		await expect(titleText).toBeVisible({ timeout: 8_000 })
+
+		// Esc cancels: open the editor, type, press Escape → title unchanged.
+		await titleText.click()
+		let input = page.locator('.board-view__title-input')
+		await expect(input).toBeFocused({ timeout: 5_000 })
+		await input.fill('Should not stick')
+		await input.press('Escape')
+		await expect(page.locator('.board-view__title-text')).toContainText('Rename me', { timeout: 6_000 })
+
+		// Enter saves: rename to a new title → header + server both reflect it.
+		const newTitle = 'Renamed board ' + Math.floor(Date.now() / 1000)
+		await page.locator('.board-view__title-text').click()
+		input = page.locator('.board-view__title-input')
+		await input.fill(newTitle)
+		await input.press('Enter')
+
+		await expect(page.locator('.board-view__title-text')).toContainText(newTitle, { timeout: 8_000 })
+		await expect.poll(async () => (await api('GET', `/boards/${state.boardId}`)).board.title, { timeout: 8_000 })
+			.toBe(newTitle)
+	})
+
+	test('add a column from the ⋯ More menu; no persistent trailing input remains', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// The board has a column, so there is NO always-on "add stack" input.
+		await expect(page.locator('.add-stack')).toHaveCount(0)
+
+		// "Add column" lives in the ⋯ More menu; clicking it reveals + focuses an
+		// on-demand composer at the end of the board.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: 'Add column' }).click()
+		const colInput = page.locator('.add-stack__input')
+		await expect(colInput).toBeVisible({ timeout: 8_000 })
+		await expect(colInput).toBeFocused({ timeout: 5_000 })
+		await colInput.fill('In review')
+		await colInput.press('Enter')
+
+		// The new column appears on the board.
+		await expect(page.locator('.stack-column__title', { hasText: 'In review' }))
+			.toBeVisible({ timeout: 8_000 })
+		await expect.poll(async () => {
+			const { stacks } = await api('GET', `/boards/${state.boardId}`)
+			return (stacks ?? []).some((s) => s.title === 'In review')
+		}, { timeout: 8_000 }).toBe(true)
+	})
+
+	test('renaming a board updates the app-navigation sidebar live', async ({ page }) => {
+		// Pin the board so it is guaranteed to appear in the sidebar regardless of
+		// the account's other pins (the nav shows pinned boards, or all when none).
+		await api('PUT', `/boards/${state.boardId}/pin`).catch(() => {})
+		const before = (await api('GET', `/boards/${state.boardId}`)).board.title
+
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		const navLink = (title) => page.locator('.app-navigation .app-navigation-entry-link', { hasText: title })
+		await expect(navLink(before)).toBeVisible({ timeout: 8_000 })
+
+		// Rename from the header.
+		const after = 'Sidebar rename ' + Math.floor(Date.now() / 1000)
+		await page.locator('.board-view__title-text').click()
+		const input = page.locator('.board-view__title-input')
+		await input.fill(after)
+		await input.press('Enter')
+		await expect(page.locator('.board-view__title-text')).toContainText(after, { timeout: 8_000 })
+
+		// The sidebar reflects the new name and drops the old one — no manual reload.
+		await expect(navLink(after)).toBeVisible({ timeout: 8_000 })
+		await expect(navLink(before)).toHaveCount(0, { timeout: 8_000 })
+	})
+})
+
+test.describe('Empty board onboarding composer', () => {
+	test.use({ viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Empty ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id // no stacks on purpose
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('a board with no columns shows the inline first-column composer', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// The onboarding composer is present precisely because the board is empty.
+		await expect(page.locator('[data-test="empty-board-hint"]')).toBeVisible({ timeout: 8_000 })
+		const firstInput = page.locator('.add-stack__input')
+		await firstInput.fill('Backlog')
+		await firstInput.press('Enter')
+
+		// The first column is created and the onboarding composer disappears.
+		await expect(page.locator('.stack-column__title', { hasText: 'Backlog' }))
+			.toBeVisible({ timeout: 8_000 })
+		await expect(page.locator('[data-test="empty-board-hint"]')).toHaveCount(0, { timeout: 8_000 })
+	})
+})

--- a/tests/e2e/density.spec.js
+++ b/tests/e2e/density.spec.js
@@ -31,6 +31,13 @@ async function ncLogin(page) {
 	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
 }
 
+// Density now lives under the Display popover (radios), not a standalone toggle.
+async function setDensity(page, label) {
+	await page.locator('.board-view__display-menu button').first().click()
+	await page.getByRole('menuitemradio', { name: label, exact: true }).click()
+	await page.keyboard.press('Escape')
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Compact density mode (#3415)
 //
@@ -80,10 +87,8 @@ test.describe('Compact density (#3415)', () => {
 		await expect(firstTile).not.toHaveClass(/card-tile--compact/)
 		const comfortableHeight = (await firstTile.boundingBox()).height
 
-		// Flip to compact via the header toggle.
-		const toggle = page.locator('.board-view__density-toggle')
-		await expect(toggle).toBeVisible({ timeout: 6_000 })
-		await toggle.click()
+		// Flip to compact via Display → Density.
+		await setDensity(page, 'Compact')
 
 		// Tiles gain the compact class and become measurably shorter.
 		await expect(firstTile).toHaveClass(/card-tile--compact/, { timeout: 6_000 })
@@ -96,7 +101,7 @@ test.describe('Compact density (#3415)', () => {
 		await expect(page.locator('.card-tile').first()).toHaveClass(/card-tile--compact/, { timeout: 8_000 })
 
 		// Flip back to comfortable and confirm it also persists.
-		await page.locator('.board-view__density-toggle').click()
+		await setDensity(page, 'Comfortable')
 		await expect(page.locator('.card-tile').first()).not.toHaveClass(/card-tile--compact/, { timeout: 6_000 })
 		await page.reload()
 		await page.waitForSelector('.card-tile', { timeout: 15_000 })
@@ -125,7 +130,7 @@ test.describe('Compact density (#3415)', () => {
 		expect(beforeCount).toBeGreaterThan(0)
 
 		// Flip to compact — the virtualizer must re-measure, not jump to the top.
-		await page.locator('.board-view__density-toggle').click()
+		await setDensity(page, 'Compact')
 		await expect(page.locator('.card-tile').first()).toHaveClass(/card-tile--compact/, { timeout: 6_000 })
 		await page.waitForTimeout(400)
 

--- a/tests/e2e/display-sort.spec.js
+++ b/tests/e2e/display-sort.spec.js
@@ -54,9 +54,21 @@ test.describe('Display sort (#3442)', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
+		// View + Sort now live in one Display popover. Pick an option then Escape to
+		// close, so the next open() is deterministic (radios don't close the menu).
+		const pick = async (name) => {
+			await page.locator('.board-view__display-menu button').first().click()
+			// Let the teleported popover settle before clicking (a click landing mid
+			// open/re-render can miss the freshly-mounted radio).
+			await page.waitForTimeout(400)
+			await page.locator('.action-radio__text', { hasText: new RegExp('^' + name + '$') }).click()
+			await page.waitForTimeout(150)
+			await page.keyboard.press('Escape')
+			await page.waitForTimeout(200)
+		}
+
 		// Switch to List view for a deterministic row order.
-		await page.locator('.board-view__view-menu button').first().click()
-		await page.getByText('List', { exact: true }).click()
+		await pick('List')
 		await expect(page.locator('.board-list-row').first()).toBeVisible({ timeout: 8_000 })
 
 		const titles = () => page.locator('.board-list-row__title').allTextContents()
@@ -65,15 +77,13 @@ test.describe('Display sort (#3442)', () => {
 		expect((await titles()).map((s) => s.trim())).toEqual(created)
 
 		// Sort by Title → alphabetical.
-		await page.locator('.board-view__sort-menu button').first().click()
-		await page.getByText('Title', { exact: true }).click()
+		await pick('Title')
 		await expect
 			.poll(async () => (await titles()).map((s) => s.trim()))
 			.toEqual(['Alpha', 'Bravo', 'Charlie'])
 
 		// Back to Manual → fractional order restored (view-only sort, keys intact).
-		await page.locator('.board-view__sort-menu button').first().click()
-		await page.getByText('Manual', { exact: true }).click()
+		await pick('Manual')
 		await expect
 			.poll(async () => (await titles()).map((s) => s.trim()))
 			.toEqual(created)

--- a/tests/e2e/estimations.spec.js
+++ b/tests/e2e/estimations.spec.js
@@ -195,7 +195,7 @@ test.describe('Estimate sorting & filtering', () => {
 
 		// Switch the display sort to Estimate (radio only present because the board
 		// has a scale). The estimate ranks by scale position, not string value.
-		await page.locator('.board-view__sort-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.locator('.action-radio__text', { hasText: 'Estimate' }).click()
 		await page.keyboard.press('Escape')
 
@@ -206,7 +206,7 @@ test.describe('Estimate sorting & filtering', () => {
 		}, { timeout: 8_000 }).toBe(true)
 
 		// Reopening the menu shows the active mode as selected (not blank).
-		await page.locator('.board-view__sort-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await expect(page.getByRole('menuitemradio', { name: 'Estimate' }))
 			.toHaveAttribute('aria-checked', 'true', { timeout: 8_000 })
 

--- a/tests/e2e/list-view.spec.js
+++ b/tests/e2e/list-view.spec.js
@@ -55,8 +55,10 @@ test.describe('Board List view (#3444)', () => {
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
 		const setView = async (name) => {
-			await page.locator('.board-view__view-menu button').first().click()
-			await page.getByText(name, { exact: true }).click()
+			await page.locator('.board-view__display-menu button').first().click()
+			await page.getByRole('menuitemradio', { name, exact: true }).click()
+			// Close the popover so the next open() is a fresh open, not a toggle-shut.
+			await page.keyboard.press('Escape')
 		}
 
 		// Switch to List → card renders as a row, Board columns hidden.
@@ -89,7 +91,7 @@ test.describe('Board List view (#3444)', () => {
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
 		// Switch to List view.
-		await page.locator('.board-view__view-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.getByText('List', { exact: true }).click()
 
 		const row = page.locator('.board-list-row', { hasText: state.cardTitle })

--- a/tests/e2e/responsive-header.spec.js
+++ b/tests/e2e/responsive-header.spec.js
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Responsive board header', () => {
+	const state = { boardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Responsive ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		await api('POST', '/stacks', { boardId: board.id, title: 'To do' })
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('wide: view/sort live in the toolbar, not the ⋯ menu', async ({ page }) => {
+		await page.setViewportSize({ width: 1500, height: 900 })
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// Standalone view + sort menus are in the toolbar.
+		await expect(page.locator('.board-view__view-menu')).toBeVisible({ timeout: 8_000 })
+		await expect(page.locator('.board-view__sort-menu')).toBeVisible()
+
+		// …and are NOT duplicated inside the ⋯ menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await expect(page.getByRole('menuitemradio', { name: 'Timeline' })).toHaveCount(0)
+	})
+
+	test('narrow: view/sort/density consolidate into the ⋯ menu; nothing off-screen', async ({ page }) => {
+		// A phone-width viewport → the NC sidebar collapses and the board header is
+		// well under the consolidation threshold.
+		await page.setViewportSize({ width: 480, height: 900 })
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// The standalone view + sort menus are gone from the toolbar.
+		await expect(page.locator('.board-view__view-menu')).toHaveCount(0, { timeout: 8_000 })
+		await expect(page.locator('.board-view__sort-menu')).toHaveCount(0)
+
+		// Search, filter and ⋯ remain reachable in the bar.
+		await expect(page.locator('.board-view__search')).toBeVisible()
+		await expect(page.locator('.board-filter-bar__filter')).toBeVisible()
+		const more = page.getByRole('button', { name: 'More' })
+		await expect(more).toBeVisible()
+
+		// The consolidated View + Sort controls now live inside the ⋯ menu.
+		await more.click()
+		await expect(page.getByRole('menuitemradio', { name: 'Timeline' })).toBeVisible({ timeout: 8_000 })
+		await expect(page.getByRole('menuitemradio', { name: 'Priority', exact: true })).toBeVisible()
+		// And they work: switch to List from the menu.
+		await page.getByRole('menuitemradio', { name: 'List', exact: true }).click()
+		await expect(page.locator('.board-list-table')).toBeVisible({ timeout: 8_000 })
+	})
+})

--- a/tests/e2e/responsive-header.spec.js
+++ b/tests/e2e/responsive-header.spec.js
@@ -44,44 +44,39 @@ test.describe('Responsive board header', () => {
 		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('wide: view/sort live in the toolbar, not the ⋯ menu', async ({ page }) => {
+	test('view / sort / group / density all live under one Display popover', async ({ page }) => {
 		await page.setViewportSize({ width: 1500, height: 900 })
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		// Standalone view + sort menus are in the toolbar.
-		await expect(page.locator('.board-view__view-menu')).toBeVisible({ timeout: 8_000 })
-		await expect(page.locator('.board-view__sort-menu')).toBeVisible()
+		// One Display control; the old standalone view/sort menus are gone.
+		await expect(page.locator('.board-view__display-menu')).toBeVisible({ timeout: 8_000 })
+		await expect(page.locator('.board-view__view-menu')).toHaveCount(0)
+		await expect(page.locator('.board-view__sort-menu')).toHaveCount(0)
 
-		// …and are NOT duplicated inside the ⋯ menu.
-		await page.getByRole('button', { name: 'More' }).click()
-		await expect(page.getByRole('menuitemradio', { name: 'Timeline' })).toHaveCount(0)
+		// It holds View + Sort (+ Group + Density).
+		await page.locator('.board-view__display-menu button').first().click()
+		await expect(page.getByRole('menuitemradio', { name: 'Timeline' })).toBeVisible({ timeout: 8_000 })
+		await expect(page.getByRole('menuitemradio', { name: 'Manual', exact: true })).toBeVisible()
 	})
 
-	test('narrow: view/sort/density consolidate into the ⋯ menu; nothing off-screen', async ({ page }) => {
-		// A phone-width viewport → the NC sidebar collapses and the board header is
-		// well under the consolidation threshold.
+	test('narrow: header stays compact and Display remains reachable; nothing off-screen', async ({ page }) => {
+		// Phone-width → the NC sidebar collapses and the header is compact.
 		await page.setViewportSize({ width: 480, height: 900 })
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		// The standalone view + sort menus are gone from the toolbar.
-		await expect(page.locator('.board-view__view-menu')).toHaveCount(0, { timeout: 8_000 })
-		await expect(page.locator('.board-view__sort-menu')).toHaveCount(0)
-
-		// Search, filter and ⋯ remain reachable in the bar.
+		// Search, filter, Display and ⋯ all remain reachable in the bar.
 		await expect(page.locator('.board-view__search')).toBeVisible()
 		await expect(page.locator('.board-filter-bar__filter')).toBeVisible()
-		const more = page.getByRole('button', { name: 'More' })
-		await expect(more).toBeVisible()
+		await expect(page.getByRole('button', { name: 'More' })).toBeVisible()
+		const display = page.locator('.board-view__display-menu button').first()
+		await expect(display).toBeVisible()
 
-		// The consolidated View + Sort controls now live inside the ⋯ menu.
-		await more.click()
-		await expect(page.getByRole('menuitemradio', { name: 'Timeline' })).toBeVisible({ timeout: 8_000 })
-		await expect(page.getByRole('menuitemradio', { name: 'Priority', exact: true })).toBeVisible()
-		// And they work: switch to List from the menu.
+		// Display still drives the view: switch to List from it.
+		await display.click()
 		await page.getByRole('menuitemradio', { name: 'List', exact: true }).click()
 		await expect(page.locator('.board-list-table')).toBeVisible({ timeout: 8_000 })
 	})

--- a/tests/e2e/swimlanes.spec.js
+++ b/tests/e2e/swimlanes.spec.js
@@ -61,10 +61,10 @@ test.describe('Swimlanes (#3406)', () => {
 		await expect(page.locator('.board-view__stacks-wrap')).toBeVisible()
 		await expect(page.locator('.swimlane')).toHaveCount(0)
 
-		// Swimlanes now live under the consolidated ⋯ More overflow menu. Open it
-		// and pick "Group by label".
-		await page.getByRole('button', { name: 'More' }).click()
-		await page.getByText('Group by label', { exact: true }).click()
+		// Swimlanes now live under Display → Group by. Open it and pick "Label".
+		await page.locator('.board-view__display-menu button').first().click()
+		await page.getByRole('menuitemradio', { name: 'Label', exact: true }).click()
+		await page.keyboard.press('Escape')
 
 		// Lanes appear: the "Frontend" label lane and the trailing "No label" lane.
 		await expect(page.locator('.swimlane')).toHaveCount(2)
@@ -85,9 +85,10 @@ test.describe('Swimlanes (#3406)', () => {
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 		await expect(page.locator('.swimlane')).toHaveCount(2)
 
-		// Toggle back to "No swimlanes" → flat board restored, lanes gone.
-		await page.getByRole('button', { name: 'More' }).click()
-		await page.getByText('No swimlanes', { exact: true }).click()
+		// Toggle back to "None" (Group by) → flat board restored, lanes gone.
+		await page.locator('.board-view__display-menu button').first().click()
+		await page.getByRole('menuitemradio', { name: 'None', exact: true }).click()
+		await page.keyboard.press('Escape')
 		await expect(page.locator('.swimlane')).toHaveCount(0)
 		await expect(page.locator('.board-view__stacks-wrap')).toBeVisible()
 		await expect(page.locator('.card-tile__title', { hasText: 'Labelled Card' })).toHaveCount(1)

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -81,7 +81,7 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
 		// Switch to Timeline.
-		await page.locator('.board-view__view-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.getByText('Timeline', { exact: true }).click()
 
 		// A ranged card → a bar; a due-only card → a milestone diamond.
@@ -120,7 +120,7 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await page.addInitScript(() => { try { localStorage.clear() } catch (e) {} })
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
-		await page.locator('.board-view__view-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.getByText('Timeline', { exact: true }).click()
 
 		await expect(page.locator('.timeline__bar', { hasText: 'Ranged task' })).toBeVisible({ timeout: 8_000 })
@@ -185,7 +185,7 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
-		await page.locator('.board-view__view-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.getByText('Timeline', { exact: true }).click()
 
 		// The track must be present (there are already scheduled cards on this board).
@@ -237,7 +237,7 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 
 		await page.reload()
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
-		await page.locator('.board-view__view-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.getByText('Timeline', { exact: true }).click()
 		await expect(page.locator('.timeline__inner')).toBeVisible({ timeout: 8_000 })
 		// It appears on the track and is no longer offered as unscheduled.
@@ -250,7 +250,7 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
-		await page.locator('.board-view__view-menu button').first().click()
+		await page.locator('.board-view__display-menu button').first().click()
 		await page.getByText('Timeline', { exact: true }).click()
 
 		const lane = page.locator('.timeline__lane', { hasText: 'Ranged task' })


### PR DESCRIPTION
## Summary

A batch of board-toolbar UX work. Backend is untouched (rename already existed server-side); this is frontend + e2e.

### Added
- **Rename a board.** Board Settings → General gains a *Board name* field (managers only). Saving updates the header, the app-navigation sidebar, the command palette and the boards grid live (`useBoard.updateBoard` now also invalidates `['boards']`).
- **"Add column" moved into the ⋯ More menu.** The always-on trailing "Add stack" input is gone; adding a column is a menu action that reveals a focused on-demand composer (a brand-new empty board still shows an inline first-column prompt). Editors only.

### Changed
- **Board toolbar consolidated behind a "Display" popover** (Linear-style): View (Board/List/Timeline), Group by (swimlanes), Sort (+direction) and Density now live in one control instead of several separate menus + the swimlanes-in-⋯ section. This declutters the header and makes it fit narrow/mobile widths by design. The ⋯ menu is now purely board *actions* (Add column, Watch, Analytics, Trash, Settings).
- On a narrow header the back / Display / ⋯ buttons go icon-only and the search box collapses to a magnifier, so nothing is pushed off-screen.

### Fixed
- **Filter radios (Due / Status / Client status) now show the selected indicator.** Same `NcActionRadio` bug as the sort/view menus — a boolean-per-radio `:model-value` with no `value` made `checked` always false (it still filtered). Switched to the group idiom with an explicit "Any" option as the clear.
- **Sort / view / swimlane menus show the active option and switch on a single click** (previously nothing looked selected and it took a double click).

## Testing
- **build-frontend**: clean.
- **e2e** (local docker stack): new `board-rename-add-column.spec.js` (rename via Settings, sidebar live-update, add-column via ⋯, empty-board composer) and `responsive-header.spec.js`; plus the specs that drove the old menus (`display-sort`, `list-view`, `timeline-view`, `density`, `swimlanes`, `estimations`) updated to go through Display — all green (20/20 in the Display-affected run).
- Backend unit tests / psalm / cs unaffected (no PHP changes in this branch).

## Notes / follow-up
- **Filter is still its own control.** The next phase (not in this PR) reworks Filter into a progressive dimension→values drill-in and folds the Saved-views menu into it.
- Includes a `.gitattributes` `merge=union` for `CHANGELOG.md` (from earlier) to avoid changelog conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)