### PR TITLE
release: cut 0.9.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.36] - 2026-08-12
+
 ### Added
 
 - **Sort a board by estimate.** The display-sort menu gains an *Estimate* option
@@ -323,8 +325,8 @@ First public release. Targets Nextcloud 30–32 and PHP 8.2+.
 - **Realtime updates** via `notify_push` (High Performance Backend) when
   available, with an automatic light polling fallback everywhere else.
 
-[Unreleased]: https://github.com/aktasfatih/kanso/compare/v0.9.35...HEAD
-[0.9.35]: https://github.com/aktasfatih/kanso/compare/v0.9.31...v0.9.35
+[Unreleased]: https://github.com/aktasfatih/kanso/compare/v0.9.36...HEAD
+[0.9.36]: https://github.com/aktasfatih/kanso/compare/v0.9.31...v0.9.36
 [0.9.31]: https://github.com/aktasfatih/kanso/compare/v0.9.2...v0.9.31
 [0.9.2]: https://github.com/aktasfatih/kanso/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/aktasfatih/kanso/compare/v0.9.0...v0.9.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.35</version>
+	<version>0.9.36</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanso",
-  "version": "0.9.0",
+  "version": "0.9.36",
   "description": "Fast open-source kanban boards for Nextcloud",
   "license": "AGPL-3.0-or-later",
   "private": true,


### PR DESCRIPTION
Cuts the **0.9.36** release (first published tarball after `v0.9.31`).

## Changes
- `CHANGELOG.md`: rename `[Unreleased]` → `[0.9.36] - 2026-08-12`, open a fresh empty `[Unreleased]`, fix the compare-link footer.
- `appinfo/info.xml`: `0.9.35` → `0.9.36`.
- `package.json`: `0.9.0` → `0.9.36` (was stranded at 0.9.0 across every prior bump — now synced).

## Context
`0.9.35` was version-bumped in `info.xml` and documented in the changelog but **never tagged or published** (no `v0.9.35` tag exists). So `v0.9.36` is the first release users receive after `v0.9.31`; its tarball carries all of the 0.9.32–0.9.35 work plus this sprint's Unreleased items. The historical `[0.9.35]` changelog section is kept as-is.

## Release steps (after merge)
Per `docs/RELEASING.md`: tag `v0.9.36` on `main` and push → the Release workflow builds/signs/attaches `kanso.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)