### PR TITLE
Mobile card-view polish, recurring-task indicators & dark-mode legibility

### DIFF
--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -22,6 +22,7 @@ use OCA\Kanso\Db\ChecklistItem;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 use OCA\Kanso\Service\AssigneeService;
 use OCA\Kanso\Service\CardRelationService;
 use OCA\Kanso\Service\CardService;
@@ -71,6 +72,7 @@ class CardController extends Controller {
 		private BoardMapper $boardMapper,
 		private BoardAccess $boardAccess,
 		private \OCA\Kanso\Service\CardVisibilityGuard $visibilityGuard,
+		private RecurRuleMapper $recurRuleMapper,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -180,7 +182,12 @@ class CardController extends Controller {
 			+ ['fieldValues' => array_map(
 				static fn (CardFieldValue $v): array => $v->jsonSerialize(),
 				$this->cardFieldValueMapper->findByCard($id)
-			)];
+			)]
+			// Live (enabled) recurrence rule present? (#61 follow-up) One boolean
+			// so the open card can swap the Due Date pill's calendar icon for a
+			// repeat icon for ALL viewers - matching the board tile. The rrule/rule
+			// object stays out; it loads via the manager-only rules fetch.
+			+ ['recurring' => $this->recurRuleMapper->hasEnabledRuleForCard($id)];
 	}
 
 	/**

--- a/lib/Db/RecurRuleMapper.php
+++ b/lib/Db/RecurRuleMapper.php
@@ -56,6 +56,30 @@ class RecurRuleMapper extends QBMapper {
 	}
 
 	/**
+	 * Template card ids on the board that carry an ENABLED recurrence rule -
+	 * powers the tile "recurring" badge in one board-scoped query (no N+1).
+	 * Disabled/exhausted rules are excluded so only live schedules badge.
+	 *
+	 * @return int[]
+	 * @throws Exception
+	 */
+	public function findTemplateCardIdsByBoard(int $boardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->selectDistinct('template_card_id')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)));
+
+		$result = $qb->executeQuery();
+		$ids = [];
+		while (($row = $result->fetch()) !== false) {
+			$ids[] = (int)$row['template_card_id'];
+		}
+		$result->closeCursor();
+		return $ids;
+	}
+
+	/**
 	 * Every enabled rule due to fire now - the cron's work list. A rule is due
 	 * when it is enabled, has a cached next fire time (`next_occurrence_at > 0`,
 	 * so exhausted/never rules are excluded) and that time has passed. Hits the

--- a/lib/Db/RecurRuleMapper.php
+++ b/lib/Db/RecurRuleMapper.php
@@ -80,6 +80,29 @@ class RecurRuleMapper extends QBMapper {
 	}
 
 	/**
+	 * Does this template card carry a live (ENABLED) recurrence rule? Drives the
+	 * "recurring" boolean on the full card detail payload so the open-card view
+	 * matches the board tile for ALL viewers (the manager-only rule fetch can't
+	 * be the sole driver). One indexed existence check - no rule object is
+	 * loaded. Mirrors findTemplateCardIdsByBoard's enabled-only gate.
+	 *
+	 * @throws Exception
+	 */
+	public function hasEnabledRuleForCard(int $cardId): bool {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('template_card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->setMaxResults(1);
+
+		$result = $qb->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+		return $row !== false;
+	}
+
+	/**
 	 * Every enabled rule due to fire now - the cron's work list. A rule is due
 	 * when it is enabled, has a cached next fire time (`next_occurrence_at > 0`,
 	 * so exhausted/never rules are excluded) and that time has passed. Hits the

--- a/lib/Service/CardSummaryService.php
+++ b/lib/Service/CardSummaryService.php
@@ -17,6 +17,7 @@ use OCA\Kanso\Db\CardRelationMapper;
 use OCA\Kanso\Db\CardReviewMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 
 /**
  * Builds board-card SUMMARIES enriched with the same per-card signal every
@@ -46,6 +47,7 @@ class CardSummaryService {
 		private CommentMapper $commentMapper,
 		private CardReviewMapper $cardReviewMapper,
 		private CardRelationMapper $cardRelationMapper,
+		private RecurRuleMapper $recurRuleMapper,
 	) {
 	}
 
@@ -66,6 +68,10 @@ class CardSummaryService {
 		$reviewStateByCard = $this->cardReviewMapper->reviewStatesByBoard($boardId);
 		// Card ids blocked by a not-done card - drives the tile "blocked" badge.
 		$blockedIds = array_flip($this->cardRelationMapper->blockedCardIdsByBoard($boardId));
+		// Template card ids with a live (enabled) recurrence rule - drives the
+		// tile "recurring" badge. Only the boolean presence ships to the summary;
+		// the rrule/rule object stays out of the board payload.
+		$recurringIds = array_flip($this->recurRuleMapper->findTemplateCardIdsByBoard($boardId));
 
 		// array_values so the result is a genuine list (Card[] may be keyed by the
 		// mapper); the consumer serializes it as a JSON array.
@@ -80,7 +86,8 @@ class CardSummaryService {
 				+ ['childProgress' => $childProgressByCard[$card->getId()] ?? ['total' => 0, 'done' => 0]]
 				+ ['commentCount' => $commentCountByCard[$card->getId()] ?? 0]
 				+ ['reviewState' => $reviewStateByCard[$card->getId()] ?? null]
-				+ ['blocked' => isset($blockedIds[$card->getId()])],
+				+ ['blocked' => isset($blockedIds[$card->getId()])]
+				+ ['recurring' => isset($recurringIds[$card->getId()])],
 			$cards
 		));
 	}

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -402,10 +402,28 @@ function isOverdue(card) {
 
 <style scoped>
 .board-list-table {
+	/* Legible success green for the approved-review indicator: stock green in
+	 * light, brighter #3fb950 under dark so it stays readable on the dark row. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
 	padding: 8px 24px 24px 52px;
+}
+
+/* Brighten success green under dark themes (explicit picker + auto). */
+body.theme--dark .board-list-table,
+[data-theme-dark] .board-list-table,
+[data-themes*='dark'] .board-list-table {
+	--kanso-success-legible: #3fb950;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .board-list-table,
+	body:not(.theme--light):not(.theme--dark) .board-list-table {
+		--kanso-success-legible: #3fb950;
+	}
 }
 
 .board-list-table__host {
@@ -633,7 +651,7 @@ function isOverdue(card) {
 	font-weight: 600;
 }
 
-.board-list-row__review--approved { color: var(--color-success, #2fb344); }
+.board-list-row__review--approved { color: var(--kanso-success-legible); }
 .board-list-row__review--changes { color: var(--color-error); }
 
 .board-list-row__assignees {

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -4906,7 +4906,7 @@ async function doDeleteAutoRule(rule) {
 
 .automation__archive-result {
 	font-size: 0.8rem;
-	color: var(--color-success, #46ba61);
+	color: var(--kanso-success-legible);
 	font-weight: 600;
 }
 
@@ -5068,7 +5068,7 @@ async function doDeleteAutoRule(rule) {
 }
 
 .github-webhook__status {
-	color: var(--color-success, #2fb344);
+	color: var(--kanso-success-legible);
 	font-weight: 600;
 }
 
@@ -5087,6 +5087,12 @@ async function doDeleteAutoRule(rule) {
 /* ── Board settings modal shell (replaces NcAppSidebar) ─────────────────────── */
 
 .bs-modal {
+	/* Legible success green for "active"/"enabled" status badges (e.g. "Link
+	 * active"): stock --color-success in light, a brighter green (#3fb950) under
+	 * dark so the badge text/border stays readable on the dark surface. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+	--kanso-success-legible-rgb: 70, 186, 97;
+
 	position: absolute;
 	/* Dock BELOW the board toolbar so the gear button that toggles this panel
 	   stays clickable — a second gear click must be able to close it. BoardView
@@ -5103,6 +5109,23 @@ async function doDeleteAutoRule(rule) {
 	border-left: 1px solid var(--color-border);
 	box-shadow: var(--shadow-dropdown, 0 0 12px rgba(0, 0, 0, 0.12));
 	box-sizing: border-box;
+}
+
+/* Brighten success green under dark themes (explicit picker + auto) so status
+ * badges clear WCAG AA on the dark surface. Mirrors the CardTile error token. */
+body.theme--dark .bs-modal,
+[data-theme-dark] .bs-modal,
+[data-themes*='dark'] .bs-modal {
+	--kanso-success-legible: #3fb950;
+	--kanso-success-legible-rgb: 63, 185, 80;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .bs-modal,
+	body:not(.theme--light):not(.theme--dark) .bs-modal {
+		--kanso-success-legible: #3fb950;
+		--kanso-success-legible-rgb: 63, 185, 80;
+	}
 }
 
 .bs-modal__header {
@@ -5435,10 +5458,10 @@ async function doDeleteAutoRule(rule) {
 	align-items: center;
 	gap: 3px;
 	padding: 1px 7px;
-	border: 1px solid var(--color-success);
+	border: 1px solid var(--kanso-success-legible);
 	border-radius: 10px;
-	color: var(--color-success);
-	background: var(--kanso-tint-success, color-mix(in srgb, var(--color-success) 12%, transparent));
+	color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.12);
 	font-size: 0.75rem;
 	font-weight: 600;
 }

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -7615,10 +7615,25 @@ body.theme--dark .card-modal,
 		word-break: normal;
 		overflow-wrap: anywhere;
 	}
-	/* Attributes live in their own "Details" tab and wrap cleanly instead of
-	   scrolling as a cramped one-line strip. */
+	/* Attributes stay at the top and wrap cleanly instead of scrolling as a
+	   cramped one-line strip. */
 	.card-modal__attrbar { flex-wrap: wrap; gap: 8px; padding: 12px 16px; }
 	.card-modal__attr-right { margin-left: 0; }
+	/* Attribute-bar popovers (review request, type, due, label, assignee…) are
+	   absolutely positioned off a small pill, so a right-anchored one can spill
+	   past the screen edge once the pill wraps mid-row (#4058). Pin them to the
+	   viewport as an inset sheet so they always render fully on-screen. */
+	.card-modal__attrbar .card-modal__popover {
+		position: fixed;
+		left: 12px;
+		right: 12px;
+		top: auto;
+		bottom: 12px;
+		width: auto;
+		min-width: 0;
+		max-width: none;
+		max-height: 60vh;
+	}
 	.card-modal__body { grid-template-columns: 1fr; }
 	/* Panes stack: the persisted split width and its drag handle are ignored. */
 	.card-modal__resizer { display: none; }

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1036,7 +1036,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						role="tab"
 						:aria-selected="viewMode === 'discussion'"
 						@click="viewMode = 'discussion'">
-						{{ t('kanso', 'Discussion') }}<span v-if="commentCount > 0"> {{ commentCount }}</span>
+						{{ t('kanso', 'Discussion') }}<span v-if="commentCount > 0" class="card-modal__tab-count">{{ commentCount }}</span>
 					</button>
 				</div>
 
@@ -7554,6 +7554,13 @@ body.theme--dark .card-modal,
 	border-bottom-color: var(--color-primary-element);
 	color: var(--color-primary-element);
 	font-weight: 600;
+}
+/* Comment-count badge on the Discussion tab — its own spacing so the number
+   never renders glued to the label (Vue condenses a leading text space away). */
+.card-modal__tab-count {
+	margin-inline-start: 6px;
+	font-variant-numeric: tabular-nums;
+	color: var(--color-text-maxcontrast);
 }
 
 /* Keep every round button/dot a perfect circle (#3492). Two forces turn them

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -545,7 +545,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							:class="cardData.duedate ? dueDateClass : 'card-modal__pill--dashed'"
 							:aria-expanded="openPicker === 'due'"
 							@click="togglePicker('due')">
-							<CalendarIcon :size="14" />
+							<!-- A recurring card swaps the calendar glyph for a repeat
+							     icon (#61 follow-up), matching the board tile cue for
+							     all viewers. Same footprint, so no layout shift. -->
+							<RepeatIcon v-if="cardIsRecurring" :size="14" :title="t('kanso', 'Repeats')" />
+							<CalendarIcon v-else :size="14" />
 							{{ cardData.duedate ? dueDateLabel : t('kanso', 'Due date') }}
 						</button>
 						<div v-if="openPicker === 'due'" class="card-modal__popover card-modal__popover--pad">
@@ -2179,6 +2183,7 @@ import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import EmoticonHappyOutlineIcon from 'vue-material-design-icons/EmoticonHappyOutline.vue'
 import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
+import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import GithubIcon from 'vue-material-design-icons/Github.vue'
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
@@ -3693,6 +3698,13 @@ const {
 const cardRecurRule = computed(() =>
 	(recurRulesData.value ?? []).find((r) => Number(r.templateCardId) === Number(props.cardId)) ?? null,
 )
+
+// Does this card recur? (#61 follow-up) Drives the repeat-icon swap on the Due
+// Date pill. Prefer the detail payload's `recurring` boolean so ALL viewers see
+// the cue (matching the board tile); OR-in the manager-only rule so the icon
+// flips instantly when a manager toggles recurrence in the popover, before any
+// refetch.
+const cardIsRecurring = computed(() => !!cardData.value?.recurring || !!cardRecurRule.value)
 
 // Split an RRULE into FREQ + INTERVAL, flagging any token this simple control
 // can't represent (BYDAY / COUNT / UNTIL / …).

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1021,16 +1021,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</div>
 
 				<!-- Mobile tab bar - visible only on narrow viewports, sits under the attribute bar -->
-				<div class="card-modal__tabbar">
+				<div class="card-modal__tabbar" role="tablist">
 					<button
 						class="card-modal__tab"
 						:class="{ 'card-modal__tab--active': viewMode === 'card' }"
+						role="tab"
+						:aria-selected="viewMode === 'card'"
 						@click="viewMode = 'card'">
 						{{ t('kanso', 'Card') }}
 					</button>
 					<button
 						class="card-modal__tab"
 						:class="{ 'card-modal__tab--active': viewMode === 'discussion' }"
+						role="tab"
+						:aria-selected="viewMode === 'discussion'"
 						@click="viewMode = 'discussion'">
 						{{ t('kanso', 'Discussion') }}<span v-if="commentCount > 0"> {{ commentCount }}</span>
 					</button>
@@ -7604,7 +7608,9 @@ body.theme--dark .card-modal,
 		word-break: normal;
 		overflow-wrap: anywhere;
 	}
-	.card-modal__attrbar { flex-wrap: nowrap; overflow-x: auto; padding: 10px 16px; }
+	/* Attributes live in their own "Details" tab and wrap cleanly instead of
+	   scrolling as a cramped one-line strip. */
+	.card-modal__attrbar { flex-wrap: wrap; gap: 8px; padding: 12px 16px; }
 	.card-modal__attr-right { margin-left: 0; }
 	.card-modal__body { grid-template-columns: 1fr; }
 	/* Panes stack: the persisted split width and its drag handle are ignored. */

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -7540,8 +7540,36 @@ async function handleToggleProject(projectId) {
 
 /* ── Responsive: stack panes, switch via tabs ────────────────────────────── */
 @media (max-width: 680px) {
-	.card-modal__header { padding: 14px 16px 10px; }
-	.card-modal__title { font-size: 1.2rem; }
+	/* Reflow the header so the action cluster wraps below the title instead of
+	   squeezing the title column toward 0 width (which made the title render one
+	   letter per line). The title row and the actions row each take the full
+	   width; the title column can no longer be crushed by flex-shrink:0 actions. */
+	.card-modal__header {
+		flex-wrap: wrap;
+		padding: 14px 16px 10px;
+	}
+	/* In modal mode NcModal teleports its own close (X) button to the top-right of
+	   the modal container, outside this component's scoped tree. Reserve room on
+	   the right so the breadcrumb/title never slide under it. */
+	.card-modal--mode-modal .card-modal__header { padding-right: 48px; }
+	.card-modal__header-main {
+		/* Force the title column onto its own full-width row. */
+		flex: 1 0 100%;
+		min-width: 0;
+	}
+	.card-modal__header-actions {
+		/* Actions drop to their own row below the title and may wrap among
+		   themselves on very narrow screens rather than overflowing. */
+		flex-basis: 100%;
+		flex-wrap: wrap;
+	}
+	.card-modal__title {
+		font-size: 1.2rem;
+		/* Wrap on word boundaries and only break inside a word as a last resort,
+		   so a long title never renders one character per line. */
+		word-break: normal;
+		overflow-wrap: anywhere;
+	}
 	.card-modal__attrbar { flex-wrap: nowrap; overflow-x: auto; padding: 10px 16px; }
 	.card-modal__attr-right { margin-left: 0; }
 	.card-modal__body { grid-template-columns: 1fr; }

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -5407,12 +5407,34 @@ async function handleToggleProject(projectId) {
 
 /* ── Modal shell ─────────────────────────────────────────────────────────── */
 .card-modal {
+	/* Legible success green for the feature-type pill, approved-review pill and
+	 * the "done" toggle: stock --color-success in light, a brighter green
+	 * (#3fb950) under dark so text/border stay readable on the dark surface. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+	--kanso-success-legible-rgb: 70, 186, 97;
+
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
 	background: var(--color-main-background);
 	color: var(--color-main-text);
 	font-size: 15px;
+}
+
+/* Brighten success green under dark themes (explicit picker + auto). */
+body.theme--dark .card-modal,
+[data-theme-dark] .card-modal,
+[data-themes*='dark'] .card-modal {
+	--kanso-success-legible: #3fb950;
+	--kanso-success-legible-rgb: 63, 185, 80;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .card-modal,
+	body:not(.theme--light):not(.theme--dark) .card-modal {
+		--kanso-success-legible: #3fb950;
+		--kanso-success-legible-rgb: 63, 185, 80;
+	}
 }
 
 /* ── Loading skeleton (shimmer, real layout) ─────────────────────────────── */
@@ -5668,9 +5690,9 @@ async function handleToggleProject(projectId) {
 	color: var(--color-primary-element);
 }
 .card-modal__done-btn--done {
-	border-color: var(--color-success);
-	color: var(--color-success-text, var(--color-success));
-	background: var(--kanso-tint-success, color-mix(in srgb, var(--color-success) 10%, var(--color-main-background)));
+	border-color: var(--kanso-success-legible);
+	color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.1);
 }
 /* Watch control: a single split-button pill — the watch toggle (left half) and
    the watchers caret (right half) sit flush, sharing one border with a thin 1px
@@ -5874,7 +5896,7 @@ async function handleToggleProject(projectId) {
 .card-modal__pill--priority-3 { border-color: #e07b00; color: #e07b00; font-weight: 600; }
 .card-modal__pill--priority-4 { border-color: var(--color-error-text); color: var(--color-error-text); font-weight: 600; }
 .card-modal__pill--type-bug { border-color: #e74c3c; color: #e74c3c; font-weight: 600; }
-.card-modal__pill--type-feature { border-color: #27ae60; color: #27ae60; font-weight: 600; }
+.card-modal__pill--type-feature { border-color: var(--kanso-success-legible); color: var(--kanso-success-legible); font-weight: 600; }
 .card-modal__pill--type-task { border-color: var(--color-primary-element); color: var(--color-primary-element); font-weight: 600; }
 .card-modal__pill--type-chore { border-color: #7f8c8d; color: #7f8c8d; font-weight: 600; }
 .card-modal__pill--overdue { border-color: var(--color-error-text); color: var(--color-error-text); font-weight: 600; }
@@ -5943,7 +5965,7 @@ async function handleToggleProject(projectId) {
 	font-size: 0.75rem;
 }
 .card-modal__review-pill--pending { border-color: var(--color-warning-text); background: rgba(236, 167, 0, 0.08); }
-.card-modal__review-pill--approved { border-color: var(--color-success-text); background: rgba(70, 186, 97, 0.08); }
+.card-modal__review-pill--approved { border-color: var(--kanso-success-legible); background: rgba(var(--kanso-success-legible-rgb), 0.08); }
 .card-modal__review-pill--changes_requested { border-color: var(--color-error-text); background: rgba(233, 50, 45, 0.08); }
 /* A gated (deferred) review reads as inert: greyed out, dashed border, muted
    colours. The lock icon + hover tooltip explain it's waiting on an earlier
@@ -5977,7 +5999,7 @@ async function handleToggleProject(projectId) {
 	font-weight: 600;
 }
 .card-modal__review-state--pending { color: var(--color-warning-text); }
-.card-modal__review-state--approved { color: var(--color-success-text); }
+.card-modal__review-state--approved { color: var(--kanso-success-legible); }
 .card-modal__review-state--changes_requested { color: var(--color-error-text); }
 .card-modal__review-state--gated { color: var(--color-text-maxcontrast); }
 /* Compact mode (3+ reviews): drop the reviewer name and the state text so the

--- a/src/components/CardPreview.vue
+++ b/src/components/CardPreview.vue
@@ -292,6 +292,10 @@ onBeforeUnmount(() => {
 	 * CardTile (#3905): stock --color-error in light, brighter red under dark. */
 	--kanso-error-legible: var(--color-error, #e30000);
 	--kanso-error-legible-rgb: var(--color-error-rgb, 227, 0, 0);
+	/* Legible success green twin for the "checklist complete" chip: stock green in
+	 * light, brighter #3fb950 under dark so it stays readable on the dark surface. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+	--kanso-success-legible-rgb: 70, 186, 97;
 
 	position: fixed;
 	z-index: 2100;
@@ -311,6 +315,8 @@ body.theme--dark .card-preview,
 [data-themes*='dark'] .card-preview {
 	--kanso-error-legible: #ff6b6b;
 	--kanso-error-legible-rgb: 255, 107, 107;
+	--kanso-success-legible: #3fb950;
+	--kanso-success-legible-rgb: 63, 185, 80;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -318,6 +324,8 @@ body.theme--dark .card-preview,
 	body:not(.theme--light):not(.theme--dark) .card-preview {
 		--kanso-error-legible: #ff6b6b;
 		--kanso-error-legible-rgb: 255, 107, 107;
+		--kanso-success-legible: #3fb950;
+		--kanso-success-legible-rgb: 63, 185, 80;
 	}
 }
 
@@ -409,9 +417,9 @@ body.theme--dark .card-preview,
 }
 
 .card-preview__checklist--complete {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
-	background: rgba(70, 186, 97, 0.1);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.1);
 }
 
 .card-preview__assignees {

--- a/src/components/CardSearchPicker.vue
+++ b/src/components/CardSearchPicker.vue
@@ -118,9 +118,27 @@ defineExpose({ focus: () => searchInputRef.value?.focus() })
 
 <style scoped>
 .card-search-picker {
+	/* Legible success green for the "selected" checkmark: stock green in light,
+	 * brighter #3fb950 under dark so the tick stays visible on the dark row. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
+}
+
+/* Brighten success green under dark themes (explicit picker + auto). */
+body.theme--dark .card-search-picker,
+[data-theme-dark] .card-search-picker,
+[data-themes*='dark'] .card-search-picker {
+	--kanso-success-legible: #3fb950;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .card-search-picker,
+	body:not(.theme--light):not(.theme--dark) .card-search-picker {
+		--kanso-success-legible: #3fb950;
+	}
 }
 
 .card-search-picker__input {
@@ -195,7 +213,7 @@ defineExpose({ focus: () => searchInputRef.value?.focus() })
 	right: 10px;
 	top: 50%;
 	transform: translateY(-50%);
-	color: var(--color-success);
+	color: var(--kanso-success-legible);
 }
 
 .card-search-picker__error {

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -456,6 +456,11 @@ const extraAssigneeCount = computed(() => {
 	 * the stock error red in light mode. Scoped to the tile so it can't leak. */
 	--kanso-error-legible: var(--color-error, #e30000);
 	--kanso-error-legible-rgb: var(--color-error-rgb, 227, 0, 0);
+	/* Legible success green twin: stock --color-success in light, a brighter
+	 * green (#3fb950) under dark so "complete"/"approved"/"feature" pills stay
+	 * readable on the dark tile surface. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+	--kanso-success-legible-rgb: 70, 186, 97;
 
 	display: flex;
 	flex-direction: column;
@@ -478,6 +483,8 @@ body.theme--dark .card-tile,
 [data-themes*='dark'] .card-tile {
 	--kanso-error-legible: #ff6b6b;
 	--kanso-error-legible-rgb: 255, 107, 107;
+	--kanso-success-legible: #3fb950;
+	--kanso-success-legible-rgb: 63, 185, 80;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -485,6 +492,8 @@ body.theme--dark .card-tile,
 	body:not(.theme--light):not(.theme--dark) .card-tile {
 		--kanso-error-legible: #ff6b6b;
 		--kanso-error-legible-rgb: 255, 107, 107;
+		--kanso-success-legible: #3fb950;
+		--kanso-success-legible-rgb: 63, 185, 80;
 	}
 }
 
@@ -651,9 +660,9 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__checklist--complete {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
-	background: rgba(70, 186, 97, 0.1);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.1);
 }
 
 /* Child-progress badge */
@@ -669,9 +678,9 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__children--complete {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
-	background: rgba(70, 186, 97, 0.1);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.1);
 }
 
 /* Comment count badge */
@@ -694,7 +703,7 @@ body.theme--dark .card-tile,
 /* Type icons use theme tokens so they keep WCAG contrast in both light and dark
    themes (bare #e74c3c/#27ae60/#7f8c8d fail contrast on the dark surface). */
 .card-tile__type--bug { color: var(--kanso-error-legible); }
-.card-tile__type--feature { color: var(--color-success, #27ae60); }
+.card-tile__type--feature { color: var(--kanso-success-legible); }
 .card-tile__type--task { color: var(--color-primary-element, #0082c9); }
 .card-tile__type--chore { color: var(--color-text-maxcontrast, #7f8c8d); }
 
@@ -758,9 +767,9 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__review--approved {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
-	background: rgba(70, 186, 97, 0.1);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.1);
 }
 
 .card-tile__review--changes_requested {

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -47,7 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<span class="card-tile__title" :class="{ 'card-tile__title--done': isDone }">{{ card.title }}</span>
 			<!-- Single meta row: all badges inline, assignees pushed to the right -->
 			<div
-				v-if="isInProgress || card.blocked || card.waitingOnExternal || card.duedate || (card.checklist && card.checklist.total > 0) || (card.childProgress && card.childProgress.total > 0) || card.commentCount > 0 || card.priority > 0 || cardType || (card.assigneeIds && card.assigneeIds.length) || card.reviewState || card.estimate || isRestricted"
+				v-if="isInProgress || card.blocked || card.waitingOnExternal || card.recurring || card.duedate || (card.checklist && card.checklist.total > 0) || (card.childProgress && card.childProgress.total > 0) || card.commentCount > 0 || card.priority > 0 || cardType || (card.assigneeIds && card.assigneeIds.length) || card.reviewState || card.estimate || isRestricted"
 				class="card-tile__meta">
 				<!-- In-progress status chip -->
 				<span
@@ -125,6 +125,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<CalendarIcon :size="14" />
 					{{ formatDue(card.duedate) }}
 				</span>
+				<!-- Recurring badge (#61) - the card carries a live recurrence rule.
+				     A single boolean rides the board summary; the rule itself is
+				     loaded only when the card is opened. -->
+				<span
+					v-if="card.recurring"
+					class="card-tile__recurring"
+					:aria-label="t('kanso', 'Recurring')"
+					:title="t('kanso', 'Recurring')">
+					<RepeatIcon :size="14" />
+				</span>
 				<!-- Checklist progress badge - only when the card has checklist items -->
 				<span
 					v-if="card.checklist && card.checklist.total > 0"
@@ -186,6 +196,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
+import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
 import ProgressClockIcon from 'vue-material-design-icons/ProgressClock.vue'
 import CheckboxMarkedOutlineIcon from 'vue-material-design-icons/CheckboxMarkedOutline.vue'
 import CommentMultipleOutlineIcon from 'vue-material-design-icons/CommentMultipleOutline.vue'
@@ -802,6 +813,14 @@ body.theme--dark .card-tile,
 	background: rgba(240, 168, 68, 0.1);
 }
 
+/* Recurring badge (#61) - a muted repeat glyph; neutral so it reads as an
+ * attribute of the card, not an alert. */
+.card-tile__recurring {
+	display: inline-flex;
+	align-items: center;
+	color: var(--color-text-maxcontrast);
+}
+
 /* Estimate chip */
 .card-tile__estimate {
 	display: inline-flex;
@@ -909,6 +928,12 @@ body.theme--dark .card-tile,
 
 .card-tile--compact .card-tile__ref {
 	font-size: 0.64rem;
+}
+
+/* Compact: shrink the icon-only recurring badge to match the denser meta row. */
+.card-tile--compact .card-tile__recurring :deep(svg) {
+	width: 12px;
+	height: 12px;
 }
 
 /* Smaller overflow badge to match the 20px compact avatars (NcAvatar itself is

--- a/src/components/ReviewRow.vue
+++ b/src/components/ReviewRow.vue
@@ -122,12 +122,33 @@ const relativeTime = computed(() => {
 
 <style scoped>
 .review-row {
+	/* Legible success green for the approved badge: stock green in light,
+	 * brighter #3fb950 under dark so text/tint stay readable. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+	--kanso-success-legible-rgb: 70, 186, 97;
+
 	display: flex;
 	align-items: center;
 	gap: 12px;
 	padding: 12px 14px;
 	cursor: pointer;
 	border-radius: var(--border-radius-large, 8px);
+}
+
+/* Brighten success green under dark themes (explicit picker + auto). */
+body.theme--dark .review-row,
+[data-theme-dark] .review-row,
+[data-themes*='dark'] .review-row {
+	--kanso-success-legible: #3fb950;
+	--kanso-success-legible-rgb: 63, 185, 80;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .review-row,
+	body:not(.theme--light):not(.theme--dark) .review-row {
+		--kanso-success-legible: #3fb950;
+		--kanso-success-legible-rgb: 63, 185, 80;
+	}
 }
 
 .review-row__content {
@@ -202,7 +223,7 @@ const relativeTime = computed(() => {
 }
 
 .review-row__state-badge--approved {
-	color: var(--color-success);
-	background: var(--color-success-hover, rgba(70, 150, 50, 0.1));
+	color: var(--kanso-success-legible);
+	background: rgba(var(--kanso-success-legible-rgb), 0.1);
 }
 </style>

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -916,6 +916,10 @@ async function createFromTemplate(templateId) {
    sunken board canvas. --color-main-background + a soft shadow gives the "raised"
    read against the board-view__stacks-wrap sunken background. */
 .stack-column {
+	/* Legible success green for the "Done" role chip: stock green in light,
+	 * brighter #3fb950 under dark so the tinted chip text stays readable. */
+	--kanso-success-legible: var(--color-success, #46ba61);
+
 	position: relative;
 	flex-shrink: 0;
 	width: 280px;
@@ -928,6 +932,20 @@ async function createFromTemplate(templateId) {
 	padding: 12px;
 	max-height: calc(100vh - 140px);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+/* Brighten success green under dark themes (explicit picker + auto). */
+body.theme--dark .stack-column,
+[data-theme-dark] .stack-column,
+[data-themes*='dark'] .stack-column {
+	--kanso-success-legible: #3fb950;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .stack-column,
+	body:not(.theme--light):not(.theme--dark) .stack-column {
+		--kanso-success-legible: #3fb950;
+	}
 }
 
 .stack-column--dragging {
@@ -1347,8 +1365,8 @@ async function createFromTemplate(templateId) {
 
 /* Done - success */
 .stack-column__role-chip--5 {
-	background: color-mix(in srgb, var(--color-success, #46ba61) 18%, transparent);
-	color: color-mix(in srgb, var(--color-success, #46ba61) 85%, var(--color-main-text));
+	background: color-mix(in srgb, var(--kanso-success-legible) 18%, transparent);
+	color: color-mix(in srgb, var(--kanso-success-legible) 85%, var(--color-main-text));
 }
 
 /* WIP badge over-limit warning */

--- a/tests/e2e/card-modal-layout.spec.js
+++ b/tests/e2e/card-modal-layout.spec.js
@@ -39,6 +39,16 @@ async function apiPatch(path, body) {
 	return r.json()
 }
 
+async function apiPut(path, body) {
+	const r = await fetch(API + path, {
+		method: 'PUT',
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: JSON.stringify(body ?? {}),
+	})
+	if (!r.ok) throw new Error(`PUT ${path} → ${r.status}: ${await r.text()}`)
+	return r.json()
+}
+
 async function apiDelete(path) {
 	const r = await fetch(API + path, {
 		method: 'DELETE',
@@ -210,6 +220,140 @@ test.describe('Card modal two-column layout', () => {
 		// Switching to the Discussion tab reveals the discussion pane.
 		await page.locator('.card-modal__tab', { hasText: 'Discussion' }).click()
 		await expect(page.locator('.card-modal__discussion')).toBeVisible({ timeout: 5_000 })
+	})
+
+	// #60 / #4057 — on a phone-width viewport the card attribute bar stays at the
+	// TOP and is always visible (like desktop), with the pills WRAPPING onto
+	// multiple lines instead of scrolling horizontally. Only the two original tabs
+	// (Card / Discussion) remain; there is no separate "Details" tab.
+	test('mobile: card attributes stay at the top and the pills wrap (#4057)', async ({ page }) => {
+		// ~360px is a common phone width, below the 680px reflow breakpoint.
+		await page.setViewportSize({ width: 360, height: 780 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+
+		await page.waitForSelector('.card-modal__tabbar', { timeout: 15_000 })
+
+		// The tab bar has exactly two tabs: Card / Discussion (no "Details").
+		const tabs = page.locator('.card-modal__tabbar .card-modal__tab')
+		await expect(tabs).toHaveCount(2)
+		await expect(tabs.nth(0)).toHaveText(/Card/)
+		await expect(tabs.nth(1)).toHaveText(/Discussion/)
+		await expect(page.locator('.card-modal__tab', { hasText: 'Details' })).toHaveCount(0)
+
+		// Tabs expose the ARIA tab role and the tablist container is a tablist.
+		await expect(page.locator('.card-modal__tabbar[role="tablist"]')).toBeVisible()
+		await expect(tabs.nth(0)).toHaveAttribute('role', 'tab')
+
+		// Default lands on the Card tab: the content is shown AND the attribute bar
+		// is visible at the top (no separate tap needed).
+		const attrbar = page.locator('.card-modal__attrbar')
+		await expect(attrbar).toBeVisible()
+		await expect(page.locator('.card-modal__content')).toBeVisible()
+		await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true')
+
+		// The attribute bar sits ABOVE the tab bar (top of the modal, like desktop).
+		const attrBox = await attrbar.boundingBox()
+		const tabbarBox = await page.locator('.card-modal__tabbar').boundingBox()
+		expect(attrBox).not.toBeNull()
+		expect(tabbarBox).not.toBeNull()
+		expect(attrBox.y).toBeLessThan(tabbarBox.y)
+
+		// The pills WRAP: the attribute bar must not overflow horizontally
+		// (scrollWidth must not meaningfully exceed clientWidth).
+		const overflow = await attrbar.evaluate((el) => el.scrollWidth - el.clientWidth)
+		expect(overflow).toBeLessThanOrEqual(2)
+
+		// Switch to Discussion → the composer is shown AND the attribute bar stays
+		// visible at the top on this tab too.
+		await tabs.nth(1).click()
+		await expect(page.locator('.card-modal__discussion')).toBeVisible({ timeout: 5_000 })
+		await expect(attrbar).toBeVisible()
+
+		// Back to Card → content returns, attribute bar still visible.
+		await tabs.nth(0).click()
+		await expect(page.locator('.card-modal__content')).toBeVisible({ timeout: 5_000 })
+		await expect(attrbar).toBeVisible()
+	})
+
+	// #4058 — on a phone-width viewport the review "Request" picker popover and the
+	// pending-review verdict banner must stay FULLY within the viewport. #4057 removed
+	// the mobile attrbar's `overflow-x: auto` (which silently forced overflow-y and
+	// clipped the absolutely-positioned popovers); this guard asserts neither surface
+	// escapes the viewport so that regression can't return.
+	test('mobile: review Request popover + verdict banner stay within the viewport (#4058)', async ({ page }) => {
+		// A dedicated card so requesting a review of admin doesn't perturb other tests.
+		const card = await apiPost('/cards', {
+			stackId: state.stackId,
+			title: 'Review popover clip guard',
+			description: 'Card used to verify the review picker/verdict stay on-screen on mobile.',
+		})
+		try {
+			const cardUrl = `${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${card.id}`
+			// ~360px is a common phone width, below the 680px reflow breakpoint.
+			await page.setViewportSize({ width: 360, height: 780 })
+			await ncLogin(page)
+
+			// 1) BEFORE any review is requested, admin is an unrequested participant, so
+			//    the review "Request" picker button is available in the attribute bar,
+			//    which stays visible at the top on mobile (no separate Details tab).
+			await page.goto(cardUrl)
+			await page.waitForSelector('.card-modal__tabbar', { timeout: 15_000 })
+			await expect(page.locator('.card-modal__attrbar')).toBeVisible({ timeout: 5_000 })
+
+			const requestBtn = page.locator('.card-modal__attr-right button.card-modal__pill--dashed', { hasText: 'Request' })
+			await expect(requestBtn).toBeVisible({ timeout: 5_000 })
+			await requestBtn.click()
+
+			// The custom (absolutely-positioned) review picker popover must render fully
+			// on-screen — no clipping by an overflow ancestor, no spilling past either
+			// viewport edge.
+			const popover = page.locator('.card-modal__popover--right')
+			await expect(popover).toBeVisible({ timeout: 5_000 })
+			const vw = page.viewportSize().width
+			const popBox = await popover.boundingBox()
+			expect(popBox).not.toBeNull()
+			expect(popBox.x).toBeGreaterThanOrEqual(0) // not clipped off the left edge
+			expect(popBox.x + popBox.width).toBeLessThanOrEqual(vw + 1) // not past the right edge
+			expect(popBox.height).toBeGreaterThan(0) // actually rendered (not overflow-clipped to 0)
+
+			// 2) Now request a review of admin so the pending-review VERDICT banner
+			//    ("Your review is requested" → Approve / Request changes) appears. It sits
+			//    at the top of the Card tab as normal block flow, but guard it anyway so a
+			//    future overflow ancestor can't clip it off-screen.
+			await apiPut(`/cards/${card.id}/reviews/admin`, {})
+			await page.goto(cardUrl)
+			const verdict = page.locator('.card-modal__verdict').first()
+			await expect(verdict).toBeVisible({ timeout: 15_000 })
+			const verdictBox = await verdict.boundingBox()
+			expect(verdictBox).not.toBeNull()
+			expect(verdictBox.x).toBeGreaterThanOrEqual(0)
+			expect(verdictBox.x + verdictBox.width).toBeLessThanOrEqual(vw + 1)
+
+			// The verdict actions (Approve / Request changes) must also be fully on-screen.
+			const actions = page.locator('.card-modal__verdict-actions').first()
+			await expect(actions).toBeVisible()
+			const actionsBox = await actions.boundingBox()
+			expect(actionsBox).not.toBeNull()
+			expect(actionsBox.x).toBeGreaterThanOrEqual(0)
+			expect(actionsBox.x + actionsBox.width).toBeLessThanOrEqual(vw + 1)
+		} finally {
+			await apiDelete(`/cards/${card.id}`).catch(() => {})
+		}
+	})
+
+	// Desktop regression guard: on a wide viewport there is NO tab bar and the
+	// attribute bar stays visible above the side-by-side content|discussion.
+	test('desktop: attribute bar is always visible and there is no tab bar (#4057)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await expect(page.locator('.card-modal__attrbar')).toBeVisible()
+		// The mobile tab bar exists in the DOM but is display:none on desktop.
+		await expect(page.locator('.card-modal__tabbar')).toBeHidden()
 	})
 
 	test('round clear/× buttons are circles, not ovals (#3492)', async ({ page }) => {

--- a/tests/e2e/card-modal-layout.spec.js
+++ b/tests/e2e/card-modal-layout.spec.js
@@ -307,6 +307,60 @@ test.describe('Card modal two-column layout', () => {
 		await expect(page).not.toHaveURL(new RegExp(`/card/${state.cardId}`), { timeout: 8_000 })
 	})
 
+	// #60 — on a phone-width viewport the card-detail header must reflow: the
+	// title must NOT wrap one character per line (its box must be wider than it is
+	// tall), and the action cluster / teleported close (X) must not overlap the
+	// title. A long, unbroken-ish title is used so a broken layout is unmissable.
+	test('mobile: card header reflows — title stays horizontal and actions do not overlap it (#60)', async ({ page }) => {
+		const longTitle = 'Refactor the notification delivery pipeline for realtime updates'
+		const card = await apiPost('/cards', {
+			stackId: state.stackId,
+			title: longTitle,
+			description: 'Long-title card used to verify the mobile header does not break.',
+		})
+		try {
+			const cardUrl = `${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${card.id}`
+			// ~360px is a common phone width and below the 680px reflow breakpoint.
+			await page.setViewportSize({ width: 360, height: 780 })
+			await ncLogin(page)
+			await page.goto(cardUrl)
+
+			const title = page.locator('.card-modal__title')
+			await expect(title).toBeVisible({ timeout: 15_000 })
+
+			// 1) The title renders horizontally, not one letter per line. A vertical
+			//    (one-char-per-line) wrap makes the box taller than it is wide.
+			const titleBox = await title.boundingBox()
+			expect(titleBox).not.toBeNull()
+			expect(titleBox.width).toBeGreaterThan(titleBox.height)
+
+			// 2) The action cluster must not horizontally overlap the title column.
+			//    After the reflow it sits on its own row below the title, so their
+			//    bounding boxes must not intersect.
+			const actions = page.locator('.card-modal__header-actions')
+			await expect(actions).toBeVisible()
+			const actionsBox = await actions.boundingBox()
+			expect(actionsBox).not.toBeNull()
+			const intersects = (a, b) => (
+				a.x < b.x + b.width && a.x + a.width > b.x
+				&& a.y < b.y + b.height && a.y + a.height > b.y
+			)
+			expect(intersects(titleBox, actionsBox)).toBe(false)
+
+			// 3) The teleported NcModal close (X) must not overlap the title either —
+			//    the header reserves right padding so the breadcrumb/title clear it.
+			const closeBtn = page.locator('.modal-container .modal-header button.modal-close, .modal-container button.header-close').first()
+			if (await closeBtn.count()) {
+				const closeBox = await closeBtn.boundingBox()
+				if (closeBox) {
+					expect(intersects(titleBox, closeBox)).toBe(false)
+				}
+			}
+		} finally {
+			await apiDelete(`/cards/${card.id}`).catch(() => {})
+		}
+	})
+
 	test('a text-selection drag that ends on the backdrop does NOT close the modal (#3656)', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 })
 		await ncLogin(page)

--- a/tests/e2e/card-recurrence.spec.js
+++ b/tests/e2e/card-recurrence.spec.js
@@ -93,3 +93,49 @@ test.describe('Repeat from the card due-date menu (#55)', () => {
 		).toBeNull()
 	})
 })
+
+test.describe('Recurring indicator on the board tile (#61)', () => {
+	const state = { boardId: 0, stackId: 0, recurCardId: 0, plainCardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Recur Tile ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'Chores' })).id
+		state.recurCardId = (await api('POST', '/cards', { stackId: state.stackId, title: 'Recurring chore' })).id
+		state.plainCardId = (await api('POST', '/cards', { stackId: state.stackId, title: 'One-off chore' })).id
+
+		// Give the first card a live weekly rule (its own column is the target,
+		// clone mode) - exactly what the due-date Repeat control creates.
+		await api('POST', `/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.recurCardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY',
+		})
+
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${state.boardId}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('board summary carries the recurring boolean derived from the rule', async () => {
+		const payload = await api('GET', `/boards/${state.boardId}`)
+		const byId = Object.fromEntries(payload.cards.map((c) => [c.id, c]))
+		expect(byId[state.recurCardId].recurring).toBe(true)
+		expect(byId[state.plainCardId].recurring).toBe(false)
+	})
+
+	test('repeat icon shows on the recurring tile and is absent on a normal tile', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.card-tile', { timeout: 10_000 })
+
+		const recurTile = page.locator('.card-tile').filter({ hasText: 'Recurring chore' })
+		const plainTile = page.locator('.card-tile').filter({ hasText: 'One-off chore' })
+
+		await expect(recurTile.locator('.card-tile__recurring')).toBeVisible({ timeout: 10_000 })
+		await expect(plainTile.locator('.card-tile__recurring')).toHaveCount(0)
+	})
+})

--- a/tests/e2e/card-recurrence.spec.js
+++ b/tests/e2e/card-recurrence.spec.js
@@ -139,3 +139,53 @@ test.describe('Recurring indicator on the board tile (#61)', () => {
 		await expect(plainTile.locator('.card-tile__recurring')).toHaveCount(0)
 	})
 })
+
+test.describe('Recurring indicator on the open card Due Date pill (#61 follow-up)', () => {
+	const state = { boardId: 0, stackId: 0, recurCardId: 0, plainCardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Recur Pill ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api('POST', '/stacks', { boardId: board.id, title: 'Chores' })).id
+		state.recurCardId = (await api('POST', '/cards', { stackId: state.stackId, title: 'Recurring pill card' })).id
+		state.plainCardId = (await api('POST', '/cards', { stackId: state.stackId, title: 'One-off pill card' })).id
+
+		// Live weekly rule on the first card (its own column is the target, clone
+		// mode) - exactly what the due-date Repeat control creates.
+		await api('POST', `/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.recurCardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY',
+		})
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('card show() payload carries the recurring boolean derived from the rule', async () => {
+		const recur = await api('GET', `/cards/${state.recurCardId}`)
+		const plain = await api('GET', `/cards/${state.plainCardId}`)
+		expect(recur.recurring).toBe(true)
+		expect(plain.recurring).toBe(false)
+	})
+
+	test('due-date pill shows the repeat icon for a recurring card, calendar icon otherwise', async ({ page }) => {
+		await ncLogin(page)
+
+		// Recurring card → the Due Date pill renders the repeat glyph, not calendar.
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${state.recurCardId}`)
+		await expect(page.locator('.card-modal')).toBeVisible({ timeout: 15_000 })
+		const recurPill = page.locator('[data-pill="due"]')
+		await expect(recurPill.locator('.repeat-icon')).toBeVisible({ timeout: 10_000 })
+		await expect(recurPill.locator('.calendar-icon')).toHaveCount(0)
+
+		// Non-recurring card → the calendar glyph stays, no repeat icon.
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${state.plainCardId}`)
+		await expect(page.locator('.card-modal')).toBeVisible({ timeout: 15_000 })
+		const plainPill = page.locator('[data-pill="due"]')
+		await expect(plainPill.locator('.calendar-icon')).toBeVisible({ timeout: 10_000 })
+		await expect(plainPill.locator('.repeat-icon')).toHaveCount(0)
+	})
+})

--- a/tests/unit/Controller/BoardControllerTest.php
+++ b/tests/unit/Controller/BoardControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 use OCA\Kanso\Db\ReviewTypeMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
@@ -68,6 +69,7 @@ class BoardControllerTest extends TestCase {
 	private PermissionService&MockObject $permissionService;
 	private SubscriptionService&MockObject $subscriptionService;
 	private CardRelationMapper&MockObject $cardRelationMapper;
+	private RecurRuleMapper&MockObject $recurRuleMapper;
 	private BoardAccess&MockObject $boardAccess;
 	private BoardController $controller;
 
@@ -94,6 +96,7 @@ class BoardControllerTest extends TestCase {
 		$this->permissionService = $this->createMock(PermissionService::class);
 		$this->subscriptionService = $this->createMock(SubscriptionService::class);
 		$this->cardRelationMapper = $this->createMock(CardRelationMapper::class);
+		$this->recurRuleMapper = $this->createMock(RecurRuleMapper::class);
 		// show()/changes() resolve the viewer context once, after the READ gate
 		// (#3743); the mapper mocks just receive it.
 		$this->boardAccess = $this->createMock(BoardAccess::class);
@@ -118,6 +121,7 @@ class BoardControllerTest extends TestCase {
 			$this->commentMapper,
 			$this->cardReviewMapper,
 			$this->cardRelationMapper,
+			$this->recurRuleMapper,
 		);
 
 		$this->controller = new BoardController(

--- a/tests/unit/Controller/CardControllerTest.php
+++ b/tests/unit/Controller/CardControllerTest.php
@@ -23,6 +23,7 @@ use OCA\Kanso\Db\CardTimeEntryMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 use OCA\Kanso\Service\AssigneeService;
 use OCA\Kanso\Service\CardRelationService;
 use OCA\Kanso\Service\CardService;
@@ -64,12 +65,13 @@ class CardControllerTest extends TestCase {
 	private BoardMapper&MockObject $boardMapper;
 	private BoardAccess&MockObject $boardAccess;
 	private CardVisibilityGuard&MockObject $visibilityGuard;
+	private RecurRuleMapper&MockObject $recurRuleMapper;
+	private IRequest&MockObject $request;
+	private IUserSession&MockObject $userSession;
 	private CardController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$request = $this->createMock(IRequest::class);
-		$userSession = $this->createMock(IUserSession::class);
 		$this->cardService = $this->createMock(CardService::class);
 		$this->labelService = $this->createMock(LabelService::class);
 		$this->assigneeService = $this->createMock(AssigneeService::class);
@@ -114,15 +116,28 @@ class CardControllerTest extends TestCase {
 			->willReturn(ViewerContext::forMember('alice', 1, ViewerContext::ROLE_INTERNAL, true));
 		$this->visibilityGuard = $this->createMock(CardVisibilityGuard::class);
 		$this->visibilityGuard->method('isVisible')->willReturn(true);
+		// No recurrence rule by default; the recurring-indicator tests override this.
+		$this->recurRuleMapper = $this->createMock(RecurRuleMapper::class);
+		$this->recurRuleMapper->method('hasEnabledRuleForCard')->willReturn(false);
 
+		$this->request = $this->createMock(IRequest::class);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
-		$userSession->method('getUser')->willReturn($user);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->userSession->method('getUser')->willReturn($user);
 
+		$this->rebuildController();
+	}
+
+	/**
+	 * (Re)build the controller from the current mocks. Called by setUp and by any
+	 * test that swaps a mock (e.g. the recurring-indicator test) after setUp.
+	 */
+	private function rebuildController(): void {
 		$this->controller = new CardController(
 			'kanso',
-			$request,
-			$userSession,
+			$this->request,
+			$this->userSession,
 			$this->cardService,
 			$this->labelService,
 			$this->assigneeService,
@@ -143,7 +158,8 @@ class CardControllerTest extends TestCase {
 			$this->cardFieldValueMapper,
 			$this->boardMapper,
 			$this->boardAccess,
-			$this->visibilityGuard
+			$this->visibilityGuard,
+			$this->recurRuleMapper
 		);
 	}
 
@@ -198,6 +214,28 @@ class CardControllerTest extends TestCase {
 		self::assertSame('Full detail', $data['description']);
 		self::assertSame([3, 7], $data['labelIds']);
 		self::assertSame(['bob', 'carol'], $data['assigneeIds']);
+	}
+
+	public function testShowMarksCardRecurringWhenAnEnabledRuleExists(): void {
+		$card = $this->card();
+		$this->cardService->method('find')->with(9, 'alice')->willReturn($card);
+		// A live recurrence rule anchored on this card - the open card swaps the
+		// Due Date pill's calendar icon for a repeat icon for all viewers (#61).
+		$this->recurRuleMapper = $this->createMock(RecurRuleMapper::class);
+		$this->recurRuleMapper->method('hasEnabledRuleForCard')->with(9)->willReturn(true);
+		$this->rebuildController();
+
+		$data = $this->controller->show(9)->getData();
+		self::assertTrue($data['recurring']);
+	}
+
+	public function testShowMarksCardNotRecurringWithoutAnEnabledRule(): void {
+		$card = $this->card();
+		$this->cardService->method('find')->with(9, 'alice')->willReturn($card);
+		// Default mock: no enabled rule for the card.
+
+		$data = $this->controller->show(9)->getData();
+		self::assertFalse($data['recurring']);
 	}
 
 	public function testResolveRefReturnsCardIdAndTitle(): void {

--- a/tests/unit/Service/CardSummaryServiceTest.php
+++ b/tests/unit/Service/CardSummaryServiceTest.php
@@ -17,6 +17,7 @@ use OCA\Kanso\Db\CardRelationMapper;
 use OCA\Kanso\Db\CardReviewMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 use OCA\Kanso\Service\CardSummaryService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +31,7 @@ class CardSummaryServiceTest extends TestCase {
 	private CommentMapper&MockObject $commentMapper;
 	private CardReviewMapper&MockObject $cardReviewMapper;
 	private CardRelationMapper&MockObject $cardRelationMapper;
+	private RecurRuleMapper&MockObject $recurRuleMapper;
 	private CardSummaryService $service;
 
 	protected function setUp(): void {
@@ -42,6 +44,7 @@ class CardSummaryServiceTest extends TestCase {
 		$this->commentMapper = $this->createMock(CommentMapper::class);
 		$this->cardReviewMapper = $this->createMock(CardReviewMapper::class);
 		$this->cardRelationMapper = $this->createMock(CardRelationMapper::class);
+		$this->recurRuleMapper = $this->createMock(RecurRuleMapper::class);
 		$this->service = new CardSummaryService(
 			$this->cardLabelMapper,
 			$this->cardAssigneeMapper,
@@ -51,6 +54,7 @@ class CardSummaryServiceTest extends TestCase {
 			$this->commentMapper,
 			$this->cardReviewMapper,
 			$this->cardRelationMapper,
+			$this->recurRuleMapper,
 		);
 	}
 
@@ -74,6 +78,8 @@ class CardSummaryServiceTest extends TestCase {
 		$this->cardMapper->method('childProgressByBoard')->with(1)->willReturn([3 => ['total' => 2, 'done' => 1]]);
 		$this->commentMapper->method('countsByBoard')->with(1)->willReturn([3 => 5]);
 		$this->cardRelationMapper->method('blockedCardIdsByBoard')->with(1)->willReturn([3]);
+		// Card 3 has an enabled recurrence rule; card 4 does not.
+		$this->recurRuleMapper->method('findTemplateCardIdsByBoard')->with(1)->willReturn([3]);
 
 		$viewer = ViewerContext::forMember('alice', 1, ViewerContext::ROLE_INTERNAL, true);
 		$out = $this->service->serialize(1, [$card, $bare], $viewer);
@@ -86,6 +92,7 @@ class CardSummaryServiceTest extends TestCase {
 		self::assertTrue($out[0]['waitingOnExternal']);
 		self::assertSame(1700000000, $out[0]['waitingSince']);
 		self::assertTrue($out[0]['blocked']);
+		self::assertTrue($out[0]['recurring']);
 		self::assertArrayNotHasKey('description', $out[0]);
 
 		// A card with no signal reads defaults (present, not absent).
@@ -95,5 +102,6 @@ class CardSummaryServiceTest extends TestCase {
 		self::assertFalse($out[1]['waitingOnExternal']);
 		self::assertNull($out[1]['waitingSince']);
 		self::assertFalse($out[1]['blocked']);
+		self::assertFalse($out[1]['recurring']);
 	}
 }

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -229,19 +229,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3588
+#: src/components/CardDetail.vue:3592
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3586
+#: src/components/CardDetail.vue:3590
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3584
+#: src/components/CardDetail.vue:3588
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -1356,7 +1356,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/components/CardDetail.vue:3761
+#: src/components/CardDetail.vue:3765
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/components/CardDetail.vue:3763
+#: src/components/CardDetail.vue:3767
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4606,7 +4606,7 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: src/components/CardDetail.vue:3762
+#: src/components/CardDetail.vue:3766
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -4682,7 +4682,7 @@ msgstr ""
 msgid "Write a reply…"
 msgstr ""
 
-#: src/components/CardDetail.vue:3764
+#: src/components/CardDetail.vue:3768
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -3599,6 +3599,10 @@ msgstr ""
 msgid "Read-only"
 msgstr ""
 
+#: src/components/CardTile.vue
+msgid "Recurring"
+msgstr ""
+
 #: src/components/BoardSettingsModal.vue
 msgid "Recurring cards"
 msgstr ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -229,19 +229,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3583
+#: src/components/CardDetail.vue:3588
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3581
+#: src/components/CardDetail.vue:3586
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3579
+#: src/components/CardDetail.vue:3584
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -1356,7 +1356,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/components/CardDetail.vue:3749
+#: src/components/CardDetail.vue:3761
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/components/CardDetail.vue:3751
+#: src/components/CardDetail.vue:3763
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -3775,6 +3775,10 @@ msgid "Repeat"
 msgstr ""
 
 #: src/components/CardDetail.vue
+msgid "Repeats"
+msgstr ""
+
+#: src/components/CardDetail.vue
 #: src/views/ProjectView.vue
 msgid "Reply"
 msgstr ""
@@ -4602,7 +4606,7 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: src/components/CardDetail.vue:3750
+#: src/components/CardDetail.vue:3762
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -4678,7 +4682,7 @@ msgstr ""
 msgid "Write a reply…"
 msgstr ""
 
-#: src/components/CardDetail.vue:3752
+#: src/components/CardDetail.vue:3764
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""


### PR DESCRIPTION
Mobile card-view polish, recurring-task indicators, and dark-mode legibility commits validated with unit/e2e run green locally.

## User-reported issues
- **Closes #60** — the card view broke on mobile (title wrapped one letter per line; the top action bar overlapped the close button / status). Header now reflows and the attribute pills wrap at the top instead of a cramped horizontal-scroll strip.
- **Closes #61** — recurring tasks were invisible on the board. A repeat icon now shows on the board card tile *and* on the card's Due Date control.

## Commits (merge as a **merge commit** to preserve the fix/feat types for semantic-release)
- `feat: recurring cards now show a repeat icon on the board` — lean `recurring` boolean added to the card summary (`RecurRuleMapper::findTemplateCardIdsByBoard` → `CardSummaryService`); repeat chip on `CardTile`.
- `feat: the open card's due date now shows a repeat icon for recurring cards` — `recurring` on the full card payload (`RecurRuleMapper::hasEnabledRuleForCard`); Due Date pill swaps calendar→repeat for all viewers.
- `fix: keep the card view header readable on mobile` — responsive header reflow (#60).
- `fix: on mobile, card attributes stay at the top and wrap instead of scrolling` — attribute bar wraps at the top; also removes the overflow that was clipping the review Request popover.
- `fix: green status pills are now legible in dark mode` — new `--kanso-success-legible` (`#3fb950`) token, ~15 pill selectors across 8 components; mirrors the existing `--kanso-error-legible`.
- `fix: put a space between the Discussion tab label and its comment count` — "Discussion2" → "Discussion 2".

## Testing
Per-card locally: PHPUnit (summary/payload + byte-identity), Playwright e2e (mobile header/attributes/tabs, recurring icon on tile + due-date pill, review popover in-viewport), psalm + php-cs-fixer clean, vite build clean, dark mode visually verified. No `appinfo/info.xml` version bump (release-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
