### PR TITLE
Views Kanban + in-context card open, public read-only detail, Deck attachment import, DnD e2e

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -51,8 +51,8 @@ class ViewController extends Controller {
 	/** The group-by fields the surface offers (mirrors the client selector / VIEW_GROUP_BY). */
 	private const GROUP_BY = ['status', 'priority', 'assignee', 'board', 'type', 'review', 'due', 'owner'];
 
-	/** The display modes the surface offers (Kanban is a separate Phase 2 card). */
-	private const DISPLAYS = ['list', 'timeline'];
+	/** The display modes the surface offers (Kanban groups the feed into columns by the group-by field). */
+	private const DISPLAYS = ['list', 'timeline', 'kanban'];
 
 	public function __construct(
 		string $appName,

--- a/lib/Service/DeckImportService.php
+++ b/lib/Service/DeckImportService.php
@@ -21,12 +21,15 @@ use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\File;
 use OCP\Files\IAppData;
+use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
 
 /**
  * One-click import of a Deck board into Kanso. Reads the source via
@@ -36,11 +39,13 @@ use OCP\Security\ISecureRandom;
  * v1 imports the structure that maps cleanly: board (title/color), stacks
  * (order preserved), cards (title/description/archived/due date/done state),
  * labels + their card assignments, user assignees that still exist, card
- * comments (author remapped to the importer when the uid is gone), and
- * `deck_file` attachments (the bytes copied out of Deck's app-data into Kanso's
- * own). Deck's user-Files reference attachments (the `file` kind) are NOT
- * re-linked - they are counted and reported as skipped. Board SHARING/ACL is
- * still out of scope for v1 (it needs participant remapping).
+ * comments (author remapped to the importer when the uid is gone), and BOTH
+ * kinds of card attachment: `deck_file` uploads (bytes copied out of Deck's
+ * app-data into Kanso's own) AND `file` user-Files references (Deck stores these
+ * as shares; the referenced file's bytes are read from the owner's Files and
+ * copied in the same way). A reference whose source file is gone/unreadable is
+ * logged and skipped (counted in `skippedFileAttachments`), never fatal. Board
+ * SHARING/ACL is still out of scope for v1 (it needs participant remapping).
  */
 class DeckImportService {
 	/**
@@ -69,6 +74,8 @@ class DeckImportService {
 		private IAppData $appData,
 		private IAppDataFactory $appDataFactory,
 		private ISecureRandom $secureRandom,
+		private IRootFolder $rootFolder,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -198,7 +205,7 @@ class DeckImportService {
 			$this->importUserAssignees($deckCardIds, $cardIdMap);
 			$commentCount = $this->importComments($deckCardIds, $cardIdMap, $actorUid);
 			$attachmentCount = $this->importAttachments($deckCardIds, $cardIdMap, $actorUid, $writtenObjects);
-			$skippedFileAttachments = $this->deckReader->countFileReferenceAttachments($deckCardIds);
+			[$fileRefCount, $skippedFileAttachments] = $this->importFileReferenceAttachments($deckCardIds, $cardIdMap, $actorUid, $writtenObjects);
 
 			$result = [
 				'boardId' => $boardId,
@@ -207,7 +214,7 @@ class DeckImportService {
 				'cards' => $cardCount,
 				'labels' => count($labelIdMap),
 				'comments' => $commentCount,
-				'attachments' => $attachmentCount,
+				'attachments' => $attachmentCount + $fileRefCount,
 				'skippedFileAttachments' => $skippedFileAttachments,
 			];
 			$this->db->commit();
@@ -308,8 +315,8 @@ class DeckImportService {
 	 * Copies Deck's `deck_file` attachments into the new Kanso cards: the bytes
 	 * are read from Deck's app-data and re-stored under a server-generated
 	 * storage key in Kanso's own app-data, then a `kanso_card_attachments` row is
-	 * inserted. The user-Files reference kind (`file`) is not handled here (it is
-	 * counted separately and reported as skipped).
+	 * inserted. The user-Files reference kind (`file`) is handled separately by
+	 * {@see self::importFileReferenceAttachments()} (Deck stores it as a share).
 	 *
 	 * A `deck_attachment` row whose source object is MISSING - or whose source
 	 * exceeds {@see AttachmentSanitizer::MAX_SIZE} - is skipped and NOT counted,
@@ -338,11 +345,19 @@ class DeckImportService {
 				continue;
 			}
 
-			// Resolve the source object from Deck's app-data. A missing source
-			// object (row present but file gone) is skipped, not fatal.
+			// Resolve the source object from Deck's app-data. Deck stores the bytes
+			// under `file-card-<cardId>` (its FileService::getFolder()), NOT under
+			// the bare card id. A missing source object (row present but file gone,
+			// e.g. an app-data key mismatch) is LOGGED and skipped, not fatal.
 			try {
-				$sourceFile = $deckAppData->getFolder((string)$att['cardId'])->getFile($att['data']);
+				$sourceFile = $deckAppData
+					->getFolder('file-card-' . $att['cardId'])
+					->getFile($att['data']);
 			} catch (NotFoundException) {
+				$this->logger->warning(
+					'Kanso Deck import: skipping deck_file attachment with missing source object',
+					['deckCardId' => $att['cardId'], 'data' => $att['data']]
+				);
 				continue;
 			}
 
@@ -350,41 +365,195 @@ class DeckImportService {
 			// Files-copy paths). An oversized source is skipped-and-not-counted,
 			// exactly like a missing source - never fatal to the whole import.
 			if ((int)$sourceFile->getSize() > AttachmentSanitizer::MAX_SIZE) {
+				$this->logger->warning(
+					'Kanso Deck import: skipping oversized deck_file attachment',
+					['deckCardId' => $att['cardId'], 'data' => $att['data'], 'size' => (int)$sourceFile->getSize()]
+				);
 				continue;
 			}
-			$bytes = $sourceFile->getContent();
 
-			$card = $this->cardMapper->find($newCardId);
-			$boardId = $card->getBoardId();
-
-			// Server-generated opaque object name - the Deck filename never selects
-			// a storage path (mirrors CardAttachmentService).
-			$storageKey = $this->secureRandom->generate(
-				32,
-				ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS
-			);
-			$folder = $this->kansoCardFolder($newCardId);
-			$folder->newFile($storageKey, $bytes);
-			$writtenObjects[] = ['cardId' => $newCardId, 'storageKey' => $storageKey];
-
-			$author = $att['createdBy'];
-			if ($author === '' || !$this->userManager->userExists($author)) {
-				$author = $actorUid;
+			// The read itself can still fail (storage error / corruption) even when
+			// the object resolved - guard it so one unreadable object is logged +
+			// skipped, never fatal to the whole import (same as the file-ref path).
+			try {
+				$bytes = $sourceFile->getContent();
+			} catch (\Throwable $e) {
+				$this->logger->warning(
+					'Kanso Deck import: could not read deck_file attachment bytes',
+					['deckCardId' => $att['cardId'], 'data' => $att['data'], 'exception' => $e]
+				);
+				continue;
 			}
 
-			$attachment = new CardAttachment();
-			$attachment->setCardId($newCardId);
-			$attachment->setBoardId($boardId);
-			$attachment->setFilename(AttachmentSanitizer::filename($att['data']));
-			$attachment->setMime(AttachmentSanitizer::mime($sourceFile->getMimeType()));
-			$attachment->setSize((int)$sourceFile->getSize());
-			$attachment->setStorageKey($storageKey);
-			$attachment->setUploadedBy($author);
-			$attachment->setCreatedAt($att['createdAt'] > 0 ? $att['createdAt'] : time());
-			$this->cardAttachmentMapper->insert($attachment);
+			$this->storeAttachment(
+				$newCardId,
+				$bytes,
+				AttachmentSanitizer::filename($att['data']),
+				AttachmentSanitizer::mime($sourceFile->getMimeType()),
+				(int)$sourceFile->getSize(),
+				$att['createdBy'],
+				$att['createdAt'],
+				$actorUid,
+				$writtenObjects,
+			);
 			$count++;
 		}
 		return $count;
+	}
+
+	/**
+	 * Imports Deck's `file` (user-Files reference) attachments. Unlike
+	 * `deck_file`, Deck stores these as SHARES (see {@see DeckReader::readFileReferenceAttachments()}),
+	 * pointing at a node in the sharer's Files. We resolve the node from the file
+	 * owner's userfolder, cap its size, then COPY the bytes into Kanso's app-data
+	 * through the SAME sanitized store path as an upload - so the imported card
+	 * owns an independent copy (a later edit/unshare of the source can't leak to,
+	 * or break for, board members). A reference whose file is gone, inaccessible,
+	 * or oversized is LOGGED and skipped (counted as skipped), never fatal.
+	 *
+	 * @param int[] $deckCardIds
+	 * @param array<int, int> $cardIdMap deck card id → kanso card id
+	 * @param list<array{cardId: int, storageKey: string}> $writtenObjects tracked, by-reference
+	 * @return array{0: int, 1: int} [imported count, skipped count]
+	 */
+	private function importFileReferenceAttachments(array $deckCardIds, array $cardIdMap, string $actorUid, array &$writtenObjects): array {
+		$refs = $this->deckReader->readFileReferenceAttachments($deckCardIds);
+		if ($refs === []) {
+			return [0, 0];
+		}
+
+		$imported = 0;
+		$skipped = 0;
+		foreach ($refs as $ref) {
+			$newCardId = $cardIdMap[$ref['cardId']] ?? null;
+			if ($newCardId === null) {
+				continue;
+			}
+
+			$node = $this->resolveFileReferenceNode($ref['owner'], $ref['fileId']);
+			if ($node === null) {
+				$this->logger->warning(
+					'Kanso Deck import: skipping file-reference attachment with missing/inaccessible source',
+					['deckCardId' => $ref['cardId'], 'fileId' => $ref['fileId'], 'owner' => $ref['owner']]
+				);
+				$skipped++;
+				continue;
+			}
+
+			$size = (int)$node->getSize();
+			if ($size <= 0 || $size > AttachmentSanitizer::MAX_SIZE) {
+				$this->logger->warning(
+					'Kanso Deck import: skipping empty/oversized file-reference attachment',
+					['deckCardId' => $ref['cardId'], 'fileId' => $ref['fileId'], 'size' => $size]
+				);
+				$skipped++;
+				continue;
+			}
+
+			try {
+				$bytes = $node->getContent();
+			} catch (\Throwable $e) {
+				$this->logger->warning(
+					'Kanso Deck import: could not read file-reference attachment bytes',
+					['deckCardId' => $ref['cardId'], 'fileId' => $ref['fileId'], 'exception' => $e]
+				);
+				$skipped++;
+				continue;
+			}
+
+			$filename = $ref['filename'] !== '' ? $ref['filename'] : $node->getName();
+			$this->storeAttachment(
+				$newCardId,
+				$bytes,
+				AttachmentSanitizer::filename($filename),
+				AttachmentSanitizer::mime($node->getMimetype()),
+				$size,
+				$ref['createdBy'],
+				$ref['createdAt'],
+				$actorUid,
+				$writtenObjects,
+			);
+			$imported++;
+		}
+		return [$imported, $skipped];
+	}
+
+	/**
+	 * Resolves the file node behind a Deck `file` reference from the file OWNER's
+	 * userfolder by file id - the same by-id resolution Kanso's own "Share from
+	 * Files" path uses. Returns null when the owner is unknown, has no userfolder,
+	 * or the id resolves to no readable file node (gone/inaccessible) - the caller
+	 * logs + skips.
+	 */
+	private function resolveFileReferenceNode(string $owner, int $fileId): ?File {
+		if ($owner === '' || $fileId <= 0) {
+			return null;
+		}
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($owner);
+		} catch (\Throwable) {
+			return null;
+		}
+		try {
+			$nodes = $userFolder->getById($fileId);
+		} catch (\Throwable) {
+			return null;
+		}
+		foreach ($nodes as $node) {
+			if ($node instanceof File) {
+				return $node;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Writes attachment bytes into Kanso's per-card app-data under a
+	 * server-generated storage key and inserts the `kanso_card_attachments` row.
+	 * Shared by both attachment kinds so the store/tracking logic never diverges.
+	 * The author uid falls back to the importer when the source uid is gone.
+	 *
+	 * @param list<array{cardId: int, storageKey: string}> $writtenObjects tracked, by-reference
+	 */
+	private function storeAttachment(
+		int $newCardId,
+		string $bytes,
+		string $filename,
+		string $mime,
+		int $size,
+		string $sourceUid,
+		int $createdAt,
+		string $actorUid,
+		array &$writtenObjects,
+	): void {
+		$card = $this->cardMapper->find($newCardId);
+		$boardId = $card->getBoardId();
+
+		// Server-generated opaque object name - the Deck filename never selects
+		// a storage path (mirrors CardAttachmentService).
+		$storageKey = $this->secureRandom->generate(
+			32,
+			ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS
+		);
+		$folder = $this->kansoCardFolder($newCardId);
+		$folder->newFile($storageKey, $bytes);
+		$writtenObjects[] = ['cardId' => $newCardId, 'storageKey' => $storageKey];
+
+		$author = $sourceUid;
+		if ($author === '' || !$this->userManager->userExists($author)) {
+			$author = $actorUid;
+		}
+
+		$attachment = new CardAttachment();
+		$attachment->setCardId($newCardId);
+		$attachment->setBoardId($boardId);
+		$attachment->setFilename($filename);
+		$attachment->setMime($mime);
+		$attachment->setSize($size);
+		$attachment->setStorageKey($storageKey);
+		$attachment->setUploadedBy($author);
+		$attachment->setCreatedAt($createdAt > 0 ? $createdAt : time());
+		$this->cardAttachmentMapper->insert($attachment);
 	}
 
 	/**

--- a/lib/Service/DeckReader.php
+++ b/lib/Service/DeckReader.php
@@ -230,11 +230,22 @@ class DeckReader {
 	}
 
 	/**
+	 * Deck's share types for a card-attached user file. Deck's `file`-kind
+	 * attachments are NOT stored in `deck_attachment`; each is an `oc_share` row
+	 * whose `share_with` is the card id (see Deck's FilesAppService). The share is
+	 * of type {@see \OCP\Share\IShare::TYPE_DECK} (12); Deck also defines
+	 * TYPE_DECK_USER (13) for per-user shares, so we accept both to avoid silently
+	 * missing an attachment. Mirrored as literals so the importer never depends on
+	 * Deck's PHP being loadable.
+	 */
+	private const SHARE_TYPES_DECK = [12, 13];
+
+	/**
 	 * A card's file attachments (`deck_file` kind only), non-deleted. The `data`
 	 * column holds the stored FILENAME (not the bytes) - the bytes live in Deck's
 	 * app-data, read separately by {@see DeckImportService}. The user-Files
-	 * reference kind (`file`) is intentionally NOT returned here; the caller
-	 * counts those skips separately.
+	 * reference kind (`file`) is NOT returned here; those are Deck SHARES, read by
+	 * {@see self::readFileReferenceAttachments()}.
 	 *
 	 * @param int[] $cardIds
 	 * @return list<array{id: int, cardId: int, type: string, data: string, createdBy: string, createdAt: int}>
@@ -260,26 +271,54 @@ class DeckReader {
 	}
 
 	/**
-	 * Count of non-deleted user-Files reference attachments (`file` kind) on the
-	 * given cards. These are deliberately NOT imported (re-linking user Files is
-	 * out of scope); the importer surfaces this count in its result summary.
+	 * The user-Files reference attachments (`file` kind) on the given cards.
+	 *
+	 * Deck stores these as SHARES, not as `deck_attachment` rows: each is an
+	 * `oc_share` of type {@see self::SHARE_TYPE_DECK} whose `share_with` is the
+	 * (stringified) card id, pointing at a node in the sharer's Files. We join
+	 * `oc_share` → `oc_filecache` to resolve the source `fileId`/`filename`/owner
+	 * so {@see DeckImportService} can copy the bytes into Kanso. A share whose
+	 * permissions are 0 (Deck's soft-delete for a file attachment) is skipped.
 	 *
 	 * @param int[] $cardIds
+	 * @return list<array{cardId: int, fileId: int, filename: string, owner: string, createdBy: string, createdAt: int}>
 	 */
-	public function countFileReferenceAttachments(array $cardIds): int {
+	public function readFileReferenceAttachments(array $cardIds): array {
 		if ($cardIds === []) {
-			return 0;
+			return [];
 		}
+		// share_with holds the card id as a STRING; compare as strings.
+		$idStrings = array_map(static fn (int $id): string => (string)$id, $cardIds);
+
 		$qb = $this->db->getQueryBuilder();
-		$qb->select($qb->func()->count('id', 'cnt'))
-			->from('deck_attachment')
-			->where($qb->expr()->in('card_id', $qb->createNamedParameter($cardIds, IQueryBuilder::PARAM_INT_ARRAY)))
-			->andWhere($qb->expr()->eq('type', $qb->createNamedParameter('file')))
-			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
-		$result = $qb->executeQuery();
-		$row = $result->fetch();
-		$result->closeCursor();
-		return (int)($row['cnt'] ?? 0);
+		$qb->select('s.share_with', 's.file_source', 's.uid_owner', 's.uid_initiator', 's.stime', 'f.name')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
+			->where($qb->expr()->in('s.share_type', $qb->createNamedParameter(self::SHARE_TYPES_DECK, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->in('s.share_with', $qb->createNamedParameter($idStrings, IQueryBuilder::PARAM_STR_ARRAY)))
+			->andWhere($qb->expr()->isNull('s.parent'))
+			->andWhere($qb->expr()->neq('s.permissions', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+		$out = [];
+		foreach ($this->fetchAll($qb) as $r) {
+			$fileId = (int)($r['file_source'] ?? 0);
+			if ($fileId <= 0) {
+				continue;
+			}
+			// The file's owner is the authoritative uid for resolving the node
+			// (uid_owner); uid_initiator is who created the share. Prefer the
+			// owner, falling back to the initiator.
+			$owner = (string)($r['uid_owner'] ?? '');
+			$initiator = (string)($r['uid_initiator'] ?? '');
+			$out[] = [
+				'cardId' => (int)$r['share_with'],
+				'fileId' => $fileId,
+				'filename' => (string)($r['name'] ?? ''),
+				'owner' => $owner !== '' ? $owner : $initiator,
+				'createdBy' => $initiator !== '' ? $initiator : $owner,
+				'createdAt' => (int)($r['stime'] ?? 0),
+			];
+		}
+		return $out;
 	}
 
 	// -------------------------------------------------------------------------

--- a/lib/Service/PublicShareService.php
+++ b/lib/Service/PublicShareService.php
@@ -40,9 +40,10 @@ use OCP\Security\ISecureRandom;
  *    narrow field list. It NEVER reuses the authenticated board payload, and it
  *    NEVER touches assignees, comments, watchers, activity/changes, ACL/members,
  *    owner uids, reviews, or the webhook config. Only board title + stacks +
- *    per-card {title, description, labels, dates, checklist counts, priority,
- *    status, human id} are exposed - nothing that identifies a person or leaks
- *    internal metadata. Archived stacks/cards are omitted.
+ *    per-card {title, description, labels, dates, cover colour, estimate,
+ *    checklist counts, priority, status, human id} are exposed - nothing that
+ *    identifies a person or leaks internal metadata. Archived stacks/cards are
+ *    omitted.
  *  - An unknown/disabled/rotated/expired token raises DoesNotExistException,
  *    which the controller maps to a throttled 404 (no oracle beyond the throttle,
  *    and no distinction between "wrong token" and "disabled board").
@@ -124,7 +125,7 @@ class PublicShareService {
 	 * @return array{
 	 *   board: array{title: ?string, color: ?string, prefix: string},
 	 *   stacks: list<array{id: int, title: ?string, color: ?string}>,
-	 *   cards: list<array{id: int, stackId: ?int, title: ?string, description: ?string, labels: list<array{name: ?string, color: ?string}>, duedate: ?string, allDay: bool, priority: int, type: string, status: string, humanId: ?string, checklist: array{total: int, done: int}}>
+	 *   cards: list<array{id: int, stackId: ?int, title: ?string, description: ?string, labels: list<array{name: ?string, color: ?string}>, duedate: ?string, coverColor: ?string, startDate: ?string, estimate: ?string, allDay: bool, priority: int, type: string, status: string, humanId: ?string, checklist: array{total: int, done: int}}>
 	 * }
 	 * @throws DoesNotExistException if the token is unknown, disabled, or expired
 	 */
@@ -203,6 +204,12 @@ class PublicShareService {
 				'description' => $card->getDescription(),
 				'labels' => $labels,
 				'duedate' => $card->getDuedate()?->format(\DateTimeInterface::ATOM),
+				// Presentational, non-person card attributes (#3951): a cover colour
+				// band, the start date, and the estimate. These are board content, not
+				// person identifiers - no assignees/comments/members/activity here.
+				'coverColor' => $card->getCoverColor(),
+				'startDate' => $card->getStartDate()?->format(\DateTimeInterface::ATOM),
+				'estimate' => $card->getEstimate(),
 				'allDay' => $card->getAllDay() ?? false,
 				'priority' => $card->getPriority() ?? 0,
 				'type' => $card->getType() ?? '',

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 namespace OCA\Kanso\Service;
 
 use OCA\Kanso\Access\BoardAccess;
+use OCA\Kanso\Db\BoardPrefix;
 use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\LabelMapper;
 
 /**
  * The cross-board feed behind saved "Views" (#3815) - every non-deleted card
@@ -42,6 +44,7 @@ class ViewService {
 		private CardMapper $cardMapper,
 		private CardSummaryService $cardSummaryService,
 		private BoardAccess $boardAccess,
+		private LabelMapper $labelMapper,
 	) {
 	}
 
@@ -54,17 +57,26 @@ class ViewService {
 	 * run over them with no extra request.
 	 *
 	 * Returned as an envelope so the client can honestly report truncation:
-	 *   ['cards' => list<array>, 'capped' => bool, 'total' => int, 'limit' => int]
+	 *   ['cards' => list<array>, 'labels' => list<array>, 'capped' => bool, 'total' => int, 'limit' => int]
 	 * where `total` is the pre-cap readable-set count and `cards` is capped to at
 	 * most {@see self::MAX_CARDS} rows. The cap is applied AFTER the per-board ACL
 	 * + #3743 masking loop, so every row is still gated before the slice.
 	 *
-	 * @return array{cards: list<array<string, mixed>>, capped: bool, total: int, limit: int}
+	 * Each card additionally carries `boardPrefix` (its board's human-id prefix) and
+	 * `labels` is the union of each readable board's serialized labels (the label's
+	 * own shape: id/boardId/title/color) across the same readable boards - all
+	 * already-readable board metadata, no leak beyond the readable set the card rows
+	 * come from - so the client can render card tiles with the real human ref
+	 * (e.g. "KAN-123") and label COLOURS — matching the board tiles (#3950) — from
+	 * this one feed, with no extra per-board request.
+	 *
+	 * @return array{cards: list<array<string, mixed>>, labels: list<array<string, mixed>>, capped: bool, total: int, limit: int}
 	 */
 	public function findMine(string $uid): array {
 		$boards = $this->boardService->findAll($uid);
 
 		$out = [];
+		$labels = [];
 		foreach ($boards as $board) {
 			$boardId = (int)$board->getId();
 			// The viewer's resolved side on THIS board scopes every card row
@@ -77,12 +89,25 @@ class ViewService {
 				$viewer,
 			);
 			$boardTitle = (string)$board->getTitle();
+			$boardPrefix = (string)($board->getPrefix() ?? BoardPrefix::DEFAULT);
 			foreach ($cards as $card) {
 				// Carry the board identity so the client can group by board and
 				// deep-link back without a per-card board lookup.
 				$card['boardId'] = $boardId;
 				$card['boardTitle'] = $boardTitle;
+				// The board's human-id prefix, so a card tile can render its real
+				// reference (prefix + '-' + boardSeq), same as the board tiles.
+				$card['boardPrefix'] = $boardPrefix;
 				$out[] = $card;
+			}
+			// Union the readable board's labels so the client can colour the card
+			// label chips. Labels are board-scoped and ids are unique per board's
+			// creation table; across boards ids can collide, but a View's tiles only
+			// reference a card's own labelIds against a single lookup — collisions are
+			// acceptable for chip colouring (the same trade-off the board makes with
+			// its per-board labelsById). Keyed by id keeps the payload deduplicated.
+			foreach ($this->labelMapper->findByBoard($boardId) as $label) {
+				$labels[(int)$label->getId()] = $label->jsonSerialize();
 			}
 		}
 
@@ -102,6 +127,7 @@ class ViewService {
 
 		return [
 			'cards' => $out,
+			'labels' => array_values($labels),
 			'capped' => $capped,
 			'total' => $total,
 			'limit' => self::MAX_CARDS,

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -166,7 +166,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
 import { useVirtualizer } from '@tanstack/vue-virtual'
@@ -207,6 +207,17 @@ const props = defineProps({
 	 */
 	boardId: { type: [String, Number], default: null },
 })
+
+const emit = defineEmits(['open'])
+
+// When a parent handles `@open` (a cross-board View owns a card-detail overlay,
+// #3950), emit the card up and let the parent open it in place — do NOT route to
+// card-modal (a child of the board route, which would swap the whole View out for
+// the board). Inside an actual board no `@open` is attached, so the classic
+// router.push deep-link behaviour is preserved unchanged.
+// A parent's `@open` presence is fixed at mount (it never toggles at runtime), so
+// this is a one-off static read, not a reactive dependency.
+const hasOpenHandler = !!getCurrentInstance()?.vnode?.props?.onOpen
 
 const router = useRouter()
 const scrollRef = ref(null)
@@ -325,6 +336,12 @@ const virtualizer = useVirtualizer(computed(() => ({
 })))
 
 function openCard(card) {
+	// A parent-owned overlay (cross-board View, #3950) takes precedence: hand the
+	// card up and stay on the current surface instead of navigating.
+	if (hasOpenHandler) {
+		emit('open', card)
+		return
+	}
 	// Prefer the card's own boardId (cross-board Views, #3815); fall back to the
 	// single-board prop for the classic per-board list.
 	const boardId = card.boardId ?? props.boardId

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -863,12 +863,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</section>
 
 				<section
-					v-if="canShare"
+					v-if="canShare || canManage"
 					v-show="activeTab === 'sharing'"
 					id="bs-pane-sharing"
 					class="bs-pane"
 					role="tabpanel"
 					aria-labelledby="bs-rail-tab-sharing">
+				<!-- Member sharing (ACL) needs the Share right; a manage-only member
+				     still reaches this pane for the public link below. -->
+				<template v-if="canShare">
 				<!-- Sharee search -->
 				<div class="sharing__search-wrap">
 					<input
@@ -1028,6 +1031,61 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							{{ t('kanso', 'Cancel') }}
 						</button>
 						<span v-if="leaveError" class="label-settings__error">{{ leaveError }}</span>
+					</div>
+				</div>
+				</template>
+
+				<!-- Public / read-only link group (#3531) — lives with sharing so
+				     public-link creation sits next to member sharing. -->
+				<div class="automation__group sharing__public-link">
+					<button
+						class="automation__group-header"
+						type="button"
+						:aria-expanded="automationGroups.publicLink ? 'true' : 'false'"
+						aria-controls="bs-sharing-public-link"
+						@click="toggleAutomationGroup('publicLink')">
+						<LinkVariantIcon :size="16" class="automation__group-icon" />
+						<span class="automation__group-title">{{ t('kanso', 'Public link') }}</span>
+						<span v-if="publicShare.enabled" class="automation__group-badge">{{ t('kanso', 'Link active') }}</span>
+						<ChevronUpIcon v-if="automationGroups.publicLink" :size="16" class="automation__group-chevron" />
+						<ChevronDownIcon v-else :size="16" class="automation__group-chevron" />
+					</button>
+					<div v-show="automationGroups.publicLink" id="bs-sharing-public-link" class="automation__group-body">
+						<p v-if="!canManage" class="workflow__readonly-notice">
+							{{ t('kanso', 'You need manage permission to configure the public link.') }}
+						</p>
+						<template v-else>
+							<p class="github-webhook__hint">
+								{{ t('kanso', 'Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Assignees, comments, activity and members are never shown.') }}
+							</p>
+
+							<div class="github-webhook__actions">
+								<NcCheckboxRadioSwitch
+									type="switch"
+									:model-value="publicShare.enabled"
+									:disabled="publicShareBusy"
+									@update:model-value="togglePublicShare">
+									{{ t('kanso', 'Enable public link') }}
+								</NcCheckboxRadioSwitch>
+							</div>
+
+							<template v-if="publicShare.enabled && publicShare.url">
+								<label class="github-webhook__label">{{ t('kanso', 'Public link') }}</label>
+								<div class="github-webhook__row">
+									<input class="github-webhook__input" type="text" readonly :value="publicShare.url">
+									<NcButton :disabled="!publicShare.url" @click="copyText(publicShare.url)">
+										{{ t('kanso', 'Copy') }}
+									</NcButton>
+								</div>
+								<div class="github-webhook__actions">
+									<NcButton :disabled="publicShareBusy" @click="handleRotatePublicShare">
+										{{ t('kanso', 'Rotate link') }}
+									</NcButton>
+									<span class="bs-share__hint">{{ t('kanso', 'Anyone with the link can view this board read-only.') }}</span>
+								</div>
+							</template>
+							<span v-if="publicShareError" class="label-settings__error">{{ publicShareError }}</span>
+						</template>
 					</div>
 				</div>
 				</section>
@@ -1248,59 +1306,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</template>
 					<span v-if="webhookError" class="label-settings__error">{{ webhookError }}</span>
 				</template>
-					</div>
-				</div>
-
-				<!-- Public / read-only link group (#3531) -->
-				<div class="automation__group">
-					<button
-						class="automation__group-header"
-						type="button"
-						:aria-expanded="automationGroups.publicLink ? 'true' : 'false'"
-						aria-controls="bs-automation-public-link"
-						@click="toggleAutomationGroup('publicLink')">
-						<LinkVariantIcon :size="16" class="automation__group-icon" />
-						<span class="automation__group-title">{{ t('kanso', 'Public link') }}</span>
-						<span v-if="publicShare.enabled" class="automation__group-badge">{{ t('kanso', 'Link active') }}</span>
-						<ChevronUpIcon v-if="automationGroups.publicLink" :size="16" class="automation__group-chevron" />
-						<ChevronDownIcon v-else :size="16" class="automation__group-chevron" />
-					</button>
-					<div v-show="automationGroups.publicLink" id="bs-automation-public-link" class="automation__group-body">
-						<p v-if="!canManage" class="workflow__readonly-notice">
-							{{ t('kanso', 'You need manage permission to configure the public link.') }}
-						</p>
-						<template v-else>
-							<p class="github-webhook__hint">
-								{{ t('kanso', 'Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Assignees, comments, activity and members are never shown.') }}
-							</p>
-
-							<div class="github-webhook__actions">
-								<NcCheckboxRadioSwitch
-									type="switch"
-									:model-value="publicShare.enabled"
-									:disabled="publicShareBusy"
-									@update:model-value="togglePublicShare">
-									{{ t('kanso', 'Enable public link') }}
-								</NcCheckboxRadioSwitch>
-							</div>
-
-							<template v-if="publicShare.enabled && publicShare.url">
-								<label class="github-webhook__label">{{ t('kanso', 'Public link') }}</label>
-								<div class="github-webhook__row">
-									<input class="github-webhook__input" type="text" readonly :value="publicShare.url">
-									<NcButton :disabled="!publicShare.url" @click="copyText(publicShare.url)">
-										{{ t('kanso', 'Copy') }}
-									</NcButton>
-								</div>
-								<div class="github-webhook__actions">
-									<NcButton :disabled="publicShareBusy" @click="handleRotatePublicShare">
-										{{ t('kanso', 'Rotate link') }}
-									</NcButton>
-									<span class="bs-share__hint">{{ t('kanso', 'Anyone with the link can view this board read-only.') }}</span>
-								</div>
-							</template>
-							<span v-if="publicShareError" class="label-settings__error">{{ publicShareError }}</span>
-						</template>
 					</div>
 				</div>
 
@@ -2433,7 +2438,8 @@ function canToggleBit(entry, bit) {
 // ── Tab / section-rail state ──────────────────────────────────────────────────
 const activeTab = ref('labels')
 
-// Section rail items. Sharing is gated behind canShare (mirrors the old tab's v-if).
+// Section rail items. Sharing shows for anyone who can share (member ACL) OR
+// manage (the public link lives here now), mirroring the pane's v-if.
 const railSections = computed(() => {
 	const sections = [
 		{ id: 'general', name: t('kanso', 'General'), icon: CogIcon },
@@ -2441,7 +2447,7 @@ const railSections = computed(() => {
 		{ id: 'review-types', name: t('kanso', 'Review types'), icon: CheckDecagramIcon },
 		{ id: 'card-fields', name: t('kanso', 'Custom fields'), icon: TableColumnIcon },
 	]
-	if (canShare.value) {
+	if (canShare.value || canManage.value) {
 		sections.push({ id: 'sharing', name: t('kanso', 'Sharing'), icon: ShareVariantIcon })
 	}
 	sections.push({ id: 'workflow', name: t('kanso', 'Workflow'), icon: SwapHorizontalIcon })

--- a/src/components/BoardTimelineView.vue
+++ b/src/components/BoardTimelineView.vue
@@ -216,7 +216,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
 import { useRouter } from 'vue-router'
 import { useQueryClient } from '@tanstack/vue-query'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
@@ -258,6 +258,17 @@ const props = defineProps({
 	 */
 	boardId: { type: [String, Number], default: null },
 })
+
+const emit = defineEmits(['open'])
+
+// When a parent handles `@open` (a cross-board View owns a card-detail overlay,
+// #3950), emit the card up and let the parent open it in place — do NOT route to
+// card-modal (a child of the board route, which would swap the whole View out for
+// the board). Inside an actual board no `@open` is attached, so the classic
+// router.push deep-link is preserved unchanged.
+// A parent's `@open` presence is fixed at mount (it never toggles at runtime), so
+// this is a one-off static read, not a reactive dependency.
+const hasOpenHandler = !!getCurrentInstance()?.vnode?.props?.onOpen
 
 const router = useRouter()
 const queryClient = useQueryClient()
@@ -585,6 +596,13 @@ function cardHumanId(card) {
 }
 
 function openCard(cardId) {
+	// A parent-owned overlay (cross-board View, #3950) takes precedence: hand the
+	// card up and stay on the View instead of navigating to its board.
+	if (hasOpenHandler) {
+		const card = props.cards.find((c) => c.id === cardId)
+		if (card) emit('open', card)
+		return
+	}
 	// Cross-board Views (#3815): resolve each card's own boardId for the deep
 	// link; fall back to the single-board prop for the classic per-board timeline.
 	let boardId = props.boardId

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -2252,12 +2252,26 @@ const props = defineProps({
 		type: [String, Number],
 		default: null,
 	},
+	// Controlled overlay mode (#3950): the card is opened as an in-place overlay by
+	// a parent that owns the open/close state (e.g. a cross-board View), NOT via the
+	// nested card-modal route. In this mode close is purely an `emit('close')` — the
+	// component performs NO router navigation on close, so the parent surface (the
+	// View's URL) is preserved instead of being swapped for the card's own board.
+	// Everything else (data fetch, mutations, realtime, expand-to-page) is unchanged.
+	controlled: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 // The shell owns closing: the modal navigates back to its board overlay origin,
 // the page has an explicit back-to-board affordance. CardDetail emits `close` and
 // lets each shell decide, so no navigation policy is duplicated across shells.
-const emit = defineEmits(['close', 'update:title', 'board-context'])
+// `navigate` is emitted (controlled mode only, #3950) when an in-card link (a
+// parent/sub-card/relation chip or a KAN-123 cross-reference) targets a DIFFERENT
+// card: the parent that owns the overlay swaps to it, since there is no card-modal
+// route to push to on a View surface.
+const emit = defineEmits(['close', 'update:title', 'board-context', 'navigate'])
 
 const router = useRouter()
 const route = useRoute()
@@ -3937,6 +3951,13 @@ const MY_WORK_RETURN_ROUTES = ['my-work', 'my-cards', 'my-reviews', 'inbox']
 
 function closeModal() {
 	isOpen.value = false
+	// Controlled overlay (#3950): the parent owns open/close and the surrounding
+	// URL (e.g. a View at /views/:id). Do NOT navigate — just tell the parent to
+	// tear the overlay down, leaving the user exactly where they were.
+	if (props.controlled) {
+		emit('close')
+		return
+	}
 	const from = route.query.from
 	if (MY_WORK_RETURN_ROUTES.includes(from)) {
 		// Preserve the hub tab when returning to the /my-work hub.
@@ -3961,6 +3982,12 @@ function closeModal() {
 // may itself no longer exist.
 function goToBoards() {
 	isOpen.value = false
+	// Controlled overlay (#3950): no board to route to — the parent surface owns
+	// navigation. Just close the overlay in place.
+	if (props.controlled) {
+		emit('close')
+		return
+	}
 	const from = route.query.from
 	if (MY_WORK_RETURN_ROUTES.includes(from)) {
 		const query = from === 'my-work' && route.query.tab ? { tab: route.query.tab } : undefined
@@ -4090,6 +4117,13 @@ const parentTitle = computed(() => {
  * @param {number|string} cardId target card id
  */
 function openCard(cardId) {
+	// Controlled overlay (#3950): there is no card-modal route to push to (the View
+	// URL carries no board id — route.params.id is undefined here). Hand the target
+	// card up so the parent re-opens the overlay on it, staying in the View.
+	if (props.controlled) {
+		emit('navigate', String(cardId))
+		return
+	}
 	if (props.mode === 'page') {
 		router.push({ name: 'card-page', params: { cardId: String(cardId) } })
 		return

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -25,7 +25,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			ref="detailRef"
 			mode="modal"
 			:card-id="cardId"
+			:controlled="controlled"
+			:board-id="boardId"
 			@update:title="modalTitle = $event"
+			@navigate="$emit('navigate', $event)"
 			@close="onDetailClose" />
 	</NcModal>
 </template>
@@ -41,7 +44,24 @@ defineProps({
 		type: String,
 		required: true,
 	},
+	// Controlled mode (#3950): rendered as an in-place overlay by a parent that owns
+	// the open/close state (a cross-board View), NOT via the nested card-modal route.
+	// CardDetail then closes by emitting `close` with no router navigation, so the
+	// parent's URL/surface is preserved.
+	controlled: {
+		type: Boolean,
+		default: false,
+	},
+	// Explicit board id for the controlled overlay — the View has no board id in its
+	// URL, so the parent passes the card's own boardId. Ignored by the routed variant
+	// (which reads route.params.id), so it's null there.
+	boardId: {
+		type: [String, Number],
+		default: null,
+	},
 })
+
+const emit = defineEmits(['close', 'navigate'])
 
 const detailRef = ref(null)
 const modalTitle = ref('')
@@ -55,9 +75,12 @@ function onModalClose() {
 }
 
 // CardDetail decided the card should actually close (Escape with no popover open,
-// backdrop click, or an action that removes the card). It already performed the
-// route navigation; nothing more to do here.
-function onDetailClose() {}
+// backdrop click, or an action that removes the card). In the routed variant it
+// already performed the navigation and nothing more is needed; in controlled mode
+// it did NOT navigate, so bubble `close` up to the parent that owns the overlay.
+function onDetailClose() {
+	emit('close')
+}
 </script>
 
 <!-- Widen the modal container for the two-pane card view (teleported outside

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -139,7 +139,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						:close-after-click="true"
 						@click="handleSetColor(opt.hex)">
 						<template #icon>
-							<span class="stack-column__swatch" :style="{ background: cssColor(opt.hex) }" />
+							<span class="stack-column__swatch-box">
+								<span class="stack-column__swatch" :style="{ background: cssColor(opt.hex) }" />
+							</span>
 						</template>
 						{{ opt.name }}
 					</NcActionButton>
@@ -148,7 +150,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						:close-after-click="true"
 						@click="handleSetColor('')">
 						<template #icon>
-							<span class="stack-column__swatch stack-column__swatch--none" />
+							<span class="stack-column__swatch-box">
+								<span class="stack-column__swatch stack-column__swatch--none" />
+							</span>
 						</template>
 						{{ t('kanso', 'No colour') }}
 					</NcActionButton>
@@ -1084,8 +1088,22 @@ async function createFromTemplate(templateId) {
 .stack-column__role-chip + .stack-column__actions {
 	margin-left: 4px;
 }
+/* The swatch sits in NcActionButton's #icon slot, which normally holds an icon
+   sized to the full clickable-area box (see .action-button__icon in @nextcloud/vue).
+   The .action-button flex row is align-items:flex-start, so a bare 16px dot pins to
+   the top and reads as misaligned with its (vertically-centred) label. This box fills
+   the same clickable-area square and flex-centres the 16px dot, so dot and label share
+   a centre line. */
+.stack-column__swatch-box {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--default-clickable-area);
+	height: var(--default-clickable-area);
+	flex: 0 0 auto;
+}
 .stack-column__swatch {
-	display: inline-block;
+	display: block;
 	width: 16px;
 	height: 16px;
 	border-radius: 50%;

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -1269,12 +1269,19 @@ async function createFromTemplate(templateId) {
 	/* height is dynamic - measured by TanStack Virtual per item */
 }
 
+/* Empty-column drop zone (#3905 follow-up): when a column has no cards, the
+   placeholder IS the drop target the user aims at. A 48px strip was easy to
+   miss — the highlight would fire but the pointer often sat just below it, so
+   the drop landed on nothing. Give it a generous min-height so an empty column
+   offers a comfortably large, easy-to-hit drop area. It only sizes the empty
+   state (rendered solely when cards.length === 0), so populated columns — whose
+   card list sizes to its cards — are unaffected. */
 .stack-column__empty-placeholder {
 	display: flex;
 	align-items: flex-start;
 	justify-content: center;
-	min-height: 48px;
-	padding: 12px 8px;
+	min-height: 160px;
+	padding: 16px 8px;
 	border-radius: var(--border-radius);
 }
 

--- a/src/components/ViewKanban.vue
+++ b/src/components/ViewKanban.vue
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="view-kanban">
+		<p v-if="groups.length === 0" class="view-kanban__empty">
+			{{ t('kanso', 'No cards to show.') }}
+		</p>
+		<div v-else class="view-kanban__board">
+			<ViewKanbanColumn
+				v-for="group in groups"
+				:key="group.key"
+				:group="group"
+				:labels-by-id="labelsById"
+				@open="openCard" />
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router'
+import { translate as t } from '@nextcloud/l10n'
+import ViewKanbanColumn from './ViewKanbanColumn.vue'
+
+defineProps({
+	/**
+	 * Ordered group list `[{ key, title, cards }]` from groupCardsByField — the
+	 * SAME array List/Timeline consume. Kanban renders one column per group.
+	 */
+	groups: { type: Array, default: () => [] },
+	/**
+	 * Map<labelId, label>. Cross-board label metadata isn't loaded, so this is an
+	 * empty map (label chips fall back to a neutral colour), mirroring the List.
+	 */
+	labelsById: { type: Map, default: () => new Map() },
+})
+
+const router = useRouter()
+
+// Deep-link to the card modal on its OWN board (cross-board correct): the card's
+// boardId — never the current route — drives the target. CardTile's own click
+// path uses route.params.id, wrong here, so the click is wired at this level.
+function openCard(card) {
+	router.push({ name: 'card-modal', params: { id: String(card.boardId), cardId: String(card.id) } })
+}
+</script>
+
+<style scoped>
+.view-kanban {
+	flex: 1;
+	min-height: 0;
+	overflow: hidden;
+	padding: 8px 24px 16px 52px;
+}
+
+.view-kanban__empty {
+	color: var(--color-text-maxcontrast);
+	padding: 24px 0;
+}
+
+/* Horizontal row of columns; scrolls sideways when the columns overflow. */
+.view-kanban__board {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	height: 100%;
+	overflow-x: auto;
+	overflow-y: hidden;
+}
+</style>

--- a/src/components/ViewKanban.vue
+++ b/src/components/ViewKanban.vue
@@ -13,13 +13,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:key="group.key"
 				:group="group"
 				:labels-by-id="labelsById"
-				@open="openCard" />
+				@open="$emit('open', $event)" />
 		</div>
 	</div>
 </template>
 
 <script setup>
-import { useRouter } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
 import ViewKanbanColumn from './ViewKanbanColumn.vue'
 
@@ -30,20 +29,16 @@ defineProps({
 	 */
 	groups: { type: Array, default: () => [] },
 	/**
-	 * Map<labelId, label>. Cross-board label metadata isn't loaded, so this is an
-	 * empty map (label chips fall back to a neutral colour), mirroring the List.
+	 * Map<labelId, label> built from the view feed's cross-board label union, so
+	 * card-tile chips render the real label colours (matches the board tiles, #3950).
 	 */
 	labelsById: { type: Map, default: () => new Map() },
 })
 
-const router = useRouter()
-
-// Deep-link to the card modal on its OWN board (cross-board correct): the card's
-// boardId — never the current route — drives the target. CardTile's own click
-// path uses route.params.id, wrong here, so the click is wired at this level.
-function openCard(card) {
-	router.push({ name: 'card-modal', params: { id: String(card.boardId), cardId: String(card.id) } })
-}
+// The parent ViewPage owns the card-detail overlay (#3950): bubble the clicked card
+// up rather than route-navigating to card-modal (which is a child of the board route
+// and would swap the whole View out for the board). The card carries its own boardId.
+defineEmits(['open'])
 </script>
 
 <style scoped>

--- a/src/components/ViewKanbanColumn.vue
+++ b/src/components/ViewKanbanColumn.vue
@@ -1,0 +1,134 @@
+<!--
+SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="view-kanban-col">
+		<!-- Column header: mirrors the List's group visual vocabulary (title + count). -->
+		<div class="view-kanban-col__header">
+			<span class="view-kanban-col__title">{{ group.title }}</span>
+			<span class="view-kanban-col__count">{{ cards.length }}</span>
+		</div>
+
+		<!-- Own scroll element + virtualizer per column (no stack chrome / DnD / composer). -->
+		<div ref="scrollRef" class="view-kanban-col__cards">
+			<div
+				class="view-kanban-col__virtual-host"
+				:style="{ height: virtualizer.getTotalSize() + 'px' }">
+				<div
+					v-for="vRow in virtualizer.getVirtualItems()"
+					:key="cards[vRow.index].id"
+					:ref="(el) => measureVirtualEl(el, vRow.index)"
+					:data-index="vRow.index"
+					class="view-kanban-col__virtual-item"
+					:style="{
+						position: 'absolute',
+						top: 0,
+						left: 0,
+						width: '100%',
+						transform: 'translateY(' + vRow.start + 'px)',
+					}">
+					<CardTile
+						:card="cards[vRow.index]"
+						:labels-by-id="labelsById"
+						:board-prefix="''"
+						@click="$emit('open', cards[vRow.index])" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import CardTile from './CardTile.vue'
+
+const props = defineProps({
+	/** One group `{ key, title, cards }` from groupCardsByField. */
+	group: { type: Object, required: true },
+	/** Map<labelId, label> (empty for cross-board Views). */
+	labelsById: { type: Map, default: () => new Map() },
+})
+
+defineEmits(['open'])
+
+const cards = computed(() => props.group.cards ?? [])
+
+const scrollRef = ref(null)
+
+// Variable-height tiles (labels / meta wrap), so estimate + measure like the
+// board column does; measureElement keeps positions exact as tiles render.
+const virtualizer = useVirtualizer(computed(() => ({
+	count: cards.value.length,
+	getScrollElement: () => scrollRef.value,
+	estimateSize: () => 96,
+	overscan: 6,
+	getItemKey: (i) => cards.value[i]?.id ?? i,
+})))
+
+function measureVirtualEl(el, index) {
+	if (el) virtualizer.value.measureElement(el)
+}
+</script>
+
+<style scoped>
+.view-kanban-col {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	height: 100%;
+	width: 280px;
+	flex: 0 0 280px;
+	background: var(--color-background-hover);
+	border-radius: var(--border-radius-large, 12px);
+	overflow: hidden;
+}
+
+/* The header mirrors the List's group bar look but is a static bar (no toggle). */
+.view-kanban-col__header {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	box-sizing: border-box;
+	flex: 0 0 auto;
+	height: 40px;
+	padding: 0 12px;
+	background: var(--color-background-dark);
+	border-bottom: 1px solid var(--color-border);
+	color: var(--color-main-text);
+}
+
+.view-kanban-col__title {
+	font-weight: 700;
+	text-transform: uppercase;
+	font-size: 0.8rem;
+	letter-spacing: 0.03em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.view-kanban-col__count {
+	color: var(--color-text-maxcontrast);
+	font-weight: 400;
+	font-size: 0.8rem;
+	flex: 0 0 auto;
+}
+
+.view-kanban-col__cards {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 8px;
+}
+
+.view-kanban-col__virtual-host {
+	position: relative;
+	width: 100%;
+}
+
+.view-kanban-col__virtual-item {
+	padding-bottom: 8px;
+}
+</style>

--- a/src/components/ViewKanbanColumn.vue
+++ b/src/components/ViewKanbanColumn.vue
@@ -31,7 +31,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<CardTile
 						:card="cards[vRow.index]"
 						:labels-by-id="labelsById"
-						:board-prefix="''"
+						:board-prefix="cards[vRow.index].boardPrefix || ''"
 						@click="$emit('open', cards[vRow.index])" />
 				</div>
 			</div>
@@ -47,7 +47,7 @@ import CardTile from './CardTile.vue'
 const props = defineProps({
 	/** One group `{ key, title, cards }` from groupCardsByField. */
 	group: { type: Object, required: true },
-	/** Map<labelId, label> (empty for cross-board Views). */
+	/** Map<labelId, label> from the view feed's cross-board label union (#3950). */
 	labelsById: { type: Map, default: () => new Map() },
 })
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -490,6 +490,9 @@ export const getViewCards = () =>
 		const d = r.data ?? {}
 		return {
 			cards: Array.isArray(d.cards) ? d.cards : [],
+			// Union of label metadata (id/title/color) across the readable boards, so
+			// the client can build a labelsById map and colour card-tile label chips.
+			labels: Array.isArray(d.labels) ? d.labels : [],
 			capped: !!d.capped,
 			total: Number.isFinite(d.total) ? d.total : (Array.isArray(d.cards) ? d.cards.length : 0),
 			limit: Number.isFinite(d.limit) ? d.limit : 0,

--- a/src/views/PublicBoard.vue
+++ b/src/views/PublicBoard.vue
@@ -28,7 +28,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						v-for="card in (cardsByStack[stack.id] || [])"
 						:key="card.id"
 						class="public-card"
-						:class="{ 'public-card--done': card.status === 'done' }">
+						:class="{ 'public-card--done': card.status === 'done' }"
+						tabindex="0"
+						role="button"
+						:aria-label="t('kanso', 'Open card details')"
+						@click="openCard(card)"
+						@keydown.enter.prevent="openCard(card)"
+						@keydown.space.prevent="openCard(card)">
 						<div v-if="card.labels.length" class="public-card__labels">
 							<span
 								v-for="(label, i) in card.labels"
@@ -58,6 +64,55 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<footer class="public-board__footer">
 			{{ t('kanso', 'Shared read-only via Kanso') }}
 		</footer>
+
+		<!-- Read-only card detail (#3945). All fields are already in the public
+		     payload; this only expands them - no fetch, no edit affordances. -->
+		<div
+			v-if="selectedCard"
+			class="public-detail__backdrop"
+			@click.self="closeCard"
+			@keydown.esc="closeCard">
+			<div
+				class="public-detail"
+				role="dialog"
+				aria-modal="true"
+				tabindex="-1">
+				<div class="public-detail__top">
+					<span v-if="selectedCard.humanId" class="public-detail__id">{{ selectedCard.humanId }}</span>
+					<h2 class="public-detail__title">{{ selectedCard.title }}</h2>
+					<button
+						class="public-detail__close"
+						type="button"
+						:aria-label="t('kanso', 'Close')"
+						@click="closeCard">
+						×
+					</button>
+				</div>
+				<div v-if="selectedCard.labels.length" class="public-detail__labels">
+					<span
+						v-for="(label, i) in selectedCard.labels"
+						:key="i"
+						class="public-detail__label"
+						:style="{ background: label.color ? '#' + label.color : 'var(--color-background-dark, #ededed)' }">
+						{{ label.name }}
+					</span>
+				</div>
+				<div
+					v-if="selectedCard.priority >= 4 || selectedCard.duedate || selectedCard.checklist.total > 0"
+					class="public-detail__meta">
+					<span v-if="selectedCard.priority >= 4" class="public-detail__prio">{{ t('kanso', 'Urgent') }}</span>
+					<span v-if="selectedCard.duedate">{{ formatDue(selectedCard.duedate) }}</span>
+					<span v-if="selectedCard.checklist.total > 0">
+						{{ selectedCard.checklist.done }}/{{ selectedCard.checklist.total }}
+					</span>
+				</div>
+				<p
+					class="public-detail__desc"
+					:class="{ 'public-detail__desc--empty': !selectedCard.description }">
+					{{ selectedCard.description || t('kanso', 'No description') }}
+				</p>
+			</div>
+		</div>
 	</div>
 </template>
 
@@ -78,6 +133,7 @@ export default {
 			board: null,
 			stacks: [],
 			cards: [],
+			selectedCard: null,
 		}
 	},
 	computed: {
@@ -101,9 +157,24 @@ export default {
 		} finally {
 			this.loading = false
 		}
+		document.addEventListener('keydown', this.onKeydown)
+	},
+	beforeUnmount() {
+		document.removeEventListener('keydown', this.onKeydown)
 	},
 	methods: {
 		t,
+		openCard(card) {
+			this.selectedCard = card
+		},
+		closeCard() {
+			this.selectedCard = null
+		},
+		onKeydown(e) {
+			if (e.key === 'Escape' && this.selectedCard) {
+				this.closeCard()
+			}
+		},
 		truncate(text) {
 			return text.length > 240 ? text.slice(0, 240) + '…' : text
 		},

--- a/src/views/PublicBoard.vue
+++ b/src/views/PublicBoard.vue
@@ -51,7 +51,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						<p v-if="card.description" class="public-card__desc">{{ truncate(card.description) }}</p>
 						<div class="public-card__meta">
 							<span v-if="card.priority >= 4" class="public-card__prio">{{ t('kanso', 'Urgent') }}</span>
-							<span v-if="card.duedate" class="public-card__due">{{ formatDue(card.duedate) }}</span>
+							<span v-if="card.duedate" class="public-card__due">{{ formatDate(card.duedate) }}</span>
 							<span v-if="card.checklist.total > 0" class="public-card__check">
 								{{ card.checklist.done }}/{{ card.checklist.total }}
 							</span>
@@ -77,6 +77,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				role="dialog"
 				aria-modal="true"
 				tabindex="-1">
+				<!-- Cover-colour band (#3951): a presentational accent, not a person. -->
+				<div
+					v-if="selectedCard.coverColor"
+					class="public-detail__cover"
+					:style="{ background: '#' + selectedCard.coverColor }" />
 				<div class="public-detail__top">
 					<span v-if="selectedCard.humanId" class="public-detail__id">{{ selectedCard.humanId }}</span>
 					<h2 class="public-detail__title">{{ selectedCard.title }}</h2>
@@ -97,19 +102,28 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						{{ label.name }}
 					</span>
 				</div>
-				<div
-					v-if="selectedCard.priority >= 4 || selectedCard.duedate || selectedCard.checklist.total > 0"
-					class="public-detail__meta">
+				<div v-if="hasMeta" class="public-detail__meta">
 					<span v-if="selectedCard.priority >= 4" class="public-detail__prio">{{ t('kanso', 'Urgent') }}</span>
-					<span v-if="selectedCard.duedate">{{ formatDue(selectedCard.duedate) }}</span>
-					<span v-if="selectedCard.checklist.total > 0">
+					<span v-if="selectedCard.startDate" class="public-detail__field">
+						{{ t('kanso', 'Start') }}: {{ formatDate(selectedCard.startDate) }}
+					</span>
+					<span v-if="selectedCard.duedate" class="public-detail__field">
+						{{ t('kanso', 'Due') }}: {{ formatDate(selectedCard.duedate) }}
+					</span>
+					<span v-if="selectedCard.estimate" class="public-detail__field">
+						{{ t('kanso', 'Estimate') }}: {{ selectedCard.estimate }}
+					</span>
+					<span v-if="selectedCard.checklist.total > 0" class="public-detail__field">
 						{{ selectedCard.checklist.done }}/{{ selectedCard.checklist.total }}
 					</span>
 				</div>
-				<p
+				<!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown (DOMPurify) -->
+				<div
+					v-if="selectedCard.description"
 					class="public-detail__desc"
-					:class="{ 'public-detail__desc--empty': !selectedCard.description }">
-					{{ selectedCard.description || t('kanso', 'No description') }}
+					v-html="renderedDescription" />
+				<p v-else class="public-detail__desc public-detail__desc--empty">
+					{{ t('kanso', 'No description') }}
 				</p>
 			</div>
 		</div>
@@ -120,6 +134,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
+import { renderMarkdown } from '../services/markdown.js'
 
 export default {
 	name: 'PublicBoard',
@@ -144,6 +159,18 @@ export default {
 				(map[card.stackId] = map[card.stackId] || []).push(card)
 			}
 			return map
+		},
+		// The open card's description rendered as sanitized markdown HTML. No refs
+		// map is passed: the public payload carries no card cross-reference data, so
+		// PREFIX-123 references render as plain text (never a broken link).
+		renderedDescription() {
+			return this.selectedCard ? renderMarkdown(this.selectedCard.description) : ''
+		},
+		// Whether the open card has any presentational meta worth a meta row.
+		hasMeta() {
+			const c = this.selectedCard
+			if (!c) return false
+			return c.priority >= 4 || !!c.startDate || !!c.duedate || !!c.estimate || c.checklist.total > 0
 		},
 	},
 	async mounted() {
@@ -178,7 +205,7 @@ export default {
 		truncate(text) {
 			return text.length > 240 ? text.slice(0, 240) + '…' : text
 		},
-		formatDue(iso) {
+		formatDate(iso) {
 			try {
 				return new Date(iso).toLocaleDateString()
 			} catch (e) {

--- a/src/views/ViewPage.vue
+++ b/src/views/ViewPage.vue
@@ -114,7 +114,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				v-if="display === 'list'"
 				:groups="groups"
 				:labels-by-id="labelsById"
-				:board-id="null" />
+				:board-id="null"
+				@open="openCard" />
 
 			<!-- Timeline display over the same groups -->
 			<BoardTimelineView
@@ -122,15 +123,30 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				:cards="filteredCards"
 				:groups="groups"
 				:can-edit="false"
-				:board-id="null" />
+				:board-id="null"
+				@open="openCard" />
 
 			<!-- Kanban display: the same groups as columns (display-only, no
 			     cross-column drag in v1 — a documented v1 stretch). -->
 			<ViewKanban
 				v-else
 				:groups="groups"
-				:labels-by-id="labelsById" />
+				:labels-by-id="labelsById"
+				@open="openCard" />
 		</template>
+
+		<!-- Card detail opens as an in-place overlay ON the View (#3950): the SAME
+		     CardModal → CardDetail the board uses, but in controlled mode so closing
+		     just tears the overlay down and leaves the URL at /views/:id — you stay in
+		     the View instead of being dumped on the card's board. -->
+		<CardModal
+			v-if="selectedCardId"
+			:key="selectedCardId"
+			:card-id="selectedCardId"
+			:board-id="selectedBoardId"
+			controlled
+			@navigate="navigateCard"
+			@close="closeCard" />
 	</div>
 </template>
 
@@ -148,6 +164,7 @@ import BoardListView from '../components/BoardListView.vue'
 import BoardTimelineView from '../components/BoardTimelineView.vue'
 import ViewKanban from '../components/ViewKanban.vue'
 import BoardFilterBar from '../components/BoardFilterBar.vue'
+import CardModal from '../components/CardModal.vue'
 import { useViews } from '../composables/useViews.js'
 import { useViewCards } from '../composables/useViewCards.js'
 import {
@@ -267,9 +284,41 @@ const participants = computed(() =>
 	[...nameByUid.value.keys()].map((uid) => ({ uid, displayName: uid })),
 )
 
-// The generalized List needs a labelsById map; cross-board label metadata isn't
-// loaded, so pass an empty map (label dots simply fall back to a neutral colour).
-const labelsById = computed(() => new Map())
+// Real cross-board labelsById map (#3950): the feed envelope carries the union of
+// label metadata (id/title/color) across the readable boards, so card tiles render
+// the actual label COLOURS — matching the board tiles — rather than neutral dots.
+const labelsById = computed(() => {
+	const m = new Map()
+	for (const label of cardsData.value?.labels ?? []) {
+		if (label && label.id != null) m.set(label.id, label)
+	}
+	return m
+})
+
+// ── Card detail overlay (#3950) ───────────────────────────────────────────────
+// Opening a card from any display renders the shared CardModal → CardDetail as an
+// in-place overlay here, in controlled mode, so the URL stays /views/:id and closing
+// returns to the View (never the card's board). We track the card id + its own board
+// id (Views are cross-board — CardDetail needs the board for its board-scoped fetches
+// and can also derive it from the loaded card, but passing it avoids a first-paint gap).
+const selectedCardId = ref(null)
+const selectedBoardId = ref(null)
+function openCard(card) {
+	selectedCardId.value = String(card.id)
+	selectedBoardId.value = card.boardId != null ? String(card.boardId) : null
+}
+function closeCard() {
+	selectedCardId.value = null
+	selectedBoardId.value = null
+}
+// An in-card link (parent/sub-card/relation/cross-ref) targeted another card:
+// swap the overlay to it in place (#3950). Its board id isn't known up front — the
+// re-mounted CardDetail derives it from the freshly loaded card (nulled here so we
+// don't carry the previous card's board into the fetch).
+function navigateCard(cardId) {
+	selectedBoardId.value = null
+	selectedCardId.value = String(cardId)
+}
 
 // ── Persist ──────────────────────────────────────────────────────────────────
 const saving = ref(false)

--- a/src/views/ViewPage.vue
+++ b/src/views/ViewPage.vue
@@ -44,7 +44,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						:aria-label="t('kanso', 'Group by')" />
 				</div>
 
-				<!-- Display switcher: List | Timeline (Kanban is Phase 2). -->
+				<!-- Display switcher: List | Timeline | Kanban. -->
 				<div class="view-page__display" role="group" :aria-label="t('kanso', 'Display mode')">
 					<button
 						class="view-page__display-btn"
@@ -59,6 +59,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						@click="setDisplay('timeline')">
 						<ChartTimelineIcon :size="18" />
 						{{ t('kanso', 'Timeline') }}
+					</button>
+					<button
+						class="view-page__display-btn"
+						:class="{ 'view-page__display-btn--active': display === 'kanban' }"
+						@click="setDisplay('kanban')">
+						<ViewColumnOutlineIcon :size="18" />
+						{{ t('kanso', 'Kanban') }}
 					</button>
 				</div>
 
@@ -111,11 +118,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 			<!-- Timeline display over the same groups -->
 			<BoardTimelineView
-				v-else
+				v-else-if="display === 'timeline'"
 				:cards="filteredCards"
 				:groups="groups"
 				:can-edit="false"
 				:board-id="null" />
+
+			<!-- Kanban display: the same groups as columns (display-only, no
+			     cross-column drag in v1 — a documented v1 stretch). -->
+			<ViewKanban
+				v-else
+				:groups="groups"
+				:labels-by-id="labelsById" />
 		</template>
 	</div>
 </template>
@@ -128,9 +142,11 @@ import NcSelect from '@nextcloud/vue/components/NcSelect'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import FormatListBulletedIcon from 'vue-material-design-icons/FormatListBulleted.vue'
 import ChartTimelineIcon from 'vue-material-design-icons/ChartTimeline.vue'
+import ViewColumnOutlineIcon from 'vue-material-design-icons/ViewColumnOutline.vue'
 import FilterVariantIcon from 'vue-material-design-icons/FilterVariant.vue'
 import BoardListView from '../components/BoardListView.vue'
 import BoardTimelineView from '../components/BoardTimelineView.vue'
+import ViewKanban from '../components/ViewKanban.vue'
 import BoardFilterBar from '../components/BoardFilterBar.vue'
 import { useViews } from '../composables/useViews.js'
 import { useViewCards } from '../composables/useViewCards.js'
@@ -201,7 +217,7 @@ const filterState = createFilterState()
 watch(view, (v) => {
 	applyFilter(filterState, v ? v.filter : {})
 	if (v) {
-		display.value = v.display === 'timeline' ? 'timeline' : 'list'
+		display.value = ['list', 'timeline', 'kanban'].includes(v.display) ? v.display : 'list'
 		groupBySel.value = groupByOptions.find((o) => o.id === v.groupBy) ?? groupByOptions[0]
 	}
 }, { immediate: true })

--- a/templates/public.php
+++ b/templates/public.php
@@ -13,6 +13,10 @@
 // styles in PublicBoard.vue never reach the page and it renders as plain text.
 ?>
 <style>
+/* The public page mounts into #kanso-public inside NC's body; give it a real
+   height so the columns/cards below the fold become reachable by scrolling. */
+html, body { height: 100%; }
+#kanso-public { height: 100%; overflow-y: auto; box-sizing: border-box; }
 .public-board { max-width: 1400px; margin: 0 auto; padding: 24px 16px 48px; box-sizing: border-box; }
 .public-board__header { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; }
 .public-board__dot { width: 16px; height: 16px; border-radius: 50%; flex: 0 0 auto; }
@@ -21,11 +25,13 @@
 .public-board__state { color: var(--color-text-maxcontrast, #666); padding: 32px 0; }
 .public-board__state--error { color: var(--color-error, #c33); }
 .public-board__columns { display: flex; gap: 16px; align-items: flex-start; overflow-x: auto; padding-bottom: 8px; }
-.public-col { flex: 0 0 300px; max-width: 300px; background: var(--color-background-hover, #f5f5f5); border-radius: 10px; padding: 10px; box-sizing: border-box; }
+.public-col { flex: 0 0 300px; max-width: 300px; max-height: calc(100vh - 180px); display: flex; flex-direction: column; background: var(--color-background-hover, #f5f5f5); border-radius: 10px; padding: 10px; box-sizing: border-box; }
 .public-col__title { display: flex; align-items: center; justify-content: space-between; font-size: 15px; font-weight: 600; margin: 4px 4px 12px; padding-bottom: 6px; border-bottom: 2px solid var(--color-border, #ddd); }
 .public-col__count { font-size: 12px; color: var(--color-text-maxcontrast, #888); font-weight: 500; }
-.public-col__cards { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-.public-card { background: var(--color-main-background, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 8px; padding: 10px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05); }
+.public-col__cards { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; overflow-y: auto; }
+.public-card { background: var(--color-main-background, #fff); border: 1px solid var(--color-border, #e0e0e0); border-radius: 8px; padding: 10px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05); cursor: pointer; }
+.public-card:hover { border-color: var(--color-primary-element, #0082c9); }
+.public-card:focus-visible { outline: 2px solid var(--color-primary-element, #0082c9); outline-offset: 1px; }
 .public-card--done { opacity: 0.6; }
 .public-card__labels { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
 .public-card__label { font-size: 11px; padding: 1px 8px; border-radius: 10px; color: #fff; text-shadow: 0 0 2px rgba(0, 0, 0, 0.4); }
@@ -36,5 +42,19 @@
 .public-card__meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; font-size: 12px; color: var(--color-text-maxcontrast, #888); }
 .public-card__prio { color: var(--color-error, #c33); font-weight: 600; }
 .public-board__footer { margin-top: 32px; text-align: center; font-size: 12px; color: var(--color-text-maxcontrast, #999); }
+
+/* Read-only card detail modal (#3945). Self-contained; no edit affordances. */
+.public-detail__backdrop { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.45); display: flex; align-items: flex-start; justify-content: center; padding: 48px 16px; overflow-y: auto; z-index: 10000; }
+.public-detail { background: var(--color-main-background, #fff); color: var(--color-main-text, #222); border-radius: 12px; width: 100%; max-width: 640px; padding: 24px; box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25); box-sizing: border-box; }
+.public-detail__top { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
+.public-detail__id { font-size: 13px; color: var(--color-text-maxcontrast, #888); font-weight: 600; flex: 0 0 auto; margin-top: 2px; }
+.public-detail__title { font-size: 20px; font-weight: 700; margin: 0; flex: 1 1 auto; word-break: break-word; }
+.public-detail__close { flex: 0 0 auto; background: transparent; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: var(--color-text-maxcontrast, #888); padding: 0 4px; }
+.public-detail__labels { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+.public-detail__label { font-size: 12px; padding: 2px 10px; border-radius: 10px; color: #fff; text-shadow: 0 0 2px rgba(0, 0, 0, 0.4); }
+.public-detail__meta { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 12px; font-size: 13px; color: var(--color-text-maxcontrast, #666); }
+.public-detail__prio { color: var(--color-error, #c33); font-weight: 600; }
+.public-detail__desc { font-size: 14px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; color: var(--color-main-text, #222); }
+.public-detail__desc--empty { color: var(--color-text-maxcontrast, #888); font-style: italic; }
 </style>
 <div id="kanso-public" data-token="<?php p($_['token'] ?? ''); ?>"></div>

--- a/templates/public.php
+++ b/templates/public.php
@@ -52,9 +52,22 @@ html, body { height: 100%; }
 .public-detail__close { flex: 0 0 auto; background: transparent; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: var(--color-text-maxcontrast, #888); padding: 0 4px; }
 .public-detail__labels { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
 .public-detail__label { font-size: 12px; padding: 2px 10px; border-radius: 10px; color: #fff; text-shadow: 0 0 2px rgba(0, 0, 0, 0.4); }
+.public-detail__cover { height: 8px; border-radius: 6px; margin: -8px 0 14px; }
 .public-detail__meta { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 12px; font-size: 13px; color: var(--color-text-maxcontrast, #666); }
 .public-detail__prio { color: var(--color-error, #c33); font-weight: 600; }
-.public-detail__desc { font-size: 14px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; color: var(--color-main-text, #222); }
+.public-detail__desc { font-size: 14px; line-height: 1.5; word-break: break-word; color: var(--color-main-text, #222); }
 .public-detail__desc--empty { color: var(--color-text-maxcontrast, #888); font-style: italic; }
+/* Rendered-markdown description: keep block spacing sane inside the modal. */
+.public-detail__desc p { margin: 0 0 10px; }
+.public-detail__desc p:last-child { margin-bottom: 0; }
+.public-detail__desc ul, .public-detail__desc ol { margin: 0 0 10px; padding-left: 22px; }
+.public-detail__desc h1, .public-detail__desc h2, .public-detail__desc h3,
+.public-detail__desc h4, .public-detail__desc h5, .public-detail__desc h6 { margin: 12px 0 6px; line-height: 1.3; }
+.public-detail__desc pre { background: var(--color-background-dark, #f0f0f0); padding: 8px 10px; border-radius: 6px; overflow-x: auto; }
+.public-detail__desc code { background: var(--color-background-dark, #f0f0f0); padding: 1px 4px; border-radius: 4px; font-size: 0.92em; }
+.public-detail__desc pre code { background: none; padding: 0; }
+.public-detail__desc blockquote { margin: 0 0 10px; padding-left: 12px; border-left: 3px solid var(--color-border, #ddd); color: var(--color-text-maxcontrast, #666); }
+.public-detail__desc a { color: var(--color-primary-element, #0082c9); }
+.public-detail__desc img { max-width: 100%; height: auto; border-radius: 6px; }
 </style>
 <div id="kanso-public" data-token="<?php p($_['token'] ?? ''); ?>"></div>

--- a/tests/e2e/board-settings-switches.spec.js
+++ b/tests/e2e/board-settings-switches.spec.js
@@ -70,8 +70,12 @@ test.describe('Board settings enable switches (public link + calendar feed)', ()
 		await expect(page.getByText('Feed active')).toBeVisible({ timeout: 8_000 })
 
 		// --- Public link (#3531) ---
+		// The public-link control moved out of Automation and into the
+		// Sharing pane (220f7d7), so switch tabs before toggling it.
+		await page.getByRole('tab', { name: /sharing/i }).click()
+		await expect(page.locator('#bs-pane-sharing')).toBeVisible({ timeout: 8_000 })
 		await page.getByRole('button', { name: /Public link/i }).click() // expand the group
-		const pubBody = page.locator('#bs-automation-public-link')
+		const pubBody = page.locator('#bs-sharing-public-link')
 		await expect(pubBody).toBeVisible()
 		await pubBody.getByText('Enable public link').click()
 		await expect(page.getByText('Link active')).toBeVisible({ timeout: 8_000 })

--- a/tests/e2e/dnd.spec.js
+++ b/tests/e2e/dnd.spec.js
@@ -90,6 +90,12 @@ test.describe('Card drag and drop', () => {
 	// IDs set by beforeAll, shared across tests
 	const state = { boardId: 0, stackS1Id: 0, stackS2Id: 0, cardAId: 0, cardBId: 0, boardUrl: '' }
 
+	// ── Same-column reorder fixture ─────────────────────────────────────────────
+	// A dedicated board so the reorder test is independent of the cross-column
+	// tests above (which empty S1 as a side effect). Three cards R1, R2, R3 in a
+	// single column let us assert a genuine above/below-sibling reorder + persist.
+	const reorder = { boardId: 0, stackId: 0, boardUrl: '' }
+
 	test.beforeAll(async () => {
 		// Delete any existing DnD Test Board to start clean
 		const boards = await apiGet('/boards')
@@ -117,6 +123,21 @@ test.describe('Card drag and drop', () => {
 
 		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
 		console.log('Setup complete - boardUrl:', state.boardUrl)
+
+		// Reorder fixture: a separate board with one column holding R1, R2, R3
+		// (created in order, so their initial top-to-bottom order is R1, R2, R3).
+		for (const b of boards) {
+			if (b.title === 'DnD Reorder Board') await apiDelete(`/boards/${b.id}`)
+		}
+		const rBoard = await apiPost('/boards', { title: 'DnD Reorder Board' })
+		reorder.boardId = rBoard.id
+		const rStack = await apiPost('/stacks', { boardId: rBoard.id, title: 'R' })
+		reorder.stackId = rStack.id
+		// Create in order so the board renders R1 (top), R2, R3 (bottom).
+		await apiPost('/cards', { stackId: rStack.id, title: 'R1' })
+		await apiPost('/cards', { stackId: rStack.id, title: 'R2' })
+		await apiPost('/cards', { stackId: rStack.id, title: 'R3' })
+		reorder.boardUrl = `${BASE}/index.php/apps/kanso#/board/${rBoard.id}`
 	})
 
 	test('drag card A into S2 above card B, persists after reload', async ({ page }) => {
@@ -258,5 +279,43 @@ test.describe('Card drag and drop', () => {
 		const titlesAfter = page.locator('.stack-column__title')
 		await expect(titlesAfter.nth(0)).toHaveText('S2', { timeout: 8000 })
 		await expect(titlesAfter.nth(1)).toHaveText('S1')
+	})
+
+	test('same-column reorder: drag R3 above R1, order changes and persists after reload', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(reorder.boardUrl)
+		await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+
+		const col = page.locator('.stack-column').nth(0)
+		const cards = col.locator('.card-tile-wrap .card-tile')
+
+		// Initial order (top-to-bottom): R1, R2, R3
+		await expect(cards).toHaveCount(3, { timeout: 8000 })
+		await expect(cards.nth(0)).toContainText('R1')
+		await expect(cards.nth(1)).toContainText('R2')
+		await expect(cards.nth(2)).toContainText('R3')
+
+		// Drag the LAST card (R3) up onto the TOP edge of the FIRST card (R1).
+		// This is a genuine same-column above-sibling reorder — a single-row
+		// fractional-key UPDATE, not a cross-stack move.
+		const r3 = cards.filter({ hasText: 'R3' })
+		const r1 = cards.filter({ hasText: 'R1' })
+		await dragWithMouse(page, r3, r1, 'top')
+
+		// New order: R3, R1, R2
+		await expect(cards.nth(0)).toContainText('R3', { timeout: 8000 })
+		await expect(cards.nth(1)).toContainText('R1')
+		await expect(cards.nth(2)).toContainText('R2')
+
+		// Persist across reload (server is source of truth for the sort keys)
+		await page.reload()
+		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		const colAfter = page.locator('.stack-column').nth(0)
+		const cardsAfter = colAfter.locator('.card-tile-wrap .card-tile')
+		await expect(cardsAfter).toHaveCount(3, { timeout: 8000 })
+		await expect(cardsAfter.nth(0)).toContainText('R3', { timeout: 8000 })
+		await expect(cardsAfter.nth(1)).toContainText('R1')
+		await expect(cardsAfter.nth(2)).toContainText('R2')
 	})
 })

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -155,7 +155,12 @@ test.describe('Public board is interactive read-only', () => {
 
 	// A description longer than the 240-char tile clip, so "full text visible"
 	// is a meaningful assertion (the tail only appears in the expanded detail).
-	const LONG_DESC = 'HEAD_MARKER ' + 'lorem ipsum dolor sit amet '.repeat(20) + 'TAIL_MARKER_UNIQUE_9317'
+	// It leads with markdown (a **bold** run) so the detail can assert the body is
+	// rendered as HTML, not printed as raw markdown source.
+	const LONG_DESC = 'HEAD_MARKER **BOLD_MARKER_7788** ' + 'lorem ipsum dolor sit amet '.repeat(20) + 'TAIL_MARKER_UNIQUE_9317'
+	const COVER = '31CC31'
+	// A token from the board's 'hours' estimate scale (set in beforeAll).
+	const ESTIMATE = '4'
 
 	let boardId = 0
 	let token = ''
@@ -168,8 +173,17 @@ test.describe('Public board is interactive read-only', () => {
 		for (let i = 1; i <= 15; i++) {
 			await api('POST', '/cards', { stackId, title: `Card number ${i}` })
 		}
+		// Enable an estimate scale so the card can carry a (non-person) estimate.
+		await api('PATCH', `/boards/${boardId}`, { estimateScale: 'hours' })
 		const detailCard = (await api('POST', '/cards', { stackId, title: 'Card with long description' })).body.id
-		await api('PATCH', `/cards/${detailCard}`, { description: LONG_DESC })
+		// Set the richer NON-person attributes exercised below (#3951): full
+		// markdown description, cover colour, start date, estimate.
+		await api('PATCH', `/cards/${detailCard}`, {
+			description: LONG_DESC,
+			coverColor: COVER,
+			startDate: '2026-03-04T00:00:00+00:00',
+			estimate: ESTIMATE,
+		})
 		token = (await api('POST', `/boards/${boardId}/public-share`)).body.token
 	})
 
@@ -197,6 +211,18 @@ test.describe('Public board is interactive read-only', () => {
 		await expect(detail).toBeVisible()
 		await expect(detail).toContainText('HEAD_MARKER')
 		await expect(detail).toContainText('TAIL_MARKER_UNIQUE_9317')
+
+		// The description is rendered as MARKDOWN (not raw source): the **bold** run
+		// becomes a <strong>, and the raw asterisks are gone.
+		await expect(detail.locator('.public-detail__desc strong')).toHaveText('BOLD_MARKER_7788')
+		await expect(detail.locator('.public-detail__desc')).not.toContainText('**BOLD_MARKER_7788**')
+
+		// The richer NON-person attributes render (#3951): a cover-colour band, the
+		// start date and the estimate. No person data is shown.
+		await expect(detail.locator('.public-detail__cover')).toBeVisible()
+		await expect(detail.locator('.public-detail__meta')).toContainText('Start')
+		await expect(detail.locator('.public-detail__meta')).toContainText('Estimate')
+		await expect(detail.locator('.public-detail__meta')).toContainText(ESTIMATE)
 
 		// No edit affordances (no inputs/textareas in the read-only detail).
 		await expect(detail.locator('input, textarea')).toHaveCount(0)

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -144,3 +144,65 @@ test.describe('Public read-only board share', () => {
 		expect((await fetchPublic('totally-made-up-token-that-does-not-exist')).status).toBe(404)
 	})
 })
+
+// The public page is an ANONYMOUS view (#3945): it must be reachable with no
+// session, scroll vertically so every card is reachable, and let a reader click
+// a card to read its FULL description (the tile truncates long text at 240 chars).
+test.describe('Public board is interactive read-only', () => {
+	// Opt OUT of the shared admin storageState: visit as a true anonymous reader,
+	// otherwise the page loads under the admin session and the test false-passes.
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	// A description longer than the 240-char tile clip, so "full text visible"
+	// is a meaningful assertion (the tail only appears in the expanded detail).
+	const LONG_DESC = 'HEAD_MARKER ' + 'lorem ipsum dolor sit amet '.repeat(20) + 'TAIL_MARKER_UNIQUE_9317'
+
+	let boardId = 0
+	let token = ''
+
+	test.beforeAll(async () => {
+		boardId = (await api('POST', '/boards', { title: 'Public Interactive E2E' })).body.id
+		const stackId = (await api('POST', '/stacks', { boardId, title: 'To do' })).body.id
+		// Enough cards to push the last one below the fold, plus one with a long
+		// description we open to read in full.
+		for (let i = 1; i <= 15; i++) {
+			await api('POST', '/cards', { stackId, title: `Card number ${i}` })
+		}
+		const detailCard = (await api('POST', '/cards', { stackId, title: 'Card with long description' })).body.id
+		await api('PATCH', `/cards/${detailCard}`, { description: LONG_DESC })
+		token = (await api('POST', `/boards/${boardId}/public-share`)).body.token
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await api('DELETE', `/boards/${boardId}`)
+	})
+
+	test('scrolls vertically and opens a read-only card detail with full description', async ({ page }) => {
+		await page.goto(`${BASE}/index.php/apps/kanso/p/${token}`)
+		await expect(page.locator('.public-board__title')).toHaveText('Public Interactive E2E')
+
+		// The mount is a real scroll container (all cards reachable, not just the
+		// top of the fold).
+		const scrollable = await page.locator('#kanso-public').evaluate((el) => el.scrollHeight > el.clientHeight)
+		expect(scrollable).toBe(true)
+
+		// The long-description tile is truncated on the board (tail marker hidden).
+		const tile = page.locator('.public-card').filter({ hasText: 'Card with long description' })
+		await tile.scrollIntoViewIfNeeded()
+		await expect(tile).not.toContainText('TAIL_MARKER_UNIQUE_9317')
+
+		// Clicking opens a read-only detail showing the FULL description.
+		await tile.click()
+		const detail = page.locator('.public-detail')
+		await expect(detail).toBeVisible()
+		await expect(detail).toContainText('HEAD_MARKER')
+		await expect(detail).toContainText('TAIL_MARKER_UNIQUE_9317')
+
+		// No edit affordances (no inputs/textareas in the read-only detail).
+		await expect(detail.locator('input, textarea')).toHaveCount(0)
+
+		// Closes again.
+		await detail.locator('.public-detail__close').click()
+		await expect(page.locator('.public-detail')).toHaveCount(0)
+	})
+})

--- a/tests/e2e/views.spec.js
+++ b/tests/e2e/views.spec.js
@@ -116,7 +116,45 @@ test.describe('Cross-board Views (#3815)', () => {
 		await expect(page.locator('.board-list-group__title', { hasText: /ViewsBoardB/ })).toBeVisible()
 	})
 
-	test('Kanban display groups the feed into columns; a tile opens its own board (#3886)', async ({ page }) => {
+	test('List display: clicking a card opens it as an overlay IN the View and closing stays in the View (#3950)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+
+		const created = await api('PUT', '/views', {
+			name: 'Views list-open ' + Math.floor(Date.now() / 1000),
+			filter: { labels: [state.labelA, state.labelB] },
+			groupBy: 'board',
+			display: 'list',
+		})
+		const view = created.views[created.views.length - 1]
+		const listViewId = view.id
+		expect(listViewId).toBeTruthy()
+
+		try {
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${listViewId}`)
+
+			const rowA = page.locator('.board-list-row__title', { hasText: state.cardA })
+			await expect(rowA).toBeVisible({ timeout: 15_000 })
+
+			// Clicking the row opens the shared card overlay ON the View (not the board).
+			await rowA.click()
+			const modal = page.locator('.card-modal-modal')
+			await expect(modal).toBeVisible({ timeout: 15_000 })
+			await expect(page).toHaveURL(new RegExp(`/views/${listViewId}`))
+			expect(page.url()).not.toMatch(/\/board\//)
+
+			// Close → overlay gone, still in the View.
+			await page.keyboard.press('Escape')
+			await expect(modal).toHaveCount(0, { timeout: 10_000 })
+			await expect(page).toHaveURL(new RegExp(`/views/${listViewId}`))
+			expect(page.url()).not.toMatch(/\/board\//)
+			await expect(rowA).toBeVisible()
+		} finally {
+			await api('DELETE', `/views/${listViewId}`).catch(() => {})
+		}
+	})
+
+	test('Kanban display groups the feed into columns; a tile opens the card IN the View (#3950)', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 900 })
 
 		// A View spanning both boards, filtered to the two per-board labels so it
@@ -153,14 +191,39 @@ test.describe('Cross-board Views (#3815)', () => {
 			const tileB = page.locator('.card-tile__title', { hasText: state.cardB })
 			await expect(tileB).toBeVisible()
 
-			// Clicking a tile opens the card modal on its OWN board (cross-board
-			// correct): card B lives on board B, so the deep-link id must be boardB.
-			await tileB.click()
-			await expect(page).toHaveURL(new RegExp(`/board/${state.boardB}/card/${state.cardBId}`), { timeout: 15_000 })
+			// Tile parity (#3950): the Kanban tile carries the real human ref (KAN-…
+			// style prefix + seq) and the label chip renders with its board colour, not
+			// a neutral dot — same as the board tiles. Card B's label is green (00ff00).
+			await expect(page.locator('.view-kanban-col .card-tile__ref').first()).toBeVisible({ timeout: 10_000 })
+			const chipBg = await page.locator('.view-kanban-col__cards .card-tile__label-chip', { hasText: /vlabelB/ })
+				.first().evaluate((el) => getComputedStyle(el).backgroundColor)
+			// A coloured chip resolves to a non-transparent rgb() background.
+			expect(chipBg).toMatch(/^rgb/)
+			expect(chipBg).not.toBe('rgba(0, 0, 0, 0)')
 
-			// Close the modal and switch to List, then back to Kanban via the switcher
-			// to prove the toggle works in-session too.
-			await page.goto(`${BASE}/index.php/apps/kanso#/views/${kanbanViewId}`)
+			// Clicking a tile opens the card detail as an in-place overlay ON the View
+			// (#3950): the shared CardModal → CardDetail opens, the URL STAYS on the
+			// View (never swaps to the card's board), and closing returns to the View.
+			await tileB.click()
+			const modal = page.locator('.card-modal-modal')
+			await expect(modal).toBeVisible({ timeout: 15_000 })
+			// URL unchanged: still the View, NOT /board/:id/card/:cardId.
+			await expect(page).toHaveURL(new RegExp(`/views/${kanbanViewId}`))
+			expect(page.url()).not.toMatch(/\/board\//)
+			// The overlay shows card B's content.
+			await expect(modal.getByText(state.cardB, { exact: false }).first()).toBeVisible({ timeout: 10_000 })
+
+			// Close the overlay (Escape) → the modal is gone and we are STILL in the
+			// View at /views/:id, not on any board.
+			await page.keyboard.press('Escape')
+			await expect(modal).toHaveCount(0, { timeout: 10_000 })
+			await expect(page).toHaveURL(new RegExp(`/views/${kanbanViewId}`))
+			expect(page.url()).not.toMatch(/\/board\//)
+			// The Kanban columns are still rendered underneath (we never left the View).
+			await expect(columns.first()).toBeVisible()
+
+			// Switch to List, then back to Kanban via the switcher to prove the toggle
+			// works in-session too.
 			await page.locator('.view-page__display-btn', { hasText: 'List' }).click()
 			await expect(page.locator('.board-list-row__title', { hasText: state.cardA })).toBeVisible({ timeout: 10_000 })
 			await kanbanBtn.click()

--- a/tests/e2e/views.spec.js
+++ b/tests/e2e/views.spec.js
@@ -116,6 +116,65 @@ test.describe('Cross-board Views (#3815)', () => {
 		await expect(page.locator('.board-list-group__title', { hasText: /ViewsBoardB/ })).toBeVisible()
 	})
 
+	test('Kanban display groups the feed into columns; a tile opens its own board (#3886)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+
+		// A View spanning both boards, filtered to the two per-board labels so it
+		// resolves to EXACTLY the two test cards, grouped by BOARD and saved with
+		// the new Kanban display so it re-seeds Kanban on reload.
+		const created = await api('PUT', '/views', {
+			name: 'Views kanban ' + Math.floor(Date.now() / 1000),
+			filter: { labels: [state.labelA, state.labelB] },
+			groupBy: 'board',
+			display: 'kanban',
+		})
+		const view = created.views[created.views.length - 1]
+		const kanbanViewId = view.id
+		expect(kanbanViewId).toBeTruthy()
+
+		try {
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${kanbanViewId}`)
+
+			// Saved display:'kanban' re-seeds the Kanban surface on load (no click needed),
+			// and the Kanban button reads as active.
+			const kanbanBtn = page.locator('.view-page__display-btn', { hasText: 'Kanban' })
+			await expect(kanbanBtn).toHaveClass(/view-page__display-btn--active/, { timeout: 15_000 })
+
+			// One column per board group (grouped by board) → ≥2 columns with the
+			// expected board-name headers.
+			const columns = page.locator('.view-kanban-col')
+			await expect(columns).toHaveCount(2, { timeout: 15_000 })
+			await expect(page.locator('.view-kanban-col__title', { hasText: /ViewsBoardA/ })).toBeVisible()
+			await expect(page.locator('.view-kanban-col__title', { hasText: /ViewsBoardB/ })).toBeVisible()
+
+			// Each card renders as a CardTile; both test cards are present.
+			await expect(page.locator('.card-tile__title', { hasText: state.cardA })).toBeVisible({ timeout: 10_000 })
+			const tileB = page.locator('.card-tile__title', { hasText: state.cardB })
+			await expect(tileB).toBeVisible()
+
+			// Clicking a tile opens the card modal on its OWN board (cross-board
+			// correct): card B lives on board B, so the deep-link id must be boardB.
+			await tileB.click()
+			await expect(page).toHaveURL(new RegExp(`/board/${state.boardB}/card/${state.cardBId}`), { timeout: 15_000 })
+
+			// Close the modal and switch to List, then back to Kanban via the switcher
+			// to prove the toggle works in-session too.
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${kanbanViewId}`)
+			await page.locator('.view-page__display-btn', { hasText: 'List' }).click()
+			await expect(page.locator('.board-list-row__title', { hasText: state.cardA })).toBeVisible({ timeout: 10_000 })
+			await kanbanBtn.click()
+			await expect(columns.first()).toBeVisible({ timeout: 10_000 })
+
+			// Reload → the saved display:'kanban' still re-seeds Kanban.
+			await page.reload()
+			await expect(kanbanBtn).toHaveClass(/view-page__display-btn--active/, { timeout: 15_000 })
+			await expect(page.locator('.view-kanban-col').first()).toBeVisible({ timeout: 10_000 })
+		} finally {
+			await api('DELETE', `/views/${kanbanViewId}`).catch(() => {})
+		}
+	})
+
 	test('richer filter dimensions + new group-by narrow a View (#3815)', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 900 })
 

--- a/tests/unit/Controller/ViewControllerTest.php
+++ b/tests/unit/Controller/ViewControllerTest.php
@@ -97,7 +97,14 @@ class ViewControllerTest extends TestCase {
 
 	public function testCreateRejectsUnknownGroupByAndDisplay(): void {
 		self::assertSame(Http::STATUS_BAD_REQUEST, $this->controller->create('X', ['a' => 1], 'nope')->getStatus());
-		self::assertSame(Http::STATUS_BAD_REQUEST, $this->controller->create('X', ['a' => 1], 'status', 'kanban')->getStatus());
+		self::assertSame(Http::STATUS_BAD_REQUEST, $this->controller->create('X', ['a' => 1], 'status', 'grid')->getStatus());
+	}
+
+	public function testCreateAcceptsKanbanDisplay(): void {
+		$response = $this->controller->create('Kanban view', ['a' => 1], 'status', 'kanban');
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		$views = $response->getData()['views'];
+		self::assertSame('kanban', $views[0]['display']);
 	}
 
 	public function testRenameChangesNameByIdAndRejectsDuplicate(): void {

--- a/tests/unit/Service/DeckImportServiceTest.php
+++ b/tests/unit/Service/DeckImportServiceTest.php
@@ -29,13 +29,17 @@ use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\SortKeyService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Files\IAppData;
+use OCP\Files\IRootFolder;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class DeckImportServiceTest extends TestCase {
 	private DeckReader&MockObject $deckReader;
@@ -52,6 +56,8 @@ class DeckImportServiceTest extends TestCase {
 	private IAppData&MockObject $appData;
 	private IAppDataFactory&MockObject $appDataFactory;
 	private ISecureRandom&MockObject $secureRandom;
+	private IRootFolder&MockObject $rootFolder;
+	private LoggerInterface&MockObject $logger;
 	private DeckImportService $service;
 
 	protected function setUp(): void {
@@ -70,6 +76,8 @@ class DeckImportServiceTest extends TestCase {
 		$this->appData = $this->createMock(IAppData::class);
 		$this->appDataFactory = $this->createMock(IAppDataFactory::class);
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = new DeckImportService(
 			$this->deckReader,
 			$this->boardService,
@@ -86,6 +94,8 @@ class DeckImportServiceTest extends TestCase {
 			$this->appData,
 			$this->appDataFactory,
 			$this->secureRandom,
+			$this->rootFolder,
+			$this->logger,
 		);
 	}
 
@@ -147,7 +157,7 @@ class DeckImportServiceTest extends TestCase {
 		$this->deckReader->method('readAssignedUsers')->willReturn([21 => ['bob', 'ghost']]);
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 
 		// Entities come back with ids assigned in insertion order.
 		$this->labelMapper->method('insert')->willReturnCallback($this->autoId());
@@ -223,7 +233,7 @@ class DeckImportServiceTest extends TestCase {
 		$this->deckReader->method('readAssignedUsers')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 
 		$this->stackMapper->method('insert')->willReturnCallback($this->autoId());
 
@@ -309,7 +319,7 @@ class DeckImportServiceTest extends TestCase {
 		$this->deckReader->method('readAssignedUsers')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 
 		$captured = null;
 		$this->stackMapper->method('insert')->willReturnCallback(function (Stack $s) use (&$captured): Stack {
@@ -342,7 +352,7 @@ class DeckImportServiceTest extends TestCase {
 		$this->deckReader->method('readAssignedUsers')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 
 		$captured = null;
 		$this->labelMapper->method('insert')->willReturnCallback(function (Label $l) use (&$captured): Label {
@@ -379,7 +389,7 @@ class DeckImportServiceTest extends TestCase {
 		$this->deckReader->method('readAssignedUsers')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 
 		$this->service->importBoard(2, 'alice');
 
@@ -415,7 +425,7 @@ class DeckImportServiceTest extends TestCase {
 		$this->deckReader->method('readAssignedUsers')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('commit');
 		$this->db->expects(self::never())->method('rollBack');
@@ -459,7 +469,10 @@ class DeckImportServiceTest extends TestCase {
 		]);
 		$this->deckReader->method('readAssignedLabels')->willReturn([]);
 		$this->deckReader->method('readAssignedUsers')->willReturn([]);
-		$this->deckReader->method('countFileReferenceAttachments')->willReturn(0);
+		// NOTE: readAttachments + readFileReferenceAttachments are intentionally
+		// NOT stubbed here - each attachment/comment test sets BOTH explicitly
+		// (PHPUnit binds the first ->method() stub, so a default here could not be
+		// overridden by a test).
 
 		$this->stackMapper->method('insert')->willReturnCallback($this->autoId());
 		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c): Card {
@@ -478,6 +491,7 @@ class DeckImportServiceTest extends TestCase {
 	public function testImportInsertsCommentsWithCardRemapAndCreatedAt(): void {
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readAttachments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([
 			['id' => 71, 'cardId' => 21, 'author' => 'bob', 'message' => 'top', 'createdAt' => 111, 'parentId' => 0],
 			['id' => 72, 'cardId' => 21, 'author' => 'bob', 'message' => 'reply', 'createdAt' => 222, 'parentId' => 71],
@@ -510,6 +524,7 @@ class DeckImportServiceTest extends TestCase {
 	public function testImportCommentAuthorMissingFallsBackToImporter(): void {
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readAttachments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->deckReader->method('readComments')->willReturn([
 			['id' => 71, 'cardId' => 21, 'author' => 'ghost', 'message' => 'hi', 'createdAt' => 111, 'parentId' => 0],
 		]);
@@ -530,6 +545,7 @@ class DeckImportServiceTest extends TestCase {
 	public function testImportCopiesDeckFileAttachment(): void {
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([
 			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'report.pdf', 'createdBy' => 'bob', 'createdAt' => 333],
 		]);
@@ -544,7 +560,7 @@ class DeckImportServiceTest extends TestCase {
 		$deckFolder = $this->createMock(ISimpleFolder::class);
 		$deckFolder->method('getFile')->with('report.pdf')->willReturn($sourceFile);
 		$deckAppData = $this->createMock(IAppData::class);
-		$deckAppData->method('getFolder')->with('21')->willReturn($deckFolder);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
 		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
 
 		// Kanso app-data write target: card-500 folder, server-generated object.
@@ -580,6 +596,7 @@ class DeckImportServiceTest extends TestCase {
 		// applies - so an imported .html can never become stored XSS.
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([
 			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'page.html', 'createdBy' => 'bob', 'createdAt' => 333],
 		]);
@@ -593,7 +610,7 @@ class DeckImportServiceTest extends TestCase {
 		$deckFolder = $this->createMock(ISimpleFolder::class);
 		$deckFolder->method('getFile')->with('page.html')->willReturn($sourceFile);
 		$deckAppData = $this->createMock(IAppData::class);
-		$deckAppData->method('getFolder')->with('21')->willReturn($deckFolder);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
 		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
 
 		$kansoFolder = $this->createMock(ISimpleFolder::class);
@@ -619,6 +636,7 @@ class DeckImportServiceTest extends TestCase {
 		// attachment (defence in depth - it never selects a storage path).
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([
 			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => "../../ev\x00il.txt", 'createdBy' => 'bob', 'createdAt' => 333],
 		]);
@@ -632,7 +650,7 @@ class DeckImportServiceTest extends TestCase {
 		$deckFolder = $this->createMock(ISimpleFolder::class);
 		$deckFolder->method('getFile')->willReturn($sourceFile);
 		$deckAppData = $this->createMock(IAppData::class);
-		$deckAppData->method('getFolder')->with('21')->willReturn($deckFolder);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
 		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
 
 		$kansoFolder = $this->createMock(ISimpleFolder::class);
@@ -658,6 +676,7 @@ class DeckImportServiceTest extends TestCase {
 		// never read, and never fatal - the rest of the import still succeeds.
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([
 			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'huge.bin', 'createdBy' => 'bob', 'createdAt' => 333],
 		]);
@@ -670,7 +689,7 @@ class DeckImportServiceTest extends TestCase {
 		$deckFolder = $this->createMock(ISimpleFolder::class);
 		$deckFolder->method('getFile')->with('huge.bin')->willReturn($sourceFile);
 		$deckAppData = $this->createMock(IAppData::class);
-		$deckAppData->method('getFolder')->with('21')->willReturn($deckFolder);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
 		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
 
 		// Nothing is written and no row is inserted for the skipped attachment.
@@ -687,73 +706,170 @@ class DeckImportServiceTest extends TestCase {
 		self::assertSame(1, $result['cards']);
 	}
 
-	public function testImportSkipsAndCountsFileReferenceAttachment(): void {
-		// readAttachments returns only deck_file rows; a `file`-kind row never
-		// reaches import - it is surfaced via countFileReferenceAttachments and
-		// the attachment mapper is never touched (asserted in the helper).
-		$result = $this->importWithSkipCount(2);
+	public function testImportSkipsUnreadableDeckFileButFinishesImport(): void {
+		// A deck_file whose object resolves but whose bytes FAIL to read (storage
+		// error) is logged + skipped, NOT fatal - the import still commits.
+		$this->stubOneCardBoard();
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([
+			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'broken.bin', 'createdBy' => 'bob', 'createdAt' => 333],
+		]);
+		$this->userManager->method('userExists')->willReturn(true);
+
+		$sourceFile = $this->createMock(ISimpleFile::class);
+		$sourceFile->method('getSize')->willReturn(10);
+		$sourceFile->method('getContent')->willThrowException(new \RuntimeException('storage boom'));
+		$deckFolder = $this->createMock(ISimpleFolder::class);
+		$deckFolder->method('getFile')->with('broken.bin')->willReturn($sourceFile);
+		$deckAppData = $this->createMock(IAppData::class);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
+		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
+
+		// Nothing written/linked; the failed read is logged, not fatal.
+		$this->cardAttachmentMapper->expects(self::never())->method('insert');
+		$this->logger->expects(self::atLeastOnce())->method('warning');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+
+		$result = $this->service->importBoard(2, 'alice');
+
+		self::assertSame(0, $result['attachments']);
+		self::assertSame(1, $result['cards']);
+	}
+
+	public function testImportSkipsUnresolvableFileReferenceAttachment(): void {
+		// Two `file`-kind references (Deck shares) whose source nodes can no longer
+		// be resolved (owner has no matching file id) are LOGGED and skipped -
+		// counted as skippedFileAttachments, never fatal, nothing written/linked.
+		$this->stubOneCardBoard();
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([
+			['cardId' => 21, 'fileId' => 900, 'filename' => 'a.pdf', 'owner' => 'carol', 'createdBy' => 'carol', 'createdAt' => 10],
+			['cardId' => 21, 'fileId' => 901, 'filename' => 'b.pdf', 'owner' => 'carol', 'createdBy' => 'carol', 'createdAt' => 20],
+		]);
+
+		// The owner's userfolder resolves NEITHER file id → no node → skipped.
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder->method('getUserFolder')->with('carol')->willReturn($userFolder);
+
+		$this->cardAttachmentMapper->expects(self::never())->method('insert');
+		$this->appData->expects(self::never())->method('getFolder');
+		$this->logger->expects(self::atLeastOnce())->method('warning');
+
+		$result = $this->service->importBoard(2, 'alice');
 
 		self::assertSame(0, $result['attachments']);
 		self::assertSame(2, $result['skippedFileAttachments']);
+		self::assertSame(1, $result['cards']);
 	}
 
-	/**
-	 * Runs a one-card import where the only Deck attachments are user-Files
-	 * references (the `file` kind), so none are copied and the count surfaces.
-	 *
-	 * @return array{boardId: int, title: string, stacks: int, cards: int, labels: int, comments: int, attachments: int, skippedFileAttachments: int}
-	 */
-	private function importWithSkipCount(int $skip): array {
-		$reader = $this->createMock(DeckReader::class);
-		$reader->method('isAvailable')->willReturn(true);
-		$reader->method('userCanReadBoard')->willReturn(true);
-		$reader->method('readBoard')->with(2)
-			->willReturn(['id' => 2, 'title' => 'B', 'color' => null, 'owner' => 'carol']);
-		$reader->method('readLabels')->willReturn([]);
-		$reader->method('readStacks')->willReturn([['id' => 11, 'title' => 'To do']]);
-		$reader->method('readCards')->willReturn([
-			['id' => 21, 'title' => 'C', 'description' => '', 'archived' => false, 'duedate' => null, 'doneAt' => 0, 'createdAt' => 0],
+	public function testImportCopiesFileReferenceAttachment(): void {
+		// A `file`-kind reference (a Deck share) is resolved from the owner's Files
+		// by file id and its bytes are COPIED into Kanso via the same sanitized
+		// store path as an upload - so it lands as a normal Kanso attachment and
+		// counts toward `attachments`, not `skippedFileAttachments`.
+		$this->stubOneCardBoard();
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([
+			['cardId' => 21, 'fileId' => 1571, 'filename' => 'View Registration Information.pdf', 'owner' => 'carol', 'createdBy' => 'carol', 'createdAt' => 444],
 		]);
-		$reader->method('readAssignedLabels')->willReturn([]);
-		$reader->method('readAssignedUsers')->willReturn([]);
-		$reader->method('readComments')->willReturn([]);
-		$reader->method('readAttachments')->willReturn([]);
-		$reader->method('countFileReferenceAttachments')->willReturn($skip);
+		$this->userManager->method('userExists')->willReturn(true);
+		$this->secureRandom->method('generate')->willReturn('reffkey1');
 
-		$board = new Board();
-		$board->setId(100);
-		$board->setTitle('B');
-		$boardService = $this->createMock(BoardService::class);
-		$boardService->method('create')->willReturn($board);
+		$node = $this->createMock(File::class);
+		$node->method('getSize')->willReturn(12);
+		$node->method('getContent')->willReturn('PDFCONTENT12');
+		$node->method('getMimetype')->willReturn('application/pdf');
+		$node->method('getName')->willReturn('View Registration Information.pdf');
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->with(1571)->willReturn([$node]);
+		$this->rootFolder->method('getUserFolder')->with('carol')->willReturn($userFolder);
 
-		$stackMapper = $this->createMock(StackMapper::class);
-		$stackMapper->method('insert')->willReturnCallback($this->autoId());
-		$cardMapper = $this->createMock(CardMapper::class);
-		$cardMapper->method('insert')->willReturnCallback(function (Card $c): Card {
-			$c->setId(500);
-			return $c;
-		});
+		$kansoFolder = $this->createMock(ISimpleFolder::class);
+		$kansoFolder->expects(self::once())->method('newFile')->with('reffkey1', 'PDFCONTENT12');
+		$this->appData->method('getFolder')->with('card-500')->willReturn($kansoFolder);
 
-		$attachmentMapper = $this->createMock(CardAttachmentMapper::class);
-		$attachmentMapper->expects(self::never())->method('insert');
+		$captured = null;
+		$this->cardAttachmentMapper->expects(self::once())->method('insert')
+			->willReturnCallback(function (CardAttachment $a) use (&$captured): CardAttachment {
+				$captured = $a;
+				$a->setId(1);
+				return $a;
+			});
 
-		$service = new DeckImportService(
-			$reader,
-			$boardService,
-			$stackMapper,
-			$cardMapper,
-			$this->createMock(LabelMapper::class),
-			$this->createMock(CardLabelMapper::class),
-			$this->createMock(CardAssigneeMapper::class),
-			$this->createMock(CommentMapper::class),
-			$attachmentMapper,
-			new SortKeyService(),
-			$this->createMock(IUserManager::class),
-			$this->createMock(\OCP\IDBConnection::class),
-			$this->createMock(IAppData::class),
-			$this->createMock(IAppDataFactory::class),
-			$this->createMock(ISecureRandom::class),
-		);
-		return $service->importBoard(2, 'alice');
+		$result = $this->service->importBoard(2, 'alice');
+
+		self::assertSame(1, $result['attachments']);
+		self::assertSame(0, $result['skippedFileAttachments']);
+		self::assertNotNull($captured);
+		self::assertSame(500, $captured->getCardId());
+		self::assertSame(100, $captured->getBoardId());
+		self::assertSame('View Registration Information.pdf', $captured->getFilename());
+		self::assertSame('application/pdf', $captured->getMime());
+		self::assertSame(12, $captured->getSize());
+		self::assertSame('reffkey1', $captured->getStorageKey());
+		self::assertSame('carol', $captured->getUploadedBy());
+		self::assertSame(444, $captured->getCreatedAt());
+	}
+
+	public function testImportImportsBothAttachmentKindsTogether(): void {
+		// A single card with BOTH a deck_file upload AND a file reference: both are
+		// copied into Kanso and the summary counts both under `attachments`.
+		$this->stubOneCardBoard();
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([
+			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'upload.pdf', 'createdBy' => 'bob', 'createdAt' => 333],
+		]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([
+			['cardId' => 21, 'fileId' => 1571, 'filename' => 'ref.pdf', 'owner' => 'carol', 'createdBy' => 'carol', 'createdAt' => 444],
+		]);
+		$this->userManager->method('userExists')->willReturn(true);
+		$this->secureRandom->method('generate')->willReturnOnConsecutiveCalls('uploadkey', 'refkey');
+
+		// deck_file source in Deck app-data under file-card-21.
+		$sourceFile = $this->createMock(ISimpleFile::class);
+		$sourceFile->method('getContent')->willReturn('UPLOADBYTES');
+		$sourceFile->method('getMimeType')->willReturn('application/pdf');
+		$sourceFile->method('getSize')->willReturn(11);
+		$deckFolder = $this->createMock(ISimpleFolder::class);
+		$deckFolder->method('getFile')->with('upload.pdf')->willReturn($sourceFile);
+		$deckAppData = $this->createMock(IAppData::class);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
+		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
+
+		// file-reference source in the owner's Files.
+		$node = $this->createMock(File::class);
+		$node->method('getSize')->willReturn(7);
+		$node->method('getContent')->willReturn('REFBYTE');
+		$node->method('getMimetype')->willReturn('application/pdf');
+		$node->method('getName')->willReturn('ref.pdf');
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->with(1571)->willReturn([$node]);
+		$this->rootFolder->method('getUserFolder')->with('carol')->willReturn($userFolder);
+
+		$kansoFolder = $this->createMock(ISimpleFolder::class);
+		$kansoFolder->expects(self::exactly(2))->method('newFile');
+		$this->appData->method('getFolder')->with('card-500')->willReturn($kansoFolder);
+
+		$captured = [];
+		$this->cardAttachmentMapper->method('insert')
+			->willReturnCallback(function (CardAttachment $a) use (&$captured): CardAttachment {
+				$captured[] = $a;
+				$a->setId(count($captured));
+				return $a;
+			});
+
+		$result = $this->service->importBoard(2, 'alice');
+
+		self::assertSame(2, $result['attachments']);
+		self::assertSame(0, $result['skippedFileAttachments']);
+		self::assertCount(2, $captured);
+		$filenames = array_map(static fn (CardAttachment $a): string => $a->getFilename(), $captured);
+		self::assertContains('upload.pdf', $filenames);
+		self::assertContains('ref.pdf', $filenames);
 	}
 }

--- a/tests/unit/Service/DeckReaderTest.php
+++ b/tests/unit/Service/DeckReaderTest.php
@@ -38,4 +38,17 @@ class DeckReaderTest extends TestCase {
 		self::assertNull($this->bareColor('12345'), 'wrong length → null');
 		self::assertNull($this->bareColor('gggggg'), 'non-hex → null');
 	}
+
+	/**
+	 * With no card ids there is nothing to read; the file-reference reader must
+	 * short-circuit to [] WITHOUT touching the DB (the share→filecache join is
+	 * only built for a non-empty id set). The full join is exercised end-to-end
+	 * against a real Deck+Files instance in the import integration run.
+	 */
+	public function testReadFileReferenceAttachmentsEmptyIdsSkipsQuery(): void {
+		$db = $this->createMock(IDBConnection::class);
+		$db->expects(self::never())->method('getQueryBuilder');
+		$reader = new DeckReader($db, $this->createMock(IAppManager::class));
+		self::assertSame([], $reader->readFileReferenceAttachments([]));
+	}
 }

--- a/tests/unit/Service/PublicShareServiceTest.php
+++ b/tests/unit/Service/PublicShareServiceTest.php
@@ -249,8 +249,10 @@ class PublicShareServiceTest extends TestCase {
 		sort($cardKeys);
 		// `type` is a public-safe display attribute (renders as a tile icon like a
 		// label/cover - no PII, no internal identifier), so it is a permitted key.
+		// `coverColor`, `startDate` and `estimate` (#3951) are presentational,
+		// non-person card content too - they carry no assignee/comment/member data.
 		self::assertSame(
-			['allDay', 'checklist', 'description', 'duedate', 'humanId', 'id', 'labels', 'priority', 'stackId', 'status', 'title', 'type'],
+			['allDay', 'checklist', 'coverColor', 'description', 'duedate', 'estimate', 'humanId', 'id', 'labels', 'priority', 'stackId', 'startDate', 'status', 'title', 'type'],
 			$cardKeys
 		);
 

--- a/tests/unit/Service/ViewServiceTest.php
+++ b/tests/unit/Service/ViewServiceTest.php
@@ -12,6 +12,8 @@ use OCA\Kanso\Access\ViewerContext;
 use OCA\Kanso\Db\Board;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Label;
+use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Service\BoardService;
 use OCA\Kanso\Service\CardSummaryService;
 use OCA\Kanso\Service\ViewService;
@@ -23,6 +25,7 @@ class ViewServiceTest extends TestCase {
 	private CardMapper&MockObject $cardMapper;
 	private CardSummaryService&MockObject $cardSummaryService;
 	private BoardAccess&MockObject $boardAccess;
+	private LabelMapper&MockObject $labelMapper;
 	private ViewService $service;
 
 	protected function setUp(): void {
@@ -31,20 +34,33 @@ class ViewServiceTest extends TestCase {
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->cardSummaryService = $this->createMock(CardSummaryService::class);
 		$this->boardAccess = $this->createMock(BoardAccess::class);
+		$this->labelMapper = $this->createMock(LabelMapper::class);
+		// Default: no labels on any board unless a test says otherwise.
+		$this->labelMapper->method('findByBoard')->willReturn([]);
 		$this->service = new ViewService(
 			$this->boardService,
 			$this->cardMapper,
 			$this->cardSummaryService,
 			$this->boardAccess,
+			$this->labelMapper,
 		);
 	}
 
-	private function board(int $id, string $title): Board {
+	private function board(int $id, string $title, ?string $prefix = null): Board {
 		$board = new Board();
 		$board->setId($id);
 		$board->setTitle($title);
 		$board->setOwner('alice');
+		$board->setPrefix($prefix);
 		return $board;
+	}
+
+	private function label(int $id, string $title, ?string $color): Label {
+		$label = new Label();
+		$label->setId($id);
+		$label->setTitle($title);
+		$label->setColor($color);
+		return $label;
 	}
 
 	private function summaryCard(int $id, int $boardId): Card {
@@ -92,6 +108,57 @@ class ViewServiceTest extends TestCase {
 		self::assertSame(22, $rows[1]['id']);
 		self::assertSame(9, $rows[1]['boardId']);
 		self::assertSame('Beta', $rows[1]['boardTitle']);
+	}
+
+	/**
+	 * Tile parity (#3950): each card carries its board's human-id prefix and the
+	 * envelope carries the union of label metadata across the readable boards, so
+	 * the client can render card refs (e.g. "KAN-123") and label COLOURS matching
+	 * the board tiles - all from this one feed with no extra request.
+	 */
+	public function testFindMineEnrichesCardsWithBoardPrefixAndUnionsLabels(): void {
+		$b3 = $this->board(3, 'Alpha', 'ALP');
+		// A board with no explicit prefix falls back to the shared default.
+		$b9 = $this->board(9, 'Beta', null);
+		$this->boardService->method('findAll')->with('alice')->willReturn([$b3, $b9]);
+
+		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
+		$ctx9 = ViewerContext::forMember('alice', 9, ViewerContext::ROLE_INTERNAL, true);
+		$this->boardAccess->method('contextFor')->willReturnMap([
+			[$b3, 'alice', $ctx3],
+			[$b9, 'alice', $ctx9],
+		]);
+
+		$this->cardMapper->method('findSummariesByBoard')
+			->willReturnCallback(fn (int $boardId): array => [$this->summaryCard($boardId === 3 ? 11 : 22, $boardId)]);
+		$this->cardSummaryService->method('serialize')
+			->willReturnCallback(fn (int $boardId): array => [['id' => $boardId === 3 ? 11 : 22]]);
+
+		// Board 3 has two labels, board 9 one; the envelope unions them.
+		$labelMapper = $this->createMock(LabelMapper::class);
+		$labelMapper->method('findByBoard')->willReturnCallback(fn (int $boardId): array => $boardId === 3
+			? [$this->label(1, 'Bug', '#ff0000'), $this->label(2, 'Chore', null)]
+			: [$this->label(5, 'Idea', '#00ff00')]);
+		$service = new ViewService($this->boardService, $this->cardMapper, $this->cardSummaryService, $this->boardAccess, $labelMapper);
+
+		$result = $service->findMine('alice');
+
+		$rows = $result['cards'];
+		// Explicit prefix carried through; missing prefix falls back to the default.
+		self::assertSame('ALP', $rows[0]['boardPrefix']);
+		self::assertSame('KAN', $rows[1]['boardPrefix']);
+
+		// Label union across boards, id/title/color preserved for the client lookup.
+		$labels = $result['labels'];
+		self::assertCount(3, $labels);
+		$byId = [];
+		foreach ($labels as $l) {
+			$byId[$l['id']] = $l;
+		}
+		self::assertSame('Bug', $byId[1]['title']);
+		self::assertSame('#ff0000', $byId[1]['color']);
+		self::assertNull($byId[2]['color']);
+		self::assertSame('Idea', $byId[5]['title']);
 	}
 
 	/**


### PR DESCRIPTION
PM sprint `pm/session-2026-08-19b` — 9 commits: the Views Kanban feature, in-context card opening, public-share read-only improvements, a real Deck-import attachment bug, and genuine DnD test coverage — including several community-reported GitHub issues. Full unit suite (1318) green, psalm + php-cs-fixer clean, `vite build` clean; each card's e2e run green locally.

## Views (cross-board saved views)
- **feat(views): Kanban display** (#3886) — adds Kanban to the `List | Timeline` switcher, grouping the filtered cross-board feed into one column per group-by field. Self-contained `ViewKanban`/`ViewKanbanColumn` reusing `CardTile`; one-line backend (`ViewController::DISPLAYS`). `3a936e3`
- **fix(views): open cards in-context** (#3950) — clicking a card in a View now opens it as an overlay ON the View (reusing the board's exact `CardModal`→`CardDetail` via a new `controlled` mode), so closing returns to the View, not the board. Kanban tiles now show label colours + `KAN-` refs (feed enriched with `boardPrefix` + a cross-board label union). `ffd3c37`

## Public share board
- **fix(public): scroll + open cards** (#3945 ← GH #48) — the `/p/{token}` static viewer now scrolls vertically and cards open a read-only detail. `2fcbcd9`
- **feat(public): richer read-only detail** (#3951) — adds cover band, start date, estimate, and full markdown description (**non-person only** — the "assignees/comments/activity/members are never shown" promise is kept). `a6f0c96`
- **refactor(ui): Public Link → Sharing** — moved the public-link control from the Automation tab into board **Sharing** settings. `220f7d7`
- **test(public):** payload-shape test updated for the new fields. `93e03c7`

## Deck import (community bug — GH #47)
- **fix(import): bring over both attachment kinds** (#3946) — the importer silently dropped **all** attachments: it read the wrong Deck app-data folder (`<cardId>` instead of Deck's real `file-card-<cardId>`), and the unit mocks encoded the same wrong key, so CI stayed green. Fixed the folder key + added logging; **also** import Nextcloud Files-reference attachments (which are stored as *shares*, not attachment rows). Tests corrected to have teeth; verified on a real import (all attachments transfer). `12a079b`

## Board / drag-and-drop
- **fix(board): colour-swatch alignment** (#3934) — column options-menu swatches now centre with their labels. `a86ebe0`
- **test(e2e): real drag-and-drop coverage** (#3944 ← GH #50) — added a same-column-reorder DnD e2e (proven to have teeth) + enlarged the empty-column drop target. NB the reported "DnD broken in 0.10.0" was **not reproducible** (the pragmatic-dnd 3.0.0 bump is byte-identical core); this adds the missing coverage + a hittability fix. `ce3f78a`

No version bump (release-only). No `CHANGELOG.md` hand-edits.

_Deferred to a follow-up PR:_ opt-in "show comments/assignees" toggles for public links (#3949) — person-data exposure on an unauthenticated link warrants its own reviewed change.