### PR TITLE
fix(attachments): mark download/inline endpoints NoCSRFRequired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Downloading (and inline-previewing) card attachments no longer fails with a
+  CSRF error.** The attachment `download` and `inline` endpoints are plain GET
+  requests reached by a browser navigation / `<img>` load, which cannot carry a
+  CSRF token — they now declare `NoCSRFRequired` (auth is still enforced by the
+  session and board-read permission check), so attachments download and preview
+  reliably again.
 - **Sort / view / swimlane menus now show the active option and switch on one
   click.** The radio menus (Sort, board view mode, Swimlanes) previously rendered
   nothing as selected when reopened and needed a double click to change — they now

--- a/lib/Controller/CardAttachmentController.php
+++ b/lib/Controller/CardAttachmentController.php
@@ -11,6 +11,7 @@ use OCA\Kanso\Service\CardAttachmentService;
 use OCA\Kanso\Service\NotPermittedException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
@@ -73,6 +74,7 @@ class CardAttachmentController extends Controller {
 	 * (DownloadResponse) so an untrusted file is never rendered inline.
 	 */
 	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function download(int $cardId, int $attachmentId): DataDownloadResponse|JSONResponse {
 		try {
 			[$attachment, $bytes] = $this->attachmentService->download(
@@ -114,6 +116,7 @@ class CardAttachmentController extends Controller {
 	 * the bytes as a scriptable type.
 	 */
 	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function inline(int $cardId, int $attachmentId): DataDisplayResponse|JSONResponse {
 		try {
 			[$attachment, $bytes] = $this->attachmentService->inline(

--- a/tests/e2e/card-attachments.spec.js
+++ b/tests/e2e/card-attachments.spec.js
@@ -211,6 +211,46 @@ test.describe('Card file attachments', () => {
 		expect(up.status).toBe(400)
 	})
 
+	// Regression for the CSRF rejection (#3784): download + inline are GET
+	// endpoints reached by a plain `<a download>` navigation / `<img src>` load
+	// — i.e. a browser *session-cookie* request that carries NO requesttoken.
+	// Nextcloud enforces CSRF on cookie-authenticated requests, so without
+	// `#[NoCSRFRequired]` these 412'd in the real app.
+	//
+	// IMPORTANT: this must go through the browser session, NOT the Basic-auth
+	// `api()`/`fetch()` helpers above — Nextcloud skips the CSRF check for
+	// non-cookie auth (Basic / app password), which is exactly why every other
+	// download assertion in this file passed even while the app was broken.
+	// `page.request` shares the logged-in context's cookies but adds no CSRF
+	// token, faithfully reproducing the `<a href>` / `<img>` fetch.
+	test('download and inline succeed over a browser session (no CSRF rejection)', async ({ page }) => {
+		await ncLogin(page)
+
+		// Seed one downloadable file and one inline-able png (setup via the API
+		// helper is fine; the assertion below is what must use the session).
+		const txt = await uploadFile(cardId, 'session-dl.txt', 'via session cookie', 'text/plain')
+		expect(txt.ok).toBe(true)
+		const png = await uploadBytes(cardId, 'session.png', PNG_1x1, 'image/png')
+		expect(png.ok).toBe(true)
+
+		// Download over the session cookie (no requesttoken) — the exact path a
+		// user's `<a download>` click takes. 412 here == the CSRF regression.
+		const dl = await page.request.get(`${API}/cards/${cardId}/attachments/${txt.body.id}`)
+		expect(dl.status(), 'attachment download rejected — likely missing NoCSRFRequired').toBe(200)
+		expect((dl.headers()['content-disposition'] || '')).toContain('attachment')
+		expect(await dl.text()).toBe('via session cookie')
+
+		// Inline serve over the session cookie — the path an `<img src>` takes.
+		const inline = await page.request.get(`${API}/cards/${cardId}/attachments/${png.body.id}/inline`)
+		expect(inline.status(), 'inline attachment rejected — likely missing NoCSRFRequired').toBe(200)
+		expect(inline.headers()['content-type']).toContain('image/png')
+		expect((inline.headers()['content-disposition'] || '')).toContain('inline')
+
+		// Cleanup.
+		await api('DELETE', `/cards/${cardId}/attachments/${txt.body.id}`)
+		await api('DELETE', `/cards/${cardId}/attachments/${png.body.id}`)
+	})
+
 	test('upload/list/download/delete through the CardModal UI', async ({ page }) => {
 		await ncLogin(page)
 		const cardUrl = `${BASE}/index.php/apps/kanso#/board/${boardId}/card/${cardId}`


### PR DESCRIPTION
## Problem
Downloading a card attachment fails with a **CSRF rejection** error (and the inline image preview is affected by the same cause).

## Root cause
`CardAttachmentController::download()` and `inline()` are plain **GET** endpoints reached by a browser navigation (`<a :href … download>` in `CardModal.vue`) or an `<img>` load — neither can carry a CSRF token. Both methods were annotated `#[NoAdminRequired]` only, so Nextcloud's default CSRF check rejected the request.

## Fix
Add `#[NoCSRFRequired]` to both `download()` and `inline()`. These are read-only, byte-streaming GET routes; access is still enforced by the session and the service-layer board-read + IDOR checks, so exempting them from CSRF is safe and standard for this kind of route.

## Changes
- `lib/Controller/CardAttachmentController.php` — import `NoCSRFRequired`, annotate `download()` and `inline()`.
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.

## Testing
- Behaviour of both endpoints (permission gating, IDOR, mime allow-list for inline) is unchanged and stays covered by `CardAttachmentServiceTest`; the CSRF exemption is a framework attribute with nothing meaningful to unit-test at the controller layer.
- Full CI (cs-check, psalm, unit-php 8.2/8.3, build-frontend, e2e) runs on this PR; the e2e suite exercises attachment download.

Fixes Kanso card #3784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)