### PR TITLE
ci(release): init 3rdparty so occ can sign the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
         if: env.HAVE_SIGNING_KEY == 'yes'
         run: |
           git clone --depth=1 --branch=v34.0.2 https://github.com/nextcloud/server.git "$RUNNER_TEMP/server"
+          # occ needs the composer autoloader, which nextcloud/server vendors in the
+          # `3rdparty` submodule (absent from a bare clone). Without it, occ aborts
+          # with "Composer autoloader not found" and integrity:sign-app never writes
+          # appinfo/signature.json.
+          git -C "$RUNNER_TEMP/server" submodule update --init --depth=1 3rdparty
           echo "path=$RUNNER_TEMP/server/occ" >> "$GITHUB_OUTPUT"
 
       - name: Build release tarball


### PR DESCRIPTION
## Problem
The release workflow's `Provide occ for signing` step clones `nextcloud/server` to get `occ` for `integrity:sign-app`, but never initializes the server's **`3rdparty`** submodule. A bare clone has no composer autoloader, so `occ` aborts with *"Composer autoloader not found"* and `integrity:sign-app` silently writes no `appinfo/signature.json`. Result: **every signed release build fails at the signing step** (surfaced now that the `APP_PRIVATE_KEY`/`APP_CERTIFICATE` secrets are set and signing is actually attempted).

## Fix
After the shallow clone, `git submodule update --init --depth=1 3rdparty` so `occ` can boot and sign. No DB/install needed — just the autoloader.

## Follow-up (not in this PR)
Once merged, re-point the `v0.9.36` tag to a commit containing this fix so the release rebuilds a properly signed tarball (`signature.json` + detached `.sig.base64`). No version bump — same 0.9.36.

Tooling-only change; no changelog entry per CONTRIBUTING.