### PR TITLE
Progressive drill-in board filter + filter-URL cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — the toolbar is now just `[Display] [Filter] [⋯]`. Filtering behaviour, the
   shareable URL, and saved views are unchanged.
 
+### Fixed
+
+- **Clearing a Type, Estimate, or Client-status filter now cleans up the shareable
+  URL.** Previously, clearing one of those filters left a stale `ft=`/`fe=`/`fw=`
+  parameter dangling in the address bar (so a copied link still carried the removed
+  filter). Clearing any filter dimension now strips its parameter from the URL.
+
 ## [0.9.36] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Progressive filter (toolbar redesign, phase 2).** The board *Filter* control is
+  now a progressive drill-in popover instead of dumping every value at once:
+  the top level lists the dimensions (Labels, Assignees, Priority, Type, Estimate,
+  Due date, Status, Client status) each with an active-value summary and a count
+  badge, and clicking one drills into only that dimension's values with a back
+  arrow. Saved views (apply / save / delete a named view, plus *Default (no filter)*)
+  now live inside the Filter control, so the separate *Saved* header button is gone
+  — the toolbar is now just `[Display] [Filter] [⋯]`. Filtering behaviour, the
+  shareable URL, and saved views are unchanged.
+
 ## [0.9.36] - 2026-08-12
 
 ### Added
@@ -46,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Board toolbar consolidated behind a "Display" control.** How the board is
   arranged — view (Board / List / Timeline), Group by (swimlanes), Sort (+
   direction) and Density — now lives in a single *Display* popover instead of
-  several separate toolbar menus (Linear-style). This declutters the header and
+  several separate toolbar menus. This declutters the header and
   makes it fit narrow / mobile widths without pushing controls off-screen; on a
   narrow header the back, Display and ⋯ buttons go icon-only and the search box
   collapses to a magnifier.

--- a/src/components/BoardFilterBar.vue
+++ b/src/components/BoardFilterBar.vue
@@ -4,234 +4,295 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
 	<div class="board-filter-bar">
-		<!-- ── Composable filter dropdown ─────────────────────────────────────────
-		     A single NcActions menu with one section per dimension. Each section
-		     is OR-within (checkboxes / radios), AND is applied across sections in
-		     the predicate. Mirrors the old label/priority dropdown, generalised. -->
-		<NcActions
+		<!-- ── Progressive drill-in filter (#3785, Phase 2) ───────────────────────
+		     One popover whose panel swaps between (a) the ROOT — a list of the
+		     filter dimensions with an active-value summary + count badge, plus the
+		     Saved-views section folded in — and (b) a single dimension's values with
+		     a back header. @nextcloud/vue's NcActions can't nest submenus, so this is
+		     a small custom NcPopover: the trigger is the header Filter button, the
+		     panel content is driven by `activeDim`. All the underlying filter
+		     state/predicate/URL/saved-views logic is unchanged (useBoardFilters). -->
+		<NcPopover
 			class="board-filter-bar__filter"
-			:aria-label="count > 0 ? t('kanso', 'Filter · {count}', { count }) : t('kanso', 'Filter cards')"
-			:menu-name="compact
-				? undefined
-				: (count > 0
-					? t('kanso', 'Filter · {count}', { count })
-					: t('kanso', 'Filter'))"
-			:primary="count > 0">
-			<template #icon>
-				<FilterVariantIcon :size="20" />
-			</template>
-
-			<!-- Labels (OR within) -->
-			<template v-if="labels.length">
-				<NcActionCaption :name="t('kanso', 'Label')" />
-				<NcActionCheckbox
-					v-for="label in labels"
-					:key="'l-' + label.id"
-					class="board-filter-bar__label-item"
-					:style="label.color ? { '--filter-dot-color': '#' + label.color } : { '--filter-dot-color': 'var(--color-border)' }"
-					:model-value="state.labels.has(label.id)"
-					@update:model-value="toggleSet('labels', label.id)">{{ label.title }}</NcActionCheckbox>
-			</template>
-
-			<!-- Assignees (OR within) + the Unassigned sentinel -->
-			<template v-if="participants.length">
-				<NcActionCaption :name="t('kanso', 'Assignee')" />
-				<NcActionCheckbox
-					:model-value="state.assignees.has(UNASSIGNED)"
-					@update:model-value="toggleSet('assignees', UNASSIGNED)">{{ t('kanso', 'Unassigned') }}</NcActionCheckbox>
-				<NcActionCheckbox
-					v-for="p in participants"
-					:key="'a-' + p.uid"
-					:model-value="state.assignees.has(p.uid)"
-					@update:model-value="toggleSet('assignees', p.uid)">{{ p.displayName || p.uid }}</NcActionCheckbox>
-			</template>
-
-			<!-- Priority (OR within) -->
-			<NcActionCaption :name="t('kanso', 'Priority')" />
-			<NcActionCheckbox
-				v-for="level in priorityLevels"
-				:key="'p-' + level.value"
-				class="board-filter-bar__priority-item"
-				:class="`board-filter-bar__priority-item--${level.value}`"
-				:model-value="state.priorities.has(level.value)"
-				@update:model-value="toggleSet('priorities', level.value)">{{ t('kanso', level.label) }}</NcActionCheckbox>
-
-			<!-- Type (OR within) - built-in card types (#3402) -->
-			<NcActionCaption :name="t('kanso', 'Type')" />
-			<NcActionCheckbox
-				v-for="tp in cardTypes"
-				:key="'t-' + tp.value"
-				class="board-filter-bar__type-item"
-				:class="`board-filter-bar__type-item--${tp.value}`"
-				:model-value="state.types.has(tp.value)"
-				@update:model-value="toggleSet('types', tp.value)">{{ t('kanso', tp.label) }}</NcActionCheckbox>
-
-			<!-- Estimate (OR within) - scale tokens + the Unestimated sentinel.
-			     Only shown when the board has an estimation scale set. -->
-			<template v-if="estimateTokens.length">
-				<NcActionCaption :name="t('kanso', 'Estimate')" />
-				<NcActionCheckbox
-					:model-value="state.estimates.has(UNESTIMATED)"
-					@update:model-value="toggleSet('estimates', UNESTIMATED)">{{ t('kanso', 'Unestimated') }}</NcActionCheckbox>
-				<NcActionCheckbox
-					v-for="token in estimateTokens"
-					:key="'e-' + token"
-					:model-value="state.estimates.has(token)"
-					@update:model-value="toggleSet('estimates', token)">{{ token }}</NcActionCheckbox>
-			</template>
-
-			<!-- Due (single-select). Radio GROUP idiom (model-value = the selected
-			     value, each radio carries its own `value`) so the selected indicator
-			     actually renders — a boolean-per-radio binding shows nothing checked.
-			     An explicit "Any" (value '') is the clear. -->
-			<NcActionCaption :name="t('kanso', 'Due date')" />
-			<NcActionRadio
-				:model-value="state.due ?? ''"
-				value=""
-				name="kanso-filter-due"
-				@update:model-value="(v) => setSingleRadio('due', v)">{{ t('kanso', 'Any') }}</NcActionRadio>
-			<NcActionRadio
-				v-for="opt in DUE_OPTIONS"
-				:key="'d-' + opt.value"
-				:model-value="state.due ?? ''"
-				:value="opt.value"
-				name="kanso-filter-due"
-				@update:model-value="(v) => setSingleRadio('due', v)">{{ t('kanso', opt.label) }}</NcActionRadio>
-
-			<!-- Done state (single-select + Any) -->
-			<NcActionCaption :name="t('kanso', 'Status')" />
-			<NcActionRadio
-				:model-value="state.done ?? ''"
-				value=""
-				name="kanso-filter-done"
-				@update:model-value="(v) => setSingleRadio('done', v)">{{ t('kanso', 'Any') }}</NcActionRadio>
-			<NcActionRadio
-				v-for="opt in DONE_OPTIONS"
-				:key="'s-' + opt.value"
-				:model-value="state.done ?? ''"
-				:value="opt.value"
-				name="kanso-filter-done"
-				@update:model-value="(v) => setSingleRadio('done', v)">{{ t('kanso', opt.label) }}</NcActionRadio>
-
-			<!-- Waiting on client (#3746) - reads the derived waitingOnExternal
-			     summary flag, no extra request. Single-select + Any. -->
-			<NcActionCaption :name="t('kanso', 'Client status')" />
-			<NcActionRadio
-				:model-value="state.waiting ?? ''"
-				value=""
-				name="kanso-filter-waiting"
-				@update:model-value="(v) => setSingleRadio('waiting', v)">{{ t('kanso', 'Any') }}</NcActionRadio>
-			<NcActionRadio
-				v-for="opt in WAITING_OPTIONS"
-				:key="'w-' + opt.value"
-				:model-value="state.waiting ?? ''"
-				:value="opt.value"
-				name="kanso-filter-waiting"
-				@update:model-value="(v) => setSingleRadio('waiting', v)">{{ t('kanso', opt.label) }}</NcActionRadio>
-
-			<!-- Clear (only when something is active) -->
-			<template v-if="count > 0">
-				<NcActionSeparator />
-				<NcActionButton @click="clearAll">
+			:shown="open"
+			:focus-trap="false"
+			no-auto-focus
+			@update:shown="onShownChange">
+			<template #trigger="{ attrs }">
+				<NcButton
+					v-bind="attrs"
+					class="board-filter-bar__trigger"
+					:type="count > 0 ? 'primary' : 'tertiary'"
+					:aria-label="triggerLabel">
 					<template #icon>
-						<FilterVariantRemoveIcon :size="20" />
+						<FilterVariantIcon :size="20" />
 					</template>
-					{{ t('kanso', 'Clear filters') }}
-				</NcActionButton>
-			</template>
-		</NcActions>
-
-		<!-- ── Saved views dropdown ───────────────────────────────────────────────
-		     Save the current filter as a named view (per-user NC config), apply a
-		     saved view, or delete one. Bookmark icon; highlighted when the active
-		     filter matches a saved view. -->
-		<NcActions
-			v-if="!compact"
-			class="board-filter-bar__saved"
-			:aria-label="t('kanso', 'Saved filters')"
-			:menu-name="activeSavedName || t('kanso', 'Saved')">
-			<template #icon>
-				<BookmarkIcon v-if="activeSavedName" :size="20" />
-				<BookmarkOutlineIcon v-else :size="20" />
+					<template v-if="!iconOnly">{{ triggerLabel }}</template>
+				</NcButton>
 			</template>
 
-			<!-- Default view: always present so there's a one-click way back to the
-			     unfiltered board — both out of a saved view and out of any ad-hoc
-			     filter. Highlighted when no filter is active (i.e. we ARE default). -->
-			<NcActionCaption :name="t('kanso', 'Views')" />
-			<NcActionButton
-				class="board-filter-bar__saved-item"
-				:class="{ 'board-filter-bar__saved-item--active': !activeSavedName && count === 0 }"
-				@click="clearAll">
-				<template #icon>
-					<CheckIcon v-if="!activeSavedName && count === 0" :size="20" />
-					<FilterVariantRemoveIcon v-else :size="20" />
+			<div class="board-filter-bar__panel">
+				<!-- ── ROOT: dimension list + saved views ───────────────────────── -->
+				<template v-if="!activeDim">
+					<ul class="board-filter-bar__dims" role="menu">
+						<li v-for="dim in visibleDimensions" :key="dim.key" role="none">
+							<button
+								type="button"
+								role="menuitem"
+								class="board-filter-bar__dim-row"
+								:class="`board-filter-bar__dim-row--${dim.key}`"
+								:data-dim="dim.key"
+								@click="activeDim = dim.key">
+								<span class="board-filter-bar__dim-name">{{ dim.label }}</span>
+								<span
+									v-if="dim.summary"
+									class="board-filter-bar__dim-summary"
+									:title="dim.summary">{{ dim.summary }}</span>
+								<span
+									v-if="dim.count > 0"
+									class="board-filter-bar__dim-badge">{{ dim.count }}</span>
+								<ChevronRightIcon class="board-filter-bar__dim-chevron" :size="20" />
+							</button>
+						</li>
+					</ul>
+
+					<!-- Clear all (only when something is active) -->
+					<template v-if="count > 0">
+						<div class="board-filter-bar__sep" role="separator" />
+						<button
+							type="button"
+							class="board-filter-bar__action board-filter-bar__clear"
+							@click="clearAll">
+							<FilterVariantRemoveIcon :size="20" />
+							<span>{{ t('kanso', 'Clear filters') }}</span>
+						</button>
+					</template>
+
+					<!-- ── Saved views (folded in from the old Saved dropdown) ──── -->
+					<div class="board-filter-bar__sep" role="separator" />
+					<p class="board-filter-bar__caption">{{ t('kanso', 'Views') }}</p>
+					<button
+						type="button"
+						class="board-filter-bar__action board-filter-bar__saved-item"
+						:class="{ 'board-filter-bar__saved-item--active': !activeSavedName && count === 0 }"
+						@click="clearAll">
+						<CheckIcon v-if="!activeSavedName && count === 0" :size="20" />
+						<FilterVariantRemoveIcon v-else :size="20" />
+						<span>{{ t('kanso', 'Default (no filter)') }}</span>
+					</button>
+
+					<template v-if="savedFilters.length">
+						<button
+							v-for="view in savedFilters"
+							:key="'v-' + view.name"
+							type="button"
+							class="board-filter-bar__action board-filter-bar__saved-item"
+							:class="{ 'board-filter-bar__saved-item--active': view.name === activeSavedName }"
+							@click="$emit('apply-saved', view)">
+							<CheckIcon v-if="view.name === activeSavedName" :size="20" />
+							<BookmarkOutlineIcon v-else :size="20" />
+							<span>{{ view.name }}</span>
+						</button>
+						<button
+							v-if="activeSavedName"
+							type="button"
+							class="board-filter-bar__action board-filter-bar__saved-delete"
+							@click="$emit('delete-saved', activeSavedName)">
+							<DeleteOutlineIcon :size="20" />
+							<span>{{ t('kanso', 'Delete "{name}"', { name: activeSavedName }) }}</span>
+						</button>
+					</template>
+
+					<!-- Save-as: type a name, Enter (or the confirm arrow) saves the
+					     current filter. Disabled with no active filter. -->
+					<div class="board-filter-bar__sep" role="separator" />
+					<p class="board-filter-bar__caption">{{ t('kanso', 'Save current filter') }}</p>
+					<div class="board-filter-bar__save-row">
+						<NcTextField
+							v-model="saveName"
+							class="board-filter-bar__save-input"
+							:disabled="count === 0"
+							:label="t('kanso', 'View name')"
+							:placeholder="t('kanso', 'View name')"
+							:label-outside="true"
+							@keydown.enter.prevent="submitSave" />
+						<NcButton
+							type="tertiary"
+							:disabled="count === 0 || !saveName.trim()"
+							:aria-label="t('kanso', 'Save filter')"
+							@click="submitSave">
+							<template #icon>
+								<ContentSaveOutlineIcon :size="20" />
+							</template>
+						</NcButton>
+					</div>
+					<p v-if="saveError" class="board-filter-bar__save-error">{{ saveError }}</p>
 				</template>
-				{{ t('kanso', 'Default (no filter)') }}
-			</NcActionButton>
 
-			<template v-if="savedFilters.length">
-				<NcActionCaption :name="t('kanso', 'Saved filters')" />
-				<NcActionButton
-					v-for="view in savedFilters"
-					:key="'v-' + view.name"
-					:class="{ 'board-filter-bar__saved-item--active': view.name === activeSavedName }"
-					@click="$emit('apply-saved', view)">
-					<template #icon>
-						<CheckIcon v-if="view.name === activeSavedName" :size="20" />
-						<BookmarkOutlineIcon v-else :size="20" />
-					</template>
-					{{ view.name }}
-				</NcActionButton>
-				<NcActionButton
-					v-if="activeSavedName"
-					class="board-filter-bar__saved-delete"
-					@click="$emit('delete-saved', activeSavedName)">
-					<template #icon>
-						<DeleteOutlineIcon :size="20" />
-					</template>
-					{{ t('kanso', 'Delete "{name}"', { name: activeSavedName }) }}
-				</NcActionButton>
-				<NcActionSeparator />
-			</template>
+				<!-- ── DIMENSION drill-in: back header + only this dimension's values -->
+				<template v-else>
+					<div class="board-filter-bar__drill-header">
+						<NcButton
+							type="tertiary"
+							class="board-filter-bar__back"
+							:aria-label="t('kanso', 'Back to filters')"
+							@click="activeDim = null">
+							<template #icon>
+								<ArrowLeftIcon :size="20" />
+							</template>
+						</NcButton>
+						<span class="board-filter-bar__drill-title">{{ activeDimMeta.label }}</span>
+					</div>
 
-			<!-- Save-as: an inline text input; Enter (or the confirm arrow) saves
-			     the current filter under the typed name. Disabled with no active
-			     filter, since an empty saved view is meaningless. -->
-			<NcActionCaption :name="t('kanso', 'Save current filter')" />
-			<NcActionInput
-				v-model="saveName"
-				:disabled="count === 0"
-				:label="t('kanso', 'View name')"
-				:label-outside="false"
-				:placeholder="t('kanso', 'View name')"
-				@submit="submitSave">
-				<template #icon>
-					<ContentSaveOutlineIcon :size="20" />
+					<!-- Labels (OR within) -->
+					<ul v-if="activeDim === 'labels'" class="board-filter-bar__opts" role="menu">
+						<li v-for="label in labels" :key="'l-' + label.id" role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.labels.has(label.id) ? 'true' : 'false'"
+								class="board-filter-bar__opt board-filter-bar__label-item"
+								:style="{ '--filter-dot-color': label.color ? '#' + label.color : 'var(--color-border)' }"
+								@click="toggleSet('labels', label.id)">
+								<span class="board-filter-bar__opt-dot" />
+								<span class="board-filter-bar__opt-text">{{ label.title }}</span>
+								<CheckIcon v-if="state.labels.has(label.id)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+					</ul>
+
+					<!-- Assignees (OR within) + Unassigned sentinel -->
+					<ul v-else-if="activeDim === 'assignees'" class="board-filter-bar__opts" role="menu">
+						<li role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.assignees.has(UNASSIGNED) ? 'true' : 'false'"
+								class="board-filter-bar__opt"
+								@click="toggleSet('assignees', UNASSIGNED)">
+								<span class="board-filter-bar__opt-text">{{ t('kanso', 'Unassigned') }}</span>
+								<CheckIcon v-if="state.assignees.has(UNASSIGNED)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+						<li v-for="p in participants" :key="'a-' + p.uid" role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.assignees.has(p.uid) ? 'true' : 'false'"
+								class="board-filter-bar__opt"
+								@click="toggleSet('assignees', p.uid)">
+								<span class="board-filter-bar__opt-text">{{ p.displayName || p.uid }}</span>
+								<CheckIcon v-if="state.assignees.has(p.uid)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+					</ul>
+
+					<!-- Priority (OR within) -->
+					<ul v-else-if="activeDim === 'priorities'" class="board-filter-bar__opts" role="menu">
+						<li v-for="level in priorityLevels" :key="'p-' + level.value" role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.priorities.has(level.value) ? 'true' : 'false'"
+								class="board-filter-bar__opt board-filter-bar__priority-item"
+								:class="`board-filter-bar__priority-item--${level.value}`"
+								@click="toggleSet('priorities', level.value)">
+								<span class="board-filter-bar__opt-dot" />
+								<span class="board-filter-bar__opt-text">{{ t('kanso', level.label) }}</span>
+								<CheckIcon v-if="state.priorities.has(level.value)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+					</ul>
+
+					<!-- Type (OR within) - built-in card types (#3402) -->
+					<ul v-else-if="activeDim === 'types'" class="board-filter-bar__opts" role="menu">
+						<li v-for="tp in cardTypes" :key="'t-' + tp.value" role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.types.has(tp.value) ? 'true' : 'false'"
+								class="board-filter-bar__opt board-filter-bar__type-item"
+								:class="`board-filter-bar__type-item--${tp.value}`"
+								@click="toggleSet('types', tp.value)">
+								<span class="board-filter-bar__opt-dot" />
+								<span class="board-filter-bar__opt-text">{{ t('kanso', tp.label) }}</span>
+								<CheckIcon v-if="state.types.has(tp.value)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+					</ul>
+
+					<!-- Estimate (OR within) - scale tokens + Unestimated sentinel -->
+					<ul v-else-if="activeDim === 'estimates'" class="board-filter-bar__opts" role="menu">
+						<li role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.estimates.has(UNESTIMATED) ? 'true' : 'false'"
+								class="board-filter-bar__opt"
+								@click="toggleSet('estimates', UNESTIMATED)">
+								<span class="board-filter-bar__opt-text">{{ t('kanso', 'Unestimated') }}</span>
+								<CheckIcon v-if="state.estimates.has(UNESTIMATED)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+						<li v-for="token in estimateTokens" :key="'e-' + token" role="none">
+							<button
+								type="button"
+								role="menuitemcheckbox"
+								:aria-checked="state.estimates.has(token) ? 'true' : 'false'"
+								class="board-filter-bar__opt"
+								@click="toggleSet('estimates', token)">
+								<span class="board-filter-bar__opt-text">{{ token }}</span>
+								<CheckIcon v-if="state.estimates.has(token)" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+					</ul>
+
+					<!-- Single-select dimensions (Due / Status / Client status): a
+					     radio group with an explicit "Any" (value '') clear. -->
+					<ul v-else class="board-filter-bar__opts" role="menu">
+						<li role="none">
+							<button
+								type="button"
+								role="menuitemradio"
+								:aria-checked="!currentSingleValue ? 'true' : 'false'"
+								class="board-filter-bar__opt"
+								@click="setSingleRadio(activeDim, '')">
+								<span class="board-filter-bar__opt-text">{{ t('kanso', 'Any') }}</span>
+								<CheckIcon v-if="!currentSingleValue" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+						<li v-for="opt in activeDimMeta.options" :key="'o-' + opt.value" role="none">
+							<button
+								type="button"
+								role="menuitemradio"
+								:aria-checked="currentSingleValue === opt.value ? 'true' : 'false'"
+								class="board-filter-bar__opt"
+								@click="setSingleRadio(activeDim, opt.value)">
+								<span class="board-filter-bar__opt-text">{{ t('kanso', opt.label) }}</span>
+								<CheckIcon v-if="currentSingleValue === opt.value" class="board-filter-bar__opt-check" :size="20" />
+							</button>
+						</li>
+					</ul>
 				</template>
-			</NcActionInput>
-			<p v-if="saveError" class="board-filter-bar__save-error">{{ saveError }}</p>
-		</NcActions>
+			</div>
+		</NcPopover>
 	</div>
 </template>
 
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { translate as t } from '@nextcloud/l10n'
-import NcActions from '@nextcloud/vue/components/NcActions'
-import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
-import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
-import NcActionButton from '@nextcloud/vue/components/NcActionButton'
-import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
-import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
-import NcActionInput from '@nextcloud/vue/components/NcActionInput'
+import NcPopover from '@nextcloud/vue/components/NcPopover'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
 import FilterVariantIcon from 'vue-material-design-icons/FilterVariant.vue'
 import FilterVariantRemoveIcon from 'vue-material-design-icons/FilterVariantRemove.vue'
-import BookmarkIcon from 'vue-material-design-icons/Bookmark.vue'
 import BookmarkOutlineIcon from 'vue-material-design-icons/BookmarkOutline.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import DeleteOutlineIcon from 'vue-material-design-icons/DeleteOutline.vue'
 import ContentSaveOutlineIcon from 'vue-material-design-icons/ContentSaveOutline.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import { PRIORITY_LEVELS } from '../composables/usePriority.js'
 import { CARD_TYPES } from '../composables/useCardType.js'
 import { scaleTokens } from '../services/estimateScales.js'
@@ -257,19 +318,17 @@ const props = defineProps({
 	activeSavedName: { type: String, default: '' },
 	/** The board's estimation scale key (e.g. 'fibonacci'); 'none' hides the facet. */
 	estimateScale: { type: String, default: 'none' },
-	/** Compact (narrow header): icon-only filter trigger, and hide the Saved menu. */
-	compact: { type: Boolean, default: false },
+	/** Icon-only trigger (narrow header) — the label text is dropped, the menu is
+	    identical. */
+	iconOnly: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['save', 'apply-saved', 'delete-saved'])
 
-// Priority levels except "None" (0) — 0 is represented by NOT selecting any
-// priority; offering an explicit "None" checkbox would be redundant AND would
-// mean "priority == 0" which is better expressed by leaving priority unfiltered.
+// Priority levels except "None" (0) — 0 is expressed by NOT selecting any.
 const priorityLevels = computed(() => PRIORITY_LEVELS.filter((l) => l.value > 0))
 
-// Built-in card types facet (#3402). "None" is expressed by leaving the type
-// dimension unfiltered - no explicit "None" checkbox (mirrors the priority facet).
+// Built-in card types facet (#3402). "None" = leaving the dimension unfiltered.
 const cardTypes = CARD_TYPES
 
 // Estimate facet tokens for the board's scale (empty ⇒ facet hidden).
@@ -277,8 +336,131 @@ const estimateTokens = computed(() => scaleTokens(props.estimateScale))
 
 const count = useFilterCount(props.state)
 
+// Popover open + which dimension is drilled into (null = root list).
+const open = ref(false)
+const activeDim = ref(null)
+
 const saveName = ref('')
 const saveError = ref('')
+
+const triggerLabel = computed(() =>
+	count.value > 0
+		? t('kanso', 'Filter · {count}', { count: count.value })
+		: t('kanso', 'Filter'),
+)
+
+// Summary text for a multi-select (Set) dimension: joined labels, truncated.
+function setSummary(set, resolveLabel) {
+	if (!set.size) return ''
+	const parts = [...set].map(resolveLabel).filter(Boolean)
+	if (parts.length <= 2) return parts.join(', ')
+	return t('kanso', '{first}, +{n} more', { first: parts.slice(0, 2).join(', '), n: parts.length - 2 })
+}
+
+const labelTitleById = computed(() => {
+	const m = new Map()
+	for (const l of props.labels) m.set(l.id, l.title)
+	return m
+})
+const participantNameByUid = computed(() => {
+	const m = new Map()
+	for (const p of props.participants) m.set(p.uid, p.displayName || p.uid)
+	return m
+})
+
+function singleSummary(value, options) {
+	if (!value) return ''
+	const opt = options.find((o) => o.value === value)
+	return opt ? t('kanso', opt.label) : ''
+}
+
+// The dimension metadata driving both the root list and each drill-in panel.
+// `count`/`summary` are computed live off the state. `options` is only set for
+// the single-select radio dimensions (due/done/waiting).
+const dimensions = computed(() => {
+	const s = props.state
+	return [
+		{
+			key: 'labels',
+			label: t('kanso', 'Labels'),
+			show: props.labels.length > 0,
+			count: s.labels.size,
+			summary: setSummary(s.labels, (id) => labelTitleById.value.get(id)),
+		},
+		{
+			key: 'assignees',
+			label: t('kanso', 'Assignees'),
+			show: props.participants.length > 0,
+			count: s.assignees.size,
+			summary: setSummary(s.assignees, (uid) =>
+				uid === UNASSIGNED ? t('kanso', 'Unassigned') : participantNameByUid.value.get(uid) || uid),
+		},
+		{
+			key: 'priorities',
+			label: t('kanso', 'Priority'),
+			show: true,
+			count: s.priorities.size,
+			summary: setSummary(s.priorities, (v) => {
+				const lvl = PRIORITY_LEVELS.find((l) => l.value === v)
+				return lvl ? t('kanso', lvl.label) : ''
+			}),
+		},
+		{
+			key: 'types',
+			label: t('kanso', 'Type'),
+			show: true,
+			count: s.types.size,
+			summary: setSummary(s.types, (v) => {
+				const tp = CARD_TYPES.find((c) => c.value === v)
+				return tp ? t('kanso', tp.label) : ''
+			}),
+		},
+		{
+			key: 'estimates',
+			label: t('kanso', 'Estimate'),
+			show: estimateTokens.value.length > 0,
+			count: s.estimates.size,
+			summary: setSummary(s.estimates, (tok) => tok === UNESTIMATED ? t('kanso', 'Unestimated') : tok),
+		},
+		{
+			key: 'due',
+			label: t('kanso', 'Due date'),
+			show: true,
+			options: DUE_OPTIONS,
+			count: s.due ? 1 : 0,
+			summary: singleSummary(s.due, DUE_OPTIONS),
+		},
+		{
+			key: 'done',
+			label: t('kanso', 'Status'),
+			show: true,
+			options: DONE_OPTIONS,
+			count: s.done ? 1 : 0,
+			summary: singleSummary(s.done, DONE_OPTIONS),
+		},
+		{
+			key: 'waiting',
+			label: t('kanso', 'Client status'),
+			show: true,
+			options: WAITING_OPTIONS,
+			count: s.waiting ? 1 : 0,
+			summary: singleSummary(s.waiting, WAITING_OPTIONS),
+		},
+	]
+})
+
+const visibleDimensions = computed(() => dimensions.value.filter((d) => d.show))
+
+const activeDimMeta = computed(() =>
+	dimensions.value.find((d) => d.key === activeDim.value) ?? {})
+
+// The current value of the drilled-in single-select dimension (due/done/waiting).
+const currentSingleValue = computed(() => {
+	if (activeDim.value === 'due') return props.state.due
+	if (activeDim.value === 'done') return props.state.done
+	if (activeDim.value === 'waiting') return props.state.waiting
+	return null
+})
 
 function toggleSet(dim, value) {
 	const set = props.state[dim]
@@ -286,8 +468,7 @@ function toggleSet(dim, value) {
 	else set.add(value)
 }
 
-// Single-select radio dimensions (due / done / waiting). The group's value is the
-// selected token, with '' meaning "Any" → stored as null (the empty state).
+// Single-select radio dimensions (due / done / waiting). '' → null (empty state).
 function setSingleRadio(dim, value) {
 	props.state[dim] = value || null
 }
@@ -309,9 +490,20 @@ function submitSave() {
 		saveError.value = t('kanso', 'Enter a name.')
 		return
 	}
+	if (count.value === 0) return
 	saveError.value = ''
 	emit('save', name)
 	saveName.value = ''
+}
+
+function onShownChange(shown) {
+	open.value = shown
+	if (!shown) resetToRoot()
+}
+
+// Always reopen at the root dimension list, never a stale drilled-in panel.
+function resetToRoot() {
+	activeDim.value = null
 }
 
 // Clear any stale save-error once the user resumes typing.
@@ -326,60 +518,177 @@ watch(saveName, () => { saveError.value = '' })
 	flex-shrink: 0;
 }
 
-/* Label color dot — same pseudo-element technique as the old dropdown:
-   NcActionCheckbox reads its slot as plain text, so the dot is drawn via a
-   ::before on the inner text span, coloured by --filter-dot-color. */
-.board-filter-bar__label-item:deep(.action-checkbox__text)::before {
-	content: '';
+.board-filter-bar__panel {
+	min-width: 260px;
+	max-width: 320px;
+	max-height: min(70vh, 520px);
+	overflow-y: auto;
+	padding: 4px;
+	box-sizing: border-box;
+}
+
+/* ── Root dimension list ─────────────────────────────────────────────────── */
+.board-filter-bar__dims {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.board-filter-bar__dim-row,
+.board-filter-bar__action,
+.board-filter-bar__opt {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	border: none;
+	background: transparent;
+	color: var(--color-main-text);
+	font-size: inherit;
+	text-align: left;
+	padding: 8px 10px;
+	border-radius: var(--border-radius, 8px);
+	cursor: pointer;
+	min-height: 40px;
+	box-sizing: border-box;
+}
+
+.board-filter-bar__dim-row:hover,
+.board-filter-bar__action:hover,
+.board-filter-bar__opt:hover,
+.board-filter-bar__dim-row:focus-visible,
+.board-filter-bar__action:focus-visible,
+.board-filter-bar__opt:focus-visible {
+	background: var(--color-background-hover);
+	outline: none;
+}
+
+.board-filter-bar__dim-name {
+	flex: 0 0 auto;
+	font-weight: 500;
+}
+
+.board-filter-bar__dim-summary {
+	flex: 1 1 auto;
+	min-width: 0;
+	color: var(--color-text-maxcontrast);
+	font-size: 0.85em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	text-align: right;
+}
+
+.board-filter-bar__dim-badge {
+	flex: 0 0 auto;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	border-radius: 9px;
+	background: var(--color-primary-element, #0082c9);
+	color: var(--color-primary-element-text, #fff);
+	font-size: 0.75em;
+	line-height: 18px;
+	text-align: center;
+}
+
+.board-filter-bar__dim-chevron {
+	flex: 0 0 auto;
+	color: var(--color-text-maxcontrast);
+	margin-left: auto;
+}
+/* When a summary is present it already takes the trailing space, so the chevron
+   should not push away with auto-margin. */
+.board-filter-bar__dim-summary + .board-filter-bar__dim-badge + .board-filter-bar__dim-chevron,
+.board-filter-bar__dim-summary + .board-filter-bar__dim-chevron {
+	margin-left: 4px;
+}
+
+/* ── Drill-in header ─────────────────────────────────────────────────────── */
+.board-filter-bar__drill-header {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 2px 6px;
+	border-bottom: 1px solid var(--color-border);
+	margin-bottom: 4px;
+}
+
+.board-filter-bar__drill-title {
+	font-weight: 600;
+}
+
+/* ── Option rows ─────────────────────────────────────────────────────────── */
+.board-filter-bar__opts {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.board-filter-bar__opt-text {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.board-filter-bar__opt-check {
+	flex: 0 0 auto;
+	color: var(--color-primary-element, #0082c9);
+	margin-left: auto;
+}
+
+.board-filter-bar__opt-dot {
+	flex: 0 0 auto;
 	display: inline-block;
 	width: 12px;
 	height: 12px;
-	min-width: 12px;
 	border-radius: 50%;
 	background: var(--filter-dot-color, var(--color-border));
-	margin-right: 6px;
-	vertical-align: middle;
 }
 
-.board-filter-bar__priority-item--1:deep(.action-checkbox__text)::before,
-.board-filter-bar__priority-item--2:deep(.action-checkbox__text)::before,
-.board-filter-bar__priority-item--3:deep(.action-checkbox__text)::before,
-.board-filter-bar__priority-item--4:deep(.action-checkbox__text)::before {
-	content: '';
-	display: inline-block;
-	width: 12px;
-	height: 12px;
-	min-width: 12px;
-	border-radius: 50%;
-	margin-right: 6px;
-	vertical-align: middle;
-}
-.board-filter-bar__priority-item--1:deep(.action-checkbox__text)::before { background: #888; }
-.board-filter-bar__priority-item--2:deep(.action-checkbox__text)::before { background: var(--color-primary-element, #0082c9); }
-.board-filter-bar__priority-item--3:deep(.action-checkbox__text)::before { background: #e07b00; }
-.board-filter-bar__priority-item--4:deep(.action-checkbox__text)::before { background: var(--color-error, #e30000); }
+/* Priority dot colours (mirror the tile/badge palette). */
+.board-filter-bar__priority-item--1 .board-filter-bar__opt-dot { background: #888; }
+.board-filter-bar__priority-item--2 .board-filter-bar__opt-dot { background: var(--color-primary-element, #0082c9); }
+.board-filter-bar__priority-item--3 .board-filter-bar__opt-dot { background: #e07b00; }
+.board-filter-bar__priority-item--4 .board-filter-bar__opt-dot { background: var(--color-error, #e30000); }
 
-/* Type facet colour dots (#3402) - matches the tile/pill type colours. */
-.board-filter-bar__type-item--bug:deep(.action-checkbox__text)::before,
-.board-filter-bar__type-item--feature:deep(.action-checkbox__text)::before,
-.board-filter-bar__type-item--task:deep(.action-checkbox__text)::before,
-.board-filter-bar__type-item--chore:deep(.action-checkbox__text)::before {
-	content: '';
-	display: inline-block;
-	width: 12px;
-	height: 12px;
-	min-width: 12px;
-	border-radius: 50%;
-	margin-right: 6px;
-	vertical-align: middle;
+/* Type dot colours (mirror the tile/pill type colours). */
+.board-filter-bar__type-item--bug .board-filter-bar__opt-dot { background: #e74c3c; }
+.board-filter-bar__type-item--feature .board-filter-bar__opt-dot { background: #27ae60; }
+.board-filter-bar__type-item--task .board-filter-bar__opt-dot { background: var(--color-primary-element, #0082c9); }
+.board-filter-bar__type-item--chore .board-filter-bar__opt-dot { background: #7f8c8d; }
+
+/* ── Saved views ─────────────────────────────────────────────────────────── */
+.board-filter-bar__caption {
+	margin: 6px 10px 2px;
+	font-size: 0.8em;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
 }
-.board-filter-bar__type-item--bug:deep(.action-checkbox__text)::before { background: #e74c3c; }
-.board-filter-bar__type-item--feature:deep(.action-checkbox__text)::before { background: #27ae60; }
-.board-filter-bar__type-item--task:deep(.action-checkbox__text)::before { background: var(--color-primary-element, #0082c9); }
-.board-filter-bar__type-item--chore:deep(.action-checkbox__text)::before { background: #7f8c8d; }
 
 .board-filter-bar__saved-item--active {
 	font-weight: 600;
+}
+
+.board-filter-bar__sep {
+	height: 1px;
+	background: var(--color-border);
+	margin: 4px 0;
+}
+
+.board-filter-bar__save-row {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 0 6px 2px;
+}
+
+.board-filter-bar__save-input {
+	flex: 1 1 auto;
 }
 
 .board-filter-bar__save-error {

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -145,7 +145,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:saved-filters="savedFilters"
 				:active-saved-name="activeSavedName"
 				:estimate-scale="boardData?.board?.estimateScale ?? 'none'"
-				:compact="isNarrow"
+				:icon-only="isNarrow"
 				@save="handleSaveFilter"
 				@apply-saved="handleApplySavedFilter"
 				@delete-saved="handleDeleteSavedFilter" />

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1058,11 +1058,6 @@ const filterState = createFilterState()
 // A live predicate rebuilt whenever the filter changes. `now` is captured once
 // per rebuild so the "this week" / "overdue" windows stay stable across a pass.
 const filterPredicate = computed(() => makePredicate(filterState, Date.now()))
-const totalActiveFilters = computed(() => {
-	const s = filterState
-	return s.labels.size + s.assignees.size + s.priorities.size
-		+ (s.due ? 1 : 0) + (s.done ? 1 : 0)
-})
 
 // ── Saved views (#3407) ───────────────────────────────────────────────────────
 // Per-user, per-board named filter snapshots persisted in NC user config.
@@ -1119,9 +1114,10 @@ async function handleDeleteSavedFilter(name) {
 // Two watchers keep the live filter and the URL query in lock-step. There is NO
 // mutation guard flag: the feedback loop is broken purely by value-equality —
 // each watcher no-ops when the two sides already encode the same filter, so an
-// edit propagates exactly one hop and then settles. Only the five filter keys
-// (fl/fa/fp/fd/fs) are owned here; other query params are preserved untouched.
-const FILTER_QUERY_KEYS = ['fl', 'fa', 'fp', 'fd', 'fs']
+// edit propagates exactly one hop and then settles. Only the filter keys
+// (fl/fa/fp/ft/fe/fd/fs/fw — one per filter dimension, matching filterToQuery)
+// are owned here; other query params are preserved untouched.
+const FILTER_QUERY_KEYS = ['fl', 'fa', 'fp', 'ft', 'fe', 'fd', 'fs', 'fw']
 
 // Apply the URL's filter params onto the state (shared link / back-forward).
 function applyUrlToFilter() {

--- a/tests/e2e/board-filters.spec.js
+++ b/tests/e2e/board-filters.spec.js
@@ -55,7 +55,7 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		// Give the board an estimate scale so the "Estimate" filter dimension is
 		// offered (it is hidden on a 'none'-scale board) — needed by the
 		// clear-removes-URL-param test below.
-		await api('PUT', `/boards/${board.id}`, { estimateScale: 'fibonacci' })
+		await api('PATCH', `/boards/${board.id}`, { estimateScale: 'fibonacci' })
 
 		const label = await api('POST', '/labels', { boardId: board.id, title: 'Backend', color: 'e74c3c' })
 		state.labelId = label.id

--- a/tests/e2e/board-filters.spec.js
+++ b/tests/e2e/board-filters.spec.js
@@ -52,6 +52,11 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		state.boardId = board.id
 		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To do' })
 
+		// Give the board an estimate scale so the "Estimate" filter dimension is
+		// offered (it is hidden on a 'none'-scale board) — needed by the
+		// clear-removes-URL-param test below.
+		await api('PUT', `/boards/${board.id}`, { estimateScale: 'fibonacci' })
+
 		const label = await api('POST', '/labels', { boardId: board.id, title: 'Backend', color: 'e74c3c' })
 		state.labelId = label.id
 
@@ -171,5 +176,45 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		await expect(page.locator('.card-tile__title', { hasText: 'Overdue Only Card' })).toHaveCount(1)
 		await expect.poll(() => page.url()).not.toContain('fl=')
 		expect(page.url()).not.toContain('fd=')
+	})
+
+	// #3828: clearing a filter must also strip its query param from the shareable
+	// URL. FILTER_QUERY_KEYS (the set of params the URL-sync watcher owns and may
+	// remove) previously omitted ft/fe/fw, so clearing a type / estimate / waiting
+	// filter left a stale ft=/fe=/fw= dangling in the URL. Load each filter from
+	// the URL, clear it via the UI, and assert the param is gone.
+	test('clearing a type / estimate / waiting filter removes its URL param (#3828)', async ({ page }) => {
+		await ncLogin(page)
+
+		// ── Type filter (ft): drill into "Type", uncheck the applied "Bug" ────────
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}?ft=bug`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		expect(page.url()).toContain('ft=bug')
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="types"]').click()
+		// Toggle the checked "Bug" option off (it is applied from the URL).
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Bug' }).click()
+		await page.keyboard.press('Escape')
+		await expect.poll(() => page.url()).not.toContain('ft=')
+
+		// ── Estimate filter (fe): drill into "Estimate", uncheck the applied token ─
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}?fe=3`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		expect(page.url()).toContain('fe=3')
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="estimates"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: /^3$/ }).click()
+		await page.keyboard.press('Escape')
+		await expect.poll(() => page.url()).not.toContain('fe=')
+
+		// ── Waiting filter (fw): drill into "Client status", pick "Any" to clear ──
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}?fw=waiting`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		expect(page.url()).toContain('fw=waiting')
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="waiting"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Any' }).click()
+		await page.keyboard.press('Escape')
+		await expect.poll(() => page.url()).not.toContain('fw=')
 	})
 })

--- a/tests/e2e/board-filters.spec.js
+++ b/tests/e2e/board-filters.spec.js
@@ -90,15 +90,16 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		await expect(page.locator('.card-tile__title', { hasText: 'Match Card' })).toHaveCount(1)
 		await expect(page.locator('.card-tile__title', { hasText: 'Plain Card' })).toHaveCount(1)
 
-		// ── Apply a label + overdue filter ────────────────────────────────────────
-		// Open the filter dropdown and check the "Backend" label + "Overdue" due.
-		// The NcActionCheckbox input is visually covered by its icon, so click the
-		// label span (which only exists inside the menu — a card's "Backend" chip
-		// is .card-tile__label-chip, so this is unambiguous).
+		// ── Apply a label + overdue filter (progressive drill-in, #3785) ──────────
+		// The Filter popover opens at the ROOT dimension list. Drill into "Labels",
+		// check "Backend", go back, drill into "Due date", pick "Overdue".
 		await page.locator('.board-filter-bar__filter button').first().click()
-		await page.locator('.action-checkbox__text', { hasText: 'Backend' }).click()
-		await page.locator('.action-radio__text', { hasText: 'Overdue' }).click()
-		// Close the menu by pressing Escape so the board is interactable.
+		await page.locator('.board-filter-bar__dim-row[data-dim="labels"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Backend' }).click()
+		await page.locator('.board-filter-bar__back').click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="due"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Overdue' }).click()
+		// Close the popover by pressing Escape so the board is interactable.
 		await page.keyboard.press('Escape')
 
 		// Only the Match Card (label AND overdue) remains.
@@ -112,18 +113,17 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		await expect.poll(() => page.url()).toContain('fd=overdue')
 		expect(page.url()).toContain(`fl=${state.labelId}`)
 
-		// ── Save it as a named view ───────────────────────────────────────────────
-		// The saved-views menu (and its NcActionInput) is teleported to the body,
-		// so target the input by its placeholder globally.
-		await page.locator('.board-filter-bar__saved button').first().click()
+		// ── Save it as a named view (Saved views now live INSIDE Filter, #3785) ───
+		// The save-as input is an NcTextField in the Filter popover root; it is
+		// teleported to the body, so target it by its placeholder globally.
+		await page.locator('.board-filter-bar__filter button').first().click()
 		const nameInput = page.getByPlaceholder('View name')
 		await nameInput.fill('Backend overdue')
 		await nameInput.press('Enter')
-		// The saved view now appears in the saved menu (reopen it). Scope to the
-		// menu item text — the toggle button also shows the active view's name.
+		// The saved view now appears as a saved-item row (reopen the popover).
 		await page.keyboard.press('Escape')
-		await page.locator('.board-filter-bar__saved button').first().click()
-		await expect(page.locator('.action-button__text', { hasText: 'Backend overdue' })).toBeVisible()
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await expect(page.locator('.board-filter-bar__saved-item', { hasText: 'Backend overdue' })).toBeVisible()
 		await page.keyboard.press('Escape')
 
 		// ── Reload → clear the filter → re-apply the saved view ──────────────────
@@ -133,9 +133,9 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		// All cards back (filter cleared).
 		await expect(page.locator('.card-tile__title', { hasText: 'Plain Card' })).toHaveCount(1)
 
-		// Apply the saved view.
-		await page.locator('.board-filter-bar__saved button').first().click()
-		await page.locator('.action-button__text', { hasText: 'Backend overdue' }).click()
+		// Apply the saved view (from the Filter popover's Views section).
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.board-filter-bar__saved-item', { hasText: 'Backend overdue' }).click()
 		await page.keyboard.press('Escape')
 		// Filter re-applied: only the Match Card remains.
 		await expect(page.locator('.card-tile__title', { hasText: 'Match Card' })).toHaveCount(1)
@@ -161,9 +161,9 @@ test.describe('Board filter bar + saved filters (#3407)', () => {
 		await expect(page.locator('.card-tile__title', { hasText: 'Match Card' })).toHaveCount(1)
 		await expect(page.locator('.card-tile__title', { hasText: 'Plain Card' })).toHaveCount(0)
 
-		// Open the Saved menu and pick "Default (no filter)".
-		await page.locator('.board-filter-bar__saved button').first().click()
-		await page.locator('.action-button__text', { hasText: 'Default (no filter)' }).click()
+		// Open the Filter popover and pick "Default (no filter)" from its Views.
+		await page.locator('.board-filter-bar__filter button').first().click()
+		await page.locator('.board-filter-bar__saved-item', { hasText: 'Default (no filter)' }).click()
 		await page.keyboard.press('Escape')
 
 		// Back to unfiltered: every card returns and the URL filter params are gone.

--- a/tests/e2e/card-type.spec.js
+++ b/tests/e2e/card-type.spec.js
@@ -172,10 +172,11 @@ test.describe('Card types', () => {
 		await expect(page.locator('.card-tile').filter({ hasText: 'Feature Type Card' }))
 			.toBeVisible({ timeout: 5000 })
 
-		// Open the filter menu (the filter toggle, not the adjacent saved-views one)
+		// Open the filter popover and drill into the Type dimension (#3785).
 		const filterMenu = page.locator('.board-filter-bar__filter button').first()
 		await expect(filterMenu).toBeVisible({ timeout: 5000 })
 		await filterMenu.click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="types"]').click()
 
 		// Check the "Bug" type filter
 		const bugFilter = page.locator('.board-filter-bar__type-item--bug')
@@ -191,8 +192,9 @@ test.describe('Card types', () => {
 		await expect(page.locator('.card-tile').filter({ hasText: 'Feature Type Card' }))
 			.not.toBeVisible({ timeout: 5000 })
 
-		// Clear the filter by unchecking Bug
+		// Clear the filter by re-opening, drilling into Type, and unchecking Bug
 		await filterMenu.click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="types"]').click()
 		const bugAgain = page.locator('.board-filter-bar__type-item--bug')
 		await expect(bugAgain).toBeVisible({ timeout: 5000 })
 		await bugAgain.click()

--- a/tests/e2e/estimations.spec.js
+++ b/tests/e2e/estimations.spec.js
@@ -225,9 +225,10 @@ test.describe('Estimate sorting & filtering', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
-		// Filter to just the "13" token → only EstBig remains.
+		// Filter to just the "13" token → only EstBig remains (drill into Estimate, #3785).
 		await page.locator('.board-filter-bar__filter button').first().click()
-		await page.locator('.action-checkbox__text', { hasText: /^13$/ }).click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="estimates"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: /^13$/ }).click()
 		await page.keyboard.press('Escape')
 		await expect(page.locator('.card-tile__title', { hasText: 'EstBig' })).toHaveCount(1)
 		await expect(page.locator('.card-tile__title', { hasText: 'EstSmall' })).toHaveCount(0)
@@ -237,8 +238,9 @@ test.describe('Estimate sorting & filtering', () => {
 
 		// Swap to the "Unestimated" facet → only EstNone remains.
 		await page.locator('.board-filter-bar__filter button').first().click()
-		await page.locator('.action-checkbox__text', { hasText: /^13$/ }).click() // uncheck 13
-		await page.locator('.action-checkbox__text', { hasText: 'Unestimated' }).click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="estimates"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: /^13$/ }).click() // uncheck 13
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Unestimated' }).click()
 		await page.keyboard.press('Escape')
 		await expect(page.locator('.card-tile__title', { hasText: 'EstNone' })).toHaveCount(1)
 		await expect(page.locator('.card-tile__title', { hasText: 'EstBig' })).toHaveCount(0)

--- a/tests/e2e/labels.spec.js
+++ b/tests/e2e/labels.spec.js
@@ -100,9 +100,11 @@ test.describe('Labels', () => {
 		const filterBtn = page.locator('.board-view__filter-menu button', { hasText: /filter/i })
 		await expect(filterBtn).toHaveCount(1)
 
-		// Opening the filter menu shows a checkbox row for the new label
+		// Opening the filter popover and drilling into Labels shows a row for the
+		// new label (progressive drill-in, #3785).
 		await filterBtn.click()
-		await expect(page.locator('.board-filter-bar__label-item .action-checkbox__text', { hasText: 'ColoredE2E' })).toHaveCount(1)
+		await page.locator('.board-filter-bar__dim-row[data-dim="labels"]').click()
+		await expect(page.locator('.board-filter-bar__label-item .board-filter-bar__opt-text', { hasText: 'ColoredE2E' })).toHaveCount(1)
 	})
 
 	test('inline create from the card view: new label is assigned + present on the board', async ({ page }) => {

--- a/tests/e2e/priority.spec.js
+++ b/tests/e2e/priority.spec.js
@@ -175,17 +175,18 @@ test.describe('Card priorities', () => {
 		await expect(page.locator('.card-tile').filter({ hasText: 'Urgent Priority Card' }))
 			.toBeVisible({ timeout: 5000 })
 
-		// Open the filter menu (the filter toggle, not the adjacent saved-views one)
+		// Open the filter popover and drill into the Priority dimension (#3785).
 		const filterMenu = page.locator('.board-filter-bar__filter button').first()
 		await expect(filterMenu).toBeVisible({ timeout: 5000 })
 		await filterMenu.click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="priorities"]').click()
 
-		// Click the "Urgent" priority filter checkbox (level 4)
+		// Click the "Urgent" priority filter option (level 4)
 		const urgentFilterCheckbox = page.locator('.board-filter-bar__priority-item--4')
 		await expect(urgentFilterCheckbox).toBeVisible({ timeout: 5000 })
 		await urgentFilterCheckbox.click()
 
-		// Close the menu by pressing Escape
+		// Close the popover by pressing Escape
 		await page.keyboard.press('Escape')
 		await page.waitForTimeout(300)
 
@@ -195,9 +196,9 @@ test.describe('Card priorities', () => {
 		await expect(page.locator('.card-tile').filter({ hasText: 'High Priority Card' }))
 			.not.toBeVisible({ timeout: 5000 })
 
-		// Clear the filter by reopening the menu and unchecking Urgent (robust -
-		// avoids the teleported "Clear filters" NcActionButton).
+		// Clear the filter by reopening, drilling into Priority, and unchecking Urgent.
 		await filterMenu.click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="priorities"]').click()
 		const urgentAgain = page.locator('.board-filter-bar__priority-item--4')
 		await expect(urgentAgain).toBeVisible({ timeout: 5000 })
 		await urgentAgain.click()

--- a/tests/e2e/waiting-on-client.spec.js
+++ b/tests/e2e/waiting-on-client.spec.js
@@ -109,8 +109,10 @@ test.describe.serial('Waiting on client (#3746)', () => {
 		await expect(plainTile.locator('.card-tile__waiting')).toHaveCount(0)
 
 		// ── Filter facet: "Waiting on client" hides the non-waiting card ──────
+		// Drill into the "Client status" dimension (#3785) and pick the facet.
 		await page.locator('.board-filter-bar__filter button').first().click()
-		await page.locator('.action-radio__text', { hasText: 'Waiting on client' }).click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="waiting"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Waiting on client' }).click()
 		await page.keyboard.press('Escape')
 		await expect(page.locator('.card-tile__title', { hasText: 'Ball With Client' })).toHaveCount(1)
 		await expect(page.locator('.card-tile__title', { hasText: 'Ball With Us' })).toHaveCount(0)
@@ -120,14 +122,16 @@ test.describe.serial('Waiting on client (#3746)', () => {
 
 		// ...and the mirror facet ("Not waiting") flips the visible set.
 		await page.locator('.board-filter-bar__filter button').first().click()
-		await page.locator('.action-radio__text', { hasText: 'Not waiting' }).click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="waiting"]').click()
+		await page.locator('.board-filter-bar__opt-text', { hasText: 'Not waiting' }).click()
 		await page.keyboard.press('Escape')
 		await expect(page.locator('.card-tile__title', { hasText: 'Ball With Us' })).toHaveCount(1)
 		await expect(page.locator('.card-tile__title', { hasText: 'Ball With Client' })).toHaveCount(0)
 
-		// Clear the filter so the chip-clearing assertions see both cards.
+		// Clear the filter (the root panel's "Clear filters") so the chip-clearing
+		// assertions see both cards.
 		await page.locator('.board-filter-bar__filter button').first().click()
-		await page.locator('.action-button__text', { hasText: 'Clear filters' }).click()
+		await page.locator('.board-filter-bar__clear').click()
 		await page.keyboard.press('Escape')
 		await expect(page.locator('.card-tile__title', { hasText: 'Ball With Client' })).toHaveCount(1)
 


### PR DESCRIPTION
## Summary

Continues the board-toolbar redesign (the *Display* popover, phase 1, landed in #29). Two changes to the **Filter** control:

- **Progressive drill-in Filter.** The Filter control is now a drill-in popover instead of rendering every value at once. The top level lists the dimensions (Labels, Assignees, Priority, Type, Estimate, Due date, Status, Client status), each with an active-value summary and a count badge; clicking one drills into only that dimension's values with a back arrow. Saved views (apply / save / delete a named view, plus *Default (no filter)*) now live inside the Filter control, so the separate *Saved* header button is gone — the toolbar is now just `[Display] [Filter] [⋯]`. Filtering behaviour, the shareable URL, and saved views are unchanged; this is a pure UI reshape (the `useBoardFilters` state/predicate/URL composable is untouched).
- **Fix: clearing a Type / Estimate / Client-status filter now cleans up the URL.** `FILTER_QUERY_KEYS` was missing `ft`/`fe`/`fw`, so clearing one of those filters left a stale parameter dangling in the shareable link. It now strips every dimension's parameter on clear. Also removed a dead `totalActiveFilters` computed (the count badge is driven by the canonical `useFilterCount`).

## Commits

- `fa30e39` feat(filter): progressive drill-in filter with folded-in saved views
- `ff8b8f0` fix(filter): strip ft/fe/fw from URL on clear; drop dead totalActiveFilters

## Testing

- Vite production build compiles clean.
- e2e specs updated to the drill-in flow (board-filters, card-type, priority, estimations, waiting-on-client, labels) plus a new assertion that clearing a Type/Estimate/Client-status filter removes its URL parameter — the full Playwright suite runs in CI.
- No PHP touched, so psalm / php-cs-fixer / PHPUnit are N/A for this change.
- `CHANGELOG.md` `[Unreleased]` updated (### Changed + ### Fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)