### PR TITLE
release: 0.9.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.37] - 2026-08-17
+
 ### Added
 
 - **Cross-board saved Views (phase 1: List & Timeline).** A *View* is a named saved

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Recurring cards on RRULE schedules, auto-archive rules, WIP limits and stack
 roles, a command palette with full-text search, trash with restore, GitHub
 links and webhook, and one-click Import from Deck.
 	]]></description>
-	<version>0.9.36</version>
+	<version>0.9.37</version>
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>


### PR DESCRIPTION
Release commit for **0.9.37** — bumps `appinfo/info.xml` to 0.9.37 and renames the changelog `[Unreleased]` block to `[0.9.37]`.

### What ships in 0.9.37
- Cross-board **saved Views** (phase 1: List & Timeline) + richer board filter dimensions
- Personal **"Remind me"** on cards and comments
- **Full-page card view** (`/card/<id>`)
- **Progressive filter** toolbar redesign (phase 2)
- **Kanso MCP server** (AI access over MCP)
- CI: release workflow now signs correctly (3rdparty fix, #38)

### After merge
Tag `v0.9.37` on main → the release workflow builds + **signs** the tarball (`signature.json` + detached `.sig.base64`) → register/upload to the App Store.

No code changes — version + changelog only.