### PR TITLE
Fix recurring-task duplication + date bugs (#64, #65) and 4 audit follow-ups

### DIFF
--- a/lib/Db/RecurRuleMapper.php
+++ b/lib/Db/RecurRuleMapper.php
@@ -103,6 +103,23 @@ class RecurRuleMapper extends QBMapper {
 	}
 
 	/**
+	 * Removes every recurrence rule anchored on a template card - the cascade for
+	 * a card purge. A rule whose template is hard-deleted can never spawn again
+	 * (its template read throws), so purging the card must drop its rules too;
+	 * otherwise an enabled orphan rule makes every cron pass log a failed spawn.
+	 *
+	 * @return int number of deleted rows (0 when the card anchored no rules)
+	 * @throws Exception
+	 */
+	public function deleteByTemplateCardId(int $templateCardId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('template_card_id', $qb->createNamedParameter($templateCardId, IQueryBuilder::PARAM_INT)));
+
+		return $qb->executeStatement();
+	}
+
+	/**
 	 * Every enabled rule due to fire now - the cron's work list. A rule is due
 	 * when it is enabled, has a cached next fire time (`next_occurrence_at > 0`,
 	 * so exhausted/never rules are excluded) and that time has passed. Hits the

--- a/lib/Migration/Version005300Date20260909000000.php
+++ b/lib/Migration/Version005300Date20260909000000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCA\Kanso\Cron\SpawnRecurringCards;
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Ensure the recurring-card spawner cron is registered on this instance (#65).
+ *
+ * {@see \OCA\Kanso\Cron\SpawnRecurringCards} is declared in info.xml
+ * <background-jobs>, but Nextcloud only syncs that list on a FRESH install, not
+ * when an existing install is upgraded. Instances that installed Kanso before
+ * the recurring-cards feature shipped therefore never had the job registered,
+ * so their recurring rules silently never fired.
+ *
+ * This is schema-less: it only (idempotently) adds the background job in
+ * postSchemaChange, mirroring the SendPersonalReminders registration in
+ * {@see Version005100Date20260908000000}. Registering it here covers both fresh
+ * install and upgrade; the jobList add is guarded so re-running is a no-op.
+ */
+class Version005300Date20260909000000 extends SimpleMigrationStep {
+	public function __construct(
+		private IJobList $jobList,
+	) {
+	}
+
+	/**
+	 * Ensure the recurring-card spawner is registered on this instance. Runs on
+	 * install and on upgrade (info.xml only auto-registers <background-jobs> on a
+	 * fresh install), guarded so re-running is a no-op.
+	 */
+	#[\Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		if (!$this->jobList->has(SpawnRecurringCards::class, null)) {
+			$this->jobList->add(SpawnRecurringCards::class);
+			$output->info('Registered background job: SpawnRecurringCards');
+		}
+	}
+}

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -244,8 +244,12 @@ class RecurrenceService {
 	}
 
 	/**
-	 * Updates the given fields of a rule (null = leave unchanged). Any change to
-	 * the RRULE or the enabled flag recomputes `next_occurrence_at` from now.
+	 * Updates the given fields of a rule (null = leave unchanged). The cached
+	 * `next_occurrence_at` is re-armed only when the schedule actually changes (a
+	 * different RRULE) or the rule is re-enabled (disabled → enabled), and even
+	 * then it is never rewound onto an occurrence the cron already spawned - a
+	 * no-op edit leaves the cursor exactly where it was, so editing a rule can no
+	 * longer duplicate an already-fired occurrence dated today (#65).
 	 *
 	 * @throws DoesNotExistException if the rule, its board, the template card or the target stack does not exist or is deleted
 	 * @throws NotPermittedException if the user may not manage the board
@@ -277,6 +281,13 @@ class RecurrenceService {
 		// Same gate as create() (#3760): re-anchoring on a hidden template is a 404.
 		$this->visibilityGuard->assertVisible($board, $this->loadCard($newTemplate), $uid);
 
+		// Capture the pre-edit schedule + enabled state BEFORE applying the setters
+		// so we can tell an actual schedule change from a no-op edit (#65). The
+		// cursor may only be re-armed when the schedule really changed, and never
+		// rewound onto an occurrence the cron has already spawned.
+		$originalRrule = $rule->getRrule();
+		$wasEnabled = $rule->getEnabled();
+
 		$rule->setTemplateCardId($newTemplate);
 		$rule->setTargetStackId($newStack);
 		$rule->setMode($newMode);
@@ -290,11 +301,22 @@ class RecurrenceService {
 			$rule->setEnabled($enabled);
 		}
 
-		// Re-arm the cached next fire time whenever the schedule or its enabled
-		// state might have changed (cheap; keeps the cron scan honest).
-		$now = $this->time->getTime();
-		if ($rule->getEnabled()) {
-			$rule->setNextOccurrenceAt($this->computeNextOccurrence($rule->getRrule(), $now - 1, $rule->getCreatedAt(), $rule->getTimezone()));
+		// Re-arm the cached next fire time ONLY when the schedule genuinely changed
+		// (the RRULE differs) or the rule was just re-enabled (disabled → enabled).
+		// A no-op edit (e.g. an {enabled} toggle that stays on, or re-writing the
+		// same RRULE from the card's Repeat control) must NOT recompute the cursor:
+		// recomputing from now-1 can REWIND next_occurrence_at back onto TODAY - an
+		// occurrence the cron already fired - so the next cron run spawns a duplicate
+		// clone dated today (#65). When we DO re-arm, never let the cursor move
+		// backward past where it already sits: anchor the "after" point at
+		// max(now-1, currentCursor-1) so an edit can only move it forward, never onto
+		// an already-spawned occurrence.
+		$scheduleChanged = $newRrule !== $originalRrule;
+		$reEnabled = $rule->getEnabled() && !$wasEnabled;
+		if ($rule->getEnabled() && ($scheduleChanged || $reEnabled)) {
+			$now = $this->time->getTime();
+			$after = max($now - 1, $rule->getNextOccurrenceAt() - 1);
+			$rule->setNextOccurrenceAt($this->computeNextOccurrence($rule->getRrule(), $after, $rule->getCreatedAt(), $rule->getTimezone()));
 		}
 
 		return $this->ruleMapper->update($rule);

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -411,6 +411,37 @@ class RecurrenceService {
 			? $rule->getNextOccurrenceAt()
 			: $this->time->getTime();
 
+		// Read the template up front - both the soft-trash pause below and the CLONE
+		// enrichment need it, so read once (a missing/hard-deleted template stays
+		// null here and falls through to the mode branch, which throws its usual
+		// DoesNotExistException that the cron logs and retries).
+		$template = $this->findTemplateOrNull($rule);
+
+		// Pause on a SOFT-trashed template (#4124): create/update guard the template
+		// via loadCard() (throws on deleted_at > 0), but the spawn hot path read it
+		// raw, so a template moved to the trash kept cloning/resetting. Treat a
+		// soft-trashed template as a pause, not an error and not a hard-disable: skip
+		// the spawn but still advance the schedule past this occurrence (like a
+		// skip_while_open skip) so the cron does not busy-loop, and leave the rule
+		// enabled so it resumes automatically when the template is restored. A PURGED
+		// template is a different case - the purge drops the rule outright (#4123).
+		if ($template !== null && $template->getDeletedAt() > 0) {
+			$this->db->beginTransaction();
+			try {
+				$this->logger->info(
+					'kanso: recurring rule ' . $rule->getId()
+					. ' paused, template card is in the trash'
+				);
+				$this->advanceSchedule($rule, $this->advanceFrom($rule, $occurrenceTs, $manual));
+				$this->ruleMapper->update($rule);
+				$this->db->commit();
+			} catch (\Throwable $e) {
+				$this->db->rollBack();
+				throw $e;
+			}
+			return null;
+		}
+
 		$this->db->beginTransaction();
 		try {
 			if ($rule->getMode() === RecurRule::MODE_RESET) {
@@ -429,7 +460,7 @@ class RecurrenceService {
 					$this->db->commit();
 					return null;
 				}
-				$card = $this->spawnClone($rule, $occurrenceTs);
+				$card = $this->spawnClone($rule, $occurrenceTs, $template);
 			}
 
 			$rule->setOccurrencesSpawned($rule->getOccurrencesSpawned() + 1);
@@ -468,8 +499,10 @@ class RecurrenceService {
 	 * and emitted by {@see self::spawn()} after commit - a pre-commit push could
 	 * make a client refetch state the transaction may still roll back.
 	 */
-	private function spawnClone(RecurRule $rule, int $occurrenceTs): Card {
-		$template = $this->cardMapper->find($rule->getTemplateCardId());
+	private function spawnClone(RecurRule $rule, int $occurrenceTs, ?Card $template = null): Card {
+		// $template is the copy spawn() already read; null only when spawn() found
+		// no template (hard-deleted) - re-read to raise the usual DoesNotExistException.
+		$template ??= $this->cardMapper->find($rule->getTemplateCardId());
 
 		// Visibility (#3760): the spawn runs as the rule OWNER - if the template
 		// has been narrowed past them since the rule was created, copying its
@@ -496,6 +529,9 @@ class RecurrenceService {
 
 		$card->setDescription($template->getDescription());
 		$card->setDuedate($this->duedateFor($rule, $occurrenceTs));
+		// Carry the template's all-day flag (#4125): without it the clone defaults
+		// to all_day=false and shows a spurious 00:00 time on an all-day template.
+		$card->setAllDay($template->getAllDay() ?? false);
 		$card->setLastModified($this->time->getTime());
 		$card = $this->cardMapper->update($card);
 
@@ -626,6 +662,21 @@ class RecurrenceService {
 		$rule->setNextOccurrenceAt($next);
 		if ($next === 0) {
 			$rule->setEnabled(false);
+		}
+	}
+
+	/**
+	 * The rule's template card, or null if it is hard-gone. spawn() reads it once
+	 * up front for both the soft-trash pause check (#4124) and CLONE enrichment.
+	 * A MISSING template returns null (not an exception here) so spawn() falls
+	 * through to the mode branch, which raises the usual DoesNotExistException the
+	 * cron logs and retries; a purge cascade drops the rule outright (#4123).
+	 */
+	private function findTemplateOrNull(RecurRule $rule): ?Card {
+		try {
+			return $this->cardMapper->find($rule->getTemplateCardId());
+		} catch (DoesNotExistException) {
+			return null;
 		}
 	}
 

--- a/lib/Service/TrashService.php
+++ b/lib/Service/TrashService.php
@@ -24,6 +24,7 @@ use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\CommentReactionMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 use OCA\Kanso\Db\ReminderMapper;
 use OCA\Kanso\Db\SubscriptionMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -65,6 +66,7 @@ class TrashService {
 		private CardTimeEntryService $cardTimeEntryService,
 		private CardFieldValueMapper $cardFieldValueMapper,
 		private ReminderMapper $reminderMapper,
+		private RecurRuleMapper $recurRuleMapper,
 		private BoardAccess $boardAccess,
 		private CardVisibilityGuard $visibilityGuard,
 	) {
@@ -159,6 +161,11 @@ class TrashService {
 		// Personal reminders (#3816) are plain per-user rows scoped by card_id;
 		// drop them so a purged card strands no pending reminders.
 		$this->reminderMapper->deleteByCard($cardId);
+		// Recurrence rules anchored on this card (#4123): a rule whose template is
+		// hard-deleted can never spawn again - each cron pass would read the missing
+		// template, throw, and log a failed spawn forever. Drop them so the purge
+		// leaves no orphan schedule behind.
+		$this->recurRuleMapper->deleteByTemplateCardId($cardId);
 		$this->cardMapper->delete($card);
 
 		$this->changeNotifier->notify(

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -128,7 +128,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							class="board-list-row__due"
 							:class="{ 'board-list-row__due--overdue': isOverdue(rows[vRow.index].card) }">
 							<CalendarIcon :size="14" />
-							{{ formatDue(rows[vRow.index].card.duedate) }}
+							{{ formatDue(rows[vRow.index].card) }}
 						</span>
 
 						<!-- Comments -->
@@ -181,6 +181,7 @@ import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import { cssColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
 import { PRIORITY_LEVELS } from '../composables/usePriority.js'
+import { formatCardDate } from '../utils/dateDisplay.js'
 
 const props = defineProps({
 	/** Non-archived stacks in display order (already filtered by BoardView). */
@@ -387,10 +388,12 @@ function priorityLabel(value) {
 	return PRIORITY_LEVELS.find((l) => l.value === value)?.label ?? ''
 }
 
-function formatDue(duedate) {
-	const d = new Date(duedate)
+function formatDue(card) {
+	const d = new Date(card.duedate)
 	if (Number.isNaN(d.getTime())) return ''
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+	// All-day dates are stored at UTC midnight; format them in UTC so the row
+	// shows the picked calendar day even west of UTC (not the previous day).
+	return formatCardDate(card.duedate, card.allDay === true, { month: 'short', day: 'numeric' })
 }
 
 function isOverdue(card) {

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -556,12 +556,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<label class="card-modal__field-label">{{ t('kanso', 'Due date') }}</label>
 							<div class="card-modal__field-row">
 								<input
-									ref="dueDateInputEl"
 									class="card-modal__date-input"
 									:type="isAllDay ? 'date' : 'datetime-local'"
-									:value="dueDateBuf"
-									@focus="dueDateBuf = dueDateInputValue"
-									@change="handleDueDateChange">
+									:value="dueDateInputValue"
+									@blur="handleDueDateChange"
+									@keyup.enter="handleDueDateChange">
 								<button v-if="cardData.duedate" class="card-modal__field-clear" :title="t('kanso', 'Clear due date')" @click="clearDueDate">
 									<CloseIcon :size="14" />
 								</button>
@@ -576,12 +575,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<label class="card-modal__field-label">{{ t('kanso', 'Start date') }}</label>
 							<div class="card-modal__field-row">
 								<input
-									ref="startDateInputEl"
 									class="card-modal__date-input"
 									type="datetime-local"
-									:value="startDateBuf"
-									@focus="startDateBuf = startDateInputValue"
-									@change="handleStartDateChange">
+									:value="startDateInputValue"
+									@blur="handleStartDateChange"
+									@keyup.enter="handleStartDateChange">
 								<button v-if="cardData.startDate" class="card-modal__field-clear" :title="t('kanso', 'Clear start date')" @click="clearStartDate">
 									<CloseIcon :size="14" />
 								</button>
@@ -3142,22 +3140,15 @@ const dueDateInputValue = computed(() => {
 	return isAllDay.value ? allDayInputValue(d) : timedInputValue(d)
 })
 
-// Native segmented date inputs fire `change` per segment, and each change kicks
-// off updateCard → refetch → cardData replaced → the bound value recomputes and
-// re-applies mid-edit, resetting the caret and dropping digits (#64). Bind the
-// input to a local buffer instead, and only re-seed it from the source value
-// when the field is NOT focused — so external updates (and the all-day type
-// swap, which forces a re-render) still sync, but keystrokes aren't clobbered.
-const dueDateInputEl = ref(null)
-const dueDateBuf = ref(dueDateInputValue.value)
-watch(dueDateInputValue, (val) => {
-	if (dueDateInputEl.value && document.activeElement === dueDateInputEl.value) return
-	dueDateBuf.value = val
-})
-
+// Native segmented date inputs fire `change` per segment, so committing on
+// `change` kicks off updateCard → refetch mid-edit and clobbers the field (#64).
+// Commit on blur/Enter instead: the value is bound straight to the computed and
+// only saved once the user leaves the field.
 async function handleDueDateChange(event) {
 	const val = event.target.value
 	if (!val) return
+	// Leaving the field without editing it shouldn't fire a redundant PATCH.
+	if (val === dueDateInputValue.value) return
 	// An all-day "YYYY-MM-DD" parses as UTC midnight; a datetime-local as local.
 	const iso = new Date(val).toISOString()
 	try {
@@ -3193,18 +3184,11 @@ const startDateInputValue = computed(() => {
 	return isAllDay.value ? `${allDayInputValue(d)}T00:00` : timedInputValue(d)
 })
 
-// Same buffered-input guard as the due date (#64): don't let the refetch write
-// back into the field while the user is typing into it.
-const startDateInputEl = ref(null)
-const startDateBuf = ref(startDateInputValue.value)
-watch(startDateInputValue, (val) => {
-	if (startDateInputEl.value && document.activeElement === startDateInputEl.value) return
-	startDateBuf.value = val
-})
-
 async function handleStartDateChange(event) {
 	const val = event.target.value
 	if (!val) return
+	// Leaving the field without editing it shouldn't fire a redundant PATCH.
+	if (val === startDateInputValue.value) return
 	const iso = new Date(val).toISOString()
 	try {
 		await updateCard.mutateAsync({ data: { startDate: iso } })

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -556,9 +556,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<label class="card-modal__field-label">{{ t('kanso', 'Due date') }}</label>
 							<div class="card-modal__field-row">
 								<input
+									ref="dueDateInputEl"
 									class="card-modal__date-input"
 									:type="isAllDay ? 'date' : 'datetime-local'"
-									:value="dueDateInputValue"
+									:value="dueDateBuf"
+									@focus="dueDateBuf = dueDateInputValue"
 									@change="handleDueDateChange">
 								<button v-if="cardData.duedate" class="card-modal__field-clear" :title="t('kanso', 'Clear due date')" @click="clearDueDate">
 									<CloseIcon :size="14" />
@@ -574,9 +576,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<label class="card-modal__field-label">{{ t('kanso', 'Start date') }}</label>
 							<div class="card-modal__field-row">
 								<input
+									ref="startDateInputEl"
 									class="card-modal__date-input"
 									type="datetime-local"
-									:value="startDateInputValue"
+									:value="startDateBuf"
+									@focus="startDateBuf = startDateInputValue"
 									@change="handleStartDateChange">
 								<button v-if="cardData.startDate" class="card-modal__field-clear" :title="t('kanso', 'Clear start date')" @click="clearStartDate">
 									<CloseIcon :size="14" />
@@ -3136,6 +3140,19 @@ const dueDateInputValue = computed(() => {
 	return isAllDay.value ? date : `${date}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 })
 
+// Native segmented date inputs fire `change` per segment, and each change kicks
+// off updateCard → refetch → cardData replaced → the bound value recomputes and
+// re-applies mid-edit, resetting the caret and dropping digits (#64). Bind the
+// input to a local buffer instead, and only re-seed it from the source value
+// when the field is NOT focused — so external updates (and the all-day type
+// swap, which forces a re-render) still sync, but keystrokes aren't clobbered.
+const dueDateInputEl = ref(null)
+const dueDateBuf = ref(dueDateInputValue.value)
+watch(dueDateInputValue, (val) => {
+	if (dueDateInputEl.value && document.activeElement === dueDateInputEl.value) return
+	dueDateBuf.value = val
+})
+
 async function handleDueDateChange(event) {
 	const val = event.target.value
 	if (!val) return
@@ -3170,6 +3187,15 @@ const startDateInputValue = computed(() => {
 	const d = new Date(cardData.value.startDate)
 	const pad = (n) => String(n).padStart(2, '0')
 	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+})
+
+// Same buffered-input guard as the due date (#64): don't let the refetch write
+// back into the field while the user is typing into it.
+const startDateInputEl = ref(null)
+const startDateBuf = ref(startDateInputValue.value)
+watch(startDateInputValue, (val) => {
+	if (startDateInputEl.value && document.activeElement === startDateInputEl.value) return
+	startDateBuf.value = val
 })
 
 async function handleStartDateChange(event) {

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -2268,6 +2268,7 @@ import { useCardActions } from '../composables/useCardActions.js'
 import { useChecklist } from '../composables/useChecklist.js'
 import { useComments, buildCommentTree, REACTION_EMOJI } from '../composables/useComments.js'
 import { buildCardPrompt } from '../utils/cardPrompt.js'
+import { allDayInputValue, timedInputValue, formatCardDate } from '../utils/dateDisplay.js'
 import { useCardHierarchy } from '../composables/useCardHierarchy.js'
 import { boardQueryKey, invalidateMyWork } from '../composables/queryKeys.js'
 import { useCardMove } from '../composables/useCardMove.js'
@@ -3135,9 +3136,10 @@ const isAllDay = computed(() => cardData.value?.allDay === true)
 const dueDateInputValue = computed(() => {
 	if (!cardData.value?.duedate) return ''
 	const d = new Date(cardData.value.duedate)
-	const pad = (n) => String(n).padStart(2, '0')
-	const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-	return isAllDay.value ? date : `${date}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+	// All-day dates are stored at UTC midnight and the input is a plain date
+	// picker: read the day back in UTC so a date typed as the 22nd shows the 22nd
+	// west of UTC (not the 21st). Timed dates keep local time (real time-of-day).
+	return isAllDay.value ? allDayInputValue(d) : timedInputValue(d)
 })
 
 // Native segmented date inputs fire `change` per segment, and each change kicks
@@ -3185,8 +3187,10 @@ async function clearDueDate() {
 const startDateInputValue = computed(() => {
 	if (!cardData.value?.startDate) return ''
 	const d = new Date(cardData.value.startDate)
-	const pad = (n) => String(n).padStart(2, '0')
-	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+	// The start input is always a datetime-local field. For an all-day card the
+	// start date is stored at UTC midnight, so read the day back in UTC (matching
+	// the due date) and pin the time to 00:00; timed dates stay in local time.
+	return isAllDay.value ? `${allDayInputValue(d)}T00:00` : timedInputValue(d)
 })
 
 // Same buffered-input guard as the due date (#64): don't let the refetch write
@@ -5173,13 +5177,15 @@ const currentPriorityLevel = computed(() =>
 )
 const dueDateLabel = computed(() => {
 	if (!cardData.value?.duedate) return ''
-	const d = new Date(cardData.value.duedate)
-	if (isAllDay.value) {
-		return d.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })
-	}
-	return d.toLocaleString(undefined, {
-		weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
-	})
+	// All-day → format in UTC (the stored calendar day) so the pill matches the
+	// picked day regardless of the viewer's timezone; timed → local with time.
+	return formatCardDate(
+		cardData.value.duedate,
+		isAllDay.value,
+		isAllDay.value
+			? { weekday: 'short', day: 'numeric', month: 'short' }
+			: { weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' },
+	)
 })
 // Labels actually assigned to this card (for the attribute-bar chips)
 const assignedLabels = computed(() => boardLabels.value.filter((l) => cardLabelIds.value.has(l.id)))

--- a/src/components/CardPreview.vue
+++ b/src/components/CardPreview.vue
@@ -121,6 +121,7 @@ import { renderMarkdown } from '../services/markdown.js'
 import { cssColor, readableColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
 import { PRIORITY_LEVELS } from '../composables/usePriority.js'
+import { formatCardDate } from '../utils/dateDisplay.js'
 
 const props = defineProps({
 	/** Board summary card (title, boardSeq, labelIds, assigneeIds, priority, duedate, checklist). */
@@ -192,8 +193,9 @@ const priorityLabel = computed(() => {
 
 const dueLabel = computed(() => {
 	if (!props.card.duedate) return ''
-	const d = new Date(props.card.duedate)
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+	// All-day dates are stored at UTC midnight; format them in UTC so the pill
+	// shows the picked calendar day even west of UTC (not the previous day).
+	return formatCardDate(props.card.duedate, props.card.allDay === true, { month: 'short', day: 'numeric' })
 })
 
 const dueDateClass = computed(() => {

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -224,6 +224,7 @@ import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-d
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine'
 import { cssColor, readableColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
+import { formatCardDate } from '../utils/dateDisplay.js'
 import { attachClosestEdge, extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 
 const props = defineProps({
@@ -348,8 +349,9 @@ const dueDateClass = computed(() => {
 })
 
 function formatDue(iso) {
-	const d = new Date(iso)
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+	// All-day dates are stored at UTC midnight; format them in UTC so the chip
+	// shows the picked calendar day even west of UTC (not the previous day).
+	return formatCardDate(iso, props.card.allDay === true, { month: 'short', day: 'numeric' })
 }
 
 // Priority label for the indicator badge

--- a/src/utils/dateDisplay.js
+++ b/src/utils/dateDisplay.js
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * dateDisplay - timezone-correct formatting for card due/start dates.
+ *
+ * All-day dates are STORED at UTC midnight (`new Date("YYYY-MM-DD").toISOString()`,
+ * e.g. `2026-07-22T00:00:00.000Z`) so the stored instant is a stable calendar day
+ * that downstream consumers (reminders, overdue calc, the calendar feed's
+ * VALUE=DATE) agree on. The storage MUST NOT change.
+ *
+ * The bug these helpers fix: reading an all-day date back with LOCAL getters
+ * (`getFullYear`/`getMonth`/`getDate`, `toLocaleDateString(...)` with no timeZone)
+ * renders UTC-midnight in the viewer's zone. West of UTC that lands on the
+ * PREVIOUS calendar day (`2026-07-22T00:00:00Z` → "Jul 21" in America/New_York),
+ * so an all-day date typed as the 22nd displays as the 21st.
+ *
+ * Fix: for all-day dates, format in UTC so read == write zero point. Timed dates
+ * (datetime-local) keep local formatting - they carry a real time-of-day the
+ * viewer should see in their own zone.
+ */
+
+/**
+ * `YYYY-MM-DD` for a `<input type="date">`, in UTC for the given instant.
+ *
+ * @param {Date} d parsed all-day date (UTC midnight)
+ * @returns {string} e.g. "2026-07-22"
+ */
+export function allDayInputValue(d) {
+	const pad = (n) => String(n).padStart(2, '0')
+	return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+}
+
+/**
+ * `YYYY-MM-DDTHH:mm` for a `<input type="datetime-local">`, in LOCAL time.
+ *
+ * @param {Date} d parsed timed date
+ * @returns {string} e.g. "2026-07-22T14:30"
+ */
+export function timedInputValue(d) {
+	const pad = (n) => String(n).padStart(2, '0')
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+		+ `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+/**
+ * Human date label for a card date, timezone-correct for all-day cards.
+ *
+ * All-day → formatted in UTC (matches the stored calendar day); timed → local
+ * (with the time-of-day). `allDay` selects which; `opts` is the
+ * Intl.DateTimeFormat options for the date part.
+ *
+ * @param {string} iso the stored ISO datetime
+ * @param {boolean} allDay whether the date is all-day (date-only)
+ * @param {Intl.DateTimeFormatOptions} opts date-part format options
+ * @returns {string}
+ */
+export function formatCardDate(iso, allDay, opts) {
+	const d = new Date(iso)
+	if (allDay) {
+		return d.toLocaleDateString(undefined, { ...opts, timeZone: 'UTC' })
+	}
+	return d.toLocaleString(undefined, opts)
+}

--- a/tests/e2e/card-allday-timezone.spec.js
+++ b/tests/e2e/card-allday-timezone.spec.js
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+// Run the whole file in a west-of-UTC zone. That is the exact condition the bug
+// needed: an all-day date stored at UTC midnight (2026-07-22T00:00:00Z) rendered
+// with the viewer's local getters lands on the PREVIOUS calendar day in
+// America/New_York (UTC-4/-5), so "the 22nd" used to display as "the 21st".
+test.use({ timezoneId: 'America/New_York' })
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+// NC serves the app JS with immutable caching; force a fresh fetch of the just-
+// built bundle so the test exercises the current code, not a cached copy.
+async function clearJsCache(page) {
+	const client = await page.context().newCDPSession(page)
+	await client.send('Network.clearBrowserCache').catch(() => {})
+}
+
+async function cardDates(boardId, cardId) {
+	const board = await api('GET', `/boards/${boardId}`)
+	const c = board.cards.find((x) => x.id === cardId)
+	return { duedate: c?.duedate, startDate: c?.startDate, allDay: c?.allDay }
+}
+
+// The card fix: an all-day due/start date is STORED at UTC midnight, and the
+// read-back (date input value + pill label) must be formatted in UTC so it shows
+// the same calendar day everywhere, regardless of the viewer's timezone.
+test.describe('All-day dates in a non-UTC timezone', () => {
+	const state = { boardId: 0, cardId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'All-Day TZ E2E' })
+		state.boardId = board.id
+		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })
+		const card = await api('POST', '/cards', { stackId: stack.id, title: 'TZ card' })
+		state.cardId = card.id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('an all-day due date shows the picked day (not the previous one) after reload', async ({ page }) => {
+		// Seed an all-day due date at UTC midnight for the 22nd — exactly what the
+		// modal writes: new Date("2026-07-22").toISOString() + allDay: true.
+		await api('PATCH', `/cards/${state.cardId}`, {
+			duedate: '2026-07-22T00:00:00.000Z',
+			allDay: true,
+		})
+
+		await ncLogin(page)
+		await clearJsCache(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		// The due pill (collapsed attribute bar) must read "22", not "21".
+		const duePill = page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]')
+		await expect(duePill).toContainText('22')
+		await expect(duePill).not.toContainText('21')
+
+		// Open the popover: the date input must be the plain date picker holding the
+		// exact stored day.
+		await duePill.click()
+		const dueInput = page.locator('.card-modal__popover .card-modal__date-input').first()
+		await expect(dueInput).toHaveAttribute('type', 'date')
+		await expect(dueInput).toHaveValue('2026-07-22')
+
+		// Storage is unchanged — still UTC midnight of the 22nd.
+		const d = await cardDates(state.boardId, state.cardId)
+		expect(d.allDay).toBe(true)
+		expect(new Date(d.duedate).toISOString()).toBe('2026-07-22T00:00:00.000Z')
+	})
+
+	test('an all-day start date shows the picked day (not the previous one) after reload', async ({ page }) => {
+		await api('PATCH', `/cards/${state.cardId}`, {
+			duedate: '2026-07-22T00:00:00.000Z',
+			startDate: '2026-07-20T00:00:00.000Z',
+			allDay: true,
+		})
+
+		await ncLogin(page)
+		await clearJsCache(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		// Second date input in the popover is the start date.
+		const startInput = page.locator('.card-modal__popover .card-modal__date-input').nth(1)
+		// An all-day card reads its start back in UTC → the 20th, not the 19th.
+		await expect(startInput).toHaveValue(/^2026-07-20T/)
+	})
+
+	test('a TIMED due date still round-trips in local time (no regression)', async ({ page }) => {
+		// A non-all-day card keeps local formatting. 2026-07-22T02:00:00Z is
+		// 2026-07-21 22:00 in America/New_York, so the input must show the 21st —
+		// the correct LOCAL day for a real instant.
+		await api('PATCH', `/cards/${state.cardId}`, {
+			duedate: '2026-07-22T02:00:00.000Z',
+			startDate: '',
+			allDay: false,
+		})
+
+		await ncLogin(page)
+		await clearJsCache(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		const dueInput = page.locator('.card-modal__popover .card-modal__date-input').first()
+		await expect(dueInput).toHaveAttribute('type', 'datetime-local')
+		// 22:00 local on the 21st — local time-of-day preserved for timed dates.
+		await expect(dueInput).toHaveValue('2026-07-21T22:00')
+	})
+})

--- a/tests/e2e/card-date-input.spec.js
+++ b/tests/e2e/card-date-input.spec.js
@@ -46,12 +46,33 @@ function localYmd(iso) {
 }
 
 // #64 — typing a full date by keyboard into the card's Start/Due date fields used
-// to be erratic: each segment "change" kicked off updateCard → refetch → the
-// controlled :value re-applied mid-edit, resetting the caret and dropping digits.
-// The buffered input must now let the user type an entire date, key-by-key, with a
-// realistic per-key delay, without the async write-back clobbering the field.
+// to be erratic: the native segmented input commits on every `change` (fired
+// per-segment as soon as one is edited), so `handleDueDateChange` ran mid-edit →
+// updateCard → refetch → the controlled :value re-applied and reset the field.
+// The fix keeps the native inputs but commits on BLUR / Enter only. So while the
+// field is focused NO PATCH may fire; exactly one PATCH fires once the user leaves
+// the field (or presses Enter), carrying the fully-typed value.
 test.describe('Typing a date by keyboard', () => {
 	const state = { boardId: 0, cardId: 0, cardUrl: '' }
+
+	// Focus the all-day checkbox to move focus OFF the date input — a real blur
+	// that fires the commit. (Pressing Tab only hops between the datetime-local's
+	// own segments, so it does not blur the field.)
+	const blur = (page) => page.locator('.card-modal__allday input[type=checkbox]').focus()
+
+	// PATCH requests to this card, tagged so we can assert none fire mid-edit and
+	// exactly one fires on commit.
+	function trackPatches(page) {
+		const patches = []
+		page.on('request', (req) => {
+			if (req.method() === 'PATCH' && new RegExp(`/cards/${state.cardId}(\\?|$)`).test(req.url())) {
+				let body = null
+				try { body = req.postDataJSON() } catch { /* non-JSON body */ }
+				patches.push(body)
+			}
+		})
+		return patches
+	}
 
 	test.beforeAll(async () => {
 		const board = await api('POST', '/boards', { title: 'Date Input E2E' })
@@ -59,8 +80,7 @@ test.describe('Typing a date by keyboard', () => {
 		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })
 		const card = await api('POST', '/cards', { stackId: stack.id, title: 'Typed date card' })
 		// Seed both dates so the segmented inputs start pre-populated (all segments
-		// present) and the time-of-day segments don't interfere while we retype the
-		// date. A timed (non-all-day) due date keeps the input a datetime-local.
+		// present). A timed (non-all-day) due date keeps the input a datetime-local.
 		await api('PATCH', `/cards/${card.id}`, {
 			duedate: '2026-01-02T09:30:00+00:00',
 			startDate: '2026-01-02T09:30:00+00:00',
@@ -73,7 +93,8 @@ test.describe('Typing a date by keyboard', () => {
 		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('typing a due date key-by-key keeps every digit and commits the typed date', async ({ page }) => {
+	test('typing a due date fires no PATCH mid-edit and one PATCH on blur with the typed date', async ({ page }) => {
+		const patches = trackPatches(page)
 		await ncLogin(page)
 		await page.goto(state.cardUrl)
 		await page.setViewportSize({ width: 1280, height: 800 })
@@ -83,26 +104,53 @@ test.describe('Typing a date by keyboard', () => {
 		const dueInput = page.locator('.card-modal__popover .card-modal__date-input').first()
 		await expect(dueInput).toHaveAttribute('type', 'datetime-local')
 
-		// Focus the first (month) segment, then type the whole date one key at a
-		// time with a real typing delay. This is what fires the per-segment change
+		// Seat the caret on the first (month) segment, then type the whole date one
+		// key at a time with a real typing delay. This drives the per-segment change
 		// events that used to trigger the mid-edit refetch clobber.
 		await dueInput.click()
-		await page.keyboard.press('Home')
-		// MM DD YYYY → 03 / 14 / 2027
+		for (let i = 0; i < 5; i++) await page.keyboard.press('ArrowLeft')
 		await dueInput.pressSequentially('03142027', { delay: 120 })
 
-		// The committed input value must contain the full date exactly as typed —
-		// no dropped digits, no reset to the first segment.
+		// The typed value must be intact — no dropped digits, no reset to segment 1 —
+		// and, crucially, NO PATCH may have fired while the field is still focused.
 		await expect(dueInput).toHaveValue(/^2027-03-14T/)
+		await page.waitForTimeout(400)
+		expect(patches, 'no PATCH may fire mid-edit').toHaveLength(0)
 
-		// And the server must store that same calendar day (the change handler ran
-		// on the intact value, not a half-typed one).
+		// Leaving the field commits exactly once, with the fully-typed date.
+		await blur(page)
 		await expect
 			.poll(() => cardDates(state.boardId, state.cardId).then((d) => localYmd(d.duedate)), { timeout: 8_000 })
 			.toBe('2027-03-14')
+		expect(patches, 'exactly one PATCH on blur').toHaveLength(1)
+		expect(patches[0]).toHaveProperty('duedate')
 	})
 
-	test('typing a start date key-by-key keeps every digit and commits the typed date', async ({ page }) => {
+	test('pressing Enter commits the typed due date', async ({ page }) => {
+		const patches = trackPatches(page)
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		const dueInput = page.locator('.card-modal__popover .card-modal__date-input').first()
+		await dueInput.click()
+		for (let i = 0; i < 5; i++) await page.keyboard.press('ArrowLeft')
+		await dueInput.pressSequentially('09102027', { delay: 120 })
+		await expect(dueInput).toHaveValue(/^2027-09-10T/)
+		await page.waitForTimeout(400)
+		expect(patches, 'no PATCH before Enter').toHaveLength(0)
+
+		await dueInput.press('Enter')
+		await expect
+			.poll(() => cardDates(state.boardId, state.cardId).then((d) => localYmd(d.duedate)), { timeout: 8_000 })
+			.toBe('2027-09-10')
+		expect(patches.length, 'Enter commits at least once').toBeGreaterThanOrEqual(1)
+	})
+
+	test('typing a start date fires no PATCH mid-edit and one PATCH on blur with the typed date', async ({ page }) => {
+		const patches = trackPatches(page)
 		await ncLogin(page)
 		await page.goto(state.cardUrl)
 		await page.setViewportSize({ width: 1280, height: 800 })
@@ -114,14 +162,32 @@ test.describe('Typing a date by keyboard', () => {
 		await expect(startInput).toHaveAttribute('type', 'datetime-local')
 
 		await startInput.click()
-		await page.keyboard.press('Home')
-		// MM DD YYYY → 05 / 09 / 2027
+		for (let i = 0; i < 5; i++) await page.keyboard.press('ArrowLeft')
 		await startInput.pressSequentially('05092027', { delay: 120 })
-
 		await expect(startInput).toHaveValue(/^2027-05-09T/)
+		await page.waitForTimeout(400)
+		expect(patches, 'no PATCH may fire mid-edit').toHaveLength(0)
 
+		await blur(page)
 		await expect
 			.poll(() => cardDates(state.boardId, state.cardId).then((d) => localYmd(d.startDate)), { timeout: 8_000 })
 			.toBe('2027-05-09')
+		expect(patches, 'exactly one PATCH on blur').toHaveLength(1)
+		expect(patches[0]).toHaveProperty('startDate')
+	})
+
+	test('leaving a date field unedited fires no redundant PATCH', async ({ page }) => {
+		const patches = trackPatches(page)
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		const dueInput = page.locator('.card-modal__popover .card-modal__date-input').first()
+		await dueInput.click()
+		await blur(page)
+		await page.waitForTimeout(600)
+		expect(patches, 'no PATCH when the field is left untouched').toHaveLength(0)
 	})
 })

--- a/tests/e2e/card-date-input.spec.js
+++ b/tests/e2e/card-date-input.spec.js
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect } from '@playwright/test'
+
+const BASE = 'http://localhost:8891'
+const USER = 'admin'
+const PASS = 'admin'
+const API = BASE + '/index.php/apps/kanso/api'
+const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
+const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
+
+async function api(method, path, body) {
+	const r = await fetch(API + path, {
+		method,
+		headers: { ...HEADERS, Authorization: AUTH },
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	return method === 'DELETE' ? null : r.json()
+}
+
+async function ncLogin(page) {
+	await page.goto(BASE + '/index.php/login')
+	await page.waitForLoadState('domcontentloaded', { timeout: 15_000 }).catch(() => {})
+	if (!(await page.locator('#user').isVisible({ timeout: 3000 }).catch(() => false))) return
+	await page.fill('#user', USER)
+	await page.fill('#password', PASS)
+	await page.click('button[type=submit]')
+	await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
+	await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {})
+}
+
+async function cardDates(boardId, cardId) {
+	const board = await api('GET', `/boards/${boardId}`)
+	const c = board.cards.find((x) => x.id === cardId)
+	return { duedate: c?.duedate, startDate: c?.startDate }
+}
+
+// The local Y-M-D of a date, matching what the datetime-local input shows and
+// what handleDueDateChange persists (`new Date(localValue).toISOString()`).
+function localYmd(iso) {
+	const d = new Date(iso)
+	const pad = (n) => String(n).padStart(2, '0')
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+// #64 — typing a full date by keyboard into the card's Start/Due date fields used
+// to be erratic: each segment "change" kicked off updateCard → refetch → the
+// controlled :value re-applied mid-edit, resetting the caret and dropping digits.
+// The buffered input must now let the user type an entire date, key-by-key, with a
+// realistic per-key delay, without the async write-back clobbering the field.
+test.describe('Typing a date by keyboard', () => {
+	const state = { boardId: 0, cardId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api('POST', '/boards', { title: 'Date Input E2E' })
+		state.boardId = board.id
+		const stack = await api('POST', '/stacks', { boardId: board.id, title: 'To Do' })
+		const card = await api('POST', '/cards', { stackId: stack.id, title: 'Typed date card' })
+		// Seed both dates so the segmented inputs start pre-populated (all segments
+		// present) and the time-of-day segments don't interfere while we retype the
+		// date. A timed (non-all-day) due date keeps the input a datetime-local.
+		await api('PATCH', `/cards/${card.id}`, {
+			duedate: '2026-01-02T09:30:00+00:00',
+			startDate: '2026-01-02T09:30:00+00:00',
+		})
+		state.cardId = card.id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api('DELETE', `/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('typing a due date key-by-key keeps every digit and commits the typed date', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		const dueInput = page.locator('.card-modal__popover .card-modal__date-input').first()
+		await expect(dueInput).toHaveAttribute('type', 'datetime-local')
+
+		// Focus the first (month) segment, then type the whole date one key at a
+		// time with a real typing delay. This is what fires the per-segment change
+		// events that used to trigger the mid-edit refetch clobber.
+		await dueInput.click()
+		await page.keyboard.press('Home')
+		// MM DD YYYY → 03 / 14 / 2027
+		await dueInput.pressSequentially('03142027', { delay: 120 })
+
+		// The committed input value must contain the full date exactly as typed —
+		// no dropped digits, no reset to the first segment.
+		await expect(dueInput).toHaveValue(/^2027-03-14T/)
+
+		// And the server must store that same calendar day (the change handler ran
+		// on the intact value, not a half-typed one).
+		await expect
+			.poll(() => cardDates(state.boardId, state.cardId).then((d) => localYmd(d.duedate)), { timeout: 8_000 })
+			.toBe('2027-03-14')
+	})
+
+	test('typing a start date key-by-key keeps every digit and commits the typed date', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.setViewportSize({ width: 1280, height: 800 })
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+
+		await page.locator('.card-modal__attrbar button.card-modal__pill[data-pill="due"]').click()
+		// Second date input in the popover is the start date (always datetime-local).
+		const startInput = page.locator('.card-modal__popover .card-modal__date-input').nth(1)
+		await expect(startInput).toHaveAttribute('type', 'datetime-local')
+
+		await startInput.click()
+		await page.keyboard.press('Home')
+		// MM DD YYYY → 05 / 09 / 2027
+		await startInput.pressSequentially('05092027', { delay: 120 })
+
+		await expect(startInput).toHaveValue(/^2027-05-09T/)
+
+		await expect
+			.poll(() => cardDates(state.boardId, state.cardId).then((d) => localYmd(d.startDate)), { timeout: 8_000 })
+			.toBe('2027-05-09')
+	})
+})

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -440,6 +440,111 @@ class RecurrenceServiceTest extends TestCase {
 		$this->service->spawn($rule);
 	}
 
+	public function testSpawnCloneCopiesTemplateAllDayFlag(): void {
+		// #4125: an all-day template must spawn an all-day clone, else the clone
+		// defaults to all_day=false and shows a spurious 00:00 time.
+		$template = $this->templateCard();
+		$template->setAllDay(true);
+		$rule = $this->rule(mode: RecurRule::MODE_CLONE, policy: RecurRule::POLICY_AT_OCCURRENCE, nextOccurrenceAt: self::NOW);
+		$this->cardMapper->method('find')->with(10)->willReturn($template);
+		$this->cardService->method('create')->willReturn($this->spawnedCard(99));
+		$this->cardLabelMapper->method('findLabelIdsByCard')->willReturn([]);
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->willReturn([]);
+		$this->ruleMapper->method('update')->willReturnArgument(0);
+
+		$this->cardMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(static function (Card $c): Card {
+				self::assertTrue($c->getAllDay());
+				return $c;
+			});
+
+		$this->service->spawn($rule);
+	}
+
+	public function testSpawnCloneDefaultsAllDayFalseForNonAllDayTemplate(): void {
+		// A template with no all-day flag (null) spawns a timed clone (all_day=false),
+		// never null - the flag is always set explicitly on the clone.
+		$rule = $this->rule(mode: RecurRule::MODE_CLONE, policy: RecurRule::POLICY_AT_OCCURRENCE, nextOccurrenceAt: self::NOW);
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->cardService->method('create')->willReturn($this->spawnedCard(99));
+		$this->cardLabelMapper->method('findLabelIdsByCard')->willReturn([]);
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->willReturn([]);
+		$this->ruleMapper->method('update')->willReturnArgument(0);
+
+		$this->cardMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(static function (Card $c): Card {
+				self::assertFalse($c->getAllDay());
+				return $c;
+			});
+
+		$this->service->spawn($rule);
+	}
+
+	// ---- soft-trashed template pauses the schedule (#4124) ----------------
+
+	public function testSpawnPausesWhenTemplateIsSoftTrashed(): void {
+		// A soft-trashed template (deleted_at > 0, not purged) must NOT spawn: the
+		// spawn hot path read the template raw and kept cloning it. It pauses -
+		// no card, no error, no hard-disable - and advances the schedule so the
+		// cron does not busy-loop; the rule stays enabled to resume on restore.
+		$trashed = $this->templateCard();
+		$trashed->setDeletedAt(self::NOW - 5);
+		$rule = $this->rule(mode: RecurRule::MODE_CLONE, rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW);
+		$this->cardMapper->method('find')->with(10)->willReturn($trashed);
+
+		// Nothing is created and no enrichment fires.
+		$this->cardService->expects(self::never())->method('create');
+		$this->cardService->expects(self::never())->method('move');
+		$this->changeNotifier->expects(self::never())->method('notify');
+		// The schedule still advances (rule saved) so the cron does not re-fire now.
+		$this->ruleMapper->expects(self::once())->method('update')->willReturnArgument(0);
+
+		$card = $this->service->spawn($rule);
+
+		self::assertNull($card);
+		// A pause is not an occurrence: counters untouched...
+		self::assertSame(0, $rule->getOccurrencesSpawned());
+		// ...but the cursor advanced past this occurrence to tomorrow...
+		self::assertSame(self::NOW + 86400, $rule->getNextOccurrenceAt());
+		// ...and the rule stays enabled so it resumes when the template is restored.
+		self::assertTrue($rule->getEnabled());
+	}
+
+	public function testSpawnPausesWhenResetTemplateIsSoftTrashed(): void {
+		// RESET mode moves the template card itself - a soft-trashed template must
+		// pause too, never move a trashed card back into play.
+		$trashed = $this->templateCard();
+		$trashed->setDeletedAt(self::NOW - 5);
+		$rule = $this->rule(mode: RecurRule::MODE_RESET, rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW);
+		$this->cardMapper->method('find')->with(10)->willReturn($trashed);
+
+		$this->cardService->expects(self::never())->method('move');
+		$this->ruleMapper->expects(self::once())->method('update')->willReturnArgument(0);
+
+		self::assertNull($this->service->spawn($rule));
+		self::assertTrue($rule->getEnabled());
+	}
+
+	public function testSpawnResumesAfterTemplateRestored(): void {
+		// Once the template is restored (deleted_at back to 0) the very next spawn
+		// clones again - the pause left the rule enabled and did not disable it.
+		$rule = $this->rule(mode: RecurRule::MODE_CLONE, rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW);
+		// A live (restored) template.
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->cardService->expects(self::once())->method('create')->willReturn($this->spawnedCard(99));
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->cardLabelMapper->method('findLabelIdsByCard')->willReturn([]);
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->willReturn([]);
+		$this->ruleMapper->method('update')->willReturnArgument(0);
+
+		$card = $this->service->spawn($rule);
+
+		self::assertNotNull($card);
+		self::assertSame(1, $rule->getOccurrencesSpawned());
+	}
+
 	// ---- spawn RESET ------------------------------------------------------
 
 	public function testSpawnResetMovesTemplateBackClearsDoneRearmsDuedate(): void {
@@ -484,8 +589,12 @@ class RecurrenceServiceTest extends TestCase {
 	public function testSpawnCloneSkipsWhenPreviousCardStillOpen(): void {
 		$rule = $this->rule(skipWhileOpen: true, nextOccurrenceAt: self::NOW, lastSpawnedAt: 42, occurrencesSpawned: 1);
 
+		// spawn() reads the (live) template first, then previousCardOpen reads the
+		// last spawned card (42), still open → skip.
 		$openCard = $this->spawnedCard(42); // done_at 0, not archived/deleted → open
-		$this->cardMapper->method('find')->with(42)->willReturn($openCard);
+		$this->cardMapper->method('find')->willReturnCallback(function (int $id) use ($openCard): Card {
+			return $id === 42 ? $openCard : $this->templateCard();
+		});
 
 		$this->cardService->expects(self::never())->method('create');
 		// The schedule still advances (rule saved) so it does not re-fire now.
@@ -652,7 +761,10 @@ class RecurrenceServiceTest extends TestCase {
 		// so the rule does not re-fire immediately, atomically.
 		$rule = $this->rule(skipWhileOpen: true, nextOccurrenceAt: self::NOW, lastSpawnedAt: 42, occurrencesSpawned: 1);
 		$openCard = $this->spawnedCard(42);
-		$this->cardMapper->method('find')->with(42)->willReturn($openCard);
+		// spawn() reads the (live) template first, then the last spawned card (42).
+		$this->cardMapper->method('find')->willReturnCallback(function (int $id) use ($openCard): Card {
+			return $id === 42 ? $openCard : $this->templateCard();
+		});
 		$this->cardService->expects(self::never())->method('create');
 		$this->ruleMapper->expects(self::once())->method('update')->willReturnArgument(0);
 
@@ -714,14 +826,16 @@ class RecurrenceServiceTest extends TestCase {
 
 	public function testRunDueRulesSpawnsEachAndSkipsBroken(): void {
 		$ruleA = $this->rule(id: 1, nextOccurrenceAt: self::NOW);
+		// Rule A's template card (id 11) is hard-gone; rule B's (id 10) is live.
+		$ruleA->setTemplateCardId(11);
 		$ruleB = $this->rule(id: 2, nextOccurrenceAt: self::NOW);
 		$this->ruleMapper->method('findDueEnabled')->with(self::NOW)->willReturn([$ruleA, $ruleB]);
 
-		// Rule A's template card is gone → spawn throws; rule B still runs.
+		// Rule A's template card is gone → spawn throws; rule B still runs. Keyed on
+		// the template id (not a call counter) so it survives spawn() reading the
+		// template once up front (#4124) instead of only inside spawnClone.
 		$this->cardMapper->method('find')->willReturnCallback(function (int $id): Card {
-			static $call = 0;
-			$call++;
-			if ($call === 1) {
+			if ($id === 11) {
 				throw new DoesNotExistException('template gone');
 			}
 			return $this->templateCard();

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -1013,4 +1013,105 @@ class RecurrenceServiceTest extends TestCase {
 		$this->expectException(DoesNotExistException::class);
 		$this->serviceWithHiddenTemplate()->update(3, null, null, null, null, null, null, null, null, 'mgr');
 	}
+
+	// ---- update() must not rewind the cursor onto an already-fired occurrence (#65)
+
+	/**
+	 * Common wiring for an update() that reaches the setters: the rule, board,
+	 * manage permission, visible template and target stack are all resolved.
+	 */
+	private function wireUpdate(RecurRule $rule): void {
+		$this->ruleMapper->method('find')->with(3)->willReturn($rule);
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->method('update')->willReturnArgument(0);
+	}
+
+	/**
+	 * The reported bug (#65): a daily rule that already fired TODAY has its cursor
+	 * sitting on tomorrow. Re-writing the SAME RRULE (e.g. the card's Repeat
+	 * control saving an unchanged rule) must NOT recompute the cursor - recomputing
+	 * from now-1 would rewind it back onto today, an occurrence the cron already
+	 * spawned, so the next cron run would stamp a duplicate clone dated today.
+	 */
+	public function testUpdateWithUnchangedRruleDoesNotRewindCursorOntoToday(): void {
+		// Cursor already advanced past today's fire to tomorrow.
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 86400);
+		$this->wireUpdate($rule);
+
+		// Same RRULE, no schedule change → cursor must stay put.
+		$this->service->update(3, null, null, null, 'FREQ=DAILY', null, null, null, null, 'alice');
+
+		self::assertSame(self::NOW + 86400, $rule->getNextOccurrenceAt());
+	}
+
+	/**
+	 * A no-op {enabled} toggle (the rule was already enabled, e.g. saving board
+	 * settings) leaves the schedule untouched, so it must NOT re-arm the cursor
+	 * either - same duplicate-clone risk as an unchanged-RRULE edit (#65).
+	 */
+	public function testUpdateWithNoOpEnableToggleDoesNotRewindCursor(): void {
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 86400);
+		$this->wireUpdate($rule);
+
+		// enabled=true but the rule was already enabled → not a re-enable.
+		$this->service->update(3, null, null, null, null, null, null, null, true, 'alice');
+
+		self::assertSame(self::NOW + 86400, $rule->getNextOccurrenceAt());
+	}
+
+	/**
+	 * A genuine schedule change (a DIFFERENT RRULE) DOES re-arm the cursor to the
+	 * next occurrence of the new schedule - the deliberate re-arm is preserved.
+	 */
+	public function testUpdateWithChangedRruleReArmsCursor(): void {
+		// Daily rule, cursor on tomorrow; switch it to weekly.
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 86400);
+		$this->wireUpdate($rule);
+
+		$this->service->update(3, null, null, null, 'FREQ=WEEKLY', null, null, null, null, 'alice');
+
+		// Anchored at createdAt (NOW), the next weekly occurrence after the current
+		// cursor (tomorrow) is one week out - re-armed forward, not rewound.
+		self::assertSame(self::NOW + 7 * 86400, $rule->getNextOccurrenceAt());
+	}
+
+	/**
+	 * Even on a genuine schedule change the cursor is never rewound BEFORE where it
+	 * already sits: a rule whose cursor has walked well past now (a catch-up in
+	 * progress, or a future-anchored rule) keeps advancing forward, never back onto
+	 * an occurrence at/behind the current cursor that may already have fired (#65).
+	 */
+	public function testUpdateWithChangedRruleNeverRewindsBehindCurrentCursor(): void {
+		// Cursor sits two days in the FUTURE (already advanced past today's fire).
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 2 * 86400);
+		$this->wireUpdate($rule);
+
+		// Re-writing to hourly would, from now-1, land the cursor at now+1h - BEHIND
+		// the current cursor. The max(now-1, cursor-1) floor forbids that: the new
+		// cursor may not move backward. now+2d is an exact hourly multiple from the
+		// NOW anchor, so the re-armed cursor stays at now+2d, never earlier.
+		$this->service->update(3, null, null, null, 'FREQ=HOURLY', null, null, null, null, 'alice');
+
+		self::assertGreaterThanOrEqual(self::NOW + 2 * 86400, $rule->getNextOccurrenceAt());
+	}
+
+	/**
+	 * Re-enabling a disabled rule (disabled → enabled) DOES re-arm from now, so a
+	 * rule that was off for a while picks up its next future occurrence rather than
+	 * staying stuck on a stale cursor.
+	 */
+	public function testUpdateReEnablingDisabledRuleReArmsFromNow(): void {
+		// A disabled rule whose cached cursor is stale (in the past).
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW - 10 * 86400);
+		$rule->setEnabled(false);
+		$this->wireUpdate($rule);
+
+		$this->service->update(3, null, null, null, null, null, null, null, true, 'alice');
+
+		// Re-armed to the next daily occurrence at/after now, not left in the past.
+		self::assertSame(self::NOW, $rule->getNextOccurrenceAt());
+		self::assertTrue($rule->getEnabled());
+	}
 }

--- a/tests/unit/Service/TrashServiceTest.php
+++ b/tests/unit/Service/TrashServiceTest.php
@@ -25,6 +25,7 @@ use OCA\Kanso\Db\ChecklistItemMapper;
 use OCA\Kanso\Db\CommentMapper;
 use OCA\Kanso\Db\CommentReactionMapper;
 use OCA\Kanso\Db\ProjectCardMapper;
+use OCA\Kanso\Db\RecurRuleMapper;
 use OCA\Kanso\Db\ReminderMapper;
 use OCA\Kanso\Db\SubscriptionMapper;
 use OCA\Kanso\Service\CardAttachmentService;
@@ -59,6 +60,7 @@ class TrashServiceTest extends TestCase {
 	private CardTimeEntryService&MockObject $cardTimeEntryService;
 	private CardFieldValueMapper&MockObject $cardFieldValueMapper;
 	private ReminderMapper&MockObject $reminderMapper;
+	private RecurRuleMapper&MockObject $recurRuleMapper;
 	private BoardAccess&MockObject $boardAccess;
 	private CardVisibilityGuard&MockObject $visibilityGuard;
 	private TrashService $service;
@@ -84,6 +86,7 @@ class TrashServiceTest extends TestCase {
 		$this->cardTimeEntryService = $this->createMock(CardTimeEntryService::class);
 		$this->cardFieldValueMapper = $this->createMock(CardFieldValueMapper::class);
 		$this->reminderMapper = $this->createMock(ReminderMapper::class);
+		$this->recurRuleMapper = $this->createMock(RecurRuleMapper::class);
 		$this->boardAccess = $this->createMock(BoardAccess::class);
 		$this->boardAccess->method('contextFor')->willReturnCallback(
 			static fn (Board $board, string $uid): ViewerContext => ViewerContext::forMember($uid, (int)$board->getId(), ViewerContext::ROLE_INTERNAL, true),
@@ -110,6 +113,7 @@ class TrashServiceTest extends TestCase {
 			$this->cardTimeEntryService,
 			$this->cardFieldValueMapper,
 			$this->reminderMapper,
+			$this->recurRuleMapper,
 			$this->boardAccess,
 			$this->visibilityGuard,
 		);
@@ -248,11 +252,30 @@ class TrashServiceTest extends TestCase {
 		$this->cardFieldValueMapper->expects(self::once())->method('deleteByCard')->with(9);
 		// Personal reminders are cascaded too (#3816).
 		$this->reminderMapper->expects(self::once())->method('deleteByCard')->with(9);
+		// Recurrence rules anchored on the purged card are cascaded too (#4123),
+		// so no orphan schedule keeps failing to spawn every cron pass.
+		$this->recurRuleMapper->expects(self::once())->method('deleteByTemplateCardId')->with(9);
 		$this->cardMapper->expects(self::once())->method('delete')->with($card);
 		$this->changeNotifier->expects(self::once())
 			->method('notify')
 			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_DELETE, 'alice')
 			->willReturn(new Change());
+
+		$this->service->purge(9, 'alice');
+	}
+
+	public function testPurgeDropsRecurrenceRulesAnchoredOnTheCard(): void {
+		// #4123: a rule whose template card is purged can never spawn again - its
+		// template read throws every cron pass and logs a failed spawn forever.
+		// Purge must drop the card's recurrence rule(s) symmetric with the other
+		// cascade deleteByCard calls.
+		$card = $this->trashedCard(9);
+		$this->cardMapper->method('find')->with(9)->willReturn($card);
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+
+		$this->recurRuleMapper->expects(self::once())
+			->method('deleteByTemplateCardId')
+			->with(9);
 
 		$this->service->purge(9, 'alice');
 	}

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -229,19 +229,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3592
+#: src/components/CardDetail.vue:3618
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3590
+#: src/components/CardDetail.vue:3616
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3588
+#: src/components/CardDetail.vue:3614
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/components/CardDetail.vue:3765
+#: src/components/CardDetail.vue:3791
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/components/CardDetail.vue:3767
+#: src/components/CardDetail.vue:3793
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: src/components/CardDetail.vue:3766
+#: src/components/CardDetail.vue:3792
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -4701,7 +4701,7 @@ msgstr ""
 msgid "Write a reply…"
 msgstr ""
 
-#: src/components/CardDetail.vue:3768
+#: src/components/CardDetail.vue:3794
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -229,19 +229,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3618
+#: src/components/CardDetail.vue:3606
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3616
+#: src/components/CardDetail.vue:3604
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:3614
+#: src/components/CardDetail.vue:3602
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/components/CardDetail.vue:3791
+#: src/components/CardDetail.vue:3779
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/components/CardDetail.vue:3793
+#: src/components/CardDetail.vue:3781
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: src/components/CardDetail.vue:3792
+#: src/components/CardDetail.vue:3780
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -4701,7 +4701,7 @@ msgstr ""
 msgid "Write a reply…"
 msgstr ""
 
-#: src/components/CardDetail.vue:3794
+#: src/components/CardDetail.vue:3782
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""


### PR DESCRIPTION
Recurrence + date bug fixes reported by @dbmtrde (#64, #65) plus four adjacent bugs found in a follow-up audit of the same area. Branch rebased onto current main.

## Closes #65 — recurring tasks duplicated, clone due-dated "today"
`RecurrenceService::update()` re-armed the occurrence cursor on any edit and could rewind it onto an already-spawned day → duplicate. Now re-arms only on a genuine schedule change / re-enable, never rewinds. Also registers `SpawnRecurringCards` on upgraded installs (migration `Version005300`; was info.xml-only, so it never ran after upgrades).

## Closes #64 — erratic keyboard entry in date fields
Per-segment `change` → refetch re-applied `:value` mid-edit. Fixed by committing on blur/Enter instead of the native input's per-segment change (no server request fires mid-typing).

## Audit follow-ups (same recurrence/date area)
- **All-day off-by-one (HIGH):** all-day dates stored at UTC-midnight were read back with local getters → previous day west of UTC. Read-back now formats all-day in UTC (new `src/utils/dateDisplay.js`, applied in CardDetail/CardTile/CardPreview/BoardListView); storage unchanged.
- **Purge orphaned the rule (HIGH):** `TrashService::purge()` now cascades to `kanso_recur_rules`, ending the every-15-min cron error after a template is hard-deleted.
- **Soft-trashed template kept spawning:** the spawn path now pauses when the template is trashed (resumes on restore).
- **CLONE dropped all-day:** spawned occurrences now inherit the template's all-day flag.

## Migration note
Main's `Version005200` (public_share_comments, from PR #63) and this branch's recurrence-job registration collided on the number; ours was renumbered to `Version005300` — both now coexist.

## Testing
PHPUnit: recurrence + trash suites green (65 tests) incl. new idempotency / pause / purge-cascade / all-day-clone cases, run in an isolated container. Playwright: date-typing, all-day-timezone (America/New_York), and recurrence specs green. psalm/cs/vite build clean. No version bump.

Merge as a **merge commit** to preserve the fix types for semantic-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)