### PR TITLE
Adoption/UX polish + MCP v1.1 write surface + Views feed cap

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -196,6 +196,11 @@ class ViewController extends Controller {
 	 * every board the user can read (ACL enforced in {@see ViewService}). The
 	 * server stays filter-agnostic - the client applies the View's saved filter
 	 * and group-by client-side, reusing the board filter predicate.
+	 *
+	 * Returns an envelope `{cards, capped, total, limit}` (see
+	 * {@see ViewService::findMine()}): `cards` is hard-capped to keep this single
+	 * unbounded feed bounded, and `capped`/`total` let the client honestly report
+	 * when it is showing only the first N of M readable cards.
 	 */
 	#[NoAdminRequired]
 	public function cards(): JSONResponse {

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -27,6 +27,16 @@ use OCA\Kanso\Db\CardMapper;
  * a board A cannot read (covered by ViewServiceTest's leak-denial test).
  */
 class ViewService {
+	/**
+	 * Hard cap on the cross-board feed payload. The readable-set + #3743 masking
+	 * still gate every row BEFORE this slice (leak-safety unchanged); the cap only
+	 * bounds how many summaries a single unbounded feed can ship, no matter how
+	 * many boards/cards the user can read. When the readable set exceeds it the
+	 * envelope's `capped` flag is set so the client surfaces an honest "showing
+	 * the first N of M" hint rather than silently truncating.
+	 */
+	public const MAX_CARDS = 5000;
+
 	public function __construct(
 		private BoardService $boardService,
 		private CardMapper $cardMapper,
@@ -43,7 +53,13 @@ class ViewService {
 	 * boardTitle - so the client's reused board filter predicate and group-by can
 	 * run over them with no extra request.
 	 *
-	 * @return list<array<string, mixed>>
+	 * Returned as an envelope so the client can honestly report truncation:
+	 *   ['cards' => list<array>, 'capped' => bool, 'total' => int, 'limit' => int]
+	 * where `total` is the pre-cap readable-set count and `cards` is capped to at
+	 * most {@see self::MAX_CARDS} rows. The cap is applied AFTER the per-board ACL
+	 * + #3743 masking loop, so every row is still gated before the slice.
+	 *
+	 * @return array{cards: list<array<string, mixed>>, capped: bool, total: int, limit: int}
 	 */
 	public function findMine(string $uid): array {
 		$boards = $this->boardService->findAll($uid);
@@ -70,6 +86,25 @@ class ViewService {
 			}
 		}
 
-		return $out;
+		// Order by a STABLE deterministic key (boardId, then card id) so the cap
+		// always slices the same first-N window across requests - never a random
+		// subset. Runs over the already ACL-gated set, so it moves no leak boundary.
+		usort($out, static function (array $a, array $b): int {
+			return [(int)($a['boardId'] ?? 0), (int)($a['id'] ?? 0)]
+				<=> [(int)($b['boardId'] ?? 0), (int)($b['id'] ?? 0)];
+		});
+
+		$total = count($out);
+		$capped = $total > self::MAX_CARDS;
+		if ($capped) {
+			$out = array_slice($out, 0, self::MAX_CARDS);
+		}
+
+		return [
+			'cards' => $out,
+			'capped' => $capped,
+			'total' => $total,
+			'limit' => self::MAX_CARDS,
+		];
 	}
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -159,6 +159,12 @@ claude mcp add --transport http kanso http://127.0.0.1:7654/mcp
 - `kanso_list_comments` — read a card's comments (author + body + timestamps)
 - `kanso_add_comment` — post a comment (optionally reply to a comment)
 
+**Checklist**
+
+- `kanso_list_checklist` — read a card's checklist items (id + title + done)
+- `kanso_add_checklist_item` — add a checklist item to a card
+- `kanso_toggle_checklist_item` — mark an item done / not done
+
 **My work**
 
 - `kanso_list_my_cards` — cards assigned to you across all boards

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -154,6 +154,11 @@ claude mcp add --transport http kanso http://127.0.0.1:7654/mcp
 - `kanso_assign_label` / `kanso_unassign_label`
 - `kanso_assign_user` / `kanso_unassign_user`
 
+**Comments**
+
+- `kanso_list_comments` — read a card's comments (author + body + timestamps)
+- `kanso_add_comment` — post a comment (optionally reply to a comment)
+
 **My work**
 
 - `kanso_list_my_cards` — cards assigned to you across all boards

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -134,6 +134,7 @@ claude mcp add --transport http kanso http://127.0.0.1:7654/mcp
 
 - `kanso_list_boards` — list all boards (with per-board stats)
 - `kanso_get_board` — read a board: stacks, labels, card summaries
+- `kanso_list_board_members` — list assignable users (uid + name) for a board
 - `kanso_create_board` / `kanso_update_board` / `kanso_delete_board`
 
 **Stacks (columns)**

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -148,6 +148,13 @@ claude mcp add --transport http kanso http://127.0.0.1:7654/mcp
 - `kanso_create_card` / `kanso_update_card` / `kanso_delete_card`
 - `kanso_move_card` — move a card into a stack (optionally after a card)
 
+**Relations & subtasks**
+
+- `kanso_list_relations` — a card's relations grouped by kind (blocks / blockedBy / duplicates / relates)
+- `kanso_add_relation` — link two same-board cards (blocks / blocked_by / duplicates / relates)
+- `kanso_remove_relation` — remove a relation by its id
+- `kanso_set_card_parent` — set or clear a card's parent (one-level subtasks)
+
 **Labels & assignees**
 
 - `kanso_create_label` — create a board label

--- a/mcp/kanso_mcp/client.py
+++ b/mcp/kanso_mcp/client.py
@@ -321,6 +321,50 @@ class KansoClient:
         )
         return Label.model_validate(data)
 
+    # --------------------------------------------------------------- relations
+    async def list_relations(self, card_id: int) -> Dict[str, Any]:
+        # Returns a grouped dict {blocks, blockedBy, duplicates, relates}, each
+        # a list of {id, cardId, title, done, hidden}.
+        data = await self._request("GET", f"/cards/{card_id}/relations")
+        return data or {}
+
+    async def add_relation(
+        self, card_id: int, other_card_id: int, kind: str
+    ) -> Dict[str, Any]:
+        # kind is one of "blocks" | "blocked_by" | "duplicates" | "relates";
+        # the server swaps "blocked_by" into a stored blocks row, so pass the
+        # string through unchanged (no client-side swapping). Same-board only;
+        # self-relations and blocks-cycles are rejected server-side.
+        data = await self._request(
+            "POST",
+            f"/cards/{card_id}/relations",
+            json={"otherCardId": other_card_id, "kind": kind},
+        )
+        return data or {}
+
+    async def remove_relation(self, card_id: int, relation_id: int) -> Any:
+        return await self._request(
+            "DELETE", f"/cards/{card_id}/relations/{relation_id}"
+        )
+
+    async def set_parent(
+        self, card_id: int, parent_card_id: Optional[int]
+    ) -> Card:
+        # NB: _request drops None values, but here None is meaningful — it is
+        # how the caller CLEARS the parent (the controller treats a null
+        # parentCardId as "unset parent"). Send the request directly so the
+        # explicit null survives the None-filter instead of being dropped.
+        response = await self._client.request(
+            "PUT",
+            f"/cards/{card_id}/parent",
+            json={"parentCardId": parent_card_id},
+        )
+        if response.status_code < 200 or response.status_code >= 300:
+            raise KansoApiError(
+                response.status_code, "PUT", f"/cards/{card_id}/parent", response.text
+            )
+        return Card.model_validate(response.json())
+
     # ----------------------------------------------------------------- my work
     async def list_my_cards(self) -> List[CardSummary]:
         data = await self._request("GET", "/my-cards")

--- a/mcp/kanso_mcp/client.py
+++ b/mcp/kanso_mcp/client.py
@@ -18,6 +18,7 @@ from kanso_mcp.config import KansoConfig
 from kanso_mcp.models import (
     Board,
     BoardDetail,
+    BoardMember,
     BoardSummary,
     Card,
     CardSummary,
@@ -97,6 +98,16 @@ class KansoClient:
     async def get_board(self, board_id: int) -> BoardDetail:
         data = await self._request("GET", f"/boards/{board_id}")
         return BoardDetail.model_validate(data)
+
+    async def list_board_members(
+        self, board_id: int, q: Optional[str] = None
+    ) -> List[BoardMember]:
+        # ?q= is only sent when set (an absent filter returns all participants).
+        params = {"q": q} if q is not None else None
+        data = await self._request(
+            "GET", f"/boards/{board_id}/participants", params=params
+        )
+        return [BoardMember.model_validate(m) for m in (data or [])]
 
     async def create_board(self, title: str, color: Optional[str] = None) -> Board:
         data = await self._request(

--- a/mcp/kanso_mcp/client.py
+++ b/mcp/kanso_mcp/client.py
@@ -212,6 +212,13 @@ class KansoClient:
         archived: Optional[bool] = None,
         priority: Optional[int] = None,
         estimate: Optional[str] = None,
+        start_date: Optional[str] = None,
+        status: Optional[str] = None,
+        all_day: Optional[bool] = None,
+        due_reminder_day_before: Optional[bool] = None,
+        cover_color: Optional[str] = None,
+        type: Optional[str] = None,
+        visibility: Optional[str] = None,
     ) -> Card:
         data = await self._request(
             "PATCH",
@@ -224,6 +231,13 @@ class KansoClient:
                 "archived": archived,
                 "priority": priority,
                 "estimate": estimate,
+                "startDate": start_date,
+                "status": status,
+                "allDay": all_day,
+                "dueReminderDayBefore": due_reminder_day_before,
+                "coverColor": cover_color,
+                "type": type,
+                "visibility": visibility,
             },
         )
         return Card.model_validate(data)

--- a/mcp/kanso_mcp/client.py
+++ b/mcp/kanso_mcp/client.py
@@ -22,6 +22,7 @@ from kanso_mcp.models import (
     BoardSummary,
     Card,
     CardSummary,
+    ChecklistItem,
     Comment,
     Label,
     Stack,
@@ -285,6 +286,31 @@ class KansoClient:
             json={"body": body, "parentCommentId": parent_comment_id},
         )
         return Comment.model_validate(data)
+
+    # --------------------------------------------------------------- checklist
+    async def list_checklist(self, card_id: int) -> List[ChecklistItem]:
+        data = await self._request("GET", f"/cards/{card_id}/checklist")
+        return [ChecklistItem.model_validate(i) for i in (data or [])]
+
+    async def add_checklist_item(self, card_id: int, title: str) -> ChecklistItem:
+        data = await self._request(
+            "POST", f"/cards/{card_id}/checklist", json={"title": title}
+        )
+        return ChecklistItem.model_validate(data)
+
+    async def update_checklist_item(
+        self,
+        item_id: int,
+        *,
+        title: Optional[str] = None,
+        done: Optional[bool] = None,
+    ) -> ChecklistItem:
+        # PATCH targets the item id directly (/checklist/{itemId}), NOT nested
+        # under the card. None fields are dropped by _request.
+        data = await self._request(
+            "PATCH", f"/checklist/{item_id}", json={"title": title, "done": done}
+        )
+        return ChecklistItem.model_validate(data)
 
     # ------------------------------------------------------------------ labels
     async def create_label(

--- a/mcp/kanso_mcp/client.py
+++ b/mcp/kanso_mcp/client.py
@@ -22,6 +22,7 @@ from kanso_mcp.models import (
     BoardSummary,
     Card,
     CardSummary,
+    Comment,
     Label,
     Stack,
 )
@@ -267,6 +268,23 @@ class KansoClient:
 
     async def unassign_user(self, card_id: int, user_id: str) -> Any:
         return await self._request("DELETE", f"/cards/{card_id}/assignees/{user_id}")
+
+    # ---------------------------------------------------------------- comments
+    async def list_comments(self, card_id: int) -> List[Comment]:
+        data = await self._request("GET", f"/cards/{card_id}/comments")
+        return [Comment.model_validate(c) for c in (data or [])]
+
+    async def add_comment(
+        self, card_id: int, body: str, parent_comment_id: Optional[int] = None
+    ) -> Comment:
+        # The controller field is `body` (NOT `text`); parentCommentId is
+        # dropped by _request when None (a top-level comment).
+        data = await self._request(
+            "POST",
+            f"/cards/{card_id}/comments",
+            json={"body": body, "parentCommentId": parent_comment_id},
+        )
+        return Comment.model_validate(data)
 
     # ------------------------------------------------------------------ labels
     async def create_label(

--- a/mcp/kanso_mcp/models.py
+++ b/mcp/kanso_mcp/models.py
@@ -82,6 +82,16 @@ class Label(_Base):
     color: Optional[str] = None
 
 
+class BoardMember(_Base):
+    """A board participant from ``GET /boards/{id}/participants``: an assignable
+    Nextcloud user (uid + display name). The uid is what ``kanso_assign_user``
+    expects.
+    """
+
+    uid: str
+    displayName: Optional[str] = None
+
+
 class CardSummary(_Base):
     """A card summary (board payload / delta upsert): no description."""
 

--- a/mcp/kanso_mcp/models.py
+++ b/mcp/kanso_mcp/models.py
@@ -110,6 +110,20 @@ class Comment(_Base):
     reactions: List[Any] = Field(default_factory=list)
 
 
+class ChecklistItem(_Base):
+    """A checklist item from ``GET/POST /api/cards/{id}/checklist`` or a
+    ``PATCH /api/checklist/{itemId}``. ``done`` is the source of truth; the
+    payload also carries assignee/due-date step fields (#3745) which are passed
+    through untyped rather than modelled.
+    """
+
+    id: int
+    cardId: Optional[int] = None
+    title: Optional[str] = None
+    done: bool = False
+    sortKey: Optional[str] = None
+
+
 class CardSummary(_Base):
     """A card summary (board payload / delta upsert): no description."""
 

--- a/mcp/kanso_mcp/models.py
+++ b/mcp/kanso_mcp/models.py
@@ -92,6 +92,24 @@ class BoardMember(_Base):
     displayName: Optional[str] = None
 
 
+class Comment(_Base):
+    """A card comment from ``GET /api/cards/{id}/comments`` (or the single
+    comment returned by a create). The body is raw markdown; ``author`` is the
+    uid and ``authorDisplayName`` its resolved display name. ``createdAt`` /
+    ``editedAt`` are unix timestamps. Reactions are passed through untyped.
+    """
+
+    id: int
+    cardId: Optional[int] = None
+    parentCommentId: Optional[int] = None
+    author: Optional[str] = None
+    authorDisplayName: Optional[str] = None
+    body: Optional[str] = None
+    createdAt: int = 0
+    editedAt: int = 0
+    reactions: List[Any] = Field(default_factory=list)
+
+
 class CardSummary(_Base):
     """A card summary (board payload / delta upsert): no description."""
 

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -378,6 +378,51 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
             await client.add_comment(card_id, body, parent_comment_id)
         ).model_dump()
 
+    # --------------------------------------------------------------- checklist
+    @mcp.tool(
+        title="List a Kanso card's checklist",
+        annotations={"readOnlyHint": True},
+    )
+    async def kanso_list_checklist(card_id: int) -> List[dict]:
+        """List a card's checklist items, in order.
+
+        Each item carries its `id`, `title` and `done` state. Use the item `id`
+        with `kanso_toggle_checklist_item` to tick it off.
+
+        Args:
+            card_id: The numeric card id.
+        """
+        items = await client.list_checklist(card_id)
+        return [i.model_dump() for i in items]
+
+    @mcp.tool(title="Add a checklist item to a Kanso card")
+    async def kanso_add_checklist_item(card_id: int, title: str) -> dict:
+        """Add a checklist item (a flat todo line) to a card.
+
+        Returns the created item, including its `id` — pass that to
+        `kanso_toggle_checklist_item` to mark it done later.
+
+        Args:
+            card_id: The numeric card id.
+            title: The checklist item text.
+        """
+        return (await client.add_checklist_item(card_id, title)).model_dump()
+
+    @mcp.tool(title="Toggle a Kanso checklist item")
+    async def kanso_toggle_checklist_item(item_id: int, done: bool) -> dict:
+        """Mark a checklist item done (true) or not done (false).
+
+        Note `item_id` is the checklist item's own id (from
+        `kanso_list_checklist` or `kanso_get_card`), NOT the card id.
+
+        Args:
+            item_id: The numeric checklist item id.
+            done: Whether the item is completed.
+        """
+        return (
+            await client.update_checklist_item(item_id, done=done)
+        ).model_dump()
+
     # ------------------------------------------------------------------ labels
     @mcp.tool(title="Create a Kanso label")
     async def kanso_create_label(

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -48,6 +48,27 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
         """
         return (await client.get_board(board_id)).model_dump()
 
+    @mcp.tool(
+        title="List Kanso board members",
+        annotations={"readOnlyHint": True},
+    )
+    async def kanso_list_board_members(
+        board_id: int, q: Optional[str] = None
+    ) -> List[dict]:
+        """List the users who can be assigned to cards on a board.
+
+        Returns each participant's `uid` and `displayName`. Feed a returned
+        `uid` into `kanso_assign_user` to assign that person to a card. Results
+        are capped server-side (~25); pass `q` to filter by name/uid substring
+        when a board has more members than that.
+
+        Args:
+            board_id: The numeric board id.
+            q: Optional case-insensitive substring filter over uid / display name.
+        """
+        members = await client.list_board_members(board_id, q)
+        return [m.model_dump() for m in members]
+
     @mcp.tool(title="Create a Kanso board")
     async def kanso_create_board(title: str, color: Optional[str] = None) -> dict:
         """Create a new board.

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -423,6 +423,75 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
             await client.update_checklist_item(item_id, done=done)
         ).model_dump()
 
+    # --------------------------------------------------------------- relations
+    @mcp.tool(
+        title="List a Kanso card's relations",
+        annotations={"readOnlyHint": True},
+    )
+    async def kanso_list_relations(card_id: int) -> dict:
+        """List a card's relations to other cards, grouped by kind.
+
+        Returns an object with four lists — `blocks` (cards this card blocks),
+        `blockedBy` (cards blocking this one), `duplicates` and `relates`. Each
+        entry is `{id, cardId, title, done, hidden}` where `id` is the RELATION
+        id (pass it to `kanso_remove_relation`) and `cardId` is the other card.
+
+        Args:
+            card_id: The numeric card id.
+        """
+        return await client.list_relations(card_id)
+
+    @mcp.tool(title="Add a relation between two Kanso cards")
+    async def kanso_add_relation(card_id: int, other_card_id: int, kind: str) -> dict:
+        """Link a card to another card on the SAME board.
+
+        `kind` must be one of:
+          - "blocks"      — this card blocks `other_card_id`
+          - "blocked_by"  — this card is blocked by `other_card_id`
+          - "duplicates"  — this card duplicates `other_card_id`
+          - "relates"     — this card is related to `other_card_id`
+
+        Both cards must be on the same board. Self-relations and cycles of
+        blocking relations are rejected by the server (surfaced as an API error).
+
+        Args:
+            card_id: The card the relation is added from.
+            other_card_id: The other card to link to (same board).
+            kind: One of "blocks", "blocked_by", "duplicates", "relates".
+        """
+        return await client.add_relation(card_id, other_card_id, kind)
+
+    @mcp.tool(title="Remove a relation from a Kanso card")
+    async def kanso_remove_relation(card_id: int, relation_id: int) -> dict:
+        """Remove a card-to-card relation.
+
+        Note `relation_id` is the relation's own id (the `id` field from
+        `kanso_list_relations`), NOT the id of the other card.
+
+        Args:
+            card_id: The card the relation belongs to.
+            relation_id: The numeric relation id to remove.
+        """
+        await client.remove_relation(card_id, relation_id)
+        return {"removed": True, "cardId": card_id, "relationId": relation_id}
+
+    @mcp.tool(title="Set or clear a Kanso card's parent")
+    async def kanso_set_card_parent(
+        card_id: int, parent_card_id: Optional[int] = None
+    ) -> dict:
+        """Set (or clear) a card's parent, building a one-level subtask
+        hierarchy. Parent and child must be on the SAME board.
+
+        Pass `parent_card_id` to make `card_id` a subtask of it; pass null/omit
+        to CLEAR the parent (detach the card from its parent). Invalid requests
+        (cross-board, deeper nesting) are rejected by the server.
+
+        Args:
+            card_id: The card to (re)parent.
+            parent_card_id: The parent card id, or null to clear the parent.
+        """
+        return (await client.set_parent(card_id, parent_card_id)).model_dump()
+
     # ------------------------------------------------------------------ labels
     @mcp.tool(title="Create a Kanso label")
     async def kanso_create_label(

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -220,6 +220,13 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
         archived: Optional[bool] = None,
         priority: Optional[int] = None,
         estimate: Optional[str] = None,
+        start_date: Optional[str] = None,
+        status: Optional[str] = None,
+        all_day: Optional[bool] = None,
+        due_reminder_day_before: Optional[bool] = None,
+        cover_color: Optional[str] = None,
+        type: Optional[str] = None,
+        visibility: Optional[str] = None,
     ) -> dict:
         """Update a card. Only the fields you pass are changed.
 
@@ -232,6 +239,16 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
             archived: Archive (true) or unarchive (false) the card.
             priority: Integer priority.
             estimate: Effort estimate token (per the board's estimate scale).
+            start_date: ISO-8601 start date/time (empty string clears it).
+            status: Workflow status automation — one of "not_started",
+                "in_progress" or "done". DISTINCT from the `done` boolean: setting
+                this stamps the card's startedAt / doneAt timestamps accordingly.
+            all_day: Whether the due date is an all-day date (no time component).
+            due_reminder_day_before: Remind the day before the due date (true/false).
+            cover_color: Card cover colour as bare 6-hex, NO leading '#',
+                e.g. "e63946"; empty string clears it.
+            type: Card type — one of "" (none), "bug", "feature", "task" or "chore".
+            visibility: Card visibility — one of "public", "internal" or "private".
         """
         return (
             await client.update_card(
@@ -243,6 +260,13 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
                 archived=archived,
                 priority=priority,
                 estimate=estimate,
+                start_date=start_date,
+                status=status,
+                all_day=all_day,
+                due_reminder_day_before=due_reminder_day_before,
+                cover_color=cover_color,
+                type=type,
+                visibility=visibility,
             )
         ).model_dump()
 

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -343,6 +343,41 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
         await client.unassign_user(card_id, user_id)
         return {"unassigned": True, "cardId": card_id, "userId": user_id}
 
+    # ---------------------------------------------------------------- comments
+    @mcp.tool(
+        title="List a Kanso card's comments",
+        annotations={"readOnlyHint": True},
+    )
+    async def kanso_list_comments(card_id: int) -> List[dict]:
+        """List the comments on a card, oldest first.
+
+        Each comment carries its `author` (uid), `authorDisplayName`, markdown
+        `body`, `createdAt`/`editedAt` timestamps and, for replies, the
+        `parentCommentId` of the top-level comment it answers.
+
+        Args:
+            card_id: The numeric card id.
+        """
+        comments = await client.list_comments(card_id)
+        return [c.model_dump() for c in comments]
+
+    @mcp.tool(title="Add a comment to a Kanso card")
+    async def kanso_add_comment(
+        card_id: int, body: str, parent_comment_id: Optional[int] = None
+    ) -> dict:
+        """Post a comment on a card. Pass `parent_comment_id` to reply to an
+        existing top-level comment (replies are one level deep).
+
+        Args:
+            card_id: The numeric card id.
+            body: The comment text (markdown).
+            parent_comment_id: Optional id of the top-level comment to reply to;
+                omit (null) for a new top-level comment.
+        """
+        return (
+            await client.add_comment(card_id, body, parent_comment_id)
+        ).model_dump()
+
     # ------------------------------------------------------------------ labels
     @mcp.tool(title="Create a Kanso label")
     async def kanso_create_label(

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -146,6 +146,66 @@ async def test_create_card_body_uses_stackId():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_update_card_serializes_all_fields():
+    route = respx.patch(f"{BASE}/cards/100").mock(
+        return_value=httpx.Response(200, json={"id": 100, "title": "T", "stackId": 11})
+    )
+    async with _client() as c:
+        card = await c.update_card(
+            100,
+            title="T",
+            description="d",
+            duedate="2026-09-01T17:00:00+00:00",
+            done=True,
+            archived=False,
+            priority=3,
+            estimate="M",
+            start_date="2026-08-20T09:00:00+00:00",
+            status="in_progress",
+            all_day=False,
+            due_reminder_day_before=True,
+            cover_color="e63946",
+            type="bug",
+            visibility="private",
+        )
+    import json as _json
+
+    # camelCase key names are what CardController::update expects.
+    assert _json.loads(route.calls.last.request.content) == {
+        "title": "T",
+        "description": "d",
+        "duedate": "2026-09-01T17:00:00+00:00",
+        "done": True,
+        "archived": False,
+        "priority": 3,
+        "estimate": "M",
+        "startDate": "2026-08-20T09:00:00+00:00",
+        "status": "in_progress",
+        "allDay": False,
+        "dueReminderDayBefore": True,
+        "coverColor": "e63946",
+        "type": "bug",
+        "visibility": "private",
+    }
+    assert card.id == 100
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_update_card_drops_none():
+    route = respx.patch(f"{BASE}/cards/100").mock(
+        return_value=httpx.Response(200, json={"id": 100, "title": "T", "stackId": 11})
+    )
+    async with _client() as c:
+        await c.update_card(100, status="done")
+    import json as _json
+
+    # Every unset field (incl. the new ones) must be dropped; only status is sent.
+    assert _json.loads(route.calls.last.request.content) == {"status": "done"}
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_move_card_body_uses_targetStackId():
     route = respx.post(f"{BASE}/cards/100/move").mock(
         return_value=httpx.Response(200, json={})

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -195,6 +195,44 @@ async def test_list_my_cards():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_board_members():
+    route = respx.get(f"{BASE}/boards/7/participants").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"uid": "alice", "displayName": "Alice"},
+                {"uid": "bob", "displayName": "Bob"},
+            ],
+        )
+    )
+    async with _client() as c:
+        members = await c.list_board_members(7)
+    assert route.called
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/boards/7/participants"
+    # No filter => no ?q= param is sent.
+    assert "q" not in req.url.params
+    assert members[0].uid == "alice"
+    assert members[0].displayName == "Alice"
+    assert members[1].uid == "bob"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_board_members_forwards_q():
+    route = respx.get(f"{BASE}/boards/7/participants").mock(
+        return_value=httpx.Response(200, json=[{"uid": "bob", "displayName": "Bob"}])
+    )
+    async with _client() as c:
+        members = await c.list_board_members(7, q="bo")
+    assert route.called
+    assert route.calls.last.request.url.params.get("q") == "bo"
+    assert members[0].uid == "bob"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_error_raises_kanso_api_error():
     respx.post(f"{BASE}/boards").mock(
         return_value=httpx.Response(412, text="CSRF check failed")

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -318,6 +318,93 @@ async def test_add_comment_forwards_parent_comment_id():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_checklist_parses():
+    route = respx.get(f"{BASE}/cards/100/checklist").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 5,
+                    "cardId": 100,
+                    "title": "step one",
+                    "done": False,
+                    "sortKey": "aaa",
+                    "assignedUser": "bob",
+                    "dueDate": "2026-09-01T17:00:00+00:00",
+                }
+            ],
+        )
+    )
+    async with _client() as c:
+        items = await c.list_checklist(100)
+    assert route.called
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/checklist"
+    assert items[0].id == 5
+    assert items[0].title == "step one"
+    assert items[0].done is False
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_add_checklist_item_body_uses_title():
+    route = respx.post(f"{BASE}/cards/100/checklist").mock(
+        return_value=httpx.Response(
+            200, json={"id": 6, "cardId": 100, "title": "new step", "done": False}
+        )
+    )
+    async with _client() as c:
+        item = await c.add_checklist_item(100, "new step")
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/checklist"
+    assert _json.loads(req.content) == {"title": "new step"}
+    assert item.id == 6
+    assert item.title == "new step"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_update_checklist_item_toggles_done():
+    route = respx.patch(f"{BASE}/checklist/6").mock(
+        return_value=httpx.Response(
+            200, json={"id": 6, "cardId": 100, "title": "new step", "done": True}
+        )
+    )
+    async with _client() as c:
+        item = await c.update_checklist_item(6, done=True)
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    # PATCH targets the item id directly, NOT nested under the card.
+    assert req.url.path == "/index.php/apps/kanso/api/checklist/6"
+    # title is None => dropped; only done is sent.
+    assert _json.loads(req.content) == {"done": True}
+    assert item.done is True
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_update_checklist_item_renames():
+    route = respx.patch(f"{BASE}/checklist/6").mock(
+        return_value=httpx.Response(
+            200, json={"id": 6, "cardId": 100, "title": "renamed", "done": False}
+        )
+    )
+    async with _client() as c:
+        await c.update_checklist_item(6, title="renamed")
+    import json as _json
+
+    # done is None => dropped; only title is sent.
+    assert _json.loads(route.calls.last.request.content) == {"title": "renamed"}
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_list_my_cards():
     route = respx.get(f"{BASE}/my-cards").mock(
         return_value=httpx.Response(200, json=[{"id": 100, "title": "Mine", "stackId": 1}])

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -243,6 +243,81 @@ async def test_assign_user_put_path():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_comments_parses():
+    route = respx.get(f"{BASE}/cards/100/comments").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 1,
+                    "cardId": 100,
+                    "parentCommentId": None,
+                    "author": "alice",
+                    "authorDisplayName": "Alice",
+                    "body": "first",
+                    "createdAt": 1700000000,
+                    "editedAt": 0,
+                    "reactions": [{"emoji": "👍", "count": 1}],
+                }
+            ],
+        )
+    )
+    async with _client() as c:
+        comments = await c.list_comments(100)
+    assert route.called
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/comments"
+    assert comments[0].id == 1
+    assert comments[0].author == "alice"
+    assert comments[0].authorDisplayName == "Alice"
+    assert comments[0].body == "first"
+    assert comments[0].createdAt == 1700000000
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_add_comment_body_uses_body_field():
+    route = respx.post(f"{BASE}/cards/100/comments").mock(
+        return_value=httpx.Response(
+            200,
+            json={"id": 2, "cardId": 100, "author": "bob", "body": "hi"},
+        )
+    )
+    async with _client() as c:
+        comment = await c.add_comment(100, "hi")
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    # The controller field is `body`, NOT `text`; parentCommentId is dropped
+    # when None (a top-level comment).
+    assert _json.loads(req.content) == {"body": "hi"}
+    assert comment.id == 2
+    assert comment.body == "hi"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_add_comment_forwards_parent_comment_id():
+    route = respx.post(f"{BASE}/cards/100/comments").mock(
+        return_value=httpx.Response(
+            200,
+            json={"id": 3, "cardId": 100, "parentCommentId": 2, "body": "re"},
+        )
+    )
+    async with _client() as c:
+        await c.add_comment(100, "re", parent_comment_id=2)
+    import json as _json
+
+    assert _json.loads(route.calls.last.request.content) == {
+        "body": "re",
+        "parentCommentId": 2,
+    }
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_list_my_cards():
     route = respx.get(f"{BASE}/my-cards").mock(
         return_value=httpx.Response(200, json=[{"id": 100, "title": "Mine", "stackId": 1}])

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -405,6 +405,116 @@ async def test_update_checklist_item_renames():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_relations_parses_grouped():
+    payload = {
+        "blocks": [{"id": 1, "cardId": 200, "title": "B", "done": False, "hidden": False}],
+        "blockedBy": [],
+        "duplicates": [],
+        "relates": [{"id": 2, "cardId": 201, "title": "R", "done": True, "hidden": False}],
+    }
+    route = respx.get(f"{BASE}/cards/100/relations").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    async with _client() as c:
+        relations = await c.list_relations(100)
+    assert route.called
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/relations"
+    assert relations["blocks"][0]["cardId"] == 200
+    assert relations["relates"][0]["id"] == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_add_relation_body_uses_other_card_id_and_kind():
+    route = respx.post(f"{BASE}/cards/100/relations").mock(
+        return_value=httpx.Response(200, json={"blocks": [], "blockedBy": []})
+    )
+    async with _client() as c:
+        await c.add_relation(100, 200, "blocks")
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/relations"
+    assert _json.loads(req.content) == {"otherCardId": 200, "kind": "blocks"}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_add_relation_forwards_blocked_by_kind_unchanged():
+    # The client must NOT swap blocked_by; the server does the swap.
+    route = respx.post(f"{BASE}/cards/100/relations").mock(
+        return_value=httpx.Response(200, json={})
+    )
+    async with _client() as c:
+        await c.add_relation(100, 200, "blocked_by")
+    import json as _json
+
+    assert _json.loads(route.calls.last.request.content) == {
+        "otherCardId": 200,
+        "kind": "blocked_by",
+    }
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_remove_relation_delete_path():
+    route = respx.delete(f"{BASE}/cards/100/relations/9").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    async with _client() as c:
+        await c.remove_relation(100, 9)
+    assert route.called
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.method == "DELETE"
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/relations/9"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_set_parent_put_path_and_body():
+    route = respx.put(f"{BASE}/cards/100/parent").mock(
+        return_value=httpx.Response(
+            200, json={"id": 100, "title": "T", "stackId": 11, "parentCardId": 50}
+        )
+    )
+    async with _client() as c:
+        card = await c.set_parent(100, 50)
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.method == "PUT"
+    assert req.url.path == "/index.php/apps/kanso/api/cards/100/parent"
+    assert _json.loads(req.content) == {"parentCardId": 50}
+    assert card.parentCardId == 50
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_set_parent_clear_sends_explicit_null():
+    # Clearing the parent MUST send {"parentCardId": null} — not drop the key,
+    # which would make the clear a silent no-op server-side.
+    route = respx.put(f"{BASE}/cards/100/parent").mock(
+        return_value=httpx.Response(
+            200, json={"id": 100, "title": "T", "stackId": 11, "parentCardId": None}
+        )
+    )
+    async with _client() as c:
+        card = await c.set_parent(100, None)
+    import json as _json
+
+    body = _json.loads(route.calls.last.request.content)
+    assert body == {"parentCardId": None}
+    assert "parentCardId" in body  # key present, value explicitly null
+    assert card.parentCardId is None
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_list_my_cards():
     route = respx.get(f"{BASE}/my-cards").mock(
         return_value=httpx.Response(200, json=[{"id": 100, "title": "Mine", "stackId": 1}])

--- a/src/App.vue
+++ b/src/App.vue
@@ -183,6 +183,38 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</template>
 				</NcAppNavigationItem>
 			</template>
+			<!-- Always-visible help affordance (#3901). Lives in the nav footer so
+			     it's reachable from anywhere in the app (any board/view/page), not
+			     only inside a board. A single "Help" menu holds two external links:
+			     file a bug/issue, and reach the MCP setup docs. NcActionLink renders
+			     a real <a> with target="_blank" and rel="…noreferrer noopener". -->
+			<template #footer>
+				<div class="app-nav__footer">
+					<NcActions :force-menu="true" :aria-label="t('kanso', 'Help')">
+						<template #icon>
+							<HelpCircleOutlineIcon :size="20" />
+						</template>
+						<NcActionLink
+							:href="ISSUES_URL"
+							target="_blank"
+							data-test="menu-file-issue">
+							<template #icon>
+								<BugOutlineIcon :size="20" />
+							</template>
+							{{ t('kanso', 'File an issue') }}
+						</NcActionLink>
+						<NcActionLink
+							:href="MCP_SETUP_URL"
+							target="_blank"
+							data-test="menu-setup-mcp">
+							<template #icon>
+								<ConnectionIcon :size="20" />
+							</template>
+							{{ t('kanso', 'Set up MCP') }}
+						</NcActionLink>
+					</NcActions>
+				</div>
+			</template>
 		</NcAppNavigation>
 		<NcAppContent>
 			<router-view />
@@ -199,6 +231,8 @@ import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcAppNavigation from '@nextcloud/vue/components/NcAppNavigation'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcContent from '@nextcloud/vue/components/NcContent'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ViewDashboardIcon from 'vue-material-design-icons/ViewDashboard.vue'
@@ -213,6 +247,9 @@ import FilterVariantIcon from 'vue-material-design-icons/FilterVariant.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import DeleteOutlineIcon from 'vue-material-design-icons/DeleteOutline.vue'
+import HelpCircleOutlineIcon from 'vue-material-design-icons/HelpCircleOutline.vue'
+import BugOutlineIcon from 'vue-material-design-icons/BugOutline.vue'
+import ConnectionIcon from 'vue-material-design-icons/Connection.vue'
 import { useBoards } from './composables/useBoards.js'
 import { useBoardGroups } from './composables/useBoardGroups.js'
 import { useMyWorkBadges } from './composables/useMyWorkBadges.js'
@@ -220,6 +257,12 @@ import { useViews } from './composables/useViews.js'
 
 const route = useRoute()
 const router = useRouter()
+
+// Help-menu destinations (#3901). Static external URLs — deliberately NOT
+// translated (they're addresses, not copy). Rendered by the nav-footer help
+// menu as real anchors opening in a new tab.
+const ISSUES_URL = 'https://github.com/aktasfatih/kanso/issues'
+const MCP_SETUP_URL = 'https://github.com/aktasfatih/kanso/tree/main/mcp'
 
 // Default-board-on-start: only when the app opened on the board list (never
 // override a deep link). On first load, if the user picked a default board and
@@ -395,6 +438,14 @@ const { tasksCount, reviewsCount, inboxCount } = useMyWorkBadges()
 	color: var(--color-text-maxcontrast);
 	font-size: 0.85rem;
 	font-style: italic;
+}
+
+/* Nav-footer help affordance (#3901): keep the trigger tucked to the start so
+   it reads as a quiet, always-present help control rather than a primary CTA. */
+.app-nav__footer {
+	display: flex;
+	align-items: center;
+	padding: 4px;
 }
 </style>
 

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1734,7 +1734,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								<div
 									v-for="{ comment: topComment, replies } in commentThread"
 									:key="topComment.id"
-									class="card-modal__comment-group">
+									:id="`comment-${topComment.id}`"
+									class="card-modal__comment-group"
+									:class="{ 'card-modal__comment-group--highlight': highlightedCommentId === topComment.id }">
 									<div class="card-modal__comment">
 										<NcAvatar
 											:user="topComment.author"
@@ -1862,7 +1864,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									</div>
 
 									<div v-if="replies.length > 0" class="card-modal__replies">
-										<div v-for="reply in replies" :key="reply.id" class="card-modal__comment card-modal__comment--reply">
+										<div
+											v-for="reply in replies"
+											:key="reply.id"
+											:id="`comment-${reply.id}`"
+											class="card-modal__comment card-modal__comment--reply"
+											:class="{ 'card-modal__comment--highlight': highlightedCommentId === reply.id }">
 											<NcAvatar
 												:user="reply.author"
 												:display-name="reply.authorDisplayName || reply.author"
@@ -3551,6 +3558,69 @@ async function handleVisibilityChange(visibility) {
 
 const flatComments = computed(() => commentsQuery.data.value ?? [])
 const commentThread = computed(() => buildCommentTree(flatComments.value))
+
+// ── Scroll-to-comment deep links (#3870) ─────────────────────────────────────
+// A reminder notification links to the card with a `#comment-<id>` fragment (see
+// Notifier::cardLink). The fragment-free deep-link boot (main.js) stashes that id
+// into the route query (`?comment=<id>`) before it hash-routes into the SPA, since
+// the router.replace would otherwise clobber the raw fragment. We ALSO read
+// window.location.hash directly as a fallback (in-app navigation that keeps the
+// fragment). Once the thread has rendered we scroll the target into view and give
+// it a brief highlight that fades. No-op when the fragment is absent or the comment
+// isn't in the loaded thread (deleted / not yet loaded) - never throws.
+const highlightedCommentId = ref(null)
+let highlightTimer = null
+
+function parseTargetCommentId() {
+	// Prefer the query the boot handoff set; fall back to a raw location hash so
+	// an in-app link that carries `#comment-<id>` still works.
+	const fromQuery = route.query.comment
+	const raw = Array.isArray(fromQuery) ? fromQuery[0] : fromQuery
+	if (raw != null && /^\d+$/.test(String(raw))) return Number(raw)
+	const m = /(?:^|#)comment-(\d+)\s*$/.exec(window.location.hash || '')
+	return m ? Number(m[1]) : null
+}
+
+let scrollHandled = false
+
+async function scrollToTargetComment() {
+	if (scrollHandled) return
+	const id = parseTargetCommentId()
+	if (!id) return
+	// The comment must actually be in the loaded thread; otherwise (deleted, or a
+	// stale link) do nothing rather than scroll to a phantom element.
+	if (!flatComments.value.some((c) => Number(c.id) === id)) return
+	// Ensure the discussion tab (not activity) is showing so the node is rendered.
+	discussionTab.value = 'discussion'
+	// The v-for nodes are patched asynchronously after the query data lands, so a
+	// single nextTick can run before the DOM node exists; poll a few frames for it
+	// before giving up rather than silently no-op'ing on a slow first paint.
+	let el = null
+	for (let attempt = 0; attempt < 20 && !el; attempt++) {
+		await nextTick()
+		el = document.getElementById(`comment-${id}`)
+		if (!el) await new Promise((r) => requestAnimationFrame(r))
+	}
+	if (!el) return
+	scrollHandled = true
+	el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+	highlightedCommentId.value = id
+	if (highlightTimer) clearTimeout(highlightTimer)
+	highlightTimer = setTimeout(() => {
+		highlightedCommentId.value = null
+		highlightTimer = null
+	}, 4000)
+}
+
+// The thread loads async, so wait until comments actually arrive, then scroll.
+// `immediate` covers the case where the query resolved before this watcher ran.
+watch(
+	() => flatComments.value.length,
+	(len) => {
+		if (len > 0) scrollToTargetComment()
+	},
+	{ immediate: true },
+)
 // Memoized per-comment rendered markdown, keyed by comment id. renderMarkdown is
 // expensive; rendering inline in-template re-ran it on any modal re-render. This
 // map only recomputes when the comments data actually changes.
@@ -3968,6 +4038,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
 	document.removeEventListener('mousedown', onDocumentMousedown, true)
+	if (highlightTimer) clearTimeout(highlightTimer)
 })
 
 // The modal shell funnels its X button here, and the backdrop handler above does
@@ -6813,6 +6884,30 @@ async function handleToggleProject(projectId) {
 	border-radius: 10px;
 	overflow: hidden;
 	flex-shrink: 0;
+}
+/* Transient highlight when a deep link scrolls to a comment (#3870): a brief
+   background/outline flash that fades out so the target is easy to spot without
+   permanently altering the comment's chrome. */
+.card-modal__comment-group--highlight {
+	animation: kanso-comment-flash 3.6s ease-out 1;
+}
+.card-modal__comment--highlight {
+	animation: kanso-comment-flash 3.6s ease-out 1;
+	border-radius: 8px;
+}
+@keyframes kanso-comment-flash {
+	0% {
+		background: var(--color-primary-element-light, var(--color-primary-light));
+		box-shadow: 0 0 0 2px var(--color-primary-element, var(--color-primary));
+	}
+	70% {
+		background: var(--color-primary-element-light, var(--color-primary-light));
+		box-shadow: 0 0 0 2px var(--color-primary-element, var(--color-primary));
+	}
+	100% {
+		background: var(--color-main-background);
+		box-shadow: 0 0 0 2px transparent;
+	}
 }
 .card-modal__comment {
 	display: flex;

--- a/src/components/CardPreview.vue
+++ b/src/components/CardPreview.vue
@@ -109,7 +109,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { translate as t } from '@nextcloud/l10n'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
@@ -254,6 +254,20 @@ function onPanelClick(e) {
 	if (e.target.closest('a')) return
 	emit('open')
 }
+
+// Live preview that follows keyboard selection (#3908): when the parent feeds a
+// new anchor rect (and swaps in the newly focused card), re-anchor the panel to
+// the new tile. Re-clamp after nextTick so the height for the new card's meta is
+// measured before the vertical clamp. Card id is watched too so a same-position
+// swap still repositions if the rect object is reused.
+watch(
+	() => [props.anchorRect, props.card.id],
+	async () => {
+		computePosition()
+		await nextTick()
+		computePosition()
+	},
+)
 
 onMounted(async () => {
 	computePosition()

--- a/src/composables/useViewCards.js
+++ b/src/composables/useViewCards.js
@@ -14,6 +14,10 @@ import { MY_WORK_POLL_INTERVAL } from './queryKeys.js'
  *
  * Like the My Work feeds it is cross-board (no board delta poll covers it), so
  * refetchOnMount 'always' + a focus/interval refetch keep it current.
+ *
+ * `data` is the server envelope `{ cards, capped, total, limit }` - `cards` is
+ * hard-capped server-side to bound this single unbounded feed; `capped`/`total`
+ * let the surface honestly report when it shows only the first N of M cards.
  */
 export function useViewCards() {
 	return useQuery({

--- a/src/main.js
+++ b/src/main.js
@@ -56,8 +56,18 @@ createApp(App)
 // '/' navigation settles.
 const openCard = readOpenCardState()
 if (openCard) {
+	// Scroll-to-comment deep link (#3870): a reminder link carries a
+	// `#comment-<id>` fragment after the fragment-free server route. The SPA is
+	// hash-routed, so the raw fragment would be clobbered by the replace below;
+	// capture it FIRST and carry it into the target route as `?comment=<id>` so
+	// CardDetail can scroll to + highlight that comment once the thread loads.
+	const commentMatch = /(?:^|#)comment-(\d+)\s*$/.exec(window.location.hash || '')
+	const target = {
+		path: `/board/${openCard.boardId}/card/${openCard.cardId}`,
+		...(commentMatch ? { query: { comment: commentMatch[1] } } : {}),
+	}
 	router.isReady().then(() => {
-		router.replace(`/board/${openCard.boardId}/card/${openCard.cardId}`)
+		router.replace(target)
 	})
 }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -481,9 +481,20 @@ export const deleteView = (id) =>
 	axios.delete(url(`/api/views/${encodeURIComponent(id)}`)).then((r) => r.data.views)
 
 // The cross-board card feed a View renders over: enriched summaries from every
-// readable board. The client applies the View's saved filter + group-by.
+// readable board. The client applies the View's saved filter + group-by. The
+// server returns an envelope `{cards, capped, total, limit}` - `cards` is hard-
+// capped to bound this single unbounded feed; `capped`/`total`/`limit` let the
+// UI honestly report when it is showing only the first N of M readable cards.
 export const getViewCards = () =>
-	axios.get(url('/api/views/cards')).then((r) => r.data)
+	axios.get(url('/api/views/cards')).then((r) => {
+		const d = r.data ?? {}
+		return {
+			cards: Array.isArray(d.cards) ? d.cards : [],
+			capped: !!d.capped,
+			total: Number.isFinite(d.total) ? d.total : (Array.isArray(d.cards) ? d.cards.length : 0),
+			limit: Number.isFinite(d.limit) ? d.limit : 0,
+		}
+	})
 
 // Review types
 export const createReviewType = (boardId, title, color, stage) =>

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1256,6 +1256,27 @@ watch(previewCard, (card) => {
 	if (previewCardId.value != null && !card) closePreview()
 })
 
+// Live preview that follows keyboard selection (#3908). While the quick-look
+// panel is open, moving the keyboard focus (arrow / hjkl) switches the preview
+// to the newly selected card and re-anchors the popover next to its tile. Only
+// keyboard focus is followed, not mouse hover, so the panel never chases the
+// cursor. navigateTo scrolls the virtualizer + focuses on the next
+// nextTick+rAF, so we read the tile rect on the same timing (a seq guard drops
+// a stale re-anchor if focus moves again before this one resolves). If the tile
+// isn't in the DOM the rect is null and the panel falls back to centered.
+let previewFollowSeq = 0
+watch(focusedCardId, async (id) => {
+	if (previewCardId.value == null || id == null) return
+	const seq = ++previewFollowSeq
+	previewCardId.value = id
+	await nextTick()
+	await new Promise((resolve) => requestAnimationFrame(resolve))
+	// A newer focus change (or a close) superseded this one - drop the re-anchor.
+	if (seq !== previewFollowSeq || previewCardId.value !== id) return
+	const el = document.querySelector(`[data-card-id="${id}"]`)
+	previewAnchorRect.value = el ? el.getBoundingClientRect() : null
+})
+
 // ── Keyboard navigation helpers (declared after cardsByStack + sortedStacks) ──
 // NOTE: function declarations are hoisted and can reference these computeds
 // safely. Only computed() and watch() calls must follow their dependencies.

--- a/src/views/ViewPage.vue
+++ b/src/views/ViewPage.vue
@@ -89,20 +89,34 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</template>
 		</NcEmptyContent>
 
-		<!-- List display over the filtered + grouped cross-board cards -->
-		<BoardListView
-			v-else-if="display === 'list'"
-			:groups="groups"
-			:labels-by-id="labelsById"
-			:board-id="null" />
+		<!-- Resolved view: an optional truncation notice, then the chosen display. -->
+		<template v-else>
+			<!-- Honest truncation notice: the readable set exceeded the server cap,
+			     so the feed carries only the first N of M cards (no silent
+			     truncation). -->
+			<div
+				v-if="capped"
+				class="view-page__capped"
+				role="status"
+				aria-live="polite">
+				{{ cappedHint }}
+			</div>
 
-		<!-- Timeline display over the same groups -->
-		<BoardTimelineView
-			v-else
-			:cards="filteredCards"
-			:groups="groups"
-			:can-edit="false"
-			:board-id="null" />
+			<!-- List display over the filtered + grouped cross-board cards -->
+			<BoardListView
+				v-if="display === 'list'"
+				:groups="groups"
+				:labels-by-id="labelsById"
+				:board-id="null" />
+
+			<!-- Timeline display over the same groups -->
+			<BoardTimelineView
+				v-else
+				:cards="filteredCards"
+				:groups="groups"
+				:can-edit="false"
+				:board-id="null" />
+		</template>
 	</div>
 </template>
 
@@ -192,7 +206,18 @@ watch(view, (v) => {
 	}
 }, { immediate: true })
 
-const cards = computed(() => cardsData.value ?? [])
+const cards = computed(() => cardsData.value?.cards ?? [])
+
+// Honest truncation hint: when the readable set exceeds the server's hard cap the
+// feed carries only the first `limit` of `total` cards. Surface that rather than
+// silently dropping rows (house rule: no silent truncation).
+const capped = computed(() => cardsData.value?.capped === true)
+const cappedHint = computed(() =>
+	t('kanso', 'Showing the first {shown} of {total} cards — refine your filter to see the rest.', {
+		shown: cardsData.value?.limit ?? cards.value.length,
+		total: cardsData.value?.total ?? cards.value.length,
+	}),
+)
 
 // Apply the reused board predicate over the cross-board card set (client-side,
 // summary fields only). now is read once per recompute for a stable window.
@@ -361,6 +386,16 @@ async function onSaveFromBar(name) {
 
 .view-page__state--error {
 	color: var(--color-error);
+}
+
+.view-page__capped {
+	flex: 0 0 auto;
+	margin: 0 24px 8px 52px;
+	padding: 8px 12px;
+	border-radius: var(--border-radius);
+	background: var(--color-warning, var(--color-background-hover));
+	color: var(--color-warning-text, var(--color-main-text));
+	font-size: 0.9rem;
 }
 
 .view-page__spinner {

--- a/tests/e2e/comment-deeplink.spec.js
+++ b/tests/e2e/comment-deeplink.spec.js
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Scroll-to-comment deep links (#3870).
+ *
+ * A reminder notification links to a card carrying a `#comment-<id>` fragment
+ * (Notifier::cardLink). The fragment-free deep-link boot (main.js) stashes that
+ * id into the route query (`?comment=<id>`) before it hash-routes into the SPA;
+ * CardDetail then scrolls to + briefly highlights that comment once the thread
+ * loads. This spec drives the full-page card route with such a target and asserts
+ * the targeted comment is scrolled into view and carries the highlight class.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = {
+	'OCS-APIREQUEST': 'true',
+	'Content-Type': 'application/json',
+}
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function apiGet(path) {
+	const r = await fetch(API + path, { headers: { ...HEADERS, Authorization: AUTH } })
+	if (!r.ok) throw new Error(`GET ${path} → ${r.status}`)
+	return r.json()
+}
+async function apiPost(path, body) {
+	const r = await fetch(API + path, {
+		method: 'POST',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+async function apiDelete(path) {
+	const r = await fetch(API + path, {
+		method: 'DELETE',
+		headers: { ...HEADERS, Authorization: AUTH },
+	})
+	if (!r.ok) throw new Error(`DELETE ${path} → ${r.status}`)
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+test.describe('Scroll-to-comment deep links (#3870)', () => {
+	const state = { boardId: 0, cardId: 0, comments: [], replyId: 0 }
+
+	test.beforeAll(async () => {
+		const boards = await apiGet('/boards')
+		for (const b of boards) {
+			if (b.title === 'Comment Deeplink E2E') {
+				await apiDelete(`/boards/${b.id}`)
+			}
+		}
+		const board = await apiPost('/boards', { title: 'Comment Deeplink E2E' })
+		state.boardId = board.id
+		const stack = await apiPost('/stacks', { boardId: board.id, title: 'To Do' })
+		const card = await apiPost('/cards', { stackId: stack.id, title: 'Card With Many Comments' })
+		state.cardId = card.id
+
+		// Enough top-level comments that the target is well below the fold, so a
+		// scroll genuinely has to happen (not already in view).
+		for (let i = 1; i <= 8; i++) {
+			const c = await apiPost(`/cards/${card.id}/comments`, { body: `Comment number ${i} body text here` })
+			state.comments.push(c.id)
+		}
+		// A reply under the first comment - replies are deep-linkable too.
+		const reply = await apiPost(`/cards/${card.id}/comments`, {
+			body: 'A nested reply to comment one',
+			parentCommentId: state.comments[0],
+		})
+		state.replyId = reply.id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await apiDelete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('full-page card route with ?comment=<id> scrolls to + highlights the target', async ({ page }) => {
+		const errors = []
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') errors.push(msg.text())
+		})
+
+		// The 6th comment - far enough down the thread to require a scroll.
+		const targetId = state.comments[5]
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}?comment=${targetId}`)
+
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const target = page.locator(`#comment-${targetId}`)
+		await expect(target).toBeVisible({ timeout: 10_000 })
+
+		// The transient highlight class lands on the target while it fades.
+		await expect(target).toHaveClass(/card-modal__comment-group--highlight/, { timeout: 5000 })
+
+		// And it is actually scrolled into the viewport (not merely present in DOM).
+		await expect(target).toBeInViewport({ timeout: 5000 })
+
+		// The highlight is transient: it clears after the fade (~4s).
+		await expect(target).not.toHaveClass(/card-modal__comment-group--highlight/, { timeout: 8000 })
+
+		// No console errors from the scroll-to-comment path.
+		const relevant = errors.filter((e) => !/favicon|manifest|ResizeObserver/i.test(e))
+		expect(relevant, `console errors: ${relevant.join('\n')}`).toEqual([])
+	})
+
+	test('raw #comment-<id> fragment on the full-page route also scrolls + highlights', async ({ page }) => {
+		// An in-app link that carries the raw fragment (no query) still works: the
+		// SPA reads window.location.hash as a fallback.
+		const targetId = state.comments[6]
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}#comment-${targetId}`)
+
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const target = page.locator(`#comment-${targetId}`)
+		await expect(target).toBeVisible({ timeout: 10_000 })
+		await expect(target).toHaveClass(/card-modal__comment-group--highlight/, { timeout: 5000 })
+		await expect(target).toBeInViewport({ timeout: 5000 })
+	})
+
+	test('a reply is deep-linkable and gets highlighted', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}?comment=${state.replyId}`)
+
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const reply = page.locator(`#comment-${state.replyId}`)
+		await expect(reply).toBeVisible({ timeout: 10_000 })
+		await expect(reply).toHaveClass(/card-modal__comment--highlight/, { timeout: 5000 })
+	})
+
+	test('an unknown comment fragment opens the card normally with no error', async ({ page }) => {
+		const errors = []
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') errors.push(msg.text())
+		})
+
+		await ncLogin(page)
+		// A comment id that does not exist in this thread.
+		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}?comment=99999999`)
+
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+		// Card opens fine and the thread renders.
+		await expect(page.locator('.card-modal__comment-group').first()).toBeVisible({ timeout: 10_000 })
+		// Nothing got the highlight class.
+		await expect(page.locator('.card-modal__comment-group--highlight')).toHaveCount(0)
+
+		const relevant = errors.filter((e) => !/favicon|manifest|ResizeObserver/i.test(e))
+		expect(relevant, `console errors: ${relevant.join('\n')}`).toEqual([])
+	})
+})

--- a/tests/e2e/help-links.spec.js
+++ b/tests/e2e/help-links.spec.js
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+
+const ISSUES_URL = 'https://github.com/aktasfatih/kanso/issues'
+const MCP_SETUP_URL = 'https://github.com/aktasfatih/kanso/tree/main/mcp'
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+
+	const userInput = page.locator('#user')
+	const isLoginPage = await userInput.isVisible({ timeout: 3000 }).catch(() => false)
+	if (!isLoginPage) return // Already logged in
+
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+async function gotoKanso(page) {
+	await page.goto(BASE + '/index.php/apps/kanso')
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// #3901: an always-visible help affordance in the nav footer, reachable from
+// anywhere in the app, exposing two external links (file an issue / set up MCP).
+test.describe('Nav-footer help links', () => {
+	test.beforeEach(async ({ page }) => {
+		await ncLogin(page)
+		await gotoKanso(page)
+	})
+
+	test('Help menu exposes issue + MCP links pointing at the exact URLs in a new tab', async ({ page }) => {
+		const nav = page.locator('.app-navigation, [class*="app-navigation"]').first()
+		await expect(nav).toBeVisible({ timeout: 10_000 })
+
+		// The footer Help trigger is present regardless of which board/view is open.
+		const helpTrigger = page.locator('.app-nav__footer button').first()
+		await expect(helpTrigger).toBeVisible({ timeout: 10_000 })
+		await helpTrigger.click()
+
+		// NcActionLink renders a real <a>; data-test lands on its <li> wrapper.
+		const issue = page.locator('[data-test="menu-file-issue"] a')
+		const mcp = page.locator('[data-test="menu-setup-mcp"] a')
+
+		await expect(issue).toHaveAttribute('href', ISSUES_URL, { timeout: 8_000 })
+		await expect(issue).toHaveAttribute('target', '_blank')
+		await expect(mcp).toHaveAttribute('href', MCP_SETUP_URL, { timeout: 8_000 })
+		await expect(mcp).toHaveAttribute('target', '_blank')
+	})
+})

--- a/tests/e2e/quick-preview.spec.js
+++ b/tests/e2e/quick-preview.spec.js
@@ -66,9 +66,10 @@ async function ncLogin(page) {
 }
 
 const DESC = 'Peekaboo description text for the quick look preview.'
+const DESC_B = 'Beta body content that only the second card shows.'
 
 test.describe('Quick-look preview (Space)', () => {
-	const state = { boardId: 0, stackId: 0, card1Id: 0, boardUrl: '' }
+	const state = { boardId: 0, stackId: 0, card1Id: 0, card2Id: 0, boardUrl: '' }
 
 	test.beforeAll(async () => {
 		const boards = await apiGet('/boards')
@@ -83,10 +84,13 @@ test.describe('Quick-look preview (Space)', () => {
 		const s1 = await apiPost('/stacks', { boardId: board.id, title: 'Stack One' })
 		state.stackId = s1.id
 		const c1 = await apiPost('/cards', { stackId: s1.id, title: 'Preview Alpha' })
-		await apiPost('/cards', { stackId: s1.id, title: 'Preview Beta' })
+		const c2 = await apiPost('/cards', { stackId: s1.id, title: 'Preview Beta' })
 		state.card1Id = c1.id
-		// Give the first card a description so the preview has body content to show.
+		state.card2Id = c2.id
+		// Give both cards distinct descriptions so the preview body proves WHICH
+		// card is being shown as the selection moves.
 		await apiPatch(`/cards/${c1.id}`, { description: DESC })
+		await apiPatch(`/cards/${c2.id}`, { description: DESC_B })
 
 		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
 	})
@@ -174,6 +178,64 @@ test.describe('Quick-look preview (Space)', () => {
 		await expect(preview).not.toBeVisible({ timeout: 3000 })
 		// Click-away must not have opened the card modal.
 		expect(page.url()).not.toContain('/card/')
+	})
+
+	test('open preview follows keyboard selection and re-anchors to the new tile (#3908)', async ({ page }) => {
+		const errors = []
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') errors.push(msg.text())
+		})
+
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+
+		// Focus the first card (Alpha) and Space to open the preview on it.
+		await page.keyboard.press('ArrowDown')
+		await page.waitForTimeout(200)
+		const alphaTile = page.locator(`[data-card-id="${state.card1Id}"]`)
+		const betaTile = page.locator(`[data-card-id="${state.card2Id}"]`)
+		await expect(alphaTile).toBeFocused({ timeout: 3000 })
+
+		await page.keyboard.press('Space')
+		const preview = page.locator('.card-preview')
+		await expect(preview).toBeVisible({ timeout: 3000 })
+		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha')
+		await expect(preview.locator('.card-preview__desc-rendered')).toContainText(DESC, { timeout: 5000 })
+
+		// Record where the panel is anchored while showing Alpha.
+		const alphaLeft = await preview.evaluate((el) => el.getBoundingClientRect().left)
+		const alphaPanelTop = await preview.evaluate((el) => el.getBoundingClientRect().top)
+
+		// Move the keyboard selection down: the OPEN preview must switch to Beta.
+		await page.keyboard.press('ArrowDown')
+		await expect(betaTile).toBeFocused({ timeout: 3000 })
+		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Beta', { timeout: 3000 })
+		// No stale content: it must now show Beta's body, not Alpha's.
+		await expect(preview.locator('.card-preview__desc-rendered')).toContainText(DESC_B, { timeout: 5000 })
+
+		// The panel re-anchored to Beta's tile: it moved DOWN from where it sat for
+		// Alpha (Beta is below Alpha in the same column) and now tracks Beta's top.
+		const betaBox = await betaTile.boundingBox()
+		const betaPanelTop = await preview.evaluate((el) => el.getBoundingClientRect().top)
+		expect(betaPanelTop).toBeGreaterThan(alphaPanelTop + 10)
+		expect(Math.abs(betaPanelTop - betaBox.y)).toBeLessThan(80)
+
+		// Move back up: preview follows to Alpha again and re-anchors.
+		await page.keyboard.press('ArrowUp')
+		await expect(alphaTile).toBeFocused({ timeout: 3000 })
+		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha', { timeout: 3000 })
+		const alphaLeft2 = await preview.evaluate((el) => el.getBoundingClientRect().left)
+		const alphaPanelTop2 = await preview.evaluate((el) => el.getBoundingClientRect().top)
+		// Same column → same horizontal anchor, and the panel returned up to Alpha.
+		expect(Math.abs(alphaLeft2 - alphaLeft)).toBeLessThan(2)
+		expect(Math.abs(alphaPanelTop2 - alphaPanelTop)).toBeLessThan(10)
+
+		// Escape still dismisses.
+		await page.keyboard.press('Escape')
+		await expect(preview).not.toBeVisible({ timeout: 3000 })
+
+		expect(errors, `console errors: ${errors.join('\n')}`).toEqual([])
 	})
 
 	test('typing space in the composer inserts a space (guard holds, no preview)', async ({ page }) => {

--- a/tests/e2e/views.spec.js
+++ b/tests/e2e/views.spec.js
@@ -64,13 +64,22 @@ test.describe('Cross-board Views (#3815)', () => {
 		if (state.boardB) await api('DELETE', `/boards/${state.boardB}`).catch(() => {})
 	})
 
-	test('the cross-board feed returns cards from every readable board', async () => {
-		const cards = await api('GET', '/views/cards')
-		const titles = cards.map((c) => c.title)
+	test('the cross-board feed returns a capped envelope of cards from every readable board', async () => {
+		// The feed is a bounded envelope { cards, capped, total, limit } (#3892) -
+		// not a bare array - so a huge readable set can never ship one unbounded
+		// payload. With only a handful of test cards it is well under the cap.
+		const feed = await api('GET', '/views/cards')
+		expect(Array.isArray(feed.cards)).toBe(true)
+		expect(typeof feed.capped).toBe('boolean')
+		expect(feed.limit).toBeGreaterThan(0)
+		expect(feed.total).toBe(feed.cards.length + (feed.capped ? feed.total - feed.cards.length : 0))
+		expect(feed.cards.length).toBeLessThanOrEqual(feed.limit)
+
+		const titles = feed.cards.map((c) => c.title)
 		expect(titles).toContain(state.cardA)
 		expect(titles).toContain(state.cardB)
 		// Each card carries its board identity for grouping + deep-link.
-		const rowA = cards.find((c) => c.title === state.cardA)
+		const rowA = feed.cards.find((c) => c.title === state.cardA)
 		expect(rowA.boardId).toBe(state.boardA)
 		expect(rowA.boardTitle).toBeTruthy()
 	})

--- a/tests/unit/Controller/ViewControllerTest.php
+++ b/tests/unit/Controller/ViewControllerTest.php
@@ -129,7 +129,13 @@ class ViewControllerTest extends TestCase {
 	}
 
 	public function testCardsDelegatesToServiceForCurrentUser(): void {
-		$feed = [['id' => 1, 'boardId' => 3, 'boardTitle' => 'B']];
+		// The service returns the capped envelope; the controller passes it through.
+		$feed = [
+			'cards' => [['id' => 1, 'boardId' => 3, 'boardTitle' => 'B']],
+			'capped' => false,
+			'total' => 1,
+			'limit' => 5000,
+		];
 		$this->viewService->expects(self::once())
 			->method('findMine')->with('alice')->willReturn($feed);
 

--- a/tests/unit/Service/ViewServiceTest.php
+++ b/tests/unit/Service/ViewServiceTest.php
@@ -75,15 +75,54 @@ class ViewServiceTest extends TestCase {
 		$this->cardSummaryService->method('serialize')
 			->willReturnCallback(fn (int $boardId): array => [['id' => $boardId === 3 ? 11 : 22]]);
 
-		$rows = $this->service->findMine('alice');
+		$result = $this->service->findMine('alice');
 
+		// The feed is an envelope: uncapped small readable set → capped=false,
+		// total = row count, limit = the hard cap.
+		self::assertFalse($result['capped']);
+		self::assertSame(2, $result['total']);
+		self::assertSame(ViewService::MAX_CARDS, $result['limit']);
+
+		$rows = $result['cards'];
 		self::assertCount(2, $rows);
+		// Rows come back in the stable (boardId, id) order the cap slices on.
 		self::assertSame(11, $rows[0]['id']);
 		self::assertSame(3, $rows[0]['boardId']);
 		self::assertSame('Alpha', $rows[0]['boardTitle']);
 		self::assertSame(22, $rows[1]['id']);
 		self::assertSame(9, $rows[1]['boardId']);
 		self::assertSame('Beta', $rows[1]['boardTitle']);
+	}
+
+	/**
+	 * The scale guard (#3892): the feed is a SINGLE unbounded payload, so it is
+	 * hard-capped. Whatever the readable-set size, `cards` never exceeds
+	 * MAX_CARDS, `total` reports the true pre-cap count, and `capped` is honest -
+	 * the cap is applied AFTER the per-board ACL loop, so it moves no leak boundary.
+	 */
+	public function testFindMineCapsThePayloadAndReportsTotalWhenReadableSetIsHuge(): void {
+		$overCap = ViewService::MAX_CARDS + 250;
+
+		// One readable board whose (viewer-gated) summary set exceeds the cap.
+		$b1 = $this->board(1, 'Huge');
+		$this->boardService->method('findAll')->with('alice')->willReturn([$b1]);
+		$ctx1 = ViewerContext::forMember('alice', 1, ViewerContext::ROLE_INTERNAL, true);
+		$this->boardAccess->method('contextFor')->with($b1, 'alice')->willReturn($ctx1);
+
+		// The mapper/serializer still run once per board (ACL gate intact); they
+		// return the whole viewer-scoped set, which the cap then slices.
+		$this->cardMapper->method('findSummariesByBoard')
+			->willReturn(array_map(fn (int $i): Card => $this->summaryCard($i, 1), range(1, $overCap)));
+		$this->cardSummaryService->method('serialize')
+			->willReturn(array_map(static fn (int $i): array => ['id' => $i], range(1, $overCap)));
+
+		$result = $this->service->findMine('alice');
+
+		self::assertTrue($result['capped']);
+		self::assertSame($overCap, $result['total']);
+		self::assertSame(ViewService::MAX_CARDS, $result['limit']);
+		// The payload is bounded regardless of the readable-set size.
+		self::assertCount(ViewService::MAX_CARDS, $result['cards']);
 	}
 
 	/**
@@ -111,7 +150,7 @@ class ViewServiceTest extends TestCase {
 		$this->cardSummaryService->method('serialize')
 			->willReturn([['id' => 11, 'title' => 'Only mine']]);
 
-		$rows = $this->service->findMine('alice');
+		$rows = $this->service->findMine('alice')['cards'];
 
 		$boardIds = array_map(static fn (array $c): int => $c['boardId'], $rows);
 		self::assertSame([3], array_values(array_unique($boardIds)));
@@ -124,6 +163,9 @@ class ViewServiceTest extends TestCase {
 		$this->boardAccess->expects(self::never())->method('contextFor');
 		$this->cardMapper->expects(self::never())->method('findSummariesByBoard');
 
-		self::assertSame([], $this->service->findMine('bob'));
+		$result = $this->service->findMine('bob');
+		self::assertSame([], $result['cards']);
+		self::assertFalse($result['capped']);
+		self::assertSame(0, $result['total']);
 	}
 }


### PR DESCRIPTION
PM sprint `pm/session-2026-08-19` — 9 cards, each validate→implement→test→commit on one branch. All e2e/unit suites run green locally; combined `vite build` ✓ + full mcp pytest (29) ✓.

## Adoption / UX
- **#3908** `feat(board)` — quick-look (Space) preview now follows keyboard selection: arrow/hjkl switches the open preview to the newly focused card and re-anchors the popover; Esc/Space/mouse-leave still dismiss. (`acad1d0`, 6/6 e2e)
- **#3901** `feat(nav)` — always-visible app-nav footer **Help** menu with "File an issue" → repo issues and "Set up MCP" → `mcp/` docs. (`bea4935`, e2e)
- **#3870** `feat(card)` — reminder links carrying `#comment-<id>` scroll to and briefly highlight the exact comment (modal + full-page); also fixes a `main.js` hash-clobber under hash routing. (`37ba244`, 4 e2e)

## MCP v1.1 — write surface for the in-repo MCP server (`mcp/`)
- **#3872** list a board's assignable members (unblocks `kanso_assign_user`). (`37f84d3`)
- **#3874** expose remaining `update_card` fields — visibility / type / status / startDate / dueReminderDayBefore / coverColor / allDay. (`3935072`)
- **#3873** read + post card comments. (`d957141`)
- **#3875** checklist tools — add / toggle / list. (`b1d39e9`)
- **#3876** card relations (blocks/blocked_by/duplicates/relates) + subtask set-parent (clear-parent None-drop handled). (`5363477`)
- 29 respx unit tests, all green.

## Scalability
- **#3892** `fix(views)` — cap the cross-board Views feed at 5000 summaries and return an envelope `{cards, capped, total, limit}` (was an unbounded bare array). Client reads `.cards` and shows an honest "showing first N of M — refine your filter" banner when capped. ACL readable-set + visibility masking unchanged; cap applied after the per-board loop. All consumers updated (`api.js`, `useViewCards`, `ViewPage`) + PHPUnit cap test; 48 PHPUnit green, psalm/cs clean. (`0448650`)

No version bump (release-only via semantic-release). No `CHANGELOG.md` hand-edits.