### PR TITLE
Show release notes on the Nextcloud app store (#57)

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -116,6 +116,41 @@ find "$STAGE_DIR" \
 	-type d -prune -exec rm -rf {} +
 
 # ---------------------------------------------------------------------------
+# 2b. Rewrite the bundled CHANGELOG.md into the App Store's format (#57)
+# ---------------------------------------------------------------------------
+# The store reads CHANGELOG.md from the archive and imports the released
+# version's notes (nextcloudappstore/api/v1/release/parser.py). It matches
+# version headings with `^## (?:\[)?(?:v)?(\d+\.\d+(\.\d+)?)`, keyed on
+# appinfo/info.xml's <version>: the heading MUST be level-2 (`## `), but a `[`
+# bracket, a `v` prefix and any trailing text (dates, links) are ignored — and
+# only the lines BELOW the heading are shown as the notes. semantic-release
+# writes minor/major headings as level-1 `# [X.Y.Z](compare-url) (date)`, which
+# the `^## ` anchor never matches, so those releases import empty notes. Rewrite
+# every version heading in the STAGED copy to `## X.Y.Z - date` (the repo's rich
+# human changelog is untouched), BEFORE signing so the rewrite is covered by the
+# integrity signature (a later edit would break it).
+if [[ -f "$STAGE_DIR/CHANGELOG.md" ]]; then
+	log "Normalising bundled CHANGELOG.md to the App Store heading format"
+	# `# [X.Y.Z](url) (date)` / `## [X.Y.Z](url)` / `# X.Y.Z (date)` → `## X.Y.Z - date`.
+	# Most-specific rule first; once a line is rewritten it no longer matches the
+	# looser rules, so no double-substitution.
+	sed -i -E \
+		-e 's|^#{1,3} \[([0-9]+\.[0-9]+\.[0-9]+)\]\([^)]*\)[[:space:]]*\(([0-9]{4}-[0-9]{2}-[0-9]{2})\).*|## \1 - \2|' \
+		-e 's|^#{1,3} \[([0-9]+\.[0-9]+\.[0-9]+)\]\([^)]*\).*|## \1|' \
+		-e 's|^#{1,3} ([0-9]+\.[0-9]+\.[0-9]+) \(([0-9]{4}-[0-9]{2}-[0-9]{2})\).*|## \1 - \2|' \
+		-e 's|^#{1,3} \[([0-9]+\.[0-9]+\.[0-9]+)\][[:space:]]*-[[:space:]]*([0-9]{4}-[0-9]{2}-[0-9]{2}).*|## \1 - \2|' \
+		"$STAGE_DIR/CHANGELOG.md"
+
+	# Sanity-check: the store keys on the info.xml version, so the released
+	# version MUST carry a `## X.Y.Z` heading now or the notes come through empty.
+	APP_VERSION="$(sed -n 's|.*<version>\([0-9][0-9.]*\)</version>.*|\1|p' "$STAGE_DIR/appinfo/info.xml" | head -1)"
+	if [[ -n "$APP_VERSION" ]] && ! grep -qE "^## ${APP_VERSION//./\\.}( |\$)" "$STAGE_DIR/CHANGELOG.md"; then
+		warn "CHANGELOG.md has no '## ${APP_VERSION}' heading after the rewrite —"
+		warn "the App Store will import empty release notes for v${APP_VERSION}."
+	fi
+fi
+
+# ---------------------------------------------------------------------------
 # 3. Sign the app (optional — needs a private key + certificate + occ)
 # ---------------------------------------------------------------------------
 KEY_FILE=""


### PR DESCRIPTION
Fixes #57 (reported by @mhzawadi) — app-store updates showed no release notes.

## Root cause
The Nextcloud app store reads `CHANGELOG.md` from the release tarball and imports the released version's section, matching version headings with `^## (\d+\.\d+\.\d+)` and keying on `appinfo/info.xml`'s `<version>` ([appstore docs](https://nextcloudappstore.readthedocs.io/en/latest/developer.html)). semantic-release writes headings as `# [0.11.0](compare-url) (date)` — level-1 and link-prefixed — which never matches that regex, so the store imported an empty changelog.

## Fix
`scripts/build-release.sh` (run by semantic-release's `@semantic-release/exec` prepare step, after `apply-version.sh`) now rewrites the **bundled** changelog's version headings to `## X.Y.Z - date` **before** signing, so the integrity signature covers the rewritten file. It also asserts the released version has a matching heading and warns if not. The repo's rich, linked `CHANGELOG.md` is left untouched — only the tarball copy is normalised.

## Verification
- `bash -n` clean.
- Ran the real script end-to-end (`SKIP_BUILD=1`): the staged `build/kanso/CHANGELOG.md` top entry becomes `## 0.11.0 - 2026-08-19`, matches `^## (\d+\.\d+\.\d+)`, and equals `info.xml`'s version. Older hand-written `## [x.y.z] - date` entries are normalised too.

## Notes
- Release-tooling only — no app/runtime code changes.
- Takes effect from the **next** release onward (the store re-parses the changelog on each new release).
- Localised `CHANGELOG.<code>.md` variants are out of scope here.
- Merge with a **merge commit** so the `fix:` type lands for semantic-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)