### PR TITLE
Public-link read-only comments, dark-mode chip legibility, bulk mark-done

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -199,6 +199,8 @@ return [
 		['name' => 'publicShare#config', 'url' => '/api/boards/{id}/public-share', 'verb' => 'GET'],
 		['name' => 'publicShare#enable', 'url' => '/api/boards/{id}/public-share', 'verb' => 'POST'],
 		['name' => 'publicShare#disable', 'url' => '/api/boards/{id}/public-share', 'verb' => 'DELETE'],
+		// "Show comments (read-only)" opt-in for the public link (#3949). MANAGE-only.
+		['name' => 'publicShare#setComments', 'url' => '/api/boards/{id}/public-share/comments', 'verb' => 'PUT'],
 
 		// Calendar-feed config (MANAGE, authenticated). Nested under a board id,
 		// distinct from board#show. Enable/rotate = POST, disable = DELETE.

--- a/lib/Controller/PublicShareController.php
+++ b/lib/Controller/PublicShareController.php
@@ -81,6 +81,20 @@ class PublicShareController extends Controller {
 		});
 	}
 
+	/**
+	 * Sets the "show comments (read-only)" opt-in for the public link (#3949).
+	 * MANAGE-only; OFF by default. Widening an intentionally person-free surface
+	 * is a deliberate owner action, so it is its own explicit endpoint.
+	 */
+	#[NoAdminRequired]
+	public function setComments(int $id, bool $enabled = false): JSONResponse {
+		return $this->respond(function () use ($id, $enabled): JSONResponse {
+			return new JSONResponse(
+				$this->publicShareService->setComments($id, $enabled, $this->currentUserId())
+			);
+		});
+	}
+
 	// ── Public read-only (unauthenticated) ────────────────────────────────────
 
 	/**

--- a/lib/Db/Board.php
+++ b/lib/Db/Board.php
@@ -46,6 +46,8 @@ use OCP\DB\Types;
  * @method void setPublicShareToken(?string $publicShareToken)
  * @method int|null getPublicShareExpiresAt()
  * @method void setPublicShareExpiresAt(?int $publicShareExpiresAt)
+ * @method bool|null getPublicShareComments()
+ * @method void setPublicShareComments(?bool $publicShareComments)
  * @method string|null getIcalFeedToken()
  * @method void setIcalFeedToken(?string $icalFeedToken)
  * @method string|null getChatUrl()
@@ -88,6 +90,14 @@ class Board extends Entity implements \JsonSerializable {
 	// Optional unix-ts expiry for the public link (NULL / 0 = never). v1 defaults
 	// to no expiry (revocable-until-disabled).
 	protected ?int $publicShareExpiresAt = null;
+	// Public-link "show comments" opt-in (#3949). MANAGE-only, OFF by default.
+	// FALSE/NULL = the public board keeps its person-free baseline (no comments
+	// ever). TRUE = a MANAGE user has DELIBERATELY widened the public link so an
+	// anonymous reader sees each public card's read-only comment thread (author
+	// display name only - never a uid, reaction, member or activity). Like the
+	// token, deliberately NEVER emitted by jsonSerialize(); it rides only the
+	// dedicated MANAGE public-share config endpoints.
+	protected ?bool $publicShareComments = null;
 	// iCal / ICS read-only due-date feed (#3541). MANAGE-only, OFF by default. NULL
 	// = no feed; a non-null value is a long ISecureRandom token that lets any
 	// calendar client subscribe to a read-only VCALENDAR of this board's due cards.
@@ -116,6 +126,7 @@ class Board extends Entity implements \JsonSerializable {
 		$this->addType('prefix', Types::STRING);
 		$this->addType('publicShareToken', Types::STRING);
 		$this->addType('publicShareExpiresAt', Types::INTEGER);
+		$this->addType('publicShareComments', Types::BOOLEAN);
 		$this->addType('icalFeedToken', Types::STRING);
 		$this->addType('chatUrl', Types::STRING);
 	}

--- a/lib/Db/CommentMapper.php
+++ b/lib/Db/CommentMapper.php
@@ -68,6 +68,39 @@ class CommentMapper extends QBMapper {
 	}
 
 	/**
+	 * The anonymous-share twin of {@see self::findByCard()} (#3949): every
+	 * non-deleted comment on a board's PUBLIC cards only, oldest first, keyed by
+	 * card id. Restricted through {@see CardVisibilityScope::applyPublicOnly()} on
+	 * the joined card, so a hidden card's comments can never surface on the public
+	 * board - and (like the label/checklist public helpers) it never fetches then
+	 * discards a hidden card's rows. Mirrors
+	 * {@see CardLabelMapper::findLabelIdsByBoardPublicOnly()}. The client nests the
+	 * flat list by parent_comment_id (one level).
+	 *
+	 * @return array<int, Comment[]> map of cardId => comments in created_at order
+	 * @throws Exception
+	 */
+	public function findByBoardPublicOnly(int $boardId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('cm.*')
+			->from($this->getTableName(), 'cm')
+			->innerJoin('cm', 'kanso_cards', 'c', $qb->expr()->eq('cm.card_id', 'c.id'))
+			->where($qb->expr()->eq('c.board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('c.deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('cm.deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->orderBy('cm.created_at', 'ASC')
+			->addOrderBy('cm.id', 'ASC');
+		$this->visibilityScope->applyPublicOnly($qb, 'c');
+
+		$map = [];
+		foreach ($this->findEntities($qb) as $comment) {
+			$map[(int)$comment->getCardId()][] = $comment;
+		}
+
+		return $map;
+	}
+
+	/**
 	 * The non-deleted direct replies of a top-level comment - used to cascade a
 	 * delete over a whole thread.
 	 *

--- a/lib/Migration/Version005200Date20260909000000.php
+++ b/lib/Migration/Version005200Date20260909000000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Public-link "show comments" opt-in (#3949): a nullable boolean
+ * `public_share_comments` on `kanso_boards`, default false. The public board's
+ * baseline promise is that no person data is ever shown; this per-share flag
+ * lets a MANAGE user DELIBERATELY widen an intentionally person-free surface so
+ * an anonymous reader sees each public card's read-only comment thread (author
+ * DISPLAY NAME only - never a uid, reaction or member). OFF by default, so a
+ * board that predates the column keeps the "never shown" guarantee unchanged.
+ * Guarded (hasColumn) so the step is idempotent.
+ */
+class Version005200Date20260909000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::getTable() is
+	 *  docblocked as Doctrine\DBAL\Schema\Table, not part of the OCP stubs.
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('kanso_boards')) {
+			return null;
+		}
+
+		$table = $schema->getTable('kanso_boards');
+		if (!$table->hasColumn('public_share_comments')) {
+			$table->addColumn('public_share_comments', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/BulkCardService.php
+++ b/lib/Service/BulkCardService.php
@@ -31,6 +31,7 @@ class BulkCardService {
 	public const ACTION_REMOVE_LABEL = 'remove_label';
 	public const ACTION_ASSIGN_USER = 'assign_user';
 	public const ACTION_SET_DUE_DATE = 'set_due_date';
+	public const ACTION_SET_STATUS = 'set_status';
 	public const ACTION_ARCHIVE = 'archive';
 	public const ACTION_DELETE = 'delete';
 
@@ -40,6 +41,7 @@ class BulkCardService {
 		self::ACTION_REMOVE_LABEL,
 		self::ACTION_ASSIGN_USER,
 		self::ACTION_SET_DUE_DATE,
+		self::ACTION_SET_STATUS,
 		self::ACTION_ARCHIVE,
 		self::ACTION_DELETE,
 	];
@@ -75,6 +77,7 @@ class BulkCardService {
 	 *   - remove_label:  labelId (int, > 0)
 	 *   - assign_user:   userId (non-empty string)
 	 *   - set_due_date:  duedate (string; '' clears it - same wire format as update())
+	 *   - set_status:    status ('done' stamps done_at via the single-card done path)
 	 *   - archive:       (none)
 	 *   - delete:        (none)
 	 *
@@ -200,6 +203,20 @@ class BulkCardService {
 				$duedate = (string)($params['duedate'] ?? '');
 				return function (int $cardId) use ($duedate, $uid): void {
 					$this->cardService->update($cardId, null, null, $duedate, null, null, $uid);
+				};
+
+			case self::ACTION_SET_STATUS:
+				// Only 'done' is supported: it reuses the single-card done path
+				// (CardService::update with $done=true), which stamps done_at once
+				// (idempotent), enforces the same per-card EDIT permission, and
+				// appends its own kanso_changes row. Anything else is a whole-request
+				// 400 - the client never sends another value.
+				$status = (string)($params['status'] ?? '');
+				if ($status !== 'done') {
+					throw new InvalidInputException('Unsupported status: ' . $status);
+				}
+				return function (int $cardId) use ($uid): void {
+					$this->cardService->update($cardId, null, null, null, true, null, $uid);
 				};
 
 			case self::ACTION_ARCHIVE:

--- a/lib/Service/PublicShareService.php
+++ b/lib/Service/PublicShareService.php
@@ -20,6 +20,7 @@ use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
@@ -70,6 +71,7 @@ class PublicShareService {
 		private ISecureRandom $secureRandom,
 		private IURLGenerator $urlGenerator,
 		private IUserManager $userManager,
+		private IL10N $l10n,
 	) {
 	}
 
@@ -291,6 +293,11 @@ class PublicShareService {
 	 * reactions, NO reactor lists. A one-level thread: a reply carries its
 	 * top-level parent id and the client nests by it.
 	 *
+	 * When the author account no longer exists (deleted user), the display-name
+	 * lookup returns null; we emit a generic "Former user" label rather than
+	 * falling back to the raw uid, so a deleted account's uid never leaks onto an
+	 * unauthenticated link (the "uid never leaves" invariant holds even then).
+	 *
 	 * @param Comment[] $comments
 	 * @param array<string, string> $displayNames uid => display name cache, reused across cards
 	 * @return list<array{id: int, parentCommentId: ?int, author: string, body: ?string, createdAt: int, editedAt: int}>
@@ -301,7 +308,9 @@ class PublicShareService {
 			$uid = (string)$comment->getAuthor();
 			if (!isset($displayNames[$uid])) {
 				$user = $this->userManager->get($uid);
-				$displayNames[$uid] = $user !== null ? $user->getDisplayName() : $uid;
+				// A deleted author resolves to null; never leak the raw uid on the
+				// public link - substitute a generic, translatable label instead.
+				$displayNames[$uid] = $user !== null ? $user->getDisplayName() : $this->l10n->t('Former user');
 			}
 			$out[] = [
 				'id' => (int)$comment->getId(),

--- a/lib/Service/PublicShareService.php
+++ b/lib/Service/PublicShareService.php
@@ -13,12 +13,15 @@ use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
+use OCA\Kanso\Db\Comment;
+use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 
 /**
@@ -38,12 +41,16 @@ use OCP\Security\ISecureRandom;
  *    resolving on the very next request (revocable + rotatable).
  *  - {@see self::getPublicBoard()} builds its OWN payload from a deliberately
  *    narrow field list. It NEVER reuses the authenticated board payload, and it
- *    NEVER touches assignees, comments, watchers, activity/changes, ACL/members,
- *    owner uids, reviews, or the webhook config. Only board title + stacks +
- *    per-card {title, description, labels, dates, cover colour, estimate,
- *    checklist counts, priority, status, human id} are exposed - nothing that
- *    identifies a person or leaks internal metadata. Archived stacks/cards are
- *    omitted.
+ *    NEVER touches assignees, watchers, activity/changes, ACL/members, owner
+ *    uids, reviews, or the webhook config. Only board title + stacks + per-card
+ *    {title, description, labels, dates, cover colour, estimate, checklist
+ *    counts, priority, status, human id} are exposed - nothing that identifies a
+ *    person or leaks internal metadata. Archived stacks/cards are omitted.
+ *  - The ONE opt-in exception (#3949): a MANAGE user may DELIBERATELY widen the
+ *    link with the `public_share_comments` toggle (OFF by default). When ON, and
+ *    only then, each public card also carries a read-only comment thread - author
+ *    DISPLAY NAME only (never a uid), body, timestamps, one-level parent link;
+ *    still no reactions, members or activity. OFF keeps the person-free baseline.
  *  - An unknown/disabled/rotated/expired token raises DoesNotExistException,
  *    which the controller maps to a throttled 404 (no oracle beyond the throttle,
  *    and no distinction between "wrong token" and "disabled board").
@@ -58,9 +65,11 @@ class PublicShareService {
 		private CardLabelMapper $cardLabelMapper,
 		private ChecklistItemMapper $checklistItemMapper,
 		private LabelMapper $labelMapper,
+		private CommentMapper $commentMapper,
 		private PermissionService $permissionService,
 		private ISecureRandom $secureRandom,
 		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -70,7 +79,7 @@ class PublicShareService {
 	 * the settings UI can render/copy the live link - it is board content the
 	 * MANAGE user already controls, unlike the webhook secret. Requires MANAGE.
 	 *
-	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int}
+	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int, commentsEnabled: bool}
 	 * @throws DoesNotExistException if the board does not exist or is deleted
 	 * @throws NotPermittedException if the actor may not manage the board
 	 */
@@ -85,7 +94,7 @@ class PublicShareService {
 	 * token, and returns the new config incl. the token + URL. Requires MANAGE.
 	 * Any previously-issued link stops working immediately.
 	 *
-	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int}
+	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int, commentsEnabled: bool}
 	 * @throws DoesNotExistException if the board does not exist or is deleted
 	 * @throws NotPermittedException if the actor may not manage the board
 	 */
@@ -117,15 +126,45 @@ class PublicShareService {
 	}
 
 	/**
+	 * Sets the "show comments (read-only)" opt-in for the public link. Requires
+	 * MANAGE. Independent of enable/disable: a MANAGE user can pre-set it, and it
+	 * persists across rotate. When ON, {@see self::getPublicBoard()} widens the
+	 * anonymous payload to include each public card's read-only comment thread
+	 * (author display name only). OFF (the default) keeps the person-free baseline.
+	 *
+	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int, commentsEnabled: bool}
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not manage the board
+	 */
+	public function setComments(int $boardId, bool $enabled, string $actorUid): array {
+		$board = $this->loadBoard($boardId);
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
+
+		if (($board->getPublicShareComments() ?? false) !== $enabled) {
+			$board->setPublicShareComments($enabled);
+			$this->boardMapper->update($board);
+		}
+
+		return $this->configPayload($board);
+	}
+
+	/**
 	 * The STRIPPED, read-only public snapshot of the board a token points at.
 	 * This is the ONLY method that runs without a session, so it is deliberately
 	 * conservative: it builds its own narrow payload and never reads people,
 	 * comments, ACL, reviews, activity or webhook data.
 	 *
+	 * When the board's `public_share_comments` opt-in is ON (#3949), each card
+	 * also carries a `comments` list - a read-only thread of author DISPLAY NAME
+	 * (never a uid), body, timestamps and one-level parent link, scoped to the
+	 * public card set via {@see CommentMapper::findByBoardPublicOnly()}. No
+	 * reactions, no members, no activity. When OFF (default), no `comments` key
+	 * is added and the person-free baseline holds.
+	 *
 	 * @return array{
-	 *   board: array{title: ?string, color: ?string, prefix: string},
+	 *   board: array{title: ?string, color: ?string, prefix: string, commentsEnabled: bool},
 	 *   stacks: list<array{id: int, title: ?string, color: ?string}>,
-	 *   cards: list<array{id: int, stackId: ?int, title: ?string, description: ?string, labels: list<array{name: ?string, color: ?string}>, duedate: ?string, coverColor: ?string, startDate: ?string, estimate: ?string, allDay: bool, priority: int, type: string, status: string, humanId: ?string, checklist: array{total: int, done: int}}>
+	 *   cards: list<array{id: int, stackId: ?int, title: ?string, description: ?string, labels: list<array{name: ?string, color: ?string}>, duedate: ?string, coverColor: ?string, startDate: ?string, estimate: ?string, allDay: bool, priority: int, type: string, status: string, humanId: ?string, checklist: array{total: int, done: int}, comments?: list<array{id: int, parentCommentId: ?int, author: string, body: ?string, createdAt: int, editedAt: int}>}>
 	 * }
 	 * @throws DoesNotExistException if the token is unknown, disabled, or expired
 	 */
@@ -156,6 +195,13 @@ class PublicShareService {
 		// only (#3743) - never fetch a hidden card's rows just to discard them.
 		$labelIdsByCard = $this->cardLabelMapper->findLabelIdsByBoardPublicOnly($boardId);
 		$checklistByCard = $this->checklistItemMapper->progressByBoardPublicOnly($boardId);
+
+		// Comments opt-in (#3949): ONLY fetch (and only ever expose) comments when
+		// the MANAGE user deliberately enabled the toggle for this share. Also over
+		// PUBLIC cards only, so a hidden card's discussion never surfaces.
+		$commentsEnabled = $board->getPublicShareComments() ?? false;
+		$commentsByCard = $commentsEnabled ? $this->commentMapper->findByBoardPublicOnly($boardId) : [];
+		$displayNames = [];
 
 		// Only NON-archived stacks, in display order; drop the internal board id.
 		$stacks = [];
@@ -195,7 +241,7 @@ class PublicShareService {
 			}
 
 			$seq = $card->getBoardSeq();
-			$cards[] = [
+			$cardPayload = [
 				'id' => $cardId,
 				'stackId' => $card->getStackId(),
 				'title' => $card->getTitle(),
@@ -217,6 +263,12 @@ class PublicShareService {
 				'humanId' => $seq !== null ? $prefix . '-' . $seq : null,
 				'checklist' => $checklistByCard[$cardId] ?? ['total' => 0, 'done' => 0],
 			];
+
+			if ($commentsEnabled) {
+				$cardPayload['comments'] = $this->serializeComments($commentsByCard[$cardId] ?? [], $displayNames);
+			}
+
+			$cards[] = $cardPayload;
 		}
 
 		return [
@@ -224,10 +276,43 @@ class PublicShareService {
 				'title' => $board->getTitle(),
 				'color' => $board->getColor(),
 				'prefix' => $prefix,
+				'commentsEnabled' => $commentsEnabled,
 			],
 			'stacks' => $stacks,
 			'cards' => $cards,
 		];
+	}
+
+	/**
+	 * The read-only public serialization of one card's comment thread (#3949).
+	 * Emits ONLY {id, parentCommentId, author DISPLAY NAME, body, timestamps} -
+	 * deliberately NO uid (the display name is resolved from the uid, like the
+	 * authenticated comment endpoint, but the uid itself never leaves), NO
+	 * reactions, NO reactor lists. A one-level thread: a reply carries its
+	 * top-level parent id and the client nests by it.
+	 *
+	 * @param Comment[] $comments
+	 * @param array<string, string> $displayNames uid => display name cache, reused across cards
+	 * @return list<array{id: int, parentCommentId: ?int, author: string, body: ?string, createdAt: int, editedAt: int}>
+	 */
+	private function serializeComments(array $comments, array &$displayNames): array {
+		$out = [];
+		foreach ($comments as $comment) {
+			$uid = (string)$comment->getAuthor();
+			if (!isset($displayNames[$uid])) {
+				$user = $this->userManager->get($uid);
+				$displayNames[$uid] = $user !== null ? $user->getDisplayName() : $uid;
+			}
+			$out[] = [
+				'id' => (int)$comment->getId(),
+				'parentCommentId' => $comment->getParentCommentId(),
+				'author' => $displayNames[$uid],
+				'body' => $comment->getBody(),
+				'createdAt' => $comment->getCreatedAt() ?? 0,
+				'editedAt' => $comment->getEditedAt() ?? 0,
+			];
+		}
+		return $out;
 	}
 
 	/**
@@ -250,7 +335,7 @@ class PublicShareService {
 	}
 
 	/**
-	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int}
+	 * @return array{enabled: bool, token: ?string, url: ?string, expiresAt: ?int, commentsEnabled: bool}
 	 */
 	private function configPayload(Board $board): array {
 		$token = $board->getPublicShareToken();
@@ -260,6 +345,9 @@ class PublicShareService {
 			'token' => $enabled ? $token : null,
 			'url' => $enabled ? $this->publicUrl((string)$token) : null,
 			'expiresAt' => $board->getPublicShareExpiresAt(),
+			// The opt-in state rides the MANAGE config so the settings UI can render
+			// the toggle; it persists independent of enable/disable.
+			'commentsEnabled' => $board->getPublicShareComments() ?? false,
 		];
 	}
 

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -402,10 +402,37 @@ function isOverdue(card) {
 
 <style scoped>
 .board-list-table {
+	/* Legible status colours for the row chips (priority, overdue, review). NC's
+	 * base --color-error / --color-warning / --color-success dark shades are near
+	 * black (#552121 / #3D3010 / #11321A) and vanish as text on the dark list
+	 * surface; brighten them under dark themes while keeping the stock values in
+	 * light mode (#3905/#4054 pattern). Scoped so they can't leak. */
+	--kanso-error-legible: var(--color-error, #e30000);
+	--kanso-warning-legible: var(--color-warning, #c98600);
+	--kanso-success-legible: var(--color-success, #2fb344);
+
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
 	padding: 8px 24px 24px 52px;
+}
+
+/* Explicit dark themes (theme picker) + auto (prefers-color-scheme) dark. */
+body.theme--dark .board-list-table,
+[data-theme-dark] .board-list-table,
+[data-themes*='dark'] .board-list-table {
+	--kanso-error-legible: #ff6b6b;
+	--kanso-warning-legible: #d29922;
+	--kanso-success-legible: #5ad07f;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .board-list-table,
+	body:not(.theme--light):not(.theme--dark) .board-list-table {
+		--kanso-error-legible: #ff6b6b;
+		--kanso-warning-legible: #d29922;
+		--kanso-success-legible: #5ad07f;
+	}
 }
 
 .board-list-table__host {
@@ -488,9 +515,9 @@ function isOverdue(card) {
 }
 
 .board-list-group__wip--over {
-	color: color-mix(in srgb, var(--color-warning) 85%, var(--color-main-text));
-	background: color-mix(in srgb, var(--color-warning) 25%, transparent);
-	outline: 1px solid color-mix(in srgb, var(--color-warning) 50%, transparent);
+	color: color-mix(in srgb, var(--kanso-warning-legible) 85%, var(--color-main-text));
+	background: color-mix(in srgb, var(--kanso-warning-legible) 25%, transparent);
+	outline: 1px solid color-mix(in srgb, var(--kanso-warning-legible) 50%, transparent);
 }
 
 /* Secondary hints (overdue · blocked) sit just after the count, muted; the
@@ -515,7 +542,7 @@ function isOverdue(card) {
 }
 
 .board-list-group__hint--overdue {
-	color: color-mix(in srgb, var(--color-error) 80%, var(--color-text-maxcontrast));
+	color: color-mix(in srgb, var(--kanso-error-legible) 80%, var(--color-text-maxcontrast));
 	font-weight: 600;
 }
 
@@ -558,7 +585,7 @@ function isOverdue(card) {
 
 .board-list-row__status--not_started { background: transparent; }
 .board-list-row__status--in_progress { background: var(--color-primary-element); border-color: var(--color-primary-element); }
-.board-list-row__status--done { background: var(--color-success, #2fb344); border-color: var(--color-success, #2fb344); }
+.board-list-row__status--done { background: var(--kanso-success-legible); border-color: var(--kanso-success-legible); }
 
 .board-list-row__id {
 	flex: 0 0 auto;
@@ -617,8 +644,8 @@ function isOverdue(card) {
 	background: var(--color-background-dark);
 }
 
-.board-list-row__priority--4 { color: var(--color-error); }
-.board-list-row__priority--3 { color: var(--color-warning, #c98600); }
+.board-list-row__priority--4 { color: var(--kanso-error-legible); }
+.board-list-row__priority--3 { color: var(--kanso-warning-legible); }
 
 .board-list-row__due,
 .board-list-row__count {
@@ -629,12 +656,12 @@ function isOverdue(card) {
 }
 
 .board-list-row__due--overdue {
-	color: var(--color-error);
+	color: var(--kanso-error-legible);
 	font-weight: 600;
 }
 
-.board-list-row__review--approved { color: var(--color-success, #2fb344); }
-.board-list-row__review--changes { color: var(--color-error); }
+.board-list-row__review--approved { color: var(--kanso-success-legible); }
+.board-list-row__review--changes { color: var(--kanso-error-legible); }
 
 .board-list-row__assignees {
 	display: inline-flex;

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -1065,7 +1065,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						</p>
 						<template v-else>
 							<p class="github-webhook__hint">
-								{{ t('kanso', 'Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Assignees, comments, activity and members are never shown.') }}
+								{{ publicShareNote }}
 							</p>
 
 							<div class="github-webhook__actions">
@@ -1079,6 +1079,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</div>
 
 							<template v-if="publicShare.enabled && publicShare.url">
+								<!-- Opt-in exposure toggles (#3949): deliberately widen the
+								     person-free public link. OFF by default. -->
+								<div class="github-webhook__actions">
+									<NcCheckboxRadioSwitch
+										type="switch"
+										:model-value="publicShare.commentsEnabled"
+										:disabled="publicShareBusy"
+										@update:model-value="togglePublicShareComments">
+										{{ t('kanso', 'Show comments (read-only)') }}
+									</NcCheckboxRadioSwitch>
+								</div>
+
 								<label class="github-webhook__label">{{ t('kanso', 'Public link') }}</label>
 								<div class="github-webhook__row">
 									<input class="github-webhook__input" type="text" readonly :value="publicShare.url">
@@ -2126,6 +2138,7 @@ import {
 	fetchPublicShareConfig,
 	enablePublicShare as apiEnablePublicShare,
 	disablePublicShare as apiDisablePublicShare,
+	setPublicShareComments as apiSetPublicShareComments,
 	fetchCalendarFeedConfig,
 	enableCalendarFeed as apiEnableCalendarFeed,
 	disableCalendarFeed as apiDisableCalendarFeed,
@@ -2317,9 +2330,18 @@ async function copyText(text) {
 }
 
 // ── Public / read-only share link (MANAGE) ───────────────────────────────────
-const publicShare = ref({ enabled: false, url: null })
+const publicShare = ref({ enabled: false, url: null, commentsEnabled: false })
 const publicShareError = ref('')
 const publicShareBusy = ref(false)
+
+// The "what's exposed" note reflects the enabled opt-in toggles (#3949): with
+// comments OFF the person-free baseline holds; with comments ON the note says so.
+const publicShareNote = computed(() => {
+	if (publicShare.value.commentsEnabled) {
+		return t('kanso', 'Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Read-only comments are shown; assignees, activity and members are never shown.')
+	}
+	return t('kanso', 'Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Assignees, comments, activity and members are never shown.')
+})
 
 async function loadPublicShareConfig() {
 	if (!canManage.value) return
@@ -2364,9 +2386,22 @@ async function disablePublicLink() {
 	publicShareBusy.value = true
 	try {
 		await apiDisablePublicShare(props.boardId)
-		publicShare.value = { enabled: false, url: null }
+		publicShare.value = { enabled: false, url: null, commentsEnabled: false }
 	} catch (e) {
 		publicShareError.value = e?.response?.data?.error || t('kanso', 'Could not disable the public link.')
+	} finally {
+		publicShareBusy.value = false
+	}
+}
+
+// Opt in / out of showing read-only comments on the public board (#3949).
+async function togglePublicShareComments(checked) {
+	publicShareError.value = ''
+	publicShareBusy.value = true
+	try {
+		publicShare.value = await apiSetPublicShareComments(props.boardId, checked)
+	} catch (e) {
+		publicShareError.value = e?.response?.data?.error || t('kanso', 'Could not update the public link options.')
 	} finally {
 		publicShareBusy.value = false
 	}

--- a/src/components/BulkActionBar.vue
+++ b/src/components/BulkActionBar.vue
@@ -109,6 +109,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</NcActionButton>
 		</NcActions>
 
+		<!-- Mark done -->
+		<NcButton
+			type="tertiary"
+			:disabled="applying || count === 0"
+			:title="t('kanso', 'Mark done')"
+			:aria-label="t('kanso', 'Mark done')"
+			@click="$emit('set-status', 'done')">
+			<template #icon>
+				<CheckIcon :size="20" />
+			</template>
+		</NcButton>
+
 		<!-- Archive -->
 		<NcButton
 			type="tertiary"
@@ -159,6 +171,7 @@ import LabelOffIcon from 'vue-material-design-icons/LabelOff.vue'
 import AccountPlusIcon from 'vue-material-design-icons/AccountPlus.vue'
 import CalendarClockIcon from 'vue-material-design-icons/CalendarClock.vue'
 import CalendarRemoveIcon from 'vue-material-design-icons/CalendarRemove.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
 import ArchiveIcon from 'vue-material-design-icons/Archive.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
@@ -191,7 +204,7 @@ defineProps({
 	},
 })
 
-const emit = defineEmits(['move', 'add-label', 'remove-label', 'assign', 'set-due', 'archive', 'delete', 'close'])
+const emit = defineEmits(['move', 'add-label', 'remove-label', 'assign', 'set-due', 'set-status', 'archive', 'delete', 'close'])
 
 function onDueDateSubmit(value) {
 	if (!value) return

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -5395,12 +5395,41 @@ async function handleToggleProject(projectId) {
 
 /* ── Modal shell ─────────────────────────────────────────────────────────── */
 .card-modal {
+	/* Legible status colours for small chip text/border. NC's stock warning
+	 * amber (#e07b00), neutral grey (#888/#7f8c8d) and error red (#e74c3c) are
+	 * too dim on the dark modal surface (#3905/#4054); brighten them under dark
+	 * themes while keeping the stock values in light mode. Scoped to the modal
+	 * so they can't leak. */
+	--kanso-error-legible: var(--color-error, #e30000);
+	--kanso-warning-legible: var(--color-warning, #e07b00);
+	--kanso-neutral-legible: var(--color-text-maxcontrast, #767676);
+
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
 	background: var(--color-main-background);
 	color: var(--color-main-text);
 	font-size: 15px;
+}
+
+/* Explicit dark themes (theme picker) + auto (prefers-color-scheme) dark.
+ * These brighter values read clearly on the dark surface and still pass AA
+ * as chip text/border. */
+body.theme--dark .card-modal,
+[data-theme-dark] .card-modal,
+[data-themes*='dark'] .card-modal {
+	--kanso-error-legible: #ff6b6b;
+	--kanso-warning-legible: #d29922;
+	--kanso-neutral-legible: #8b949e;
+}
+
+@media (prefers-color-scheme: dark) {
+	body.theme--default .card-modal,
+	body:not(.theme--light):not(.theme--dark) .card-modal {
+		--kanso-error-legible: #ff6b6b;
+		--kanso-warning-legible: #d29922;
+		--kanso-neutral-legible: #8b949e;
+	}
 }
 
 /* ── Loading skeleton (shimmer, real layout) ─────────────────────────────── */
@@ -5857,14 +5886,14 @@ async function handleToggleProject(projectId) {
 	color: var(--color-primary-element);
 }
 /* Priority pill colours (only colours Kanso invents) */
-.card-modal__pill--priority-1 { border-color: #888; color: #888; font-weight: 600; }
+.card-modal__pill--priority-1 { border-color: var(--kanso-neutral-legible); color: var(--kanso-neutral-legible); font-weight: 600; }
 .card-modal__pill--priority-2 { border-color: var(--color-primary-element); color: var(--color-primary-element); font-weight: 600; }
-.card-modal__pill--priority-3 { border-color: #e07b00; color: #e07b00; font-weight: 600; }
+.card-modal__pill--priority-3 { border-color: var(--kanso-warning-legible); color: var(--kanso-warning-legible); font-weight: 600; }
 .card-modal__pill--priority-4 { border-color: var(--color-error-text); color: var(--color-error-text); font-weight: 600; }
-.card-modal__pill--type-bug { border-color: #e74c3c; color: #e74c3c; font-weight: 600; }
+.card-modal__pill--type-bug { border-color: var(--kanso-error-legible); color: var(--kanso-error-legible); font-weight: 600; }
 .card-modal__pill--type-feature { border-color: #27ae60; color: #27ae60; font-weight: 600; }
 .card-modal__pill--type-task { border-color: var(--color-primary-element); color: var(--color-primary-element); font-weight: 600; }
-.card-modal__pill--type-chore { border-color: #7f8c8d; color: #7f8c8d; font-weight: 600; }
+.card-modal__pill--type-chore { border-color: var(--kanso-neutral-legible); color: var(--kanso-neutral-legible); font-weight: 600; }
 .card-modal__pill--overdue { border-color: var(--color-error-text); color: var(--color-error-text); font-weight: 600; }
 .card-modal__pill--soon { border-color: var(--color-warning-text); color: var(--color-warning-text); font-weight: 600; }
 

--- a/src/components/CardPreview.vue
+++ b/src/components/CardPreview.vue
@@ -288,10 +288,13 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .card-preview {
-	/* Legible error red for the overdue date + urgent priority chips. Mirrors
-	 * CardTile (#3905): stock --color-error in light, brighter red under dark. */
+	/* Legible status colours for the priority + overdue chips. Mirrors CardTile
+	 * (#3905/#4054): stock values in light, brighter under dark where the stock
+	 * error red / warning amber / neutral grey go too dim on the dark surface. */
 	--kanso-error-legible: var(--color-error, #e30000);
 	--kanso-error-legible-rgb: var(--color-error-rgb, 227, 0, 0);
+	--kanso-warning-legible: var(--color-warning, #e07b00);
+	--kanso-neutral-legible: var(--color-text-maxcontrast, #767676);
 
 	position: fixed;
 	z-index: 2100;
@@ -311,6 +314,8 @@ body.theme--dark .card-preview,
 [data-themes*='dark'] .card-preview {
 	--kanso-error-legible: #ff6b6b;
 	--kanso-error-legible-rgb: 255, 107, 107;
+	--kanso-warning-legible: #d29922;
+	--kanso-neutral-legible: #8b949e;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -318,6 +323,8 @@ body.theme--dark .card-preview,
 	body:not(.theme--light):not(.theme--dark) .card-preview {
 		--kanso-error-legible: #ff6b6b;
 		--kanso-error-legible-rgb: 255, 107, 107;
+		--kanso-warning-legible: #d29922;
+		--kanso-neutral-legible: #8b949e;
 	}
 }
 
@@ -391,9 +398,9 @@ body.theme--dark .card-preview,
 	border-color: currentColor;
 }
 
-.card-preview__priority--1 { color: #888; border-color: #888; background: rgba(136, 136, 136, 0.1); }
+.card-preview__priority--1 { color: var(--kanso-neutral-legible); border-color: var(--kanso-neutral-legible); background: rgba(136, 136, 136, 0.1); }
 .card-preview__priority--2 { color: var(--color-primary-element, #0082c9); border-color: var(--color-primary-element, #0082c9); background: rgba(0, 130, 201, 0.1); }
-.card-preview__priority--3 { color: #e07b00; border-color: #e07b00; background: rgba(224, 123, 0, 0.1); }
+.card-preview__priority--3 { color: var(--kanso-warning-legible); border-color: var(--kanso-warning-legible); background: rgba(224, 123, 0, 0.1); }
 .card-preview__priority--4 { color: var(--kanso-error-legible); border-color: var(--kanso-error-legible); background: rgba(var(--kanso-error-legible-rgb), 0.1); }
 
 .card-preview__due--overdue {

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -447,6 +447,7 @@ const extraAssigneeCount = computed(() => {
 	--kanso-error-legible: var(--color-error, #e30000);
 	--kanso-error-legible-rgb: var(--color-error-rgb, 227, 0, 0);
 	--kanso-warning-legible: var(--color-warning, #e07b00);
+	--kanso-success-legible: var(--color-success, #2d7d46);
 
 	display: flex;
 	flex-direction: column;
@@ -470,6 +471,7 @@ body.theme--dark .card-tile,
 	--kanso-error-legible: #ff6b6b;
 	--kanso-error-legible-rgb: 255, 107, 107;
 	--kanso-warning-legible: #d29922;
+	--kanso-success-legible: #3fb950;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -478,6 +480,7 @@ body.theme--dark .card-tile,
 		--kanso-error-legible: #ff6b6b;
 		--kanso-error-legible-rgb: 255, 107, 107;
 		--kanso-warning-legible: #d29922;
+		--kanso-success-legible: #3fb950;
 	}
 }
 
@@ -644,8 +647,8 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__checklist--complete {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
 	background: rgba(70, 186, 97, 0.1);
 }
 
@@ -662,8 +665,8 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__children--complete {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
 	background: rgba(70, 186, 97, 0.1);
 }
 
@@ -687,7 +690,7 @@ body.theme--dark .card-tile,
 /* Type icons use theme tokens so they keep WCAG contrast in both light and dark
    themes (bare #e74c3c/#27ae60/#7f8c8d fail contrast on the dark surface). */
 .card-tile__type--bug { color: var(--kanso-error-legible); }
-.card-tile__type--feature { color: var(--color-success, #27ae60); }
+.card-tile__type--feature { color: var(--kanso-success-legible); }
 .card-tile__type--task { color: var(--color-primary-element, #0082c9); }
 .card-tile__type--chore { color: var(--color-text-maxcontrast, #7f8c8d); }
 
@@ -751,8 +754,8 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__review--approved {
-	color: var(--color-success, #46ba61);
-	border-color: var(--color-success, #46ba61);
+	color: var(--kanso-success-legible);
+	border-color: var(--kanso-success-legible);
 	background: rgba(70, 186, 97, 0.1);
 }
 

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -439,12 +439,14 @@ const extraAssigneeCount = computed(() => {
 }
 
 .card-tile {
-	/* Legible error red for small foreground elements (bug icon, overdue date,
-	 * urgent priority, blocked chip). NC's --color-error dark shade is too dim on
-	 * the dark tile surface (#3905); brighten it under dark themes while keeping
-	 * the stock error red in light mode. Scoped to the tile so it can't leak. */
+	/* Legible status colours for small foreground elements (bug icon, overdue
+	 * date, urgent priority, blocked chip, warning/amber review + priority chips).
+	 * NC's --color-error / --color-warning dark shades are near black on the dark
+	 * tile surface (#3905/#4054); brighten them under dark themes while keeping
+	 * the stock values in light mode. Scoped to the tile so they can't leak. */
 	--kanso-error-legible: var(--color-error, #e30000);
 	--kanso-error-legible-rgb: var(--color-error-rgb, 227, 0, 0);
+	--kanso-warning-legible: var(--color-warning, #e07b00);
 
 	display: flex;
 	flex-direction: column;
@@ -467,6 +469,7 @@ body.theme--dark .card-tile,
 [data-themes*='dark'] .card-tile {
 	--kanso-error-legible: #ff6b6b;
 	--kanso-error-legible-rgb: 255, 107, 107;
+	--kanso-warning-legible: #d29922;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -474,6 +477,7 @@ body.theme--dark .card-tile,
 	body:not(.theme--light):not(.theme--dark) .card-tile {
 		--kanso-error-legible: #ff6b6b;
 		--kanso-error-legible-rgb: 255, 107, 107;
+		--kanso-warning-legible: #d29922;
 	}
 }
 
@@ -564,8 +568,8 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__due--soon {
-	color: var(--color-warning, #f0a844);
-	border-color: var(--color-warning, #f0a844);
+	color: var(--kanso-warning-legible);
+	border-color: var(--kanso-warning-legible);
 	background: rgba(240, 168, 68, 0.08);
 }
 
@@ -713,11 +717,11 @@ body.theme--dark .card-tile,
 	background: rgba(0, 130, 201, 0.1);
 }
 
-/* High: orange — --color-warning adapts per theme and keeps ≥4.5:1 text
-   contrast; stays distinct from Urgent's --color-error red. */
+/* High: orange — --kanso-warning-legible keeps ≥4.5:1 text contrast in both
+   themes; stays distinct from Urgent's red. */
 .card-tile__priority--3 {
-	color: var(--color-warning, #e07b00);
-	border-color: var(--color-warning, #e07b00);
+	color: var(--kanso-warning-legible);
+	border-color: var(--kanso-warning-legible);
 	background: rgba(224, 123, 0, 0.1);
 }
 
@@ -741,8 +745,8 @@ body.theme--dark .card-tile,
 }
 
 .card-tile__review--pending {
-	color: var(--color-warning, #f0a844);
-	border-color: var(--color-warning, #f0a844);
+	color: var(--kanso-warning-legible);
+	border-color: var(--kanso-warning-legible);
 	background: rgba(240, 168, 68, 0.08);
 }
 
@@ -787,8 +791,9 @@ body.theme--dark .card-tile,
 }
 
 /* Waiting-on-client chip (#3746) - amber "ball is with the client" signal.
- * --color-warning adapts per theme and keeps text contrast; distinct from the
- * blocked chip's red (blocked = stuck, waiting = parked with the other side). */
+ * --kanso-warning-legible adapts per theme and keeps text contrast; distinct
+ * from the blocked chip's red (blocked = stuck, waiting = parked with the other
+ * side). */
 .card-tile__waiting {
 	display: inline-flex;
 	align-items: center;
@@ -797,8 +802,8 @@ body.theme--dark .card-tile,
 	font-weight: 600;
 	padding: 1px 6px;
 	border-radius: 8px;
-	color: var(--color-warning, #e07b00);
-	border: 1px solid var(--color-warning, #e07b00);
+	color: var(--kanso-warning-legible);
+	border: 1px solid var(--kanso-warning-legible);
 	background: rgba(240, 168, 68, 0.1);
 }
 

--- a/src/composables/useBulkSelect.js
+++ b/src/composables/useBulkSelect.js
@@ -108,7 +108,7 @@ export function useBulkSelect(boardId, queryClient) {
 	/**
 	 * Apply a bulk action to the current selection.
 	 *
-	 * @param {string} action - one of: move, add_label, remove_label, assign_user, set_due_date, archive, delete
+	 * @param {string} action - one of: move, add_label, remove_label, assign_user, set_due_date, set_status, archive, delete
 	 * @param {object} params - action-specific params
 	 * @throws on server error
 	 */

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -409,6 +409,10 @@ export const enablePublicShare = (boardId) =>
 export const disablePublicShare = (boardId) =>
 	axios.delete(url(`/api/boards/${boardId}/public-share`)).then((r) => r.data)
 
+// Opt in / out of showing read-only comments on the public board (#3949).
+export const setPublicShareComments = (boardId, enabled) =>
+	axios.put(url(`/api/boards/${boardId}/public-share/comments`), { enabled }).then((r) => r.data)
+
 // Read-only iCal / ICS feed of card due dates (board-level, MANAGE)
 export const fetchCalendarFeedConfig = (boardId) =>
 	axios.get(url(`/api/boards/${boardId}/calendar-feed`)).then((r) => r.data)

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -522,6 +522,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			@remove-label="onBulkRemoveLabel"
 			@assign="onBulkAssign"
 			@set-due="onBulkSetDue"
+			@set-status="onBulkSetStatus"
 			@archive="onBulkArchive"
 			@delete="onBulkDelete"
 			@close="bulk.exitMode()" />
@@ -1939,6 +1940,7 @@ const onBulkAddLabel = (labelId) => runBulkAction('add_label', { labelId })
 const onBulkRemoveLabel = (labelId) => runBulkAction('remove_label', { labelId })
 const onBulkAssign = (userId) => runBulkAction('assign_user', { userId })
 const onBulkSetDue = (due) => runBulkAction('set_due_date', { duedate: due })
+const onBulkSetStatus = (status) => runBulkAction('set_status', { status })
 const onBulkArchive = () => runBulkAction('archive', {})
 const onBulkDelete = () => runBulkAction('delete', {})
 </script>

--- a/src/views/PublicBoard.vue
+++ b/src/views/PublicBoard.vue
@@ -267,8 +267,10 @@ export default {
 				return ''
 			}
 		},
-		// A comment's created_at is a unix-seconds int (public payload).
+		// A comment's created_at is a unix-seconds int (public payload). Guard a
+		// missing/zero timestamp so it renders empty rather than the epoch (1970).
 		formatDateTime(ts) {
+			if (!ts) return ''
 			try {
 				return new Date(ts * 1000).toLocaleString()
 			} catch (e) {

--- a/src/views/PublicBoard.vue
+++ b/src/views/PublicBoard.vue
@@ -125,6 +125,38 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				<p v-else class="public-detail__desc public-detail__desc--empty">
 					{{ t('kanso', 'No description') }}
 				</p>
+
+				<!-- Read-only comments (#3949): shown ONLY when the board owner opted
+				     in. Author DISPLAY NAME + an initials avatar (no NcAvatar / no uid),
+				     markdown body, one-level threads. No reply box, no reactions. -->
+				<section v-if="commentsEnabled" class="public-comments">
+					<h3 class="public-comments__title">{{ t('kanso', 'Comments') }}</h3>
+					<p v-if="!threadedComments.length" class="public-comments__empty">
+						{{ t('kanso', 'No comments') }}
+					</p>
+					<ul v-else class="public-comments__list">
+						<li v-for="c in threadedComments" :key="c.id" class="public-comment">
+							<div class="public-comment__head">
+								<span class="public-comment__avatar" aria-hidden="true">{{ initials(c.author) }}</span>
+								<span class="public-comment__author">{{ c.author }}</span>
+								<span class="public-comment__date">{{ formatDateTime(c.createdAt) }}</span>
+							</div>
+							<!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown (DOMPurify) -->
+							<div class="public-comment__body" v-html="renderComment(c.body)" />
+							<ul v-if="c.replies.length" class="public-comment__replies">
+								<li v-for="r in c.replies" :key="r.id" class="public-comment">
+									<div class="public-comment__head">
+										<span class="public-comment__avatar" aria-hidden="true">{{ initials(r.author) }}</span>
+										<span class="public-comment__author">{{ r.author }}</span>
+										<span class="public-comment__date">{{ formatDateTime(r.createdAt) }}</span>
+									</div>
+									<!-- eslint-disable-next-line vue/no-v-html -- sanitized by renderMarkdown (DOMPurify) -->
+									<div class="public-comment__body" v-html="renderComment(r.body)" />
+								</li>
+							</ul>
+						</li>
+					</ul>
+				</section>
 			</div>
 		</div>
 	</div>
@@ -149,6 +181,7 @@ export default {
 			stacks: [],
 			cards: [],
 			selectedCard: null,
+			commentsEnabled: false,
 		}
 	},
 	computed: {
@@ -172,6 +205,27 @@ export default {
 			if (!c) return false
 			return c.priority >= 4 || !!c.startDate || !!c.duedate || !!c.estimate || c.checklist.total > 0
 		},
+		// The open card's flat comment list nested one level by parentCommentId:
+		// top-level comments in order, each with its direct replies (also in order).
+		// The server already scopes and orders the list; this only groups it.
+		threadedComments() {
+			const list = (this.selectedCard && this.selectedCard.comments) || []
+			const byId = {}
+			const roots = []
+			for (const c of list) {
+				byId[c.id] = { ...c, replies: [] }
+			}
+			for (const c of list) {
+				const node = byId[c.id]
+				const parent = c.parentCommentId != null ? byId[c.parentCommentId] : null
+				if (parent) {
+					parent.replies.push(node)
+				} else {
+					roots.push(node)
+				}
+			}
+			return roots
+		},
 	},
 	async mounted() {
 		try {
@@ -179,6 +233,7 @@ export default {
 			this.board = data.board
 			this.stacks = data.stacks
 			this.cards = data.cards
+			this.commentsEnabled = !!(data.board && data.board.commentsEnabled)
 		} catch (e) {
 			this.error = true
 		} finally {
@@ -211,6 +266,27 @@ export default {
 			} catch (e) {
 				return ''
 			}
+		},
+		// A comment's created_at is a unix-seconds int (public payload).
+		formatDateTime(ts) {
+			try {
+				return new Date(ts * 1000).toLocaleString()
+			} catch (e) {
+				return ''
+			}
+		},
+		// Initials avatar (no NcAvatar, no uid): first letters of the display name.
+		initials(name) {
+			const parts = String(name || '').trim().split(/\s+/).filter(Boolean)
+			if (!parts.length) return '?'
+			const first = parts[0][0] || ''
+			const last = parts.length > 1 ? parts[parts.length - 1][0] : ''
+			return (first + last).toUpperCase()
+		},
+		// Comment body rendered as sanitized markdown (same pipeline as the
+		// description; no refs map, so PREFIX-123 stays plain text).
+		renderComment(body) {
+			return renderMarkdown(body || '')
 		},
 	},
 }

--- a/templates/public.php
+++ b/templates/public.php
@@ -69,5 +69,21 @@ html, body { height: 100%; }
 .public-detail__desc blockquote { margin: 0 0 10px; padding-left: 12px; border-left: 3px solid var(--color-border, #ddd); color: var(--color-text-maxcontrast, #666); }
 .public-detail__desc a { color: var(--color-primary-element, #0082c9); }
 .public-detail__desc img { max-width: 100%; height: auto; border-radius: 6px; }
+/* Read-only comments (#3949): shown only when the owner opted in. */
+.public-comments { margin-top: 18px; border-top: 1px solid var(--color-border, #ddd); padding-top: 14px; }
+.public-comments__title { margin: 0 0 10px; font-size: 14px; font-weight: 600; color: var(--color-main-text, #222); }
+.public-comments__empty { margin: 0; font-size: 13px; font-style: italic; color: var(--color-text-maxcontrast, #888); }
+.public-comments__list, .public-comment__replies { list-style: none; margin: 0; padding: 0; }
+.public-comment { margin-bottom: 14px; }
+.public-comment__replies { margin-top: 12px; padding-left: 20px; border-left: 2px solid var(--color-border, #eee); }
+.public-comment__head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+.public-comment__avatar { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 50%; background: var(--color-primary-element, #0082c9); color: #fff; font-size: 11px; font-weight: 600; flex: 0 0 auto; }
+.public-comment__author { font-size: 13px; font-weight: 600; color: var(--color-main-text, #222); }
+.public-comment__date { font-size: 12px; color: var(--color-text-maxcontrast, #888); }
+.public-comment__body { font-size: 14px; line-height: 1.5; word-break: break-word; color: var(--color-main-text, #222); }
+.public-comment__body p { margin: 0 0 8px; }
+.public-comment__body p:last-child { margin-bottom: 0; }
+.public-comment__body a { color: var(--color-primary-element, #0082c9); }
+.public-comment__body code { background: var(--color-background-dark, #f0f0f0); padding: 1px 4px; border-radius: 4px; font-size: 0.92em; }
 </style>
 <div id="kanso-public" data-token="<?php p($_['token'] ?? ''); ?>"></div>

--- a/tests/e2e/bulk-mark-done.spec.js
+++ b/tests/e2e/bulk-mark-done.spec.js
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// doneAt for each card in the stack, keyed by title (from the board summary).
+async function doneByTitle(boardId, stackId) {
+	const board = await api('GET', `/boards/${boardId}`)
+	const out = {}
+	for (const c of board.cards) {
+		if (c.stackId === stackId && !c.archived) out[c.title] = Number(c.doneAt) > 0
+	}
+	return out
+}
+
+// #4045 — multi-select cards, then bulk "Mark done" via the bulk action bar.
+test.describe('Bulk mark done (multi-select)', () => {
+	const state = { boardId: 0, todoId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Bulk-Mark-Done E2E' })
+		state.boardId = board.id
+		state.todoId = (await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })).id
+		await api('POST', '/cards', { stackId: state.todoId, title: 'Alpha' })
+		await api('POST', '/cards', { stackId: state.todoId, title: 'Bravo' })
+		await api('POST', '/cards', { stackId: state.todoId, title: 'Charlie' })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('selecting two cards and bulk-marking done stamps them done', async ({ page }) => {
+		expect(await doneByTitle(state.boardId, state.todoId))
+			.toEqual({ Alpha: false, Bravo: false, Charlie: false })
+
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.stack-column', { timeout: 15_000 })
+		await expect(page.locator('.card-tile', { hasText: 'Alpha' })).toBeVisible({ timeout: 10_000 })
+
+		// Enter multi-select mode via the consolidated ⋯ More overflow menu.
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: 'Select multiple cards' }).click()
+
+		// Select Alpha and Bravo (Charlie stays untouched).
+		await page.locator('.card-tile', { hasText: 'Alpha' }).click()
+		await page.locator('.card-tile', { hasText: 'Bravo' }).click()
+
+		// The bulk action bar reports the selection count.
+		await expect(page.locator('.bulk-action-bar')).toContainText('2')
+
+		// The "Mark done" control renders a visible icon and is clickable.
+		const markDone = page.getByRole('button', { name: 'Mark done' })
+		await expect(markDone).toBeVisible()
+		await expect(markDone.locator('.material-design-icon')).toBeVisible()
+		await markDone.click()
+
+		// Both selected cards are stamped done server-side; Charlie is not.
+		await expect
+			.poll(() => doneByTitle(state.boardId, state.todoId), { timeout: 10_000 })
+			.toEqual({ Alpha: true, Bravo: true, Charlie: false })
+
+		// The board reflects the done state on the two tiles.
+		await expect(page.locator('.card-tile--done', { hasText: 'Alpha' })).toBeVisible({ timeout: 10_000 })
+		await expect(page.locator('.card-tile--done', { hasText: 'Bravo' })).toBeVisible({ timeout: 10_000 })
+		await expect(page.locator('.card-tile--done', { hasText: 'Charlie' })).toHaveCount(0)
+	})
+})

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -232,3 +232,100 @@ test.describe('Public board is interactive read-only', () => {
 		await expect(page.locator('.public-detail')).toHaveCount(0)
 	})
 })
+
+// Opt-in exposure toggle (#3949): the public board is person-free by default,
+// but a MANAGE user may DELIBERATELY enable read-only comments. When ON, an
+// anonymous reader sees the thread (author display names only); when OFF, the
+// comments never surface and the payload never carries them.
+test.describe('Public board comments opt-in', () => {
+	// True anonymous reader (opt out of the shared admin storageState).
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	let boardId = 0
+	let cardId = 0
+	let token = ''
+
+	test.beforeAll(async () => {
+		boardId = (await api('POST', '/boards', { title: 'Public Comments E2E' })).body.id
+		const stackId = (await api('POST', '/stacks', { boardId, title: 'To do' })).body.id
+		cardId = (await api('POST', '/cards', { stackId, title: 'Card with a discussion' })).body.id
+		// A top-level comment (markdown) and a reply, both by admin.
+		const top = (await api('POST', `/cards/${cardId}/comments`, { body: 'PUBLIC_TOP **bold**' })).body
+		await api('POST', `/cards/${cardId}/comments`, { body: 'PUBLIC_REPLY here', parentCommentId: top.id })
+		token = (await api('POST', `/boards/${boardId}/public-share`)).body.token
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await api('DELETE', `/boards/${boardId}`)
+	})
+
+	test('OFF by default: payload carries no comments and the page hides them', async ({ page }) => {
+		const res = await fetchPublic(token)
+		expect(res.status).toBe(200)
+		expect(res.body.board.commentsEnabled).toBe(false)
+		const card = res.body.cards.find((c) => c.title === 'Card with a discussion')
+		expect(card).toBeTruthy()
+		expect(card.comments).toBeUndefined()
+		const json = JSON.stringify(res.body)
+		expect(json).not.toContain('PUBLIC_TOP')
+		expect(json).not.toContain('PUBLIC_REPLY')
+
+		await page.goto(`${BASE}/index.php/apps/kanso/p/${token}`)
+		await page.locator('.public-card').filter({ hasText: 'Card with a discussion' }).click()
+		const detail = page.locator('.public-detail')
+		await expect(detail).toBeVisible()
+		// No comments section when the opt-in is off.
+		await expect(detail.locator('.public-comments')).toHaveCount(0)
+		await expect(detail).not.toContainText('PUBLIC_TOP')
+	})
+
+	test('ON: enabling the toggle surfaces a read-only thread with author display names', async ({ page }) => {
+		// MANAGE user opts in.
+		const cfg = (await api('PUT', `/boards/${boardId}/public-share/comments`, { enabled: true })).body
+		expect(cfg.commentsEnabled).toBe(true)
+
+		// Payload now carries the comments (author display name only, not the uid).
+		const res = await fetchPublic(token)
+		expect(res.body.board.commentsEnabled).toBe(true)
+		const card = res.body.cards.find((c) => c.title === 'Card with a discussion')
+		expect(Array.isArray(card.comments)).toBe(true)
+		expect(card.comments.length).toBe(2)
+		// The comment carries the author's DISPLAY NAME (resolved from the uid, like
+		// the authenticated endpoint) - a non-empty string - and its markdown body,
+		// timestamps and one-level parent link. (In this dev instance the admin's
+		// display name and uid coincide; the display-name resolution itself is pinned
+		// by the unit test with distinct names.)
+		expect(typeof card.comments[0].author).toBe('string')
+		expect(card.comments[0].author.length).toBeGreaterThan(0)
+		expect(card.comments[0].parentCommentId).toBeNull()
+		expect(card.comments[1].parentCommentId).toBe(card.comments[0].id)
+		const json = JSON.stringify(res.body)
+		expect(json).toContain('PUBLIC_TOP')
+		// No reactions / reactor lists / assignee data ride the public comment.
+		expect(card.comments[0].reactions).toBeUndefined()
+		expect(json).not.toContain('reactor')
+		expect(json).not.toContain('assignee')
+
+		// The anonymous page renders the read-only thread with a rendered markdown
+		// body and an initials avatar (no NcAvatar, no reply box).
+		await page.goto(`${BASE}/index.php/apps/kanso/p/${token}`)
+		await page.locator('.public-card').filter({ hasText: 'Card with a discussion' }).click()
+		const comments = page.locator('.public-detail .public-comments')
+		await expect(comments).toBeVisible()
+		await expect(comments.locator('.public-comment__body strong').first()).toHaveText('bold')
+		await expect(comments).toContainText('PUBLIC_REPLY')
+		await expect(comments.locator('.public-comment__avatar').first()).toBeVisible()
+		// Read-only: no comment input in the public thread.
+		await expect(comments.locator('input, textarea')).toHaveCount(0)
+	})
+
+	test('toggling OFF again hides the thread and drops it from the payload', async () => {
+		const cfg = (await api('PUT', `/boards/${boardId}/public-share/comments`, { enabled: false })).body
+		expect(cfg.commentsEnabled).toBe(false)
+		const res = await fetchPublic(token)
+		expect(res.body.board.commentsEnabled).toBe(false)
+		const card = res.body.cards.find((c) => c.title === 'Card with a discussion')
+		expect(card.comments).toBeUndefined()
+		expect(JSON.stringify(res.body)).not.toContain('PUBLIC_TOP')
+	})
+})

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -31,6 +31,12 @@ async function fetchPublic(token) {
 // Public / read-only board share links (#3531). A MANAGE user mints a token; an
 // unauthenticated reader gets a STRIPPED read-only board; disabling 404s it.
 test.describe('Public read-only board share', () => {
+	// The unauthenticated fetchPublic / anonymous page assertions below must run as
+	// a true anonymous reader. Opt OUT of the shared admin storageState, otherwise
+	// the public payload/page loads under the admin session and the tests
+	// false-pass or false-fail.
+	test.use({ storageState: { cookies: [], origins: [] } })
+
 	let boardId = 0
 	let todoStackId = 0
 	let cardId = 0
@@ -70,8 +76,9 @@ test.describe('Public read-only board share', () => {
 		expect(res.status).toBe(200)
 		expect(res.body.board.title).toBe('Public Share E2E')
 
-		// The board object carries no owner / acl / token / webhook.
-		expect(Object.keys(res.body.board).sort()).toEqual(['color', 'prefix', 'title'])
+		// The board object carries no owner / acl / token / webhook - only the
+		// presentational fields plus the comments opt-in flag (#3949).
+		expect(Object.keys(res.body.board).sort()).toEqual(['color', 'commentsEnabled', 'prefix', 'title'])
 
 		const card = res.body.cards.find((c) => c.title === 'Public visible card')
 		expect(card).toBeTruthy()

--- a/tests/unit/Service/BulkCardServiceTest.php
+++ b/tests/unit/Service/BulkCardServiceTest.php
@@ -147,6 +147,51 @@ class BulkCardServiceTest extends TestCase {
 		self::assertSame([11], $result['ok']);
 	}
 
+	public function testBulkSetStatusDoneCallsUpdateWithDoneTrue(): void {
+		$this->cardService->expects(self::exactly(2))->method('update')
+			->willReturnCallback(function (int $id, $t, $d, $due, $done, $arch, string $uid) {
+				self::assertNull($t);
+				self::assertNull($d);
+				self::assertNull($due);
+				self::assertTrue($done); // marks the card done
+				self::assertNull($arch);
+				self::assertSame('alice', $uid);
+				return $this->card($id);
+			});
+
+		$result = $this->service->apply([11, 12], BulkCardService::ACTION_SET_STATUS, ['status' => 'done'], 'alice');
+		self::assertSame([11, 12], $result['ok']);
+		self::assertSame([], $result['skipped']);
+	}
+
+	public function testBulkSetStatusForbiddenCardIsSkipped(): void {
+		// Card 12 lives on a board alice cannot edit → update throws
+		// NotPermittedException. The other card still gets marked done.
+		$this->cardService->method('update')
+			->willReturnCallback(function (int $id, $t, $d, $due, $done, $arch, string $uid): Card {
+				if ($id === 12) {
+					throw new NotPermittedException('nope');
+				}
+				return $this->card($id);
+			});
+
+		$result = $this->service->apply([11, 12], BulkCardService::ACTION_SET_STATUS, ['status' => 'done'], 'alice');
+
+		self::assertSame([11], $result['ok']);
+		self::assertSame([['id' => 12, 'reason' => 'forbidden']], $result['skipped']);
+	}
+
+	public function testBulkSetStatusWithUnsupportedStatusThrowsInvalidInput(): void {
+		$this->cardService->expects(self::never())->method('update');
+		$this->expectException(InvalidInputException::class);
+		$this->service->apply([11], BulkCardService::ACTION_SET_STATUS, ['status' => 'open'], 'alice');
+	}
+
+	public function testBulkSetStatusWithoutStatusThrowsInvalidInput(): void {
+		$this->expectException(InvalidInputException::class);
+		$this->service->apply([11], BulkCardService::ACTION_SET_STATUS, [], 'alice');
+	}
+
 	public function testBulkArchiveCallsUpdateWithArchivedTrue(): void {
 		$this->cardService->expects(self::exactly(2))->method('update')
 			->willReturnCallback(function (int $id, $t, $d, $due, $done, $arch, string $uid) {

--- a/tests/unit/Service/PublicShareServiceTest.php
+++ b/tests/unit/Service/PublicShareServiceTest.php
@@ -23,6 +23,7 @@ use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\PermissionService;
 use OCA\Kanso\Service\PublicShareService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -44,6 +45,7 @@ class PublicShareServiceTest extends TestCase {
 	private ISecureRandom&MockObject $secureRandom;
 	private IURLGenerator&MockObject $urlGenerator;
 	private IUserManager&MockObject $userManager;
+	private IL10N&MockObject $l10n;
 	private PublicShareService $service;
 
 	protected function setUp(): void {
@@ -59,6 +61,9 @@ class PublicShareServiceTest extends TestCase {
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		// Translate returns the source string verbatim (the mock just echoes it).
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 		$this->service = new PublicShareService(
 			$this->boardMapper,
 			$this->stackMapper,
@@ -71,6 +76,7 @@ class PublicShareServiceTest extends TestCase {
 			$this->secureRandom,
 			$this->urlGenerator,
 			$this->userManager,
+			$this->l10n,
 		);
 	}
 
@@ -410,6 +416,37 @@ class PublicShareServiceTest extends TestCase {
 		foreach (['reaction', 'reactor', 'assignee', 'watcher', 'member'] as $forbidden) {
 			self::assertStringNotContainsStringIgnoringCase($forbidden, $json, "public comments leaked '$forbidden'");
 		}
+	}
+
+	public function testDeletedCommentAuthorShowsGenericLabelNotRawUid(): void {
+		$this->boardMapper->method('findByPublicToken')->with(self::TOKEN)
+			->willReturn($this->board(1, self::TOKEN, null, true));
+		$this->stackMapper->method('findByBoard')->with(1)->willReturn([$this->stack(10, 'To do')]);
+		$this->cardMapper->method('findPublicByBoard')->with(1)->willReturn([$this->card(100, 10, 'Live card')]);
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardLabelMapper->method('findLabelIdsByBoardPublicOnly')->willReturn([]);
+		$this->checklistItemMapper->method('progressByBoardPublicOnly')->willReturn([]);
+		// A comment whose author account was deleted: 'ghostuid' is a real,
+		// identifying uid that must NEVER surface on the anonymous link.
+		$this->commentMapper->expects(self::once())->method('findByBoardPublicOnly')->with(1)->willReturn([
+			100 => [
+				$this->comment(1, 100, 'ghostuid', 'left before deletion'),
+			],
+		]);
+		// The deleted account no longer resolves - IUserManager::get() returns null.
+		$this->userManager->method('get')->with('ghostuid')->willReturn(null);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		$comments = $payload['cards'][0]['comments'];
+		self::assertCount(1, $comments);
+		// The generic label is shown instead of the raw uid.
+		self::assertSame('Former user', $comments[0]['author']);
+		self::assertSame('left before deletion', $comments[0]['body']);
+
+		// The raw uid must appear NOWHERE in the serialized public payload.
+		$json = json_encode($payload);
+		self::assertStringNotContainsString('ghostuid', $json, 'deleted author uid leaked into the public payload');
 	}
 
 	public function testSetCommentsRequiresManageAndPersists(): void {

--- a/tests/unit/Service/PublicShareServiceTest.php
+++ b/tests/unit/Service/PublicShareServiceTest.php
@@ -13,6 +13,8 @@ use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\ChecklistItemMapper;
+use OCA\Kanso\Db\Comment;
+use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
@@ -22,6 +24,8 @@ use OCA\Kanso\Service\PermissionService;
 use OCA\Kanso\Service\PublicShareService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -35,9 +39,11 @@ class PublicShareServiceTest extends TestCase {
 	private CardLabelMapper&MockObject $cardLabelMapper;
 	private ChecklistItemMapper&MockObject $checklistItemMapper;
 	private LabelMapper&MockObject $labelMapper;
+	private CommentMapper&MockObject $commentMapper;
 	private PermissionService&MockObject $permissionService;
 	private ISecureRandom&MockObject $secureRandom;
 	private IURLGenerator&MockObject $urlGenerator;
+	private IUserManager&MockObject $userManager;
 	private PublicShareService $service;
 
 	protected function setUp(): void {
@@ -48,9 +54,11 @@ class PublicShareServiceTest extends TestCase {
 		$this->cardLabelMapper = $this->createMock(CardLabelMapper::class);
 		$this->checklistItemMapper = $this->createMock(ChecklistItemMapper::class);
 		$this->labelMapper = $this->createMock(LabelMapper::class);
+		$this->commentMapper = $this->createMock(CommentMapper::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->service = new PublicShareService(
 			$this->boardMapper,
 			$this->stackMapper,
@@ -58,13 +66,15 @@ class PublicShareServiceTest extends TestCase {
 			$this->cardLabelMapper,
 			$this->checklistItemMapper,
 			$this->labelMapper,
+			$this->commentMapper,
 			$this->permissionService,
 			$this->secureRandom,
 			$this->urlGenerator,
+			$this->userManager,
 		);
 	}
 
-	private function board(int $id = 1, ?string $token = self::TOKEN, ?int $expiresAt = null): Board {
+	private function board(int $id = 1, ?string $token = self::TOKEN, ?int $expiresAt = null, bool $comments = false): Board {
 		$b = new Board();
 		$b->setId($id);
 		$b->setOwner('alice');
@@ -73,7 +83,21 @@ class PublicShareServiceTest extends TestCase {
 		$b->setDeletedAt(0);
 		$b->setPublicShareToken($token);
 		$b->setPublicShareExpiresAt($expiresAt);
+		$b->setPublicShareComments($comments);
 		return $b;
+	}
+
+	private function comment(int $id, int $cardId, string $author, string $body, ?int $parentCommentId = null): Comment {
+		$c = new Comment();
+		$c->setId($id);
+		$c->setCardId($cardId);
+		$c->setParentCommentId($parentCommentId);
+		$c->setAuthor($author);
+		$c->setBody($body);
+		$c->setCreatedAt(1000 + $id);
+		$c->setEditedAt(0);
+		$c->setDeletedAt(0);
+		return $c;
 	}
 
 	private function stack(int $id, string $title, bool $archived = false): Stack {
@@ -239,10 +263,14 @@ class PublicShareServiceTest extends TestCase {
 		$this->checklistItemMapper->expects(self::never())->method('waitingByBoard');
 		$payload = $this->service->getPublicBoard(self::TOKEN);
 
-		// Board: no owner, no acl, no webhook secret, no share token.
+		// Board: no owner, no acl, no webhook secret, no share token. The
+		// `commentsEnabled` flag is a public-safe boolean gate (#3949) - it says
+		// WHETHER comments are shown, never who; with the opt-in OFF here it is
+		// false and no comment data is present.
 		$boardKeys = array_keys($payload['board']);
 		sort($boardKeys);
-		self::assertSame(['color', 'prefix', 'title'], $boardKeys);
+		self::assertSame(['color', 'commentsEnabled', 'prefix', 'title'], $boardKeys);
+		self::assertFalse($payload['board']['commentsEnabled']);
 
 		// Card: exactly the whitelisted, people-free field set.
 		$cardKeys = array_keys($payload['cards'][0]);
@@ -256,11 +284,18 @@ class PublicShareServiceTest extends TestCase {
 			$cardKeys
 		);
 
+		// With the comments opt-in OFF (the default), no card carries a comment
+		// thread at all - the person-free baseline holds.
+		self::assertArrayNotHasKey('comments', $payload['cards'][0]);
+
 		// Explicitly assert the sensitive keys never appear. 'waiting' pins the
 		// #3746 exclusion: the derived waiting-on-client state is provider-side
 		// signal (who the ball is with) and must never ride the anonymous payload.
+		// ('comment' is intentionally NOT in this list: the public-safe boolean
+		// gate `commentsEnabled` contains that substring; the OFF-state absence of
+		// any comment data is asserted directly above.)
 		$json = json_encode($payload);
-		foreach (['owner', 'assignee', 'comment', 'acl', 'webhook', 'subscriber', 'watcher', 'reviewState', 'activity', 'waiting'] as $forbidden) {
+		foreach (['owner', 'assignee', 'acl', 'webhook', 'subscriber', 'watcher', 'reviewState', 'activity', 'waiting'] as $forbidden) {
 			self::assertStringNotContainsStringIgnoringCase($forbidden, $json, "public payload leaked '$forbidden'");
 		}
 	}
@@ -318,5 +353,88 @@ class PublicShareServiceTest extends TestCase {
 
 		$payload = $this->service->getPublicBoard(self::TOKEN);
 		self::assertSame('Roadmap', $payload['board']['title']);
+	}
+
+	// ── comments opt-in (#3949) ────────────────────────────────────────────
+
+	public function testCommentsOffByDefaultOmitsCommentsAndNeverQueriesThem(): void {
+		$this->primePublicBoard();
+		// With the opt-in OFF, comments must NEVER be fetched (no leak, no query).
+		$this->commentMapper->expects(self::never())->method('findByBoardPublicOnly');
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertFalse($payload['board']['commentsEnabled']);
+		self::assertArrayNotHasKey('comments', $payload['cards'][0]);
+	}
+
+	public function testCommentsOnIncludesReadOnlyThreadWithDisplayNamesOnly(): void {
+		$this->boardMapper->method('findByPublicToken')->with(self::TOKEN)
+			->willReturn($this->board(1, self::TOKEN, null, true));
+		$this->stackMapper->method('findByBoard')->with(1)->willReturn([$this->stack(10, 'To do')]);
+		$this->cardMapper->method('findPublicByBoard')->with(1)->willReturn([$this->card(100, 10, 'Live card')]);
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardLabelMapper->method('findLabelIdsByBoardPublicOnly')->willReturn([]);
+		$this->checklistItemMapper->method('progressByBoardPublicOnly')->willReturn([]);
+		// A top-level comment and a reply, both on the public card.
+		$this->commentMapper->expects(self::once())->method('findByBoardPublicOnly')->with(1)->willReturn([
+			100 => [
+				$this->comment(1, 100, 'bob', 'first!'),
+				$this->comment(2, 100, 'carol', 'reply to bob', 1),
+			],
+		]);
+		// The uid resolves to a display name; the uid itself must never appear.
+		$bob = $this->createMock(IUser::class);
+		$bob->method('getDisplayName')->willReturn('Bob Builder');
+		$carol = $this->createMock(IUser::class);
+		$carol->method('getDisplayName')->willReturn('Carol Danvers');
+		$this->userManager->method('get')->willReturnMap([
+			['bob', $bob],
+			['carol', $carol],
+		]);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertTrue($payload['board']['commentsEnabled']);
+		$comments = $payload['cards'][0]['comments'];
+		self::assertCount(2, $comments);
+		self::assertSame('Bob Builder', $comments[0]['author']);
+		self::assertSame('first!', $comments[0]['body']);
+		self::assertNull($comments[0]['parentCommentId']);
+		self::assertSame('Carol Danvers', $comments[1]['author']);
+		self::assertSame(1, $comments[1]['parentCommentId']);
+
+		// Author DISPLAY NAMES only - the uids must not leak, nor any reaction key.
+		$json = json_encode($payload);
+		self::assertStringNotContainsString('"author":"bob"', $json);
+		self::assertStringNotContainsString('"author":"carol"', $json);
+		foreach (['reaction', 'reactor', 'assignee', 'watcher', 'member'] as $forbidden) {
+			self::assertStringNotContainsStringIgnoringCase($forbidden, $json, "public comments leaked '$forbidden'");
+		}
+	}
+
+	public function testSetCommentsRequiresManageAndPersists(): void {
+		$board = $this->board(1, self::TOKEN, null, false);
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://nc/p/tok');
+		$this->permissionService->expects(self::once())->method('assertPermission')
+			->with($board, 'alice', PermissionService::PERMISSION_MANAGE);
+		$this->boardMapper->expects(self::once())->method('update')
+			->willReturnCallback(function (Board $b): Board {
+				self::assertTrue($b->getPublicShareComments());
+				return $b;
+			});
+
+		$config = $this->service->setComments(1, true, 'alice');
+		self::assertTrue($config['commentsEnabled']);
+	}
+
+	public function testSetCommentsDeniedWithoutManage(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->permissionService->method('assertPermission')
+			->willThrowException(new NotPermittedException());
+		$this->boardMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->setComments(1, true, 'mallory');
 	}
 }

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -1098,6 +1098,7 @@ msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardTile.vue
+#: src/views/PublicBoard.vue
 msgid "Comments"
 msgstr ""
 
@@ -1246,6 +1247,10 @@ msgstr ""
 
 #: src/views/BoardList.vue
 msgid "Could not set up the starter board."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not update the public link options."
 msgstr ""
 
 #: src/views/BoardView.vue
@@ -3128,6 +3133,7 @@ msgid "No colour"
 msgstr ""
 
 #: src/composables/useBoardFilters.js
+#: src/views/PublicBoard.vue
 msgid "No comments"
 msgstr ""
 
@@ -4036,6 +4042,10 @@ msgstr ""
 msgid "Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Assignees, comments, activity and members are never shown."
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Share a read-only view of this board with anyone via a public link. No sign-in is required to view it. Read-only comments are shown; assignees, activity and members are never shown."
+msgstr ""
+
 #: src/views/PublicBoard.vue
 msgid "Shared read-only via Kanso"
 msgstr ""
@@ -4046,6 +4056,10 @@ msgstr ""
 
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Show comments (read-only)"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -2444,6 +2444,10 @@ msgstr ""
 msgid "Formatting"
 msgstr ""
 
+#: lib/Service/PublicShareService.php
+msgid "Former user"
+msgstr ""
+
 #: src/components/BoardSettingsModal.vue
 msgid "Frequency"
 msgstr ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -2819,6 +2819,7 @@ msgstr ""
 msgid "Mark as template"
 msgstr ""
 
+#: src/components/BulkActionBar.vue
 #: src/components/CardDetail.vue
 msgid "Mark done"
 msgstr ""


### PR DESCRIPTION
PM session 2026-08-20 (worktree=single, branched off origin/main). Milestone objective: **release-quality polish + the next public-share PR** — three groomed cards, each validate→implement→adversarial-review→test→commit.

## Cards
- **#3949 `feat:` Public links can opt in to read-only comments** — per-share, default OFF, MANAGE-gated toggle in Public Link settings. When ON the public payload includes each public card's comments (author display name only, markdown body, one-level replies); assignees/members/reactions/activity remain never exposed. Migration `Version005200` adds nullable `public_share_comments` to `kanso_boards`. PHPUnit covers both payload states (no leak when OFF) + MANAGE-denial; new anonymous e2e for the enabled thread.
- **#4056 `fix:` Priority/type/review chips stay legible in dark mode** — adds theme-aware `--kanso-warning-legible` / `--kanso-neutral-legible` tokens (alongside the existing error/success legible tokens) and replaces near-black `--color-error`/`--color-warning` text on transparent chips across CardDetail, CardPreview, CardTile, BoardListView. Light mode unchanged; each chip visually verified in NC 34 dark.
- **#4045 `feat:` Multi-select cards can be marked done in one action** — adds a visible "Mark done" (check icon) action to the bulk bar; backend `set_status` bulk action reuses the single-card done path per card (same per-card EDIT permission, `done_at` stamp, `kanso_changes` row). PHPUnit happy-path + permission-denial + bad-input; e2e drives multi-select → Mark done.

## Verification
- Full unit suite green (1348 tests); psalm + php-cs-fixer clean; frontend build clean; l10n `.pot` regenerated.
- New e2e specs run green against the local dev stack.
- No `appinfo/info.xml` / `package.json` version bump (release-only).

Opened by /pm — review and merge when the required CI checks (cs-check, psalm, unit-php 8.2/8.3, build-frontend, e2e) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)