### PR TITLE
fix: import boards with very large lists without a "rebalance_required" error

### DIFF
--- a/lib/Service/DeckImportService.php
+++ b/lib/Service/DeckImportService.php
@@ -148,15 +148,24 @@ class DeckImportService {
 			$deckCardIds = [];
 			$stackCount = 0;
 			$cardCount = 0;
-			$stackKey = null;
-			foreach ($this->deckReader->readStacks($deckBoardId) as $ds) {
+			// Lay out sort keys as one bounded, evenly-spaced block per level
+			// (stacks here, each stack's cards below) rather than chaining after()
+			// once per item. A single append grows the fractional key by a
+			// character every ~26 items, so a stack of ~1150+ cards (or that many
+			// stacks) would push a key past the varchar(64) column and abort the
+			// whole import with a spurious "rebalance_required". appendSequence
+			// keeps every key short (<= 4 chars even for 200k items) while
+			// preserving source order - the same layout the CSV importer uses.
+			$stacks = $this->deckReader->readStacks($deckBoardId);
+			$stackKeys = $this->sortKeyService->appendSequence(count($stacks), null);
+			$stackIndex = 0;
+			foreach ($stacks as $ds) {
 				$stack = new Stack();
 				$stack->setBoardId($boardId);
 				// Stack title column is STRING(100); no description to spill the
 				// remainder into, so a long title is just safely truncated.
 				$stack->setTitle(TitleSanitizer::truncate($ds['title'], self::MAX_STACK_TITLE_LENGTH));
-				$stackKey = $stackKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($stackKey);
-				$stack->setSortKey($stackKey);
+				$stack->setSortKey($stackKeys[$stackIndex++]);
 				$stack->setArchived(false);
 				$stack->setRole(Stack::ROLE_NONE);
 				$stack->setWipLimit(null);
@@ -164,8 +173,10 @@ class DeckImportService {
 				$newStackId = $this->stackMapper->insert($stack)->getId();
 				$stackCount++;
 
-				$cardKey = null;
-				foreach ($this->deckReader->readCards($ds['id']) as $dc) {
+				$cards = $this->deckReader->readCards($ds['id']);
+				$cardKeys = $this->sortKeyService->appendSequence(count($cards), null);
+				$cardIndex = 0;
+				foreach ($cards as $dc) {
 					$card = new Card();
 					$card->setBoardId($boardId);
 					$card->setStackId($newStackId);
@@ -183,8 +194,7 @@ class DeckImportService {
 					}
 					$card->setTitle(TitleSanitizer::truncate($title, CardService::MAX_TITLE_LENGTH));
 					$card->setDescription($description);
-					$cardKey = $cardKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($cardKey);
-					$card->setSortKey($cardKey);
+					$card->setSortKey($cardKeys[$cardIndex++]);
 					$card->setDuedate($dc['duedate'] !== null ? (new \DateTime())->setTimestamp($dc['duedate']) : null);
 					$card->setDoneAt($dc['doneAt']);
 					$card->setArchived($dc['archived']);

--- a/lib/Service/TrelloImportService.php
+++ b/lib/Service/TrelloImportService.php
@@ -207,8 +207,13 @@ class TrelloImportService {
 		$lists = $this->rows($doc, 'lists');
 		usort($lists, static fn (array $a, array $b): int => ((float)($a['pos'] ?? 0)) <=> ((float)($b['pos'] ?? 0)));
 
+		// One bounded, evenly-spaced key block instead of chaining after() per
+		// list: a board with ~1150+ lists would otherwise overflow the varchar(64)
+		// sort_key column and abort the import. See the note in importCards().
+		$listKeys = $this->sortKeyService->appendSequence(count($lists), null);
+		$listIndex = 0;
+
 		$map = [];
-		$stackKey = null;
 		foreach ($lists as $row) {
 			$trelloId = isset($row['id']) ? (string)$row['id'] : null;
 			if ($trelloId === null) {
@@ -217,8 +222,7 @@ class TrelloImportService {
 			$stack = new Stack();
 			$stack->setBoardId($boardId);
 			$stack->setTitle($this->title(isset($row['name']) && is_string($row['name']) ? $row['name'] : ''));
-			$stackKey = $stackKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($stackKey);
-			$stack->setSortKey($stackKey);
+			$stack->setSortKey($listKeys[$listIndex++]);
 			$stack->setArchived((bool)($row['closed'] ?? false));
 			$stack->setRole(Stack::ROLE_NONE);
 			$stack->setWipLimit(null);
@@ -262,15 +266,21 @@ class TrelloImportService {
 			$cards = $byList[$trelloListId] ?? [];
 			usort($cards, static fn (array $a, array $b): int => ((float)($a['pos'] ?? 0)) <=> ((float)($b['pos'] ?? 0)));
 
-			$cardKey = null;
+			// One bounded, evenly-spaced key block per list rather than chaining
+			// after() per card: an append grows the fractional key by a character
+			// every ~26 cards, so a list of ~1150+ cards would push a key past the
+			// varchar(64) sort_key column and abort the whole import with a
+			// spurious "rebalance_required". appendSequence keeps keys short (<= 4
+			// chars for 200k cards) while preserving Trello `pos` order.
+			$cardKeys = $this->sortKeyService->appendSequence(count($cards), null);
+			$cardIndex = 0;
 			foreach ($cards as $row) {
 				$card = new Card();
 				$card->setBoardId($boardId);
 				$card->setStackId($newStackId);
 				$card->setTitle($this->title(isset($row['name']) && is_string($row['name']) ? $row['name'] : ''));
 				$card->setDescription(isset($row['desc']) && is_string($row['desc']) && $row['desc'] !== '' ? $row['desc'] : null);
-				$cardKey = $cardKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($cardKey);
-				$card->setSortKey($cardKey);
+				$card->setSortKey($cardKeys[$cardIndex++]);
 				$due = $this->toTimestamp($row['due'] ?? null);
 				$card->setDuedate($due !== null ? (new \DateTime())->setTimestamp($due) : null);
 				// Trello marks a due date complete with `dueComplete`; treat that as
@@ -350,7 +360,12 @@ class TrelloImportService {
 	 * @param list<array<string, mixed>> $checklists
 	 */
 	private function attachChecklists(array $checklists, int $newCardId, int $now): void {
-		$itemKey = null;
+		// Flatten every checkItem across the card's checklists into one ordered run
+		// first, then hand the whole run a single bounded, evenly-spaced key block.
+		// Chaining after() per item would grow the fractional key a character every
+		// ~26 items, so a card with ~1150+ checklist items would overflow the
+		// varchar(64) sort_key column and abort the import (see importCards()).
+		$ordered = [];
 		foreach ($checklists as $checklist) {
 			$items = [];
 			foreach ((array)($checklist['checkItems'] ?? []) as $item) {
@@ -359,21 +374,24 @@ class TrelloImportService {
 				}
 			}
 			usort($items, static fn (array $a, array $b): int => ((float)($a['pos'] ?? 0)) <=> ((float)($b['pos'] ?? 0)));
-
 			foreach ($items as $item) {
-				$entity = new ChecklistItem();
-				$entity->setCardId($newCardId);
-				$entity->setTitle($this->title(isset($item['name']) && is_string($item['name']) ? $item['name'] : ''));
-				$entity->setDone(($item['state'] ?? null) === 'complete');
-				$itemKey = $itemKey === null ? $this->sortKeyService->initial() : $this->sortKeyService->after($itemKey);
-				$entity->setSortKey($itemKey);
-				$entity->setCreatedAt($now);
-				$due = $this->parseCheckItemDue($item['due'] ?? null);
-				if ($due !== null) {
-					$entity->setDueDate($due);
-				}
-				$this->checklistItemMapper->insert($entity);
+				$ordered[] = $item;
 			}
+		}
+
+		$itemKeys = $this->sortKeyService->appendSequence(count($ordered), null);
+		foreach ($ordered as $index => $item) {
+			$entity = new ChecklistItem();
+			$entity->setCardId($newCardId);
+			$entity->setTitle($this->title(isset($item['name']) && is_string($item['name']) ? $item['name'] : ''));
+			$entity->setDone(($item['state'] ?? null) === 'complete');
+			$entity->setSortKey($itemKeys[$index]);
+			$entity->setCreatedAt($now);
+			$due = $this->parseCheckItemDue($item['due'] ?? null);
+			if ($due !== null) {
+				$entity->setDueDate($due);
+			}
+			$this->checklistItemMapper->insert($entity);
 		}
 	}
 

--- a/tests/unit/Service/DeckImportServiceTest.php
+++ b/tests/unit/Service/DeckImportServiceTest.php
@@ -404,6 +404,73 @@ class DeckImportServiceTest extends TestCase {
 		self::assertSame([], $this->service->listImportableBoards('alice'));
 	}
 
+	// ---- large stacks do not overflow the sort key (#rebalance_required) ----
+
+	/**
+	 * A stack far larger than ~1150 cards used to abort the import: chaining
+	 * after() once per card grew the fractional sort key past the varchar(64)
+	 * column, surfacing as a spurious "rebalance_required" 409. The block is now
+	 * laid out with a single bounded appendSequence, so a huge stack imports with
+	 * short, strictly-increasing, source-ordered keys.
+	 */
+	public function testImportLargeStackDoesNotOverflowSortKey(): void {
+		$this->deckReader->method('isAvailable')->willReturn(true);
+		$this->deckReader->method('userCanReadBoard')->willReturn(true);
+		$this->deckReader->method('readBoard')->with(2)
+			->willReturn(['id' => 2, 'title' => 'B', 'color' => null, 'owner' => 'carol']);
+		$board = new Board();
+		$board->setId(100);
+		$board->setTitle('B');
+		$this->boardService->method('create')->willReturn($board);
+
+		// Well past the old ~1153-card overflow threshold.
+		$cardCount = 2000;
+		$deckCards = [];
+		for ($i = 0; $i < $cardCount; $i++) {
+			$deckCards[] = [
+				'id' => $i + 1,
+				'title' => 'Card ' . $i,
+				'description' => '',
+				'archived' => false,
+				'duedate' => null,
+				'doneAt' => 0,
+				'createdAt' => 0,
+			];
+		}
+
+		$this->deckReader->method('readLabels')->willReturn([]);
+		$this->deckReader->method('readStacks')->willReturn([['id' => 11, 'title' => 'To do']]);
+		$this->deckReader->method('readCards')->willReturn($deckCards);
+		$this->deckReader->method('readAssignedLabels')->willReturn([]);
+		$this->deckReader->method('readAssignedUsers')->willReturn([]);
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
+
+		$this->stackMapper->method('insert')->willReturnCallback($this->autoId());
+
+		$sortKeys = [];
+		$cardId = 500;
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$sortKeys, &$cardId): Card {
+			$c->setId($cardId++);
+			$sortKeys[] = $c->getSortKey();
+			return $c;
+		});
+
+		$result = $this->service->importBoard(2, 'alice');
+
+		self::assertSame($cardCount, $result['cards']);
+		self::assertCount($cardCount, $sortKeys);
+		// Every key stays well under the varchar(64) column and preserves order.
+		foreach ($sortKeys as $key) {
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($key));
+		}
+		$sorted = $sortKeys;
+		sort($sorted, SORT_STRING);
+		self::assertSame($sorted, $sortKeys, 'imported sort keys must be strictly increasing in source order');
+		self::assertSame(count(array_unique($sortKeys)), count($sortKeys), 'sort keys must be unique');
+	}
+
 	// ---- transaction (#3478) ----------------------------------------------
 
 	private function stubReadableBoard(): void {

--- a/tests/unit/Service/DeckImportServiceTest.php
+++ b/tests/unit/Service/DeckImportServiceTest.php
@@ -205,6 +205,11 @@ class DeckImportServiceTest extends TestCase {
 		self::assertSame(1, $capturedCards[1]->getStackId());
 		// Sort keys are strictly increasing within the stack.
 		self::assertLessThan($capturedCards[1]->getSortKey(), $capturedCards[0]->getSortKey());
+		// ...and every key stays within the varchar(64) sort_key column - the
+		// invariant that a large import must not break (#rebalance_required).
+		foreach ($capturedCards as $c) {
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($c->getSortKey()));
+		}
 	}
 
 	// ---- long / edge-case titles (#3906) ----------------------------------

--- a/tests/unit/Service/TrelloImportServiceTest.php
+++ b/tests/unit/Service/TrelloImportServiceTest.php
@@ -247,6 +247,12 @@ class TrelloImportServiceTest extends TestCase {
 		self::assertSame(strtotime('2026-02-01T09:00:00.000Z'), $checklistItems[1]->getDueDate()?->getTimestamp());
 		self::assertNull($checklistItems[1]->getAssignedUser());
 		self::assertNull($checklistItems[0]->getDueDate());
+
+		// Every generated key stays within the varchar(64) sort_key column - the
+		// invariant that a large import must not break (#rebalance_required).
+		foreach ([...$stacks, ...$cards, ...$checklistItems] as $entity) {
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($entity->getSortKey()));
+		}
 	}
 
 	public function testTruncatesLongTitlesToFitColumns(): void {

--- a/tests/unit/Service/TrelloImportServiceTest.php
+++ b/tests/unit/Service/TrelloImportServiceTest.php
@@ -281,6 +281,67 @@ class TrelloImportServiceTest extends TestCase {
 		self::assertSame(100, mb_strlen($capturedCard->getTitle()));
 	}
 
+	/**
+	 * A list of far more than ~1150 cards - and a card with that many checklist
+	 * items - used to abort the import: chaining after() once per item grew the
+	 * fractional sort key past the varchar(64) column ("rebalance_required").
+	 * Both are now laid out with a single bounded appendSequence, so a huge board
+	 * imports with short, strictly-increasing, source-ordered keys.
+	 */
+	public function testImportLargeListAndChecklistDoNotOverflowSortKey(): void {
+		$this->db->expects(self::once())->method('commit');
+		$this->boardService->method('create')->willReturn($this->newBoard('Big'));
+		$this->stackMapper->method('insert')->willReturnCallback($this->autoId('stack', 30));
+
+		$cardKeys = [];
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$cardKeys): Card {
+			$this->seq['card'] ??= 100;
+			$c->setId($this->seq['card']++);
+			$cardKeys[] = $c->getSortKey();
+			return $c;
+		});
+
+		$itemKeys = [];
+		$this->checklistItemMapper->method('insert')->willReturnCallback(function (ChecklistItem $i) use (&$itemKeys): ChecklistItem {
+			$i->setId(count($itemKeys) + 5000);
+			$itemKeys[] = $i->getSortKey();
+			return $i;
+		});
+
+		// Well past the old ~1153-item overflow threshold, on ONE list.
+		$count = 2000;
+		$cards = [];
+		$checkItems = [];
+		for ($i = 0; $i < $count; $i++) {
+			$cards[] = ['id' => 'C' . $i, 'idList' => 'L1', 'name' => 'Card ' . $i, 'pos' => $i + 1];
+			$checkItems[] = ['name' => 'Item ' . $i, 'pos' => $i + 1, 'state' => 'incomplete'];
+		}
+		// One card also carries a huge single checklist (its items share one key run).
+		$checklists = [['id' => 'CL1', 'idCard' => 'C0', 'pos' => 1, 'checkItems' => $checkItems]];
+
+		$doc = [
+			'name' => 'Big',
+			'lists' => [['id' => 'L1', 'name' => 'To do', 'pos' => 1]],
+			'cards' => $cards,
+			'checklists' => $checklists,
+		];
+
+		$result = $this->service->import(json_encode($doc), 'importer');
+
+		self::assertSame($count, $result['cards']);
+		self::assertCount($count, $cardKeys);
+		self::assertCount($count, $itemKeys);
+		foreach ([$cardKeys, $itemKeys] as $keys) {
+			foreach ($keys as $key) {
+				self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($key));
+			}
+			$sorted = $keys;
+			sort($sorted, SORT_STRING);
+			self::assertSame($sorted, $keys, 'keys must be strictly increasing in source order');
+			self::assertSame(count(array_unique($keys)), count($keys), 'keys must be unique');
+		}
+	}
+
 	public function testImportRollsBackOnFailure(): void {
 		$this->db->expects(self::once())->method('beginTransaction');
 		$this->db->expects(self::once())->method('rollBack');


### PR DESCRIPTION
## What & why

Importing a board (Deck or Trello) whose stack contained more than **~1150 cards** aborted with a `rebalance_required` 409 and imported nothing.

### Root cause

The whole-board importers assigned each stack / card / checklist-item its fractional sort key by chaining `SortKeyService::after()` once per item, starting from `initial()`. That's the exact anti-pattern the `SortKeyService::appendSequence()` docblock warns against: a single append grows the key by a character every ~26 items, so the key crosses the `varchar(64)` `sort_key` column mid-batch and `SortKeyService::guardLength()` throws `\OverflowException` → `ApiErrorTrait` maps it to `{"error":"rebalance_required"}`. The import runs in one transaction, so the whole thing rolls back.

Reproduced with the real `SortKeyService`: chaining `after()` overflows at **card #1153** in a single stack. The spreadsheet importer (`CsvImportService`) already dodged this by pre-laying-out one bounded `appendSequence()` block; the Deck/Trello importers never got the same treatment.

### Fix

Replace the per-item `after()` chaining with a single `appendSequence(count, null)` block per level, in all three affected paths:
- `DeckImportService` — stacks + each stack's cards
- `TrelloImportService::importLists` / `importCards` — lists + each list's cards
- `TrelloImportService::attachChecklists` — a card's checklist items (flattened across its checklists into one ordered run first)

`appendSequence` sizes a fixed-width base-36 grid to the item count, so keys stay **≤ 4 chars even for 200k items**, strictly increasing, source order preserved.

## Tests

- New regression test in `DeckImportServiceTest` (2000-card stack) and `TrelloImportServiceTest` (2000-card list + a 2000-item checklist). Both assert the import succeeds with short, unique, strictly-increasing keys.
- Verified the Deck test **fails on the old code** with the exact `OverflowException: Sort key would exceed 64 characters` and passes on the fix.
- `cs-check` clean, `psalm` no errors, all 67 import/sort-key unit tests green.

## Notes / follow-up

Out of scope here, but worth considering: there's still **no auto-rebalance-and-retry** on the *interactive* CSV-append path (`CsvImportService` appending into a stack whose existing tail key is already near the wall). That path can still legitimately return `rebalance_required`; silently rebalancing the target stack and retrying once would be a nicer UX than telling the user to run `occ kanso:rebalance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)