### PR TITLE
feat: show cards with due dates in your calendar (read-only CalDAV / DAVx5)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,6 +30,12 @@ links and webhook, and one-click Import from Deck.
 	<licence>agpl</licence>
 	<author mail="akfatih2@gmail.com">Fatih AKTAS</author>
 	<namespace>Kanso</namespace>
+	<!-- Marks Kanso as a DAV-integration app so the DAV app's PluginManager loads
+	     the <sabre> calendar plugin below (read-only board VTODO calendars, #3534
+	     / issue #49). Without the `dav` type the plugin is silently skipped. -->
+	<types>
+		<dav/>
+	</types>
 	<category>organization</category>
 	<website>https://github.com/aktasfatih/kanso</website>
 	<bugs>https://github.com/aktasfatih/kanso/issues</bugs>
@@ -71,4 +77,13 @@ links and webhook, and one-click Import from Deck.
 			<icon>app.svg</icon>
 		</navigation>
 	</navigations>
+	<!-- Read-only CalDAV VTODO calendars, one per board (#3534 / issue #49). The
+	     DAV app instantiates this provider through the app container, so it is
+	     dependency-injected; it surfaces each board a user can access as a
+	     calendar of card due dates, auto-discovered by Nextcloud Calendar + DAVx5. -->
+	<sabre>
+		<calendar-plugins>
+			<plugin>OCA\Kanso\CalDav\CalendarProvider</plugin>
+		</calendar-plugins>
+	</sabre>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -206,6 +206,13 @@ return [
 		['name' => 'calendarFeed#enable', 'url' => '/api/boards/{id}/calendar-feed', 'verb' => 'POST'],
 		['name' => 'calendarFeed#disable', 'url' => '/api/boards/{id}/calendar-feed', 'verb' => 'DELETE'],
 
+		// Per-user "show this board in my calendar" toggle for the CalDAV VTODO
+		// calendars (#3534 / issue #49). Personal preference (any member, not
+		// MANAGE); boards sync by default, this hides the noisy ones. Distinct
+		// from the board-wide calendar-feed above.
+		['name' => 'calendarSync#show', 'url' => '/api/boards/{id}/calendar-sync', 'verb' => 'GET'],
+		['name' => 'calendarSync#update', 'url' => '/api/boards/{id}/calendar-sync', 'verb' => 'PUT'],
+
 		// Per-user board pinning (#3632). Nested under a board id, distinct from
 		// board#show. Pin = PUT (READ-gated), unpin = DELETE (own pin only).
 		['name' => 'boardPin#pin', 'url' => '/api/boards/{id}/pin', 'verb' => 'PUT'],

--- a/lib/CalDav/CalendarProvider.php
+++ b/lib/CalDav/CalendarProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\CalDav;
+
+use OCA\DAV\CalDAV\Integration\ExternalCalendar;
+use OCA\DAV\CalDAV\Integration\ICalendarProvider;
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Service\CardCalendarService;
+
+/**
+ * Exposes Kanso boards to the CalDAV stack as read-only VTODO calendars (#3534 /
+ * issue #49). Registered via `appinfo/info.xml` `<sabre><calendar-plugins>`; the
+ * DAV app instantiates it through the app container, so it is dependency-injected
+ * like any service. The DAV app's `CalendarHome` calls these methods when a
+ * client (Nextcloud Calendar, DAVx5, Tasks apps) lists or opens a calendar.
+ *
+ * Every decision is delegated to {@see CardCalendarService} - this class only
+ * bridges the DAV integration interface to that Sabre-free core.
+ */
+class CalendarProvider implements ICalendarProvider {
+	public function __construct(
+		private CardCalendarService $service,
+	) {
+	}
+
+	#[\Override]
+	public function getAppId(): string {
+		return CardCalendarService::APP_ID;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @return ExternalCalendar[]
+	 */
+	#[\Override]
+	public function fetchAllForCalendarHome(string $principalUri): array {
+		return array_map(
+			fn (Board $board): ExternalCalendar => new CardCalendar($this->service, $board, $principalUri),
+			$this->service->boardsForPrincipal($principalUri),
+		);
+	}
+
+	#[\Override]
+	public function hasCalendarInCalendarHome(string $principalUri, string $calendarUri): bool {
+		return $this->service->boardForPrincipal($principalUri, $calendarUri) !== null;
+	}
+
+	#[\Override]
+	public function getCalendarInCalendarHome(string $principalUri, string $calendarUri): ?ExternalCalendar {
+		$board = $this->service->boardForPrincipal($principalUri, $calendarUri);
+		if ($board === null) {
+			return null;
+		}
+		return new CardCalendar($this->service, $board, $principalUri);
+	}
+}

--- a/lib/CalDav/CardCalendar.php
+++ b/lib/CalDav/CardCalendar.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\CalDav;
+
+use OCA\DAV\CalDAV\Integration\ExternalCalendar;
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Service\CardCalendarService;
+use Sabre\CalDAV\CalendarQueryValidator;
+use Sabre\CalDAV\Plugin;
+use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\PropPatch;
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader;
+
+/**
+ * One board, presented to the CalDAV stack as a read-only calendar of VTODOs
+ * (#3534 / issue #49). The children are {@see CardCalendarObject}s, one per due
+ * card the syncing user may see. Every write is rejected: this is a display /
+ * one-way-sync surface, not an editor. All data + access decisions come from
+ * {@see CardCalendarService}.
+ */
+class CardCalendar extends ExternalCalendar {
+	/** @var Card[]|null the board's due cards, loaded once per request. VTODO
+	 *  serialisation happens per object only when it is actually read, so a
+	 *  calendar-home listing never serialises anything. */
+	private ?array $cards = null;
+
+	public function __construct(
+		private CardCalendarService $service,
+		private Board $board,
+		private string $principalUri,
+	) {
+		parent::__construct(CardCalendarService::APP_ID, $service->calendarUri($board));
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getOwner() {
+		return $this->principalUri;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getGroup() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Read-only for the owner: the read privileges, no write. That is what makes
+	 * a client (DAVx5, Calendar, Tasks) treat the calendar as non-editable.
+	 */
+	#[\Override]
+	public function getACL() {
+		return [
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			],
+			[
+				'privilege' => '{' . Plugin::NS_CALDAV . '}read-free-busy',
+				'principal' => '{DAV:}authenticated',
+				'protected' => true,
+			],
+		];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function setACL(array $acl) {
+		throw new Forbidden('Setting ACL is not supported on this calendar');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getSupportedPrivilegeSet() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Validates each child object against the calendar-query filters and returns
+	 * the names that match - the standard external-calendar approach. Sync is not
+	 * a hot path, so re-parsing each VTODO per query is acceptable.
+	 *
+	 * @return string[]
+	 */
+	#[\Override]
+	public function calendarQuery(array $filters) {
+		$validator = new CalendarQueryValidator();
+		$matches = [];
+		foreach ($this->cards() as $card) {
+			$vObject = Reader::read($this->service->serializeCard($this->board, $card));
+			if ($vObject instanceof VCalendar && $validator->validate($vObject, $filters)) {
+				$matches[] = $this->service->objectName($card);
+			}
+			$vObject->destroy();
+		}
+		return $matches;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getChild($name) {
+		$card = $this->cardByName($name);
+		if ($card === null) {
+			throw new NotFound('Card ' . $name . ' not found on this calendar');
+		}
+		return $this->object($card);
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return CardCalendarObject[]
+	 */
+	#[\Override]
+	public function getChildren() {
+		return array_map(fn (Card $card): CardCalendarObject => $this->object($card), $this->cards());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function childExists($name) {
+		return $this->cardByName($name) !== null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function createFile($name, $data = null) {
+		throw new Forbidden('This calendar is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function delete() {
+		throw new Forbidden('This calendar is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getLastModified() {
+		$latest = 0;
+		foreach ($this->cards() as $card) {
+			$latest = max($latest, $this->service->lastModified($card));
+		}
+		if ($latest > 0) {
+			return $latest;
+		}
+		return (int)$this->board->getLastModified();
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Read-only: silently accept nothing. The PropPatch stays unhandled, which
+	 * the DAV server reports back as a 403 for each attempted property change.
+	 */
+	#[\Override]
+	public function propPatch(PropPatch $propPatch) {
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return array<string, mixed>
+	 */
+	#[\Override]
+	public function getProperties($properties) {
+		$props = [
+			'{DAV:}displayname' => $this->service->displayName($this->board),
+			'{' . Plugin::NS_CALDAV . '}supported-calendar-component-set' => new SupportedCalendarComponentSet(['VTODO']),
+		];
+		$color = $this->service->calendarColor($this->board);
+		if ($color !== null) {
+			$props['{http://apple.com/ns/ical/}calendar-color'] = $color;
+		}
+		return $props;
+	}
+
+	/**
+	 * The board's due cards, loaded once per request. A non-user principal
+	 * (should never reach here) yields nothing.
+	 *
+	 * @return Card[]
+	 */
+	private function cards(): array {
+		if ($this->cards !== null) {
+			return $this->cards;
+		}
+		$uid = $this->service->principalUid($this->principalUri);
+		$this->cards = $uid === null ? [] : $this->service->dueCards($this->board, $uid);
+		return $this->cards;
+	}
+
+	private function cardByName(string $name): ?Card {
+		$cardId = $this->service->cardIdFromObjectName($name);
+		if ($cardId === null) {
+			return null;
+		}
+		foreach ($this->cards() as $card) {
+			if ((int)$card->getId() === $cardId) {
+				return $card;
+			}
+		}
+		return null;
+	}
+
+	/** Serialises one due card into a read-only VTODO object. */
+	private function object(Card $card): CardCalendarObject {
+		return new CardCalendarObject(
+			$this->service->objectName($card),
+			$this->service->serializeCard($this->board, $card),
+			$this->service->etag($card),
+			$this->service->lastModified($card),
+		);
+	}
+}

--- a/lib/CalDav/CardCalendar.php
+++ b/lib/CalDav/CardCalendar.php
@@ -116,7 +116,12 @@ class CardCalendar extends ExternalCalendar {
 		$matches = [];
 		foreach ($this->cards() as $card) {
 			$vObject = Reader::read($this->service->serializeCard($this->board, $card));
-			if ($vObject instanceof VCalendar && $validator->validate($vObject, $filters)) {
+			// serializeCard always yields a VCALENDAR; the guard also narrows the
+			// type so destroy() is never called on a possibly-null Reader result.
+			if (!$vObject instanceof VCalendar) {
+				continue;
+			}
+			if ($validator->validate($vObject, $filters)) {
 				$matches[] = $this->service->objectName($card);
 			}
 			$vObject->destroy();

--- a/lib/CalDav/CardCalendar.php
+++ b/lib/CalDav/CardCalendar.php
@@ -60,8 +60,14 @@ class CardCalendar extends ExternalCalendar {
 	/**
 	 * @inheritDoc
 	 *
-	 * Read-only for the owner: the read privileges, no write. That is what makes
-	 * a client (DAVx5, Calendar, Tasks) treat the calendar as non-editable.
+	 * Read + write-properties for the owner. `write-properties` is deliberately
+	 * NOT `write`/`write-content`/`bind` - it only lets Nextcloud persist the
+	 * per-user calendar properties a client sets (visibility toggle, personal
+	 * colour) in its own property store; it never permits changing card data
+	 * (object PUT/DELETE are still refused). Without it, toggling the calendar's
+	 * visibility in the Calendar app fails with "unable to change visibility of
+	 * the calendar" (the PROPPATCH is denied). Same rationale as Deck's board
+	 * calendars.
 	 */
 	#[\Override]
 	public function getACL() {
@@ -72,8 +78,8 @@ class CardCalendar extends ExternalCalendar {
 				'protected' => true,
 			],
 			[
-				'privilege' => '{' . Plugin::NS_CALDAV . '}read-free-busy',
-				'principal' => '{DAV:}authenticated',
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $this->getOwner(),
 				'protected' => true,
 			],
 		];

--- a/lib/CalDav/CardCalendarObject.php
+++ b/lib/CalDav/CardCalendarObject.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\CalDav;
+
+use Sabre\CalDAV\ICalendarObject;
+use Sabre\DAV\Exception\Forbidden;
+
+/**
+ * One card, presented as a read-only VTODO calendar object (#3534 / issue #49).
+ * A pure value object: the VCALENDAR body, ETag, name and mtime are computed up
+ * front by {@see \OCA\Kanso\Service\CardCalendarService}; every write is rejected.
+ */
+class CardCalendarObject implements ICalendarObject {
+	public function __construct(
+		private string $name,
+		private string $calendarData,
+		private string $etag,
+		private int $lastModified,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function get() {
+		return $this->calendarData;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getContentType() {
+		return 'text/calendar; charset=utf-8';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getETag() {
+		return $this->etag;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getSize() {
+		return \strlen($this->calendarData);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getLastModified() {
+		return $this->lastModified;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function put($data) {
+		throw new Forbidden('This calendar is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function setName($name) {
+		throw new Forbidden('This calendar is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function delete() {
+		throw new Forbidden('This calendar is read-only');
+	}
+}

--- a/lib/Controller/CalendarSyncController.php
+++ b/lib/Controller/CalendarSyncController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Controller;
+
+use OCA\Kanso\Service\CardCalendarService;
+use OCA\Kanso\Service\NotPermittedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Per-user "show this board in my calendar" toggle for the read-only CalDAV
+ * VTODO calendars (#3534 / issue #49).
+ *
+ * This is a PERSONAL preference, not a board setting: it only changes whether the
+ * board appears in the calling user's OWN CalDAV account, never anyone else's, and
+ * any board member may set it (no MANAGE needed). Boards sync by default; this
+ * lets a user hide the noisy ones. Stored in the NC user config via
+ * {@see CardCalendarService}. Distinct from the MANAGE-only, board-wide ICS feed
+ * ({@see CalendarFeedController}).
+ */
+class CalendarSyncController extends Controller {
+	use ApiErrorTrait;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private CardCalendarService $cardCalendarService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Whether this board currently syncs to the calling user's calendar.
+	 */
+	#[NoAdminRequired]
+	public function show(int $id): JSONResponse {
+		return $this->respond(function () use ($id): JSONResponse {
+			return new JSONResponse([
+				'enabled' => $this->cardCalendarService->isEnabledForUser($this->currentUserId(), $id),
+			]);
+		});
+	}
+
+	/**
+	 * Show (enabled=true) or hide (enabled=false) this board in the calling user's
+	 * calendar. Requires board membership; returns the resulting state.
+	 */
+	#[NoAdminRequired]
+	public function update(int $id, bool $enabled = true): JSONResponse {
+		return $this->respond(function () use ($id, $enabled): JSONResponse {
+			$this->cardCalendarService->setEnabledForUser($this->currentUserId(), $id, $enabled);
+			return new JSONResponse(['enabled' => $enabled]);
+		});
+	}
+
+	/**
+	 * @throws NotPermittedException if there is no user session
+	 */
+	private function currentUserId(): string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No authenticated user');
+		}
+		return $user->getUID();
+	}
+}

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -284,6 +284,34 @@ class CardMapper extends QBMapper {
 	}
 
 	/**
+	 * Summaries (no description) of the non-deleted, non-archived, non-template
+	 * cards on a board that HAVE a due date, scoped to what a SPECIFIC VIEWER may
+	 * see - the source for the read-only CalDAV VTODO calendar (#3534 / issue
+	 * #49). The authenticated counterpart of {@see self::findWithDuedateByBoard}:
+	 * that one is anonymous (public-only) for the token feed, this one honours the
+	 * viewer's card-visibility so a board member syncing over CalDAV sees exactly
+	 * the due cards they see on the board. Board-scoped like every board query.
+	 *
+	 * @return Card[]
+	 * @throws Exception
+	 */
+	public function findDuedateSummariesByBoard(int $boardId, ViewerContext $viewer): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(self::SUMMARY_COLUMNS)
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('is_template', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->eq('archived', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->isNotNull('duedate'))
+			->orderBy('duedate', 'ASC')
+			->addOrderBy('id', 'ASC');
+		$this->visibilityScope->applyForViewer($qb, '', $viewer);
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * FULL rows (description included) of every non-deleted card on a board
 	 * that the VIEWER can see - templates and archived cards included, exactly
 	 * the set the board export/duplicate may serialize (#3743). One query

--- a/lib/Service/CardCalendarService.php
+++ b/lib/Service/CardCalendarService.php
@@ -14,6 +14,7 @@ use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 use Sabre\VObject\Component\VCalendar;
 
@@ -55,12 +56,25 @@ class CardCalendarService {
 
 	private const PRODID = '-//Kanso//Card calendar//EN';
 
+	/**
+	 * Per-user config key holding the JSON list of board ids the user has hidden
+	 * from THEIR calendar. Opt-out: a board a user can access syncs by default;
+	 * this list removes the noisy ones. Personal preference, so it lives in the
+	 * NC user config (like {@see \OCA\Kanso\Controller\SavedFilterController}) -
+	 * no schema change, and it never affects another user's calendar.
+	 */
+	private const HIDDEN_BOARDS_KEY = 'calendar_hidden_boards';
+
+	/** Bounds the stored list so a scripted client can't grow the value forever. */
+	private const MAX_HIDDEN_BOARDS = 2000;
+
 	public function __construct(
 		private BoardMapper $boardMapper,
 		private CardMapper $cardMapper,
 		private BoardAccess $boardAccess,
 		private PermissionService $permissionService,
 		private IURLGenerator $urlGenerator,
+		private IConfig $config,
 	) {
 	}
 
@@ -95,10 +109,64 @@ class CardCalendarService {
 			$uid,
 			$this->permissionService->getUserGroupIds($uid),
 		);
+		$hidden = $this->hiddenBoardIds($uid);
 		return array_values(array_filter(
 			$boards,
-			static fn (Board $board): bool => !$board->getArchived(),
+			static fn (Board $board): bool => !$board->getArchived() && !\in_array((int)$board->getId(), $hidden, true),
 		));
+	}
+
+	/**
+	 * The board ids this user has hidden from their calendar (empty by default).
+	 *
+	 * @return int[]
+	 */
+	public function hiddenBoardIds(string $uid): array {
+		$raw = $this->config->getUserValue($uid, 'kanso', self::HIDDEN_BOARDS_KEY, '');
+		if (!\is_string($raw) || $raw === '') {
+			return [];
+		}
+		$decoded = json_decode($raw, true);
+		if (!\is_array($decoded)) {
+			return [];
+		}
+		return array_values(array_unique(array_map('intval', $decoded)));
+	}
+
+	/** Whether this board currently syncs to $uid's calendar (default: yes). */
+	public function isEnabledForUser(string $uid, int $boardId): bool {
+		return !\in_array($boardId, $this->hiddenBoardIds($uid), true);
+	}
+
+	/**
+	 * Show or hide a board in $uid's own calendar. Requires the user to be a
+	 * member of the board (you cannot set a preference for a board you can't see),
+	 * which also bounds the stored list to real, accessible boards.
+	 *
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws \OCA\Kanso\Access\NotAMemberException if $uid is not a member
+	 */
+	public function setEnabledForUser(string $uid, int $boardId, bool $enabled): void {
+		$board = $this->boardMapper->find($boardId);
+		if ($board->getDeletedAt() > 0) {
+			throw new DoesNotExistException('Board ' . $boardId . ' is deleted');
+		}
+		// Throws NotAMemberException for a non-member.
+		$this->boardAccess->contextFor($board, $uid);
+
+		$hidden = $this->hiddenBoardIds($uid);
+		$isHidden = \in_array($boardId, $hidden, true);
+		if ($enabled && $isHidden) {
+			$hidden = array_values(array_filter($hidden, static fn (int $id): bool => $id !== $boardId));
+		} elseif (!$enabled && !$isHidden) {
+			if (\count($hidden) >= self::MAX_HIDDEN_BOARDS) {
+				return;
+			}
+			$hidden[] = $boardId;
+		} else {
+			return; // already in the desired state
+		}
+		$this->config->setUserValue($uid, 'kanso', self::HIDDEN_BOARDS_KEY, json_encode($hidden) ?: '[]');
 	}
 
 	/**

--- a/lib/Service/CardCalendarService.php
+++ b/lib/Service/CardCalendarService.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Access\BoardAccess;
+use OCA\Kanso\Access\NotAMemberException;
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IURLGenerator;
+use Sabre\VObject\Component\VCalendar;
+
+/**
+ * The read-only CalDAV VTODO surface (#3534 / issue #49): every board a user can
+ * access is exposed to their CalDAV principal as a calendar of VTODOs, one per
+ * card that HAS a due date. Discoverable by Nextcloud Calendar and DAVx5 exactly
+ * the way Deck's board calendars are (via the DAV app's
+ * {@see \OCA\DAV\CalDAV\Integration\ICalendarProvider} extension point, wired in
+ * `appinfo/info.xml`).
+ *
+ * This class is the Sabre-free CORE: it resolves boards for a principal, applies
+ * the viewer's card visibility, and serialises a card to a VTODO. The thin
+ * `OCA\Kanso\CalDav\*` adapters (which extend the DAV/Sabre base classes that
+ * only exist at runtime) delegate every decision here, so the logic stays unit
+ * testable without the server on the include path.
+ *
+ * Security posture:
+ *  - READ-ONLY. The adapters reject every write (PUT/DELETE/MKCALENDAR/PROPPATCH);
+ *    nothing here mutates a card. Two-way sync is a separate, larger feature.
+ *  - Authenticated + per-person. Unlike the anonymous token ICS feed
+ *    ({@see CalendarFeedService}), the reader is the logged-in CalDAV principal:
+ *    {@see BoardAccess::contextFor} gates board membership and
+ *    {@see CardMapper::findDuedateSummariesByBoard} applies that viewer's
+ *    card-visibility, so a member sees exactly the due cards they see on the
+ *    board - never another board's, never a card hidden from them.
+ */
+class CardCalendarService {
+	/** Matches `appinfo/info.xml` `<sabre><calendar-plugins>` registration. */
+	public const APP_ID = 'kanso';
+
+	/** The per-board calendar uri: `board-<id>` (the DAV app prefixes it with
+	 *  `app-generated--kanso--`). Board id keeps it stable across renames. */
+	private const CALENDAR_URI_PREFIX = 'board-';
+
+	/** The per-card object name inside a board calendar: `kanso-card-<id>.ics`. */
+	private const OBJECT_PREFIX = 'kanso-card-';
+	private const OBJECT_SUFFIX = '.ics';
+
+	private const PRODID = '-//Kanso//Card calendar//EN';
+
+	public function __construct(
+		private BoardMapper $boardMapper,
+		private CardMapper $cardMapper,
+		private BoardAccess $boardAccess,
+		private PermissionService $permissionService,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	/**
+	 * The uid behind a CalDAV principal, or null if it is not a personal user
+	 * principal (`principals/users/<uid>`). Group/system/calendar-resource
+	 * principals get no Kanso calendars - the feature is per-person.
+	 */
+	public function principalUid(string $principalUri): ?string {
+		$prefix = 'principals/users/';
+		if (!str_starts_with($principalUri, $prefix)) {
+			return null;
+		}
+		$uid = substr($principalUri, \strlen($prefix));
+		return $uid === '' ? null : $uid;
+	}
+
+	/**
+	 * Every board the principal may see, one calendar each. Archived boards are
+	 * skipped (the user shelved them - keep them out of the calendar list);
+	 * deleted boards never reach here. Empty for a non-user principal.
+	 *
+	 * @return Board[]
+	 */
+	public function boardsForPrincipal(string $principalUri): array {
+		$uid = $this->principalUid($principalUri);
+		if ($uid === null) {
+			return [];
+		}
+
+		$boards = $this->boardMapper->findAllForUser(
+			$uid,
+			$this->permissionService->getUserGroupIds($uid),
+		);
+		return array_values(array_filter(
+			$boards,
+			static fn (Board $board): bool => !$board->getArchived(),
+		));
+	}
+
+	/**
+	 * The board a `board-<id>` calendar uri resolves to FOR THIS principal, or
+	 * null when the uri is malformed, the board is gone/archived, or the user is
+	 * not a member. The membership check is the access gate for every child read.
+	 */
+	public function boardForPrincipal(string $principalUri, string $calendarUri): ?Board {
+		$uid = $this->principalUid($principalUri);
+		$boardId = $this->boardIdFromCalendarUri($calendarUri);
+		if ($uid === null || $boardId === null) {
+			return null;
+		}
+
+		try {
+			$board = $this->boardMapper->find($boardId);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+		if ($board->getDeletedAt() > 0 || $board->getArchived()) {
+			return null;
+		}
+
+		try {
+			// Throws for a non-member - the per-board access gate.
+			$this->boardAccess->contextFor($board, $uid);
+		} catch (NotAMemberException) {
+			return null;
+		}
+		return $board;
+	}
+
+	/**
+	 * The board's due cards visible to $uid, as VTODO source rows. The caller has
+	 * already proven membership (via {@see self::boardForPrincipal}); this mints
+	 * the viewer context again to scope card visibility.
+	 *
+	 * @return Card[]
+	 * @throws NotAMemberException if $uid is not a member (defence in depth)
+	 */
+	public function dueCards(Board $board, string $uid): array {
+		$viewer = $this->boardAccess->contextFor($board, $uid);
+		return $this->cardMapper->findDuedateSummariesByBoard((int)$board->getId(), $viewer);
+	}
+
+	public function calendarUri(Board $board): string {
+		return self::CALENDAR_URI_PREFIX . (int)$board->getId();
+	}
+
+	/** Parses `board-<id>` back to the board id, or null if it does not match. */
+	public function boardIdFromCalendarUri(string $calendarUri): ?int {
+		if (!str_starts_with($calendarUri, self::CALENDAR_URI_PREFIX)) {
+			return null;
+		}
+		$rest = substr($calendarUri, \strlen(self::CALENDAR_URI_PREFIX));
+		if ($rest === '' || !ctype_digit($rest)) {
+			return null;
+		}
+		return (int)$rest;
+	}
+
+	public function objectName(Card $card): string {
+		return self::OBJECT_PREFIX . (int)$card->getId() . self::OBJECT_SUFFIX;
+	}
+
+	/** Parses `kanso-card-<id>.ics` back to the card id, or null if it does not match. */
+	public function cardIdFromObjectName(string $name): ?int {
+		if (!str_starts_with($name, self::OBJECT_PREFIX) || !str_ends_with($name, self::OBJECT_SUFFIX)) {
+			return null;
+		}
+		$mid = substr($name, \strlen(self::OBJECT_PREFIX), -\strlen(self::OBJECT_SUFFIX));
+		if ($mid === '' || !ctype_digit($mid)) {
+			return null;
+		}
+		return (int)$mid;
+	}
+
+	/** The calendar's display name (the board title) for CalDAV clients. */
+	public function displayName(Board $board): string {
+		return $board->getTitle() ?? 'Kanso board';
+	}
+
+	/** The board colour as a CSS hex (`#rrggbb`) for calendar-color, or null. */
+	public function calendarColor(Board $board): ?string {
+		$color = $board->getColor();
+		if ($color === null || $color === '') {
+			return null;
+		}
+		return str_starts_with($color, '#') ? $color : ('#' . $color);
+	}
+
+	/**
+	 * The card's ETag - changes whenever the card changes. `last_modified` is
+	 * bumped by every card-mutating call (it backs delta-sync), so it is a
+	 * sufficient version stamp for a client's conditional sync.
+	 */
+	public function etag(Card $card): string {
+		return '"kanso-' . (int)$card->getId() . '-' . $this->lastModified($card) . '"';
+	}
+
+	/** The card's last-modified unix time (falls back to created, then 0). */
+	public function lastModified(Card $card): int {
+		$modified = (int)$card->getLastModified();
+		if ($modified > 0) {
+			return $modified;
+		}
+		return (int)$card->getCreatedAt();
+	}
+
+	/**
+	 * Serialises one card to a single-VTODO VCALENDAR string.
+	 *
+	 * @psalm-suppress UndefinedMagicPropertyAssignment VCalendar exposes PRODID
+	 *  via Sabre\VObject's magic __set, which psalm can't see (same use as
+	 *  {@see CalendarFeedService} and {@see RecurrenceService}).
+	 */
+	public function serializeCard(Board $board, Card $card): string {
+		$calendar = new VCalendar();
+		$calendar->PRODID = self::PRODID;
+		$this->addTodo($calendar, $board, $card);
+		return $calendar->serialize();
+	}
+
+	/**
+	 * @psalm-suppress UndefinedMethod Sabre\VObject\Component::add() is a real
+	 *  method on the concrete VTODO/VCalendar components but is typed on the
+	 *  abstract Node in the shipped stubs, so psalm can't resolve it here.
+	 */
+	private function addTodo(VCalendar $calendar, Board $board, Card $card): void {
+		$cardId = (int)$card->getId();
+		// Pin DTSTAMP to the card's own version stamp for a DETERMINISTIC body:
+		// passing it in the create array means VObject does not auto-add its own
+		// "now" DTSTAMP (which would both duplicate the property and churn the
+		// serialisation on every fetch).
+		$stamp = $this->utc($this->lastModified($card));
+		$todo = $calendar->add('VTODO', [
+			// Stable per card, so a client updates the same task across syncs
+			// instead of duplicating it. Scoped to the card + app + board.
+			'UID' => 'kanso-card-' . $cardId . '@board-' . $board->getId(),
+			'SUMMARY' => $card->getTitle() ?? ('#' . $cardId),
+			'DTSTAMP' => $stamp,
+		]);
+
+		$allDay = $card->getAllDay() ?? false;
+		$this->addDate($todo, 'DUE', $card->getDuedate(), $allDay);
+		$this->addDate($todo, 'DTSTART', $card->getStartDate(), $allDay);
+
+		$doneAt = (int)$card->getDoneAt();
+		if ($doneAt > 0) {
+			$todo->add('STATUS', 'COMPLETED');
+			$todo->add('PERCENT-COMPLETE', 100);
+			$todo->add('COMPLETED', $this->utc($doneAt));
+		} else {
+			$todo->add('STATUS', 'NEEDS-ACTION');
+		}
+
+		$link = $this->cardUrl($card);
+		$todo->add('URL', $link);
+		$todo->add('DESCRIPTION', $link);
+
+		$created = (int)$card->getCreatedAt();
+		if ($created > 0) {
+			$todo->add('CREATED', $this->utc($created));
+		}
+		$todo->add('LAST-MODIFIED', $stamp);
+	}
+
+	/**
+	 * Adds a date-valued property, mirroring the ICS feed's all-day handling: an
+	 * all-day card emits `NAME;VALUE=DATE:YYYYMMDD` (timezone-irrelevant); a timed
+	 * card is normalised to an unambiguous UTC instant. No-op when $value is null.
+	 *
+	 * @psalm-suppress UndefinedMethod see {@see self::addTodo}.
+	 */
+	private function addDate(object $todo, string $name, ?\DateTime $value, bool $allDay): void {
+		if ($value === null) {
+			return;
+		}
+		if ($allDay) {
+			$todo->add($name, $value, ['VALUE' => 'DATE']);
+		} else {
+			$todo->add($name, (clone $value)->setTimezone(new \DateTimeZone('UTC')));
+		}
+	}
+
+	private function utc(int $timestamp): \DateTime {
+		return (new \DateTime('@' . $timestamp))->setTimezone(new \DateTimeZone('UTC'));
+	}
+
+	/**
+	 * The deep link back to a card via the fragment-free SERVER route (#3744),
+	 * so a calendar client can open the card cold (surviving the login round-trip).
+	 */
+	private function cardUrl(Card $card): string {
+		return $this->urlGenerator->linkToRouteAbsolute('kanso.deepLink.card', ['id' => (int)$card->getId()]);
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -31,6 +31,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		     Files" (#3645) event listener. The real class is autoloaded at runtime
 		     (the Files app is always enabled). -->
 		<file name="tests/stubs/files.php" />
+		<!-- OCA\DAV\CalDAV\Integration\* (DAV app) and Sabre\DAV\* / Sabre\CalDAV\* /
+		     Sabre\DAVACL\* (server 3rdparty) are not in composer - only sabre/vobject
+		     is. Stub the CalDAV integration surface so psalm can resolve the
+		     read-only VTODO calendar adapters (#3534 / issue #49) in lib/CalDav. The
+		     real classes are autoloaded at runtime (the DAV app is always enabled). -->
+		<file name="tests/stubs/caldav.php" />
 	</stubs>
 	<issueHandlers>
 		<!-- Psalm wants every class marked `final`. We deliberately do NOT: the

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -114,6 +114,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							{{ t('kanso', 'Kanso opens the board list by default. Turn this on to open this board instead.') }}
 						</p>
 						<NcCheckboxRadioSwitch
+							:model-value="inMyCalendar"
+							:disabled="calendarSyncBusy"
+							@update:model-value="setInMyCalendar">
+							{{ t('kanso', 'Show this board in my calendar') }}
+						</NcCheckboxRadioSwitch>
+						<p class="board-settings__general-hint">
+							{{ t('kanso', 'Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you.') }}
+						</p>
+						<NcCheckboxRadioSwitch
 							v-if="canManage"
 							:model-value="newCardsOnTop"
 							:disabled="newCardsOnTopSaving"
@@ -2115,6 +2124,8 @@ import {
 	fetchCalendarFeedConfig,
 	enableCalendarFeed as apiEnableCalendarFeed,
 	disableCalendarFeed as apiDisableCalendarFeed,
+	fetchCalendarSync,
+	setCalendarSync,
 	getSettings,
 	updateSettings,
 } from '../services/api.js'
@@ -2549,6 +2560,30 @@ async function setDefaultBoard(checked) {
 		isDefaultBoard.value = !checked // revert on failure
 	} finally {
 		settingsBusy.value = false
+	}
+}
+
+// ── General: per-user "show this board in my calendar" (CalDAV, issue #49) ────
+// Personal preference; boards sync to your calendar by default, this hides them.
+const inMyCalendar = ref(true)
+const calendarSyncBusy = ref(false)
+onMounted(async () => {
+	try {
+		const res = await fetchCalendarSync(props.boardId)
+		inMyCalendar.value = res.enabled !== false
+	} catch {
+		// Non-fatal: default to on (its server-side default).
+	}
+})
+async function setInMyCalendar(checked) {
+	calendarSyncBusy.value = true
+	try {
+		const res = await setCalendarSync(props.boardId, checked)
+		inMyCalendar.value = res.enabled !== false
+	} catch {
+		inMyCalendar.value = !checked // revert on failure
+	} finally {
+		calendarSyncBusy.value = false
 	}
 }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -420,6 +420,15 @@ export const enableCalendarFeed = (boardId) =>
 export const disableCalendarFeed = (boardId) =>
 	axios.delete(url(`/api/boards/${boardId}/calendar-feed`)).then((r) => r.data)
 
+// Per-user "show this board in my calendar" toggle for the CalDAV VTODO
+// calendars (issue #49). Personal preference (any member); boards sync by
+// default, so this hides the noisy ones from your own calendar.
+export const fetchCalendarSync = (boardId) =>
+	axios.get(url(`/api/boards/${boardId}/calendar-sync`)).then((r) => r.data)
+
+export const setCalendarSync = (boardId, enabled) =>
+	axios.put(url(`/api/boards/${boardId}/calendar-sync`), { enabled }).then((r) => r.data)
+
 // Subscriptions (board watchers)
 export const subscribeBoard = (boardId) =>
 	axios.put(url(`/api/boards/${boardId}/subscription`)).then((r) => r.data)

--- a/tests/e2e/caldav-calendar.spec.js
+++ b/tests/e2e/caldav-calendar.spec.js
@@ -87,4 +87,24 @@ test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 		// Sabre maps the Forbidden the calendar throws to 403 (never 201/204).
 		expect(r.status).toBe(403)
 	})
+
+	test('visibility can be toggled: PROPPATCH calendar-enabled is accepted', async () => {
+		// Clicking a calendar in the Calendar app toggles its visibility via this
+		// PROPPATCH. The calendar grants write-properties, so Nextcloud persists it
+		// as a per-user property (it never touches card data) - it must NOT 403.
+		const body = '<?xml version="1.0"?>\n'
+			+ '<d:propertyupdate xmlns:d="DAV:" xmlns:x="http://owncloud.org/ns">'
+			+ '<d:set><d:prop><x:calendar-enabled>0</x:calendar-enabled></d:prop></d:set>'
+			+ '</d:propertyupdate>'
+		const r = await fetch(DAV + `/${calUri}/`, {
+			method: 'PROPPATCH',
+			headers: { Authorization: AUTH, 'Content-Type': 'application/xml' },
+			body,
+		})
+		expect(r.status).toBe(207)
+		const text = await r.text()
+		expect(text).toContain('calendar-enabled')
+		expect(text).toContain('200 OK')
+		expect(text).not.toContain('403')
+	})
 })

--- a/tests/e2e/caldav-calendar.spec.js
+++ b/tests/e2e/caldav-calendar.spec.js
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const KAN = BASE + '/index.php/apps/kanso/api'
+const DAV = BASE + '/remote.php/dav/calendars/admin'
+const HEADERS = { 'OCS-APIRequest': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from('admin:admin').toString('base64')
+
+async function kanso(method, path, body) {
+	const r = await fetch(KAN + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	const text = await r.text()
+	return text ? JSON.parse(text) : null
+}
+
+async function dav(method, path, extraHeaders = {}) {
+	const r = await fetch(DAV + path, {
+		method,
+		headers: { Authorization: AUTH, ...extraHeaders },
+	})
+	return { status: r.status, body: await r.text() }
+}
+
+// Read-only CalDAV VTODO calendars, one per board (#3534 / issue #49). Cards with
+// a due date surface to the user's CalDAV principal as VTODOs, so Nextcloud
+// Calendar and DAVx5 auto-discover them (the way Deck's board calendars work).
+// This drives the REAL DAV stack over HTTP: it proves the info.xml <sabre>
+// registration is picked up, the board calendar is listed in the calendar-home,
+// and the per-card VTODO object is fetchable and well-formed.
+test.describe('CalDAV board calendar (read-only VTODOs)', () => {
+	let boardId = 0
+	let cardId = 0
+	const title = 'E2E CalDAV ' + Math.floor(Date.now() / 1000)
+	const cardTitle = 'Sync me'
+	// A stable calendar uri (board-<id>) prefixed by the DAV app's app-generated tag.
+	let calUri = ''
+	let objUri = ''
+
+	test.beforeAll(async () => {
+		const board = await kanso('POST', '/boards', { title, color: '0082c9' })
+		boardId = board.id
+		const stack = await kanso('POST', '/stacks', { boardId, title: 'To do' })
+		const card = await kanso('POST', '/cards', { stackId: stack.id, title: cardTitle })
+		cardId = card.id
+		await kanso('PATCH', `/cards/${cardId}`, { duedate: '2026-08-15T09:30:00+00:00' })
+
+		calUri = `app-generated--kanso--board-${boardId}`
+		objUri = `/${calUri}/kanso-card-${cardId}.ics`
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await kanso('DELETE', `/boards/${boardId}`).catch(() => {})
+	})
+
+	test('the board calendar is discoverable in the CalDAV calendar-home', async () => {
+		// PROPFIND the user's calendar-home; the external board calendar must be a child.
+		const { status, body } = await dav('PROPFIND', '/', { Depth: '1' })
+		expect(status).toBe(207)
+		expect(body).toContain(calUri)
+	})
+
+	test('the calendar exposes the due card as a fetchable VTODO', async () => {
+		const { status, body } = await dav('GET', objUri)
+		expect(status).toBe(200)
+		expect(body).toContain('BEGIN:VTODO')
+		expect(body).toContain(`SUMMARY:${cardTitle}`)
+		// Timed due date normalised to a UTC instant.
+		expect(body).toContain('DUE:20260815T093000Z')
+		expect(body).toContain('STATUS:NEEDS-ACTION')
+		// Stable UID so a client updates the same task across syncs.
+		expect(body).toContain(`UID:kanso-card-${cardId}@board-${boardId}`)
+	})
+
+	test('the calendar is read-only: a PUT of a new object is rejected', async () => {
+		const r = await fetch(DAV + `/${calUri}/injected.ics`, {
+			method: 'PUT',
+			headers: { Authorization: AUTH, 'Content-Type': 'text/calendar' },
+			body: 'BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VTODO\r\nUID:x\r\nEND:VTODO\r\nEND:VCALENDAR\r\n',
+		})
+		// Sabre maps the Forbidden the calendar throws to 403 (never 201/204).
+		expect(r.status).toBe(403)
+	})
+})

--- a/tests/e2e/caldav-calendar.spec.js
+++ b/tests/e2e/caldav-calendar.spec.js
@@ -37,6 +37,8 @@ async function dav(method, path, extraHeaders = {}) {
 test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 	let boardId = 0
 	let cardId = 0
+	let allDayCardId = 0
+	let doneCardId = 0
 	const title = 'E2E CalDAV ' + Math.floor(Date.now() / 1000)
 	const cardTitle = 'Sync me'
 	// A stable calendar uri (board-<id>) prefixed by the DAV app's app-generated tag.
@@ -50,6 +52,16 @@ test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 		const card = await kanso('POST', '/cards', { stackId: stack.id, title: cardTitle })
 		cardId = card.id
 		await kanso('PATCH', `/cards/${cardId}`, { duedate: '2026-08-15T09:30:00+00:00' })
+
+		// An all-day due card → the VTODO must carry a DATE-valued DUE (no time).
+		const allDay = await kanso('POST', '/cards', { stackId: stack.id, title: 'All day' })
+		allDayCardId = allDay.id
+		await kanso('PATCH', `/cards/${allDayCardId}`, { duedate: '2026-08-20T00:00:00+00:00', allDay: true })
+
+		// A completed card → the VTODO must be STATUS:COMPLETED.
+		const done = await kanso('POST', '/cards', { stackId: stack.id, title: 'Finished' })
+		doneCardId = done.id
+		await kanso('PATCH', `/cards/${doneCardId}`, { duedate: '2026-08-10T09:00:00+00:00', done: true })
 
 		calUri = `app-generated--kanso--board-${boardId}`
 		objUri = `/${calUri}/kanso-card-${cardId}.ics`
@@ -88,6 +100,21 @@ test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 		expect(r.status).toBe(403)
 	})
 
+	test('an all-day due card is a DATE-valued VTODO (no time component)', async () => {
+		const { status, body } = await dav('GET', `/${calUri}/kanso-card-${allDayCardId}.ics`)
+		expect(status).toBe(200)
+		expect(body).toContain('DUE;VALUE=DATE:20260820')
+		// Must not have emitted a timed DUE for an all-day card.
+		expect(body).not.toContain('DUE:20260820T')
+	})
+
+	test('a completed card is a STATUS:COMPLETED VTODO', async () => {
+		const { status, body } = await dav('GET', `/${calUri}/kanso-card-${doneCardId}.ics`)
+		expect(status).toBe(200)
+		expect(body).toContain('STATUS:COMPLETED')
+		expect(body).toContain('PERCENT-COMPLETE:100')
+	})
+
 	test('visibility can be toggled: PROPPATCH calendar-enabled is accepted', async () => {
 		// Clicking a calendar in the Calendar app toggles its visibility via this
 		// PROPPATCH. The calendar grants write-properties, so Nextcloud persists it
@@ -106,5 +133,62 @@ test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 		expect(text).toContain('calendar-enabled')
 		expect(text).toContain('200 OK')
 		expect(text).not.toContain('403')
+	})
+})
+
+// Per-person access control (#3534 / issue #49). The CalDAV surface is scoped to
+// board membership: a user who is NOT a member of a board must never see that
+// board's calendar in their own calendar-home, nor be able to fetch its cards -
+// and sharing the board with them must grant access. This drives two real
+// principals (admin owns the board; `tester` is the outsider) over HTTP.
+test.describe.serial('CalDAV board calendar access control', () => {
+	// Multi-user: BasicAuth per request, and must NOT inherit the shared admin
+	// session (see the e2e storageState guard).
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	const TESTER = 'Basic ' + Buffer.from('tester:kanso-dev-tester!1').toString('base64')
+	const TESTER_DAV = BASE + '/remote.php/dav/calendars/tester'
+	let boardId = 0
+	let cardId = 0
+	let calUri = ''
+
+	async function testerDav(method, path) {
+		const r = await fetch(TESTER_DAV + path, { method, headers: { Authorization: TESTER, Depth: '1' } })
+		return { status: r.status, body: await r.text() }
+	}
+
+	test.beforeAll(async () => {
+		const board = await kanso('POST', '/boards', { title: 'E2E CalDAV ACL ' + Math.floor(Date.now() / 1000) })
+		boardId = board.id
+		const stack = await kanso('POST', '/stacks', { boardId, title: 'To do' })
+		const card = await kanso('POST', '/cards', { stackId: stack.id, title: 'members only' })
+		cardId = card.id
+		await kanso('PATCH', `/cards/${cardId}`, { duedate: '2026-08-15T09:30:00+00:00' })
+		calUri = `app-generated--kanso--board-${boardId}`
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await kanso('DELETE', `/boards/${boardId}`).catch(() => {})
+	})
+
+	test('a non-member never sees the board calendar and cannot fetch its cards', async () => {
+		const home = await testerDav('PROPFIND', '/')
+		expect(home.status).toBe(207)
+		expect(home.body).not.toContain(calUri)
+		// The card object is existence-safe: not found (never 200) for a non-member.
+		const obj = await testerDav('GET', `/${calUri}/kanso-card-${cardId}.ics`)
+		expect(obj.status).toBe(404)
+	})
+
+	test('sharing the board grants the member the calendar', async () => {
+		await kanso('POST', `/boards/${boardId}/acl`, {
+			participant: 'tester', participantType: 'user', permission: 1, role: 'internal',
+		})
+		const home = await testerDav('PROPFIND', '/')
+		expect(home.status).toBe(207)
+		expect(home.body).toContain(calUri)
+		const obj = await testerDav('GET', `/${calUri}/kanso-card-${cardId}.ics`)
+		expect(obj.status).toBe(200)
+		expect(obj.body).toContain('SUMMARY:members only')
 	})
 })

--- a/tests/e2e/caldav-toggle.spec.js
+++ b/tests/e2e/caldav-toggle.spec.js
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+// Does the user's CalDAV calendar-home currently list this board's calendar?
+async function calendarPresent(boardId) {
+	const r = await fetch(`${BASE}/remote.php/dav/calendars/admin/`, {
+		method: 'PROPFIND',
+		headers: { Authorization: AUTH, Depth: '1' },
+	})
+	return (await r.text()).includes(`app-generated--kanso--board-${boardId}`)
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// Per-user "show this board in my calendar" toggle (issue #49). Boards sync to
+// your CalDAV calendar by default; this personal switch (in board settings →
+// General, available to any member) hides the noisy ones from YOUR calendar.
+// Driven through the real UI so a broken switch binding can't pass silently
+// (the calendar-feed switch once regressed exactly that way).
+test.describe('CalDAV per-board calendar toggle (UI)', () => {
+	const state = { boardId: 0, cardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'CalDAV toggle ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })
+		const card = await api('POST', '/cards', { stackId: stack.id, title: 'due card' })
+		state.cardId = card.id
+		await api('PATCH', `/cards/${card.id}`, { duedate: '2026-08-15T09:30:00+00:00' })
+	})
+
+	test.afterAll(async () => {
+		// Re-enable (clears the per-user hidden preference) then delete the board.
+		await api('PUT', `/boards/${state.boardId}/calendar-sync`, { enabled: true }).catch(() => {})
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('toggling it off removes the board from your calendar, on restores it', async ({ page }) => {
+		// Default: on, so the board is already in the calendar-home.
+		expect(await calendarPresent(state.boardId)).toBe(true)
+
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /general/i }).click()
+		await expect(page.locator('#bs-pane-general')).toBeVisible({ timeout: 8_000 })
+		// Personal calendar switch lives in the General pane (any member).
+		const toggle = page.getByText('Show this board in my calendar')
+		await expect(toggle).toBeVisible({ timeout: 8_000 })
+
+		// Turn it OFF → the board must drop out of the calendar-home.
+		await toggle.click()
+		await expect.poll(() => calendarPresent(state.boardId), { timeout: 8_000 }).toBe(false)
+
+		// Turn it back ON → it returns.
+		await toggle.click()
+		await expect.poll(() => calendarPresent(state.boardId), { timeout: 8_000 }).toBe(true)
+	})
+})

--- a/tests/e2e/caldav-visibility.spec.js
+++ b/tests/e2e/caldav-visibility.spec.js
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const ADMIN = 'Basic ' + Buffer.from('admin:admin').toString('base64')
+const TESTER = 'Basic ' + Buffer.from('tester:kanso-dev-tester!1').toString('base64')
+
+async function api(auth, method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: auth },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+// GET a card's VTODO from a principal's own board calendar.
+async function davGet(auth, principal, calUri, cardId) {
+	const r = await fetch(`${BASE}/remote.php/dav/calendars/${principal}/${calUri}/kanso-card-${cardId}.ics`, {
+		method: 'GET',
+		headers: { Authorization: auth },
+	})
+	return { status: r.status, body: await r.text() }
+}
+
+// Security / multi-tenancy for the CalDAV VTODO calendars (#3534 / issue #49).
+// The feed is per-principal AND per-card-visibility: a board member only receives
+// the due cards they'd see on the board, and a card hidden from them (private,
+// owner-only) must never reach their CalDAV feed even though they CAN see the
+// board. Plus: the per-user calendar-sync toggle is membership-gated. Two real
+// users over the real DAV/HTTP stack.
+test.describe.serial('CalDAV visibility + endpoint permissions', () => {
+	// Multi-user: BasicAuth per request, do not inherit the shared admin session.
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	const token = 'cv' + Math.floor(Date.now() / 1000)
+	const state = { boardId: 0, otherBoardId: 0, calUri: '', pubId: 0, privId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api(ADMIN, 'POST', '/boards', { title: 'CalDAV visibility ' + token })
+		state.boardId = board.id
+		state.calUri = `app-generated--kanso--board-${board.id}`
+		const stack = await api(ADMIN, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
+
+		// tester is an INTERNAL member — sees public + internal cards, never private.
+		await api(ADMIN, 'POST', `/boards/${board.id}/acl`, {
+			participant: 'tester', participantType: 'user', permission: 1, role: 'internal',
+		})
+
+		// A public card both can see, and a private (owner-only) card only admin
+		// can see. Both have due dates, so both are candidates for the feed.
+		const pub = await api(ADMIN, 'POST', '/cards', { stackId: stack.id, title: 'pub ' + token })
+		state.pubId = pub.id
+		await api(ADMIN, 'PATCH', `/cards/${pub.id}`, { duedate: '2026-08-15T09:30:00+00:00' })
+
+		const priv = await api(ADMIN, 'POST', '/cards', { stackId: stack.id, title: 'secret ' + token })
+		state.privId = priv.id
+		await api(ADMIN, 'PATCH', `/cards/${priv.id}`, { duedate: '2026-08-16T09:30:00+00:00', visibility: 'private' })
+
+		// A second board admin does NOT share with tester (for the endpoint test).
+		const other = await api(ADMIN, 'POST', '/boards', { title: 'CalDAV unshared ' + token })
+		state.otherBoardId = other.id
+	})
+
+	test.afterAll(async () => {
+		for (const id of [state.boardId, state.otherBoardId]) {
+			if (id) await api(ADMIN, 'DELETE', `/boards/${id}`).catch(() => {})
+		}
+	})
+
+	test('a member never receives a card hidden from them (private stays owner-only)', async () => {
+		// The owner sees their own private card over CalDAV…
+		expect((await davGet(ADMIN, 'admin', state.calUri, state.privId)).status).toBe(200)
+
+		// …the member sees the public card…
+		const memberPub = await davGet(TESTER, 'tester', state.calUri, state.pubId)
+		expect(memberPub.status).toBe(200)
+		expect(memberPub.body).toContain(`pub ${token}`)
+
+		// …but NOT the private one: existence-safe 404, never the card body.
+		const memberPriv = await davGet(TESTER, 'tester', state.calUri, state.privId)
+		expect(memberPriv.status).toBe(404)
+		expect(memberPriv.body).not.toContain(`secret ${token}`)
+	})
+
+	test('a non-member cannot toggle calendar-sync for a board they cannot see', async () => {
+		const r = await fetch(`${API}/boards/${state.otherBoardId}/calendar-sync`, {
+			method: 'PUT',
+			headers: { ...HEADERS, Authorization: TESTER },
+			body: JSON.stringify({ enabled: false }),
+		})
+		// NotAMemberException → NotPermittedException → 403 (never silently applied).
+		expect(r.status).toBe(403)
+	})
+})

--- a/tests/stubs/caldav.php
+++ b/tests/stubs/caldav.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Psalm stubs for the CalDAV integration surface Kanso builds on for the
+// read-only VTODO calendar (#3534 / issue #49). None of these symbols ship via
+// composer: `OCA\DAV\CalDAV\Integration\*` lives in the Nextcloud DAV app and
+// `Sabre\DAV\*` / `Sabre\CalDAV\*` / `Sabre\DAVACL\*` live in the server's
+// bundled 3rdparty (only `sabre/vobject` is a composer dependency). All are
+// autoloaded at runtime - the DAV app is always enabled - so these declarations
+// exist purely so psalm can resolve the symbols and type-check the adapters in
+// `lib/CalDav`. Signatures mirror the real (largely untyped) Sabre interfaces so
+// the adapter implementations stay compatible.
+
+namespace Sabre\DAV {
+	interface INode {
+		public function delete();
+		public function getName();
+		public function setName($name);
+		public function getLastModified();
+	}
+
+	interface ICollection extends INode {
+		public function createFile($name, $data = null);
+		public function createDirectory($name);
+		public function getChild($name);
+		public function getChildren();
+		public function childExists($name);
+	}
+
+	interface IFile extends INode {
+		public function put($data);
+		public function get();
+		public function getContentType();
+		public function getETag();
+		public function getSize();
+	}
+
+	interface IProperties extends INode {
+		public function propPatch(PropPatch $propPatch);
+		public function getProperties($properties);
+	}
+
+	class PropPatch {
+	}
+
+	class Exception extends \Exception {
+	}
+}
+
+namespace Sabre\DAV\Exception {
+	class Forbidden extends \Sabre\DAV\Exception {
+	}
+
+	class NotFound extends \Sabre\DAV\Exception {
+	}
+
+	class MethodNotAllowed extends \Sabre\DAV\Exception {
+	}
+}
+
+namespace Sabre\DAVACL {
+	interface IACL {
+		public function getOwner();
+		public function getGroup();
+		public function getACL();
+		public function setACL(array $acl);
+		public function getSupportedPrivilegeSet();
+	}
+}
+
+namespace Sabre\CalDAV {
+	interface ICalendarObjectContainer extends \Sabre\DAV\ICollection {
+		public function calendarQuery(array $filters);
+	}
+
+	interface ICalendar extends ICalendarObjectContainer, \Sabre\DAVACL\IACL {
+	}
+
+	interface ICalendarObject extends \Sabre\DAV\IFile {
+	}
+
+	class Plugin {
+		public const NS_CALDAV = 'urn:ietf:params:xml:ns:caldav';
+	}
+
+	class CalendarQueryValidator {
+		public function validate(\Sabre\VObject\Component\VCalendar $vObject, array $filters): bool {
+			return true;
+		}
+	}
+}
+
+namespace Sabre\CalDAV\Xml\Property {
+	class SupportedCalendarComponentSet {
+		/** @param string[] $components */
+		public function __construct(array $components) {
+		}
+	}
+}
+
+namespace OCA\DAV\CalDAV\Integration {
+	interface ICalendarProvider {
+		public function getAppId(): string;
+		public function fetchAllForCalendarHome(string $principalUri): array;
+		public function hasCalendarInCalendarHome(string $principalUri, string $calendarUri): bool;
+		public function getCalendarInCalendarHome(string $principalUri, string $calendarUri): ?ExternalCalendar;
+	}
+
+	abstract class ExternalCalendar implements \Sabre\CalDAV\ICalendar, \Sabre\DAV\IProperties {
+		public function __construct(string $appId, string $calendarUri) {
+		}
+
+		public function getName() {
+			return '';
+		}
+
+		public function setName($name) {
+		}
+
+		public function createDirectory($name) {
+		}
+
+		public static function isAppGeneratedCalendar(string $calendarUri): bool {
+			return false;
+		}
+
+		/** @return string[] */
+		public static function splitAppGeneratedCalendarUri(string $calendarUri): array {
+			return [];
+		}
+
+		public static function doesViolateReservedName(string $calendarUri): bool {
+			return false;
+		}
+	}
+}

--- a/tests/unit/Service/CardCalendarServiceTest.php
+++ b/tests/unit/Service/CardCalendarServiceTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Access\BoardAccess;
+use OCA\Kanso\Access\NotAMemberException;
+use OCA\Kanso\Access\ViewerContext;
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Service\CardCalendarService;
+use OCA\Kanso\Service\PermissionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CardCalendarServiceTest extends TestCase {
+	private const PRINCIPAL = 'principals/users/alice';
+
+	private BoardMapper&MockObject $boardMapper;
+	private CardMapper&MockObject $cardMapper;
+	private BoardAccess&MockObject $boardAccess;
+	private PermissionService&MockObject $permissionService;
+	private IURLGenerator&MockObject $urlGenerator;
+	private CardCalendarService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->boardMapper = $this->createMock(BoardMapper::class);
+		$this->cardMapper = $this->createMock(CardMapper::class);
+		$this->boardAccess = $this->createMock(BoardAccess::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->urlGenerator->method('linkToRouteAbsolute')
+			->willReturnCallback(static fn (string $route, array $args): string => 'https://nc/index.php/apps/kanso/card/' . $args['id']);
+		$this->service = new CardCalendarService(
+			$this->boardMapper,
+			$this->cardMapper,
+			$this->boardAccess,
+			$this->permissionService,
+			$this->urlGenerator,
+		);
+	}
+
+	private function board(int $id = 7, string $owner = 'alice', ?string $color = '0082c9', bool $archived = false, int $deletedAt = 0): Board {
+		$b = new Board();
+		$b->setId($id);
+		$b->setOwner($owner);
+		$b->setTitle('Roadmap');
+		$b->setColor($color);
+		$b->setArchived($archived);
+		$b->setDeletedAt($deletedAt);
+		$b->setLastModified(1000);
+		return $b;
+	}
+
+	private function card(int $id, string $title, ?\DateTime $due, bool $allDay = false, int $doneAt = 0): Card {
+		$c = new Card();
+		$c->setId($id);
+		$c->setBoardId(7);
+		$c->setStackId(10);
+		$c->setTitle($title);
+		$c->setDuedate($due);
+		$c->setAllDay($allDay);
+		$c->setDoneAt($doneAt);
+		$c->setCreatedAt(1_700_000_000);
+		$c->setLastModified(1_700_000_500);
+		return $c;
+	}
+
+	private function member(int $boardId = 7): ViewerContext {
+		return ViewerContext::forMember('alice', $boardId, ViewerContext::ROLE_INTERNAL, true);
+	}
+
+	// ── principal parsing ──────────────────────────────────────────────────
+
+	public function testPrincipalUidAcceptsOnlyUserPrincipals(): void {
+		self::assertSame('alice', $this->service->principalUid('principals/users/alice'));
+		self::assertNull($this->service->principalUid('principals/groups/team'));
+		self::assertNull($this->service->principalUid('principals/system/system'));
+		self::assertNull($this->service->principalUid('principals/users/'));
+		self::assertNull($this->service->principalUid('nonsense'));
+	}
+
+	// ── uri / name round-trips ─────────────────────────────────────────────
+
+	public function testCalendarUriRoundTrips(): void {
+		$board = $this->board(42);
+		self::assertSame('board-42', $this->service->calendarUri($board));
+		self::assertSame(42, $this->service->boardIdFromCalendarUri('board-42'));
+		self::assertNull($this->service->boardIdFromCalendarUri('board-'));
+		self::assertNull($this->service->boardIdFromCalendarUri('board-x'));
+		self::assertNull($this->service->boardIdFromCalendarUri('personal'));
+	}
+
+	public function testObjectNameRoundTrips(): void {
+		$card = $this->card(99, 'x', null);
+		self::assertSame('kanso-card-99.ics', $this->service->objectName($card));
+		self::assertSame(99, $this->service->cardIdFromObjectName('kanso-card-99.ics'));
+		self::assertNull($this->service->cardIdFromObjectName('kanso-card-.ics'));
+		self::assertNull($this->service->cardIdFromObjectName('kanso-card-99'));
+		self::assertNull($this->service->cardIdFromObjectName('other.ics'));
+	}
+
+	// ── board listing ──────────────────────────────────────────────────────
+
+	public function testBoardsForPrincipalSkipsArchivedAndNonUserPrincipals(): void {
+		$this->permissionService->method('getUserGroupIds')->with('alice')->willReturn(['team']);
+		$this->boardMapper->method('findAllForUser')->with('alice', ['team'])->willReturn([
+			$this->board(1),
+			$this->board(2, archived: true),
+			$this->board(3),
+		]);
+
+		$boards = $this->service->boardsForPrincipal(self::PRINCIPAL);
+		self::assertSame([1, 3], array_map(static fn (Board $b): int => (int)$b->getId(), $boards));
+
+		// A group/system principal gets nothing (never even queries the mapper).
+		self::assertSame([], $this->service->boardsForPrincipal('principals/groups/team'));
+	}
+
+	public function testBoardForPrincipalReturnsBoardForMember(): void {
+		$board = $this->board(7);
+		$this->boardMapper->method('find')->with(7)->willReturn($board);
+		$this->boardAccess->expects(self::once())->method('contextFor')
+			->with($board, 'alice')->willReturn($this->member());
+
+		self::assertSame($board, $this->service->boardForPrincipal(self::PRINCIPAL, 'board-7'));
+	}
+
+	public function testBoardForPrincipalNullForNonMember(): void {
+		$board = $this->board(7);
+		$this->boardMapper->method('find')->with(7)->willReturn($board);
+		$this->boardAccess->method('contextFor')
+			->willThrowException(new NotAMemberException('nope'));
+
+		self::assertNull($this->service->boardForPrincipal(self::PRINCIPAL, 'board-7'));
+	}
+
+	public function testBoardForPrincipalNullForDeletedArchivedOrMissing(): void {
+		// Deleted board.
+		$this->boardMapper->method('find')->willReturnCallback(function (int $id): Board {
+			if ($id === 8) {
+				throw new DoesNotExistException('gone');
+			}
+			return $this->board(9, deletedAt: $id === 9 ? 12345 : 0, archived: $id === 10);
+		});
+
+		self::assertNull($this->service->boardForPrincipal(self::PRINCIPAL, 'board-8')); // missing
+		self::assertNull($this->service->boardForPrincipal(self::PRINCIPAL, 'board-9')); // deleted
+		self::assertNull($this->service->boardForPrincipal(self::PRINCIPAL, 'board-10')); // archived
+		self::assertNull($this->service->boardForPrincipal(self::PRINCIPAL, 'garbage')); // bad uri
+	}
+
+	public function testDueCardsScopesToViewer(): void {
+		$board = $this->board(7);
+		$viewer = $this->member();
+		$cards = [$this->card(1, 'a', new \DateTime('2026-08-15T09:30:00+00:00'))];
+		$this->boardAccess->method('contextFor')->with($board, 'alice')->willReturn($viewer);
+		$this->cardMapper->expects(self::once())->method('findDuedateSummariesByBoard')
+			->with(7, $viewer)->willReturn($cards);
+
+		self::assertSame($cards, $this->service->dueCards($board, 'alice'));
+	}
+
+	// ── VTODO serialisation ────────────────────────────────────────────────
+
+	public function testSerializeTimedCardEmitsUtcVtodo(): void {
+		$board = $this->board(7);
+		$card = $this->card(3, 'Ship it', new \DateTime('2026-08-15T09:30:00+00:00'));
+
+		$ics = $this->service->serializeCard($board, $card);
+		self::assertStringContainsString('BEGIN:VTODO', $ics);
+		self::assertStringContainsString('UID:kanso-card-3@board-7', $ics);
+		self::assertStringContainsString('SUMMARY:Ship it', $ics);
+		self::assertStringContainsString('DUE:20260815T093000Z', $ics);
+		self::assertStringContainsString('STATUS:NEEDS-ACTION', $ics);
+		self::assertStringContainsString('https://nc/index.php/apps/kanso/card/3', $ics);
+		self::assertStringNotContainsString('STATUS:COMPLETED', $ics);
+		// Exactly one DTSTAMP - the auto-added "now" one must be replaced, not doubled.
+		self::assertSame(1, substr_count($ics, 'DTSTAMP:'));
+	}
+
+	public function testSerializeAllDayCardEmitsDateValue(): void {
+		$board = $this->board(7);
+		$card = $this->card(4, 'All day', new \DateTime('2026-08-15T00:00:00+00:00'), allDay: true);
+
+		$ics = $this->service->serializeCard($board, $card);
+		self::assertStringContainsString('DUE;VALUE=DATE:20260815', $ics);
+		self::assertStringNotContainsString('DUE:20260815T', $ics);
+	}
+
+	public function testSerializeDoneCardMarksCompleted(): void {
+		$board = $this->board(7);
+		$card = $this->card(5, 'Done card', new \DateTime('2026-08-15T09:30:00+00:00'), doneAt: 1_700_001_000);
+
+		$ics = $this->service->serializeCard($board, $card);
+		self::assertStringContainsString('STATUS:COMPLETED', $ics);
+		self::assertStringContainsString('PERCENT-COMPLETE:100', $ics);
+		self::assertStringContainsString('COMPLETED:', $ics);
+	}
+
+	// ── etag + colour ──────────────────────────────────────────────────────
+
+	public function testEtagChangesWithLastModified(): void {
+		$card = $this->card(6, 'x', null);
+		$first = $this->service->etag($card);
+		$card->setLastModified(1_700_009_999);
+		self::assertNotSame($first, $this->service->etag($card));
+	}
+
+	public function testCalendarColorGetsHashPrefix(): void {
+		self::assertSame('#0082c9', $this->service->calendarColor($this->board(1, color: '0082c9')));
+		self::assertSame('#abc', $this->service->calendarColor($this->board(1, color: '#abc')));
+		self::assertNull($this->service->calendarColor($this->board(1, color: null)));
+	}
+}

--- a/tests/unit/Service/CardCalendarServiceTest.php
+++ b/tests/unit/Service/CardCalendarServiceTest.php
@@ -17,6 +17,7 @@ use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Service\CardCalendarService;
 use OCA\Kanso\Service\PermissionService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -29,6 +30,7 @@ class CardCalendarServiceTest extends TestCase {
 	private BoardAccess&MockObject $boardAccess;
 	private PermissionService&MockObject $permissionService;
 	private IURLGenerator&MockObject $urlGenerator;
+	private IConfig&MockObject $config;
 	private CardCalendarService $service;
 
 	protected function setUp(): void {
@@ -38,6 +40,7 @@ class CardCalendarServiceTest extends TestCase {
 		$this->boardAccess = $this->createMock(BoardAccess::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->urlGenerator->method('linkToRouteAbsolute')
 			->willReturnCallback(static fn (string $route, array $args): string => 'https://nc/index.php/apps/kanso/card/' . $args['id']);
 		$this->service = new CardCalendarService(
@@ -46,6 +49,7 @@ class CardCalendarServiceTest extends TestCase {
 			$this->boardAccess,
 			$this->permissionService,
 			$this->urlGenerator,
+			$this->config,
 		);
 	}
 
@@ -124,6 +128,44 @@ class CardCalendarServiceTest extends TestCase {
 
 		// A group/system principal gets nothing (never even queries the mapper).
 		self::assertSame([], $this->service->boardsForPrincipal('principals/groups/team'));
+	}
+
+	public function testBoardsForPrincipalHidesUserHiddenBoards(): void {
+		$this->permissionService->method('getUserGroupIds')->willReturn([]);
+		$this->boardMapper->method('findAllForUser')->willReturn([
+			$this->board(1), $this->board(2), $this->board(3),
+		]);
+		// alice has hidden board 2 from her calendar.
+		$this->config->method('getUserValue')
+			->with('alice', 'kanso', 'calendar_hidden_boards', '')
+			->willReturn('[2]');
+
+		$boards = $this->service->boardsForPrincipal(self::PRINCIPAL);
+		self::assertSame([1, 3], array_map(static fn (Board $b): int => (int)$b->getId(), $boards));
+		self::assertFalse($this->service->isEnabledForUser('alice', 2));
+		self::assertTrue($this->service->isEnabledForUser('alice', 1));
+	}
+
+	public function testSetEnabledForUserHidesAMemberBoard(): void {
+		$board = $this->board(7);
+		$this->boardMapper->method('find')->with(7)->willReturn($board);
+		$this->boardAccess->expects(self::once())->method('contextFor')
+			->with($board, 'alice')->willReturn($this->member());
+		$this->config->method('getUserValue')->willReturn(''); // nothing hidden yet
+		$this->config->expects(self::once())->method('setUserValue')
+			->with('alice', 'kanso', 'calendar_hidden_boards', '[7]');
+
+		$this->service->setEnabledForUser('alice', 7, false);
+	}
+
+	public function testSetEnabledForUserRejectsNonMember(): void {
+		$board = $this->board(7);
+		$this->boardMapper->method('find')->with(7)->willReturn($board);
+		$this->boardAccess->method('contextFor')->willThrowException(new NotAMemberException('nope'));
+		$this->config->expects(self::never())->method('setUserValue');
+
+		$this->expectException(NotAMemberException::class);
+		$this->service->setEnabledForUser('alice', 7, false);
 	}
 
 	public function testBoardForPrincipalReturnsBoardForMember(): void {


### PR DESCRIPTION
## What & why

Closes #49. Board cards with due dates now appear as a **read-only calendar in each user's Nextcloud CalDAV account**, so they show up automatically in Nextcloud Calendar, the Tasks app, and mobile CalDAV clients like **DAVx5** — no manual subscription URL. This is the "cards in the calendar, synced to my phone" ask from the issue.

Scoped (with the user) as **read-only VTODOs, v1** of card #3534. Two-way write-back (completing/editing from the calendar client) is deliberately out of scope and can be a follow-up.

## How it works

- Registers an `OCA\DAV\CalDAV\Integration\ICalendarProvider` via the `info.xml` `<sabre>` block, gated by the new `dav` app `<type>` (without that type the DAV app's `PluginManager` silently skips the plugin — discovered during live testing).
- Each accessible, non-archived board becomes a calendar `app-generated--kanso--board-<id>`; each card **with a due date** becomes a `VTODO` (title, due — all-day or timed/UTC, start date, `STATUS` NEEDS-ACTION/COMPLETED, and a deep link back to the card). Stable UID + deterministic `DTSTAMP` so a client updates rather than duplicates, and the body doesn't churn.
- **Per-person + access-scoped:** the reader is the authenticated CalDAV principal. `BoardAccess::contextFor` gates board membership and the new `CardMapper::findDuedateSummariesByBoard(boardId, viewer)` applies that viewer's card visibility — a member only sees the due cards they'd see on the board (unlike the anonymous, public-only ICS token feed).
- **Strictly read-only:** every write (PUT/DELETE/MKCALENDAR/PROPPATCH/setACL) is rejected with `403`.

## Structure

- `lib/Service/CardCalendarService.php` — Sabre-free, unit-tested core (board resolution, visibility, VTODO serialisation, uri/name round-trips).
- `lib/CalDav/{CalendarProvider,CardCalendar,CardCalendarObject}.php` — thin Sabre/DAV adapters that delegate to the service. Serialisation is lazy per object, so a calendar-home listing never serialises card bodies.
- `tests/stubs/caldav.php` — psalm stubs for the DAV-app + Sabre-DAV symbols (not shipped via composer; the DAV app provides them at runtime), registered in `psalm.xml`.

## Testing

- **Unit:** `CardCalendarServiceTest` (13 tests) — principal parsing, uri/name round-trips, archived/deleted/non-member filtering, viewer scoping, and VTODO output (timed vs all-day, done→COMPLETED, single DTSTAMP). Full suite green (1325 tests).
- **e2e:** `caldav-calendar.spec.js` drives the **real DAV stack over HTTP** — PROPFINDs the calendar-home and asserts the board calendar is discoverable, GETs the per-card VTODO, and asserts a PUT is rejected `403`. Ran green locally against the dev Nextcloud.
- **Runtime contract check:** verified the adapters bind to the *real* `ExternalCalendar`/Sabre interfaces inside the running container (so the psalm stubs are faithful).
- `psalm` + `php-cs-fixer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)