### PR TITLE
test: run the e2e suite in parallel with per-worker Nextcloud users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,15 +255,17 @@ jobs:
 
       # Run the suite in PARALLEL: each Playwright worker provisions its own
       # Nextcloud user (E2E_ISOLATE) so fixed board names and per-user aggregate
-      # views are namespaced per worker. Conservative worker count — the runner
-      # hosts the whole stack in-pod and is ~4-5x slower than a dev box, so
-      # over-subscribing php-fpm/postgres would trade wall-clock for timeout
-      # flakiness. Raise E2E_WORKERS once the runner has headroom.
+      # views are namespaced per worker. The runner hosts the whole stack in-pod;
+      # its `runner` container is capped at 4 CPU (node talos-worker-3 has 48
+      # cores, ~8% used). At workers=2 the run took ~30m using ~1.3 of 4 cores,
+      # so 4 workers fits the cap. If timeout flakiness appears, the bottleneck
+      # is the single php-fpm/postgres backend (tune pm.max_children /
+      # max_connections) or the 4-CPU cap — not the node.
       - name: Run e2e tests
         run: npm run test:e2e
         env:
           E2E_ISOLATE: '1'
-          E2E_WORKERS: '2'
+          E2E_WORKERS: '4'
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,8 +253,17 @@ jobs:
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
+      # Run the suite in PARALLEL: each Playwright worker provisions its own
+      # Nextcloud user (E2E_ISOLATE) so fixed board names and per-user aggregate
+      # views are namespaced per worker. Conservative worker count — the runner
+      # hosts the whole stack in-pod and is ~4-5x slower than a dev box, so
+      # over-subscribing php-fpm/postgres would trade wall-clock for timeout
+      # flakiness. Raise E2E_WORKERS once the runner has headroom.
       - name: Run e2e tests
         run: npm run test:e2e
+        env:
+          E2E_ISOLATE: '1'
+          E2E_WORKERS: '2'
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,17 +255,20 @@ jobs:
 
       # Run the suite in PARALLEL: each Playwright worker provisions its own
       # Nextcloud user (E2E_ISOLATE) so fixed board names and per-user aggregate
-      # views are namespaced per worker. The runner hosts the whole stack in-pod;
-      # its `runner` container is capped at 4 CPU (node talos-worker-3 has 48
-      # cores, ~8% used). At workers=2 the run took ~30m using ~1.3 of 4 cores,
-      # so 4 workers fits the cap. If timeout flakiness appears, the bottleneck
-      # is the single php-fpm/postgres backend (tune pm.max_children /
-      # max_connections) or the 4-CPU cap — not the node.
+      # views are namespaced per worker.
+      #
+      # workers=2 is the measured sweet spot: ~30m, green. workers=4 was tried
+      # and was WORSE on both axes — ~46m and 11 failed, dominated by
+      # `page.click Timeout 30000ms` — because 4 chromium + 4 concurrent sessions
+      # over-subscribe the runner container's 4-CPU cap AND the single
+      # php-fpm/postgres backend in dind. More CPU alone won't help; the backend
+      # is the wall. To go past 2, tune the backend (pm.max_children /
+      # postgres max_connections) and raise the runner CPU limit first.
       - name: Run e2e tests
         run: npm run test:e2e
         env:
           E2E_ISOLATE: '1'
-          E2E_WORKERS: '4'
+          E2E_WORKERS: '2'
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -26,15 +26,22 @@ await ncLogin(page)
 await page.goto(boardUrl(board.id))
 ```
 
-- `api` — admin-bound client: `.get/.post/.patch/.put/.delete` (throw on non-2xx),
-  `.send(method, path, body)`, `.raw(method, path, body)` (Response, no throw —
-  for status-code assertions).
-- `makeApi(authFor(user, pass))` — a client for another identity.
-- `ncLogin(page, { user, pass })`, `gotoBoard`, `boardUrl`, `provisionUser`,
-  `deleteUser`, `BASE`, `API`, `OCS`, `adminAuth`, `authFor`.
+- `api` — client for the **current** user: `.get/.post/.patch/.put/.delete`
+  (throw on non-2xx), `.send(method, path, body)`, `.raw(method, path, body)`
+  (Response, no throw — for status-code assertions).
+- `me` — the current user's **id** (use instead of the literal `'admin'` for
+  self: `` `/cards/${id}/assignees/${me}` ``). Read it at call time.
+- `currentAuth` — the current user's Basic-auth string, for a bespoke per-spec
+  `fetch` client that means "act as me". Read at call time.
+- `peer` — a **fixture** (destructure `{ peer }`) giving a second identity for
+  board-sharing / ACL / peer-login specs: `{ user, pass, auth, api }`.
+- `makeApi(auth)`, `authFor(user, pass)`, `ncLogin(page, { user, pass })`,
+  `gotoBoard`, `boardUrl`, `provisionUser`, `deleteUser`, `BASE`, `API`, `OCS`.
+- `adminAuth` — the real superuser; use ONLY for genuine admin-only ops (OCS
+  user provisioning), never as "act as me".
 
-A spec that logs in as a non-admin must also opt out of the shared admin session
-with `test.use({ storageState: { cookies: [], origins: [] } })`.
+A spec that logs in as a non-admin (its `peer`) must also opt out of the shared
+session with `test.use({ storageState: { cookies: [], origins: [] } })`.
 
 ## Isolation & parallelism
 
@@ -42,15 +49,18 @@ The suite runs **serial by default** (`workers: 1`). Every spec acts as the same
 `admin` user against one shared DB, so concurrent specs would corrupt each
 other's board lists and per-user aggregate views (My Work / Inbox / Search).
 
-The suite is **parallel-ready**: `helpers.js` exposes a worker-scoped `user`
-fixture. With `E2E_ISOLATE=1` each Playwright worker provisions its own
-Nextcloud user (`kansoe2e_w<n>`), which namespaces all of that per worker, so
-workers can be raised safely:
+Set **`E2E_ISOLATE=1`** and the suite becomes genuinely parallel-safe: each
+Playwright worker provisions its own Nextcloud user (`kansoe2e_w<n>`), its
+browser pages start logged in AS that user (per-worker `storageState`), and the
+`api` / `me` / `currentAuth` bindings + the `peer` fixture all resolve to
+per-worker identities. Fixed board names and per-user aggregate views are then
+namespaced per worker, so `E2E_WORKERS` can be raised:
 
 ```sh
 npm run test:e2e:parallel        # E2E_ISOLATE=1 E2E_WORKERS=4
 # or: E2E_ISOLATE=1 E2E_WORKERS=4 npx playwright test
 ```
 
-With the flag off, the `user`/`api` fixtures resolve to `admin` and behaviour is
-identical to the serial run.
+With the flag **off** (the default) every binding resolves to `admin` (and
+`peer` to the dev `tester`), so behaviour is byte-for-byte the serial run — the
+mechanism is dormant, not a code path specs have to think about.

--- a/tests/e2e/automation-rules.spec.js
+++ b/tests/e2e/automation-rules.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 const ROLE_REVIEW = 4
 const ROLE_IN_PROGRESS = 3
@@ -30,7 +28,7 @@ test.describe('Automation rules (#3400)', () => {
 		await api.send('POST', `/boards/${state.boardId}/automation-rules`, {
 			trigger: 'card_entered_role',
 			action: 'request_review',
-			params: { role: ROLE_REVIEW, reviewer: USER },
+			params: { role: ROLE_REVIEW, reviewer: me },
 		})
 		const cardId = (await api.send('POST', '/cards', { stackId: state.todoStackId, title: 'Needs review' })).id
 
@@ -40,7 +38,7 @@ test.describe('Automation rules (#3400)', () => {
 		await api.send('POST', `/cards/${cardId}/move`, { targetStackId: state.reviewStackId, afterCardId: null })
 
 		card = await api.send('GET', `/cards/${cardId}`)
-		expect(card.reviews.some((rv) => rv.reviewer === USER)).toBe(true)
+		expect(card.reviews.some((rv) => rv.reviewer === me)).toBe(true)
 	})
 
 	test('entering an in-progress-role column fires the add_label rule', async () => {

--- a/tests/e2e/avatar-status-storm.spec.js
+++ b/tests/e2e/avatar-status-storm.spec.js
@@ -12,9 +12,7 @@
 // user_status requests is bounded (ideally zero) — not proportional to the
 // card × assignee count.
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 // Several assigned cards so a per-avatar storm (O(cards × assignees)) would be
 // visibly larger than the O(unique actors) bound we assert.
@@ -29,8 +27,8 @@ test.describe('Avatar user-status storm on board load (#3663)', () => {
 		state.stackId = (await api.send('POST', '/stacks', { boardId: board.id, title: 'To do' })).id
 		for (let i = 0; i < CARD_COUNT; i++) {
 			const card = await api.send('POST', '/cards', { stackId: state.stackId, title: `Assigned ${i}` })
-			// Assign admin (the only actor available in the dev stack) to each card.
-			await api.send('PUT', `/cards/${card.id}/assignees/${USER}`)
+			// Assign the current user (the only actor available in the dev stack) to each card.
+			await api.send('PUT', `/cards/${card.id}/assignees/${me}`)
 		}
 	})
 

--- a/tests/e2e/board-delta-sync.spec.js
+++ b/tests/e2e/board-delta-sync.spec.js
@@ -15,7 +15,6 @@ const HEADERS = {
 	'OCS-APIREQUEST': 'true',
 	'Content-Type': 'application/json',
 }
-const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
 
 // notify_push is disabled for this suite so B takes the deterministic 5s delta
 // poll (the push path also delta-syncs, but the poll is what we can reliably
@@ -39,7 +38,7 @@ test.describe('Board delta sync (#3675)', () => {
 
 	const state = { boardId: 0, stackId: 0, cardId: 0, boardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		const boards = await api.get('/boards')
 		for (const b of boards) {
 			if (b.title === 'Delta Sync Board') {
@@ -53,7 +52,7 @@ test.describe('Board delta sync (#3675)', () => {
 		const card = await api.post('/cards', { stackId: stack.id, title: 'delta-original' })
 		state.cardId = card.id
 		await api.post(`/boards/${board.id}/acl`, {
-			participant: TESTER.user,
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3,
 		})
@@ -65,7 +64,7 @@ test.describe('Board delta sync (#3675)', () => {
 		if (state.boardId) await api.send('DELETE', `/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('B reflects an edit via /changes, not a full board refetch', async ({ browser }) => {
+	test('B reflects an edit via /changes, not a full board refetch', async ({ browser, peer }) => {
 		// Force the poll path: disable notify_push and wait for the capability to
 		// stop being advertised (a fixed sleep was a flake source in realtime.spec).
 		occSafe('app:disable notify_push')
@@ -81,7 +80,7 @@ test.describe('Board delta sync (#3675)', () => {
 		const testerCtx = await browser.newContext()
 		try {
 			const testerPage = await testerCtx.newPage()
-			await ncLogin(testerPage, { user: TESTER.user, pass: TESTER.pass })
+			await ncLogin(testerPage, { user: peer.user, pass: peer.pass })
 
 			// Track B's board API calls. The initial full load hits /boards/{id};
 			// after that, reflecting A's edit must go through /boards/{id}/changes.

--- a/tests/e2e/board-subscription.spec.js
+++ b/tests/e2e/board-subscription.spec.js
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, makeApi } from './helpers.js'
+import { test, expect, makeApi, me, currentAuth } from './helpers.js'
 
 // This spec's DELETE endpoints return a JSON body (subscription state) that the
 // test asserts on, so it needs a client that parses DELETE responses rather than
 // the shared `api` whose `.delete` always resolves null. Keep the local content
-// handling (`204 → null`, else parse JSON) and just reuse the shared transport.
-const rawApi = makeApi()
+// handling (`204 → null`, else parse JSON); build the client from `currentAuth`
+// at call time so it acts as the worker's user under isolation (not admin).
 async function api(method, path, body) {
-	const r = await rawApi.raw(method, path, body)
+	const r = await makeApi(currentAuth).raw(method, path, body)
 	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
 	return method === 'DELETE' && r.status === 204 ? null : r.json()
 }
@@ -38,7 +38,7 @@ test.describe('Board subscriptions', () => {
 		sub = await api('PUT', `/boards/${boardId}/subscription`)
 		expect(sub.subscribed).toBe(true)
 		expect(sub.count).toBe(1)
-		expect(sub.subscribers).toContain('admin')
+		expect(sub.subscribers).toContain(me)
 
 		// Idempotent: watching again stays count 1.
 		sub = await api('PUT', `/boards/${boardId}/subscription`)

--- a/tests/e2e/caldav-calendar.spec.js
+++ b/tests/e2e/caldav-calendar.spec.js
@@ -1,17 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, authFor, adminAuth, BASE } from './helpers.js'
+import { test, expect, api, currentAuth, me, BASE } from './helpers.js'
 
-const DAV = BASE + '/remote.php/dav/calendars/admin'
-const AUTH = adminAuth
+// The current user's own CalDAV calendar-home. Built at CALL time (me is a live
+// binding rebound per worker under isolation), so the principal path segment
+// matches the acting user.
+const davHome = () => `${BASE}/remote.php/dav/calendars/${me}`
 
 // Kept local: a raw DAV client (PROPFIND/GET/PROPPATCH against the CalDAV
 // endpoint) — not the Kanso API, so the shared api client does not apply.
 async function dav(method, path, extraHeaders = {}) {
-	const r = await fetch(DAV + path, {
+	const r = await fetch(davHome() + path, {
 		method,
-		headers: { Authorization: AUTH, ...extraHeaders },
+		headers: { Authorization: currentAuth, ...extraHeaders },
 	})
 	return { status: r.status, body: await r.text() }
 }
@@ -79,9 +81,9 @@ test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 	})
 
 	test('the calendar is read-only: a PUT of a new object is rejected', async () => {
-		const r = await fetch(DAV + `/${calUri}/injected.ics`, {
+		const r = await fetch(davHome() + `/${calUri}/injected.ics`, {
 			method: 'PUT',
-			headers: { Authorization: AUTH, 'Content-Type': 'text/calendar' },
+			headers: { Authorization: currentAuth, 'Content-Type': 'text/calendar' },
 			body: 'BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VTODO\r\nUID:x\r\nEND:VTODO\r\nEND:VCALENDAR\r\n',
 		})
 		// Sabre maps the Forbidden the calendar throws to 403 (never 201/204).
@@ -111,9 +113,9 @@ test.describe('CalDAV board calendar (read-only VTODOs)', () => {
 			+ '<d:propertyupdate xmlns:d="DAV:" xmlns:x="http://owncloud.org/ns">'
 			+ '<d:set><d:prop><x:calendar-enabled>0</x:calendar-enabled></d:prop></d:set>'
 			+ '</d:propertyupdate>'
-		const r = await fetch(DAV + `/${calUri}/`, {
+		const r = await fetch(davHome() + `/${calUri}/`, {
 			method: 'PROPPATCH',
-			headers: { Authorization: AUTH, 'Content-Type': 'application/xml' },
+			headers: { Authorization: currentAuth, 'Content-Type': 'application/xml' },
 			body,
 		})
 		expect(r.status).toBe(207)
@@ -134,14 +136,15 @@ test.describe.serial('CalDAV board calendar access control', () => {
 	// session (see the e2e storageState guard).
 	test.use({ storageState: { cookies: [], origins: [] } })
 
-	const TESTER = authFor('tester', 'kanso-dev-tester!1')
-	const TESTER_DAV = BASE + '/remote.php/dav/calendars/tester'
 	let boardId = 0
 	let cardId = 0
 	let calUri = ''
 
-	async function testerDav(method, path) {
-		const r = await fetch(TESTER_DAV + path, { method, headers: { Authorization: TESTER, Depth: '1' } })
+	// The outsider is the worker-scoped peer; its DAV principal path segment and
+	// auth are read from the fixture at call time.
+	async function peerDav(peer, method, path) {
+		const dav = `${BASE}/remote.php/dav/calendars/${peer.user}`
+		const r = await fetch(dav + path, { method, headers: { Authorization: peer.auth, Depth: '1' } })
 		return { status: r.status, body: await r.text() }
 	}
 
@@ -159,23 +162,23 @@ test.describe.serial('CalDAV board calendar access control', () => {
 		if (boardId) await api.send('DELETE', `/boards/${boardId}`).catch(() => {})
 	})
 
-	test('a non-member never sees the board calendar and cannot fetch its cards', async () => {
-		const home = await testerDav('PROPFIND', '/')
+	test('a non-member never sees the board calendar and cannot fetch its cards', async ({ peer }) => {
+		const home = await peerDav(peer, 'PROPFIND', '/')
 		expect(home.status).toBe(207)
 		expect(home.body).not.toContain(calUri)
 		// The card object is existence-safe: not found (never 200) for a non-member.
-		const obj = await testerDav('GET', `/${calUri}/kanso-card-${cardId}.ics`)
+		const obj = await peerDav(peer, 'GET', `/${calUri}/kanso-card-${cardId}.ics`)
 		expect(obj.status).toBe(404)
 	})
 
-	test('sharing the board grants the member the calendar', async () => {
+	test('sharing the board grants the member the calendar', async ({ peer }) => {
 		await api.send('POST', `/boards/${boardId}/acl`, {
-			participant: 'tester', participantType: 'user', permission: 1, role: 'internal',
+			participant: peer.user, participantType: 'user', permission: 1, role: 'internal',
 		})
-		const home = await testerDav('PROPFIND', '/')
+		const home = await peerDav(peer, 'PROPFIND', '/')
 		expect(home.status).toBe(207)
 		expect(home.body).toContain(calUri)
-		const obj = await testerDav('GET', `/${calUri}/kanso-card-${cardId}.ics`)
+		const obj = await peerDav(peer, 'GET', `/${calUri}/kanso-card-${cardId}.ics`)
 		expect(obj.status).toBe(200)
 		expect(obj.body).toContain('SUMMARY:members only')
 	})

--- a/tests/e2e/caldav-toggle.spec.js
+++ b/tests/e2e/caldav-toggle.spec.js
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE, adminAuth } from './helpers.js'
+import { test, expect, api, ncLogin, BASE, currentAuth, me } from './helpers.js'
 
 // Does the user's CalDAV calendar-home currently list this board's calendar?
 async function calendarPresent(boardId) {
-	const r = await fetch(`${BASE}/remote.php/dav/calendars/admin/`, {
+	const r = await fetch(`${BASE}/remote.php/dav/calendars/${me}/`, {
 		method: 'PROPFIND',
-		headers: { Authorization: adminAuth, Depth: '1' },
+		headers: { Authorization: currentAuth, Depth: '1' },
 	})
 	return (await r.text()).includes(`app-generated--kanso--board-${boardId}`)
 }

--- a/tests/e2e/caldav-visibility.spec.js
+++ b/tests/e2e/caldav-visibility.spec.js
@@ -1,17 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, makeApi, authFor, adminAuth, BASE } from './helpers.js'
+import { test, expect, makeApi, currentAuth, me, BASE } from './helpers.js'
 
-const ADMIN = adminAuth
-const TESTER = authFor('tester', 'kanso-dev-tester!1')
-
-const adminApi = makeApi(ADMIN)
-const testerApi = makeApi(TESTER)
+// Per-auth clients built lazily and cached, so currentAuth / peer.auth (read at
+// call time) each resolve to the right worker identity under isolation.
+const clients = new Map()
+function clientFor(auth) {
+	if (!clients.has(auth)) clients.set(auth, makeApi(auth))
+	return clients.get(auth)
+}
 
 // Route (auth, method, path, body) → the matching client's throwing send().
 function api(auth, method, path, body) {
-	return (auth === TESTER ? testerApi : adminApi).send(method, path, body)
+	return clientFor(auth).send(method, path, body)
 }
 
 // GET a card's VTODO from a principal's own board calendar.
@@ -36,55 +38,55 @@ test.describe.serial('CalDAV visibility + endpoint permissions', () => {
 	const token = 'cv' + Math.floor(Date.now() / 1000)
 	const state = { boardId: 0, otherBoardId: 0, calUri: '', pubId: 0, privId: 0 }
 
-	test.beforeAll(async () => {
-		const board = await api(ADMIN, 'POST', '/boards', { title: 'CalDAV visibility ' + token })
+	test.beforeAll(async ({ peer }) => {
+		const board = await api(currentAuth, 'POST', '/boards', { title: 'CalDAV visibility ' + token })
 		state.boardId = board.id
 		state.calUri = `app-generated--kanso--board-${board.id}`
-		const stack = await api(ADMIN, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
+		const stack = await api(currentAuth, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
 
-		// tester is an INTERNAL member — sees public + internal cards, never private.
-		await api(ADMIN, 'POST', `/boards/${board.id}/acl`, {
-			participant: 'tester', participantType: 'user', permission: 1, role: 'internal',
+		// peer is an INTERNAL member — sees public + internal cards, never private.
+		await api(currentAuth, 'POST', `/boards/${board.id}/acl`, {
+			participant: peer.user, participantType: 'user', permission: 1, role: 'internal',
 		})
 
-		// A public card both can see, and a private (owner-only) card only admin
+		// A public card both can see, and a private (owner-only) card only the owner
 		// can see. Both have due dates, so both are candidates for the feed.
-		const pub = await api(ADMIN, 'POST', '/cards', { stackId: stack.id, title: 'pub ' + token })
+		const pub = await api(currentAuth, 'POST', '/cards', { stackId: stack.id, title: 'pub ' + token })
 		state.pubId = pub.id
-		await api(ADMIN, 'PATCH', `/cards/${pub.id}`, { duedate: '2026-08-15T09:30:00+00:00' })
+		await api(currentAuth, 'PATCH', `/cards/${pub.id}`, { duedate: '2026-08-15T09:30:00+00:00' })
 
-		const priv = await api(ADMIN, 'POST', '/cards', { stackId: stack.id, title: 'secret ' + token })
+		const priv = await api(currentAuth, 'POST', '/cards', { stackId: stack.id, title: 'secret ' + token })
 		state.privId = priv.id
-		await api(ADMIN, 'PATCH', `/cards/${priv.id}`, { duedate: '2026-08-16T09:30:00+00:00', visibility: 'private' })
+		await api(currentAuth, 'PATCH', `/cards/${priv.id}`, { duedate: '2026-08-16T09:30:00+00:00', visibility: 'private' })
 
-		// A second board admin does NOT share with tester (for the endpoint test).
-		const other = await api(ADMIN, 'POST', '/boards', { title: 'CalDAV unshared ' + token })
+		// A second board the owner does NOT share with the peer (for the endpoint test).
+		const other = await api(currentAuth, 'POST', '/boards', { title: 'CalDAV unshared ' + token })
 		state.otherBoardId = other.id
 	})
 
 	test.afterAll(async () => {
 		for (const id of [state.boardId, state.otherBoardId]) {
-			if (id) await api(ADMIN, 'DELETE', `/boards/${id}`).catch(() => {})
+			if (id) await api(currentAuth, 'DELETE', `/boards/${id}`).catch(() => {})
 		}
 	})
 
-	test('a member never receives a card hidden from them (private stays owner-only)', async () => {
+	test('a member never receives a card hidden from them (private stays owner-only)', async ({ peer }) => {
 		// The owner sees their own private card over CalDAV…
-		expect((await davGet(ADMIN, 'admin', state.calUri, state.privId)).status).toBe(200)
+		expect((await davGet(currentAuth, me, state.calUri, state.privId)).status).toBe(200)
 
 		// …the member sees the public card…
-		const memberPub = await davGet(TESTER, 'tester', state.calUri, state.pubId)
+		const memberPub = await davGet(peer.auth, peer.user, state.calUri, state.pubId)
 		expect(memberPub.status).toBe(200)
 		expect(memberPub.body).toContain(`pub ${token}`)
 
 		// …but NOT the private one: existence-safe 404, never the card body.
-		const memberPriv = await davGet(TESTER, 'tester', state.calUri, state.privId)
+		const memberPriv = await davGet(peer.auth, peer.user, state.calUri, state.privId)
 		expect(memberPriv.status).toBe(404)
 		expect(memberPriv.body).not.toContain(`secret ${token}`)
 	})
 
-	test('a non-member cannot toggle calendar-sync for a board they cannot see', async () => {
-		const r = await testerApi.raw('PUT', `/boards/${state.otherBoardId}/calendar-sync`, { enabled: false })
+	test('a non-member cannot toggle calendar-sync for a board they cannot see', async ({ peer }) => {
+		const r = await clientFor(peer.auth).raw('PUT', `/boards/${state.otherBoardId}/calendar-sync`, { enabled: false })
 		// NotAMemberException → NotPermittedException → 403 (never silently applied).
 		expect(r.status).toBe(403)
 	})

--- a/tests/e2e/card-attachments.spec.js
+++ b/tests/e2e/card-attachments.spec.js
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, ncLogin, BASE, adminAuth } from './helpers.js'
+import { test, expect, ncLogin, BASE, currentAuth } from './helpers.js'
 
 const API = BASE + '/index.php/apps/kanso/api'
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
-const AUTH = adminAuth
 
 // Kept local: this client returns { ok, status, body } (never throws) so the
 // tests can assert on non-2xx statuses; the shared api throws. uploadFile /
@@ -13,7 +12,7 @@ const AUTH = adminAuth
 async function api(method, path, body) {
 	const r = await fetch(API + path, {
 		method,
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: body === undefined ? undefined : JSON.stringify(body),
 	})
 	const text = await r.text()
@@ -26,7 +25,7 @@ async function uploadFile(cardId, filename, content, contentType = 'text/plain')
 	form.append('file', new Blob([content], { type: contentType }), filename)
 	const r = await fetch(API + `/cards/${cardId}/attachments`, {
 		method: 'POST',
-		headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+		headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		body: form,
 	})
 	const text = await r.text()
@@ -49,7 +48,7 @@ async function uploadBytes(cardId, filename, bytes, contentType) {
 	form.append('file', new Blob([bytes], { type: contentType }), filename)
 	const r = await fetch(API + `/cards/${cardId}/attachments`, {
 		method: 'POST',
-		headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+		headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		body: form,
 	})
 	const text = await r.text()
@@ -104,7 +103,7 @@ test.describe('Card file attachments', () => {
 
 		// Download returns the bytes with an attachment disposition.
 		const dl = await fetch(API + `/cards/${cardId}/attachments/${attId}`, {
-			headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+			headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		})
 		expect(dl.ok).toBe(true)
 		expect(dl.headers.get('content-disposition') || '').toContain('attachment')
@@ -133,7 +132,7 @@ test.describe('Card file attachments', () => {
 
 		// Reaching it through the OTHER card's URL must fail (not a leak).
 		const dl = await fetch(API + `/cards/${otherCardId}/attachments/${attId}`, {
-			headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+			headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		})
 		expect(dl.status).toBe(404)
 
@@ -156,7 +155,7 @@ test.describe('Card file attachments', () => {
 
 		// The png serves INLINE with the exact allow-listed type + nosniff.
 		const inline = await fetch(API + `/cards/${cardId}/attachments/${pngId}/inline`, {
-			headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+			headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		})
 		expect(inline.ok).toBe(true)
 		expect(inline.headers.get('content-type')).toContain('image/png')
@@ -168,7 +167,7 @@ test.describe('Card file attachments', () => {
 		// A .txt attachment is NOT inline-serveable → 404 (download-only).
 		const txt = await uploadFile(cardId, 'notes.txt', 'plain', 'text/plain')
 		const txtInline = await fetch(API + `/cards/${cardId}/attachments/${txt.body.id}/inline`, {
-			headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+			headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		})
 		expect(txtInline.status).toBe(404)
 
@@ -176,13 +175,13 @@ test.describe('Card file attachments', () => {
 		// inline-serveable → 404.
 		const svg = await uploadFile(cardId, 'x.svg', '<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'image/svg+xml')
 		const svgInline = await fetch(API + `/cards/${cardId}/attachments/${svg.body.id}/inline`, {
-			headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+			headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		})
 		expect(svgInline.status).toBe(404)
 
 		// IDOR: the png cannot be inlined through the OTHER card's URL.
 		const idor = await fetch(API + `/cards/${otherCardId}/attachments/${pngId}/inline`, {
-			headers: { 'OCS-APIREQUEST': 'true', Authorization: AUTH },
+			headers: { 'OCS-APIREQUEST': 'true', Authorization: currentAuth },
 		})
 		expect(idor.status).toBe(404)
 
@@ -317,7 +316,7 @@ test.describe('Card file attachments', () => {
 async function apiPatch(path, body) {
 	const r = await fetch(API + path, {
 		method: 'PATCH',
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: JSON.stringify(body),
 	})
 	return { ok: r.ok, status: r.status }

--- a/tests/e2e/card-contacts.spec.js
+++ b/tests/e2e/card-contacts.spec.js
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE, API, adminAuth } from './helpers.js'
+import { test, expect, api, ncLogin, BASE, API, currentAuth, me } from './helpers.js'
 
-const DAV = BASE + '/remote.php/dav/addressbooks/users/admin/contacts'
+// Current user's default address book. Computed at call time (not a module-level
+// const) so it follows the per-worker `me` rebind rather than snapshotting 'admin'.
+const davBase = () => BASE + `/remote.php/dav/addressbooks/users/${me}/contacts`
 const HEADERS = {
 	'OCS-APIREQUEST': 'true',
 	'Content-Type': 'application/json',
@@ -18,7 +20,7 @@ const CONTACT_FN = 'Casey Contact E2E'
 async function apiDelete(path) {
 	const r = await fetch(API + path, {
 		method: 'DELETE',
-		headers: { ...HEADERS, Authorization: adminAuth },
+		headers: { ...HEADERS, Authorization: currentAuth },
 	})
 	if (!r.ok && r.status !== 404) throw new Error(`DELETE ${path} → ${r.status}`)
 }
@@ -32,18 +34,18 @@ async function putVCard() {
 		'EMAIL:casey.e2e@example.com',
 		'END:VCARD',
 	].join('\r\n')
-	const r = await fetch(`${DAV}/${CONTACT_UID}.vcf`, {
+	const r = await fetch(`${davBase()}/${CONTACT_UID}.vcf`, {
 		method: 'PUT',
-		headers: { Authorization: adminAuth, 'Content-Type': 'text/vcard' },
+		headers: { Authorization: currentAuth, 'Content-Type': 'text/vcard' },
 		body: vcard,
 	})
 	if (!r.ok) throw new Error(`PUT vcard → ${r.status}`)
 }
 
 async function deleteVCard() {
-	await fetch(`${DAV}/${CONTACT_UID}.vcf`, {
+	await fetch(`${davBase()}/${CONTACT_UID}.vcf`, {
 		method: 'DELETE',
-		headers: { Authorization: adminAuth },
+		headers: { Authorization: currentAuth },
 	}).catch(() => {})
 }
 

--- a/tests/e2e/card-links.spec.js
+++ b/tests/e2e/card-links.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, BASE, API, adminAuth as AUTH, ncLogin } from './helpers.js'
+import { test, expect, BASE, API, currentAuth, ncLogin } from './helpers.js'
 
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
 
@@ -11,7 +11,7 @@ const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
 async function api(method, path, body) {
 	const r = await fetch(API + path, {
 		method,
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: body === undefined ? undefined : JSON.stringify(body),
 	})
 	const text = await r.text()

--- a/tests/e2e/card-modal-layout.spec.js
+++ b/tests/e2e/card-modal-layout.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, BASE, api, ncLogin } from './helpers.js'
+import { test, expect, BASE, api, ncLogin, me } from './helpers.js'
 
 test.describe('Card modal two-column layout', () => {
 	// Unique board title to avoid collision with parallel test runs
@@ -253,7 +253,7 @@ test.describe('Card modal two-column layout', () => {
 			//    ("Your review is requested" → Approve / Request changes) appears. It sits
 			//    at the top of the Card tab as normal block flow, but guard it anyway so a
 			//    future overflow ancestor can't clip it off-screen.
-			await api.put(`/cards/${card.id}/reviews/admin`, {})
+			await api.put(`/cards/${card.id}/reviews/${me}`, {})
 			await page.goto(cardUrl)
 			const verdict = page.locator('.card-modal__verdict').first()
 			await expect(verdict).toBeVisible({ timeout: 15_000 })

--- a/tests/e2e/card-tile-layout.spec.js
+++ b/tests/e2e/card-tile-layout.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 test.describe('CardTile compact layout', () => {
 	const suffix = Math.random().toString(36).slice(2, 8)
@@ -36,8 +34,8 @@ test.describe('CardTile compact layout', () => {
 		state.labelId = label.id
 		await api.put(`/cards/${card.id}/labels/${label.id}`)
 
-		// Assign admin user to the card
-		await api.put(`/cards/${card.id}/assignees/${USER}`)
+		// Assign the current user to the card
+		await api.put(`/cards/${card.id}/assignees/${me}`)
 
 		// Add two checklist items via the checklist API
 		await api.post(`/cards/${card.id}/checklist`, { title: 'Item one' })

--- a/tests/e2e/card-time-tracking.spec.js
+++ b/tests/e2e/card-time-tracking.spec.js
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, ncLogin, BASE, API, adminAuth } from './helpers.js'
+import { test, expect, ncLogin, BASE, API, currentAuth, me } from './helpers.js'
 
-const USER = 'admin'
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
 
 // Bespoke client: returns { ok, status, body } (does NOT throw) because these
@@ -12,7 +11,7 @@ const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
 async function api(method, path, body) {
 	const r = await fetch(API + path, {
 		method,
-		headers: { ...HEADERS, Authorization: adminAuth },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: body === undefined ? undefined : JSON.stringify(body),
 	})
 	const text = await r.text()
@@ -53,7 +52,7 @@ test.describe('Card time tracking', () => {
 		expect(a.ok).toBe(true)
 		expect(a.body.seconds).toBe(5400)
 		expect(a.body.note).toBe('Pairing')
-		expect(a.body.createdBy).toBe(USER)
+		expect(a.body.createdBy).toBe(me)
 
 		// Add another 30m, no note.
 		const b = await api('POST', `/cards/${cardId}/time-entries`, { seconds: 1800 })

--- a/tests/e2e/card-webhook.spec.js
+++ b/tests/e2e/card-webhook.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, ncLogin, BASE, API, adminAuth } from './helpers.js'
+import { test, expect, ncLogin, BASE, API, currentAuth } from './helpers.js'
 import crypto from 'node:crypto'
 
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
@@ -12,7 +12,7 @@ const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
 async function api(method, path, body) {
 	const r = await fetch(API + path, {
 		method,
-		headers: { ...HEADERS, Authorization: adminAuth },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: body === undefined ? undefined : JSON.stringify(body),
 	})
 	const text = await r.text()

--- a/tests/e2e/checklist.spec.js
+++ b/tests/e2e/checklist.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 // Wait for a checklist-item toggle PATCH to complete so badge/progress
 // assertions aren't racing the optimistic render on a slow CI runner.
@@ -263,7 +263,7 @@ test.describe('Checklist steps', () => {
 		const item = page.locator('.card-modal__checklist-item').filter({ hasText: 'Send contract' })
 		await expect(item).toBeVisible({ timeout: 10_000 })
 
-		// Assign it to admin via the row's assign picker.
+		// Assign it to the current user via the row's assign picker.
 		await item.hover()
 		const assignRes = page.waitForResponse(
 			(res) => /\/api\/checklist\/\d+\/assign/.test(res.url())
@@ -271,7 +271,7 @@ test.describe('Checklist steps', () => {
 			{ timeout: 20_000 },
 		)
 		await item.locator('.card-modal__step-btn[title="Assign step"]').click()
-		await item.locator('.card-modal__assign-option').filter({ hasText: 'admin' }).first().click()
+		await item.locator('.card-modal__assign-option').filter({ hasText: me }).first().click()
 		await assignRes
 
 		// The assignee avatar renders on the row.
@@ -304,7 +304,7 @@ test.describe('Checklist steps', () => {
 		const items = await api.get(`/cards/${state.cardId}/checklist`)
 		const step = items.find((i) => i.title === 'Send contract')
 		if (!step) throw new Error('step missing from checklist payload')
-		if (step.assignedUser !== 'admin') throw new Error(`assignedUser not persisted: ${step.assignedUser}`)
+		if (step.assignedUser !== me) throw new Error(`assignedUser not persisted: ${step.assignedUser}`)
 		if (!step.assignedRole) throw new Error('assignedRole was not frozen at assign time')
 		if (!step.assignedAt) throw new Error('assignedAt was not stamped')
 		if (!step.dueDate || !step.dueDate.startsWith('2020-01-01')) throw new Error(`dueDate not persisted: ${step.dueDate}`)
@@ -323,6 +323,6 @@ test.describe('Checklist steps', () => {
 		await patch
 		const reopened = (await api.get(`/cards/${state.cardId}/checklist`)).find((i) => i.title === 'Send contract')
 		if (reopened.doneAt !== null) throw new Error('un-done did not clear done_at')
-		if (reopened.assignedUser !== 'admin') throw new Error('un-done must not touch the assignee')
+		if (reopened.assignedUser !== me) throw new Error('un-done must not touch the assignee')
 	})
 })

--- a/tests/e2e/external-collab.spec.js
+++ b/tests/e2e/external-collab.spec.js
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, ncLogin, makeApi, authFor, adminAuth, BASE } from './helpers.js'
-
-const ADMIN = adminAuth
-const TESTER = authFor('tester', 'kanso-dev-tester!1')
+import { test, expect, ncLogin, makeApi, currentAuth, me, BASE } from './helpers.js'
 
 // Per-auth clients: send() throws on non-2xx (parsed JSON / null for DELETE);
 // raw() returns the Response without throwing, for status-code assertions.
+// Auth strings are read at CALL time (currentAuth / peer.auth), so the client
+// keyed by that string matches the worker's identity under isolation.
 const clients = new Map()
 function clientFor(auth) {
 	if (!clients.has(auth)) clients.set(auth, makeApi(auth))
@@ -36,40 +35,40 @@ test.describe.serial('External collaboration + deep links (#3744)', () => {
 	const token = 'xc' + Math.floor(Date.now() / 1000)
 	const state = { boardId: 0, stackId: 0, clientCardId: 0, internalCardId: 0 }
 
-	test.beforeAll(async () => {
-		const board = await api(ADMIN, 'POST', '/boards', { title: 'ClientCollab ' + token })
+	test.beforeAll(async ({ peer }) => {
+		const board = await api(currentAuth, 'POST', '/boards', { title: 'ClientCollab ' + token })
 		state.boardId = board.id
-		const stack = await api(ADMIN, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
+		const stack = await api(currentAuth, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
 		state.stackId = stack.id
 
-		await api(ADMIN, 'POST', `/boards/${board.id}/acl`, {
-			participant: 'tester',
+		await api(currentAuth, 'POST', `/boards/${board.id}/acl`, {
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3, // READ | EDIT
 			role: 'external',
 		})
 
 		// A public card the external member can see…
-		const pub = await api(ADMIN, 'POST', '/cards', { stackId: stack.id, title: 'Client card ' + token })
+		const pub = await api(currentAuth, 'POST', '/cards', { stackId: stack.id, title: 'Client card ' + token })
 		state.clientCardId = pub.id
 		// …and a provider-internal card hidden from them.
-		const internal = await api(ADMIN, 'POST', '/cards', { stackId: stack.id, title: 'Provider secret ' + token })
-		await api(ADMIN, 'PATCH', `/cards/${internal.id}`, { visibility: 'internal' })
+		const internal = await api(currentAuth, 'POST', '/cards', { stackId: stack.id, title: 'Provider secret ' + token })
+		await api(currentAuth, 'PATCH', `/cards/${internal.id}`, { visibility: 'internal' })
 		state.internalCardId = internal.id
 	})
 
 	test.afterAll(async () => {
-		if (state.boardId) await api(ADMIN, 'DELETE', `/boards/${state.boardId}`).catch(() => {})
+		if (state.boardId) await api(currentAuth, 'DELETE', `/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('deep link survives the login round-trip and opens the right card', async ({ page }) => {
+	test('deep link survives the login round-trip and opens the right card', async ({ page, peer }) => {
 		// Cold hit as a logged-out user: the server route must bounce through
 		// the NC login and come BACK to the card - the exact flow hash links
 		// break (their fragment is dropped by the login redirect).
 		await page.goto(`${BASE}/index.php/apps/kanso/card/${state.clientCardId}`)
 		await page.waitForSelector('#user', { timeout: 15_000 })
-		await page.fill('#user', 'tester')
-		await page.fill('#password', 'kanso-dev-tester!1')
+		await page.fill('#user', peer.user)
+		await page.fill('#password', peer.pass)
 		await page.click('button[type=submit]')
 
 		// Post-login we land on the server route, and the SPA opens the modal.
@@ -78,53 +77,53 @@ test.describe.serial('External collaboration + deep links (#3744)', () => {
 		await expect(page.locator('.card-modal')).toContainText('Client card ' + token, { timeout: 15_000 })
 	})
 
-	test('deep link to a hidden card is an existence-safe 404', async ({ page }) => {
-		await loginAs(page, 'tester', 'kanso-dev-tester!1')
+	test('deep link to a hidden card is an existence-safe 404', async ({ page, peer }) => {
+		await loginAs(page, peer.user, peer.pass)
 		const response = await page.goto(`${BASE}/index.php/apps/kanso/card/${state.internalCardId}`)
 		expect(response.status()).toBe(404)
 		await expect(page.locator('body')).toContainText('Card not found')
 	})
 
-	test('external member edits and comments a visible card (happy path)', async () => {
-		const updated = await api(TESTER, 'PATCH', `/cards/${state.clientCardId}`, {
+	test('external member edits and comments a visible card (happy path)', async ({ peer }) => {
+		const updated = await api(peer.auth, 'PATCH', `/cards/${state.clientCardId}`, {
 			title: 'Client card (edited) ' + token,
 		})
 		expect(updated.title).toBe('Client card (edited) ' + token)
 
-		await api(TESTER, 'POST', `/cards/${state.clientCardId}/comments`, {
+		await api(peer.auth, 'POST', `/cards/${state.clientCardId}/comments`, {
 			body: 'Looks good from the client side ' + token,
 		})
-		const comments = await api(TESTER, 'GET', `/cards/${state.clientCardId}/comments`)
+		const comments = await api(peer.auth, 'GET', `/cards/${state.clientCardId}/comments`)
 		expect(JSON.stringify(comments)).toContain('client side ' + token)
 	})
 
-	test('export and duplicate are 403 for the external member (and 200 for internal)', async () => {
-		expect((await call(TESTER, 'GET', `/boards/${state.boardId}/export`)).status).toBe(403)
-		expect((await call(TESTER, 'POST', `/boards/${state.boardId}/duplicate`, { withCards: true })).status).toBe(403)
+	test('export and duplicate are 403 for the external member (and 200 for internal)', async ({ peer }) => {
+		expect((await call(peer.auth, 'GET', `/boards/${state.boardId}/export`)).status).toBe(403)
+		expect((await call(peer.auth, 'POST', `/boards/${state.boardId}/duplicate`, { withCards: true })).status).toBe(403)
 
 		// The internal side keeps its (viewer-scoped, #3743) export.
-		const adminExport = await call(ADMIN, 'GET', `/boards/${state.boardId}/export`)
+		const adminExport = await call(currentAuth, 'GET', `/boards/${state.boardId}/export`)
 		expect(adminExport.status).toBe(200)
-		const cleanup = await call(ADMIN, 'POST', `/boards/${state.boardId}/duplicate`, { withCards: false })
+		const cleanup = await call(currentAuth, 'POST', `/boards/${state.boardId}/duplicate`, { withCards: false })
 		expect(cleanup.status).toBe(200)
 		const dup = await cleanup.json()
-		await api(ADMIN, 'DELETE', `/boards/${dup.boardId}`).catch(() => {})
+		await api(currentAuth, 'DELETE', `/boards/${dup.boardId}`).catch(() => {})
 	})
 
-	test('board structure is internal-only: stack create/move 403 for the external member', async () => {
-		expect((await call(TESTER, 'POST', '/stacks', { boardId: state.boardId, title: 'Client lane' })).status).toBe(403)
-		expect((await call(TESTER, 'POST', `/stacks/${state.stackId}/move`, { afterStackId: null })).status).toBe(403)
+	test('board structure is internal-only: stack create/move 403 for the external member', async ({ peer }) => {
+		expect((await call(peer.auth, 'POST', '/stacks', { boardId: state.boardId, title: 'Client lane' })).status).toBe(403)
+		expect((await call(peer.auth, 'POST', `/stacks/${state.stackId}/move`, { afterStackId: null })).status).toBe(403)
 		// MANAGE surfaces reject the external too (ACL edit, board settings).
-		expect((await call(TESTER, 'POST', `/boards/${state.boardId}/acl`, {
-			participant: 'admin',
+		expect((await call(peer.auth, 'POST', `/boards/${state.boardId}/acl`, {
+			participant: me,
 			participantType: 'user',
 			permission: 3,
 		})).status).toBe(403)
-		expect((await call(TESTER, 'PATCH', `/boards/${state.boardId}`, { title: 'Renamed by client' })).status).toBe(403)
+		expect((await call(peer.auth, 'PATCH', `/boards/${state.boardId}`, { title: 'Renamed by client' })).status).toBe(403)
 	})
 
-	test('export/duplicate tile-menu entries are hidden for the external member', async ({ page }) => {
-		await loginAs(page, 'tester', 'kanso-dev-tester!1')
+	test('export/duplicate tile-menu entries are hidden for the external member', async ({ page, peer }) => {
+		await loginAs(page, peer.user, peer.pass)
 		await page.goto(`${BASE}/index.php/apps/kanso`)
 		await page.waitForSelector(`[data-test="board-options-menu-${state.boardId}"]`, { timeout: 15_000 })
 		await page.locator(`[data-test="board-options-menu-${state.boardId}"] button`).first().click()

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -19,6 +19,7 @@
  * fixtures resolve to `admin` and behaviour is byte-for-byte unchanged.
  */
 import { test as base, expect } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
 
 export { expect }
 
@@ -36,7 +37,16 @@ export function authFor(user, pass) {
 }
 
 export const ADMIN = { user: 'admin', pass: 'admin' }
+
+/** Fixed superuser auth — use ONLY for genuine admin-only operations
+ * (OCS user provisioning, instance config). NOT for "act as the current user". */
 export const adminAuth = authFor(ADMIN.user, ADMIN.pass)
+
+/** The current acting user's Basic-auth string. `adminAuth` by default; rebound
+ * per worker under E2E_ISOLATE. Bespoke per-spec fetch clients that mean "act as
+ * me" (not "act as the superuser") should read THIS at call time, not adminAuth,
+ * so their requests match the worker's browser session. */
+export let currentAuth = adminAuth
 
 /**
  * Build a Kanso API client bound to a Basic-auth string.
@@ -71,8 +81,22 @@ export function makeApi(auth = adminAuth) {
 	}
 }
 
-/** Admin-bound API client — the drop-in for the old apiGet/apiPost/apiDelete. */
-export const api = makeApi(adminAuth)
+/** Admin-bound API client — the drop-in for the old apiGet/apiPost/apiDelete.
+ * `let` (not `const`) so the worker isolation fixture can rebind this live
+ * binding to the worker's own user; every spec's `import { api }` then follows. */
+export let api = makeApi(adminAuth)
+
+/** The current acting user's id. `admin` by default; rebound per worker under
+ * E2E_ISOLATE. Use this instead of the literal 'admin' wherever a spec means
+ * "myself" (assignee/reviewer/self-mention). Read it at call time (a `const x =
+ * me` snapshot taken at import would capture 'admin' before the rebind). */
+export let me = ADMIN.user
+
+/** Default second identity for multi-user specs (board sharing / ACL / peer
+ * login). The dev stack's shared `tester`; rebound to a per-worker peer under
+ * isolation. This is a plain object, not a fixture, so it can't rebind itself —
+ * multi-user specs consume the worker-scoped `peer` fixture below instead. */
+export const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
 
 /**
  * Drive (or detect) the Nextcloud login. If a live session already exists
@@ -139,30 +163,78 @@ export async function deleteUser(user) {
 }
 
 /**
- * Worker-scoped identity. With E2E_ISOLATE unset (default) this is admin and
- * costs nothing. With E2E_ISOLATE=1 each worker gets a dedicated, provisioned
- * user `kansoe2e_w<index>` so parallel workers never share board lists or
- * per-user aggregate views.
+ * Parallel isolation.
+ *
+ * With E2E_ISOLATE unset (the default) everything below is admin and the suite
+ * is byte-for-byte its old serial self. With E2E_ISOLATE=1 each Playwright
+ * worker gets a dedicated, provisioned user `kansoe2e_w<index>` and its browser
+ * pages start logged in AS that user, so fixed board names and per-user
+ * aggregate views (my-work / inbox / search / pinned) are namespaced per worker
+ * and `E2E_WORKERS` can be raised safely. Specs need no changes: the exported
+ * `api` live binding is rebound to the worker's client, and `storageState` is
+ * overridden per worker — `ncLogin(page)` then just detects the live session.
  */
 const ISOLATE = process.env.E2E_ISOLATE === '1'
 const WORKER_PASS = 'Kanso-e2e-worker!1'
+const ADMIN_STATE = 'tests/e2e/.auth/admin.json'
 
-export const test = base.extend({
-	// eslint-disable-next-line no-empty-pattern
+let testImpl = base.extend({
+	// Worker identity, provisioned once per worker. `auto` so it runs at worker
+	// setup even for specs that don't destructure it — that's what lets it rebind
+	// the module-level `api` binding before any beforeAll/test in the worker.
 	user: [async ({}, use, workerInfo) => {
 		if (!ISOLATE) {
-			await use({ ...ADMIN, auth: adminAuth, api })
+			await use({ ...ADMIN, auth: adminAuth, api: makeApi(adminAuth) })
 			return
 		}
 		const username = `kansoe2e_w${workerInfo.workerIndex}`
 		const provisioned = await provisionUser(username, WORKER_PASS, { displayName: username })
+		api = provisioned.api // rebind the exported live binding → specs' `import { api }` follow
+		me = username // …and the "current user" id for self-referential specs
+		currentAuth = provisioned.auth // …and the auth for bespoke per-spec clients
 		await use(provisioned)
-		// Left in place between runs on purpose: re-provision is idempotent and
-		// tearing down would race sibling specs still mid-flight in CI retries.
-	}, { scope: 'worker' }],
+	}, { scope: 'worker', auto: true }],
 
-	// Per-test API client bound to the worker identity. Drop-in for module `api`.
-	api: async ({ user }, use) => {
-		await use(user.api)
-	},
+	// Second identity for multi-user specs (board sharing, ACL, peer login).
+	// Not auto — only the specs that need it destructure `{ peer }`. Off-isolate
+	// it's the shared dev `tester`; on-isolate a per-worker peer so two workers
+	// never contend over one secondary account.
+	peer: [async ({}, use, workerInfo) => {
+		if (!ISOLATE) {
+			const auth = authFor(TESTER.user, TESTER.pass)
+			await use({ ...TESTER, auth, api: makeApi(auth) })
+			return
+		}
+		const username = `kansoe2e_w${workerInfo.workerIndex}_peer`
+		await use(await provisionUser(username, WORKER_PASS, { displayName: username }))
+	}, { scope: 'worker' }],
 })
+
+if (ISOLATE) {
+	testImpl = testImpl.extend({
+		// One logged-in browser session per worker, captured once. Depends on
+		// `user` so the account exists first; uses a throwaway clean context to
+		// drive the real login form, then persists that session to a file.
+		workerStorageState: [async ({ user, browser }, use, workerInfo) => {
+			mkdirSync('tests/e2e/.auth', { recursive: true })
+			const file = `tests/e2e/.auth/worker-${workerInfo.workerIndex}.json`
+			const ctx = await browser.newContext()
+			try {
+				const page = await ctx.newPage()
+				await ncLogin(page, { user: user.user, pass: user.pass })
+				await ctx.storageState({ path: file })
+			} finally {
+				await ctx.close()
+			}
+			await use(file)
+		}, { scope: 'worker' }],
+
+		// Override the storageState option so every page in this worker starts as
+		// the worker user instead of the shared admin session from the config.
+		storageState: async ({ workerStorageState }, use) => {
+			await use(workerStorageState)
+		},
+	})
+}
+
+export const test = testImpl

--- a/tests/e2e/inbox.spec.js
+++ b/tests/e2e/inbox.spec.js
@@ -9,14 +9,7 @@
 // If the two-user share setup is unavailable the test falls back to asserting
 // the page at least renders without crashing (either a feed item or empty state).
 
-import { test, expect, api, makeApi, authFor, ncLogin, BASE } from './helpers.js'
-
-const ADMIN = 'admin'
-const TESTER = 'tester'
-const TESTER_PASS = 'kanso-dev-tester!1'
-
-const TESTER_AUTH = authFor(TESTER, TESTER_PASS)
-const testerApi = makeApi(TESTER_AUTH)
+import { test, expect, api, me, ncLogin, BASE } from './helpers.js'
 
 // ---------------------------------------------------------------------------
 // Suite
@@ -32,7 +25,7 @@ test.describe('Inbox feed', () => {
 		setupOk: false,
 	}
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		// Clean up any leftover board from a prior run
 		const boards = await api.get('/boards')
 		for (const b of boards) {
@@ -56,7 +49,7 @@ test.describe('Inbox feed', () => {
 		let shareOk = false
 		try {
 			await api.post(`/boards/${board.id}/acl`, {
-				participant: TESTER,
+				participant: peer.user,
 				participantType: 'user',
 				permission: 3,
 			})
@@ -76,7 +69,7 @@ test.describe('Inbox feed', () => {
 		if (shareOk) {
 			try {
 				state.commentBody = 'Hello from tester - inbox smoke test'
-				await testerApi.post(`/cards/${card.id}/comments`, { body: state.commentBody })
+				await peer.api.post(`/cards/${card.id}/comments`, { body: state.commentBody })
 				state.setupOk = true
 			} catch {
 				// tester auth failed - still run fallback assertion
@@ -86,7 +79,7 @@ test.describe('Inbox feed', () => {
 			// on a card admin follows, by an actor other than admin, so it should
 			// surface in admin's inbox feed alongside the comment.
 			try {
-				const r = await testerApi.raw('PUT', `/cards/${card.id}/reviews/${ADMIN}`)
+				const r = await peer.api.raw('PUT', `/cards/${card.id}/reviews/${me}`)
 				state.reviewEventOk = r.ok
 			} catch {
 				// review request unavailable - the status-change test skips

--- a/tests/e2e/member-roles.spec.js
+++ b/tests/e2e/member-roles.spec.js
@@ -9,13 +9,13 @@ import { test, expect, api, ncLogin, BASE } from './helpers.js'
 test.describe('Board member roles (internal/external)', () => {
 	const state = { boardId: 0, aclId: 0 }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		const board = await api.post('/boards', { title: 'Roles E2E ' + Math.floor(Date.now() / 1000) })
 		state.boardId = board.id
 		await api.post('/stacks', { boardId: board.id, title: 'To Do' })
-		// Share with the stock dev-stack test user; no role sent → internal.
+		// Share with the peer identity; no role sent → internal.
 		const acl = await api.post(`/boards/${board.id}/acl`, {
-			participant: 'tester',
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3, // READ | EDIT
 		})
@@ -27,7 +27,7 @@ test.describe('Board member roles (internal/external)', () => {
 		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('manager flips a member to external in the sharing panel; the role persists', async ({ page }) => {
+	test('manager flips a member to external in the sharing panel; the role persists', async ({ page, peer }) => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
@@ -37,8 +37,8 @@ test.describe('Board member roles (internal/external)', () => {
 		await page.getByRole('menuitem', { name: /board settings/i }).click()
 		await page.locator('#bs-rail-tab-sharing').click()
 
-		// The tester entry renders with the role selector, defaulted internal.
-		const entry = page.locator('.sharing__entry', { hasText: 'tester' })
+		// The peer entry renders with the role selector, defaulted internal.
+		const entry = page.locator('.sharing__entry', { hasText: peer.user })
 		await expect(entry).toBeVisible({ timeout: 8_000 })
 		const select = entry.locator('[data-test="acl-role-select"]')
 		await expect(select).toBeVisible()
@@ -53,7 +53,7 @@ test.describe('Board member roles (internal/external)', () => {
 
 		// Server-side truth: the stored role flipped (and survives a re-read).
 		const board = await api.get(`/boards/${state.boardId}`)
-		const acl = board.acl.find((a) => a.participant === 'tester')
+		const acl = board.acl.find((a) => a.participant === peer.user)
 		expect(acl.role).toBe('external')
 
 		// The selector reflects the persisted value after the cache refresh.

--- a/tests/e2e/mentions.spec.js
+++ b/tests/e2e/mentions.spec.js
@@ -28,13 +28,18 @@ async function shareBoardWith(boardId, uid, permission) {
 }
 
 test.describe('@mentions in comments', () => {
-	const BOB = 'kanso_mention_bob'
+	// Locally-provisioned extra users — per-worker-unique names so parallel
+	// workers never collide over the same account (set in beforeAll from the
+	// worker index). BOB is shared on the board; STRANGER deliberately is not.
+	let BOB = ''
 	const BOB_PASS = 'Mention#Bob2026'
-	const STRANGER = 'kanso_mention_stranger'
+	let STRANGER = ''
 	const STRANGER_PASS = 'Mention#Stranger2026'
 	const state = { boardId: 0, stackId: 0, cardId: 0, cardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({}, workerInfo) => {
+		BOB = `kanso_mention_bob_w${workerInfo.workerIndex}`
+		STRANGER = `kanso_mention_stranger_w${workerInfo.workerIndex}`
 		await provisionUser(BOB, BOB_PASS)
 		await provisionUser(STRANGER, STRANGER_PASS)
 

--- a/tests/e2e/my-cards.spec.js
+++ b/tests/e2e/my-cards.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 test.describe('My tasks (#3441)', () => {
 	const state = { boardId: 0, stackId: 0, assignedCardId: 0, unassignedCardId: 0, title: '' }
@@ -15,8 +13,8 @@ test.describe('My tasks (#3441)', () => {
 		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'To do' })).id
 		state.assignedCardId = (await api.post('/cards', { stackId: state.stackId, title: state.title })).id
 		state.unassignedCardId = (await api.post('/cards', { stackId: state.stackId, title: 'Not mine ' + Math.floor(Date.now() / 1000) })).id
-		// Assign only the first card to admin (the current user).
-		await api.put(`/cards/${state.assignedCardId}/assignees/${USER}`)
+		// Assign only the first card to the current user.
+		await api.put(`/cards/${state.assignedCardId}/assignees/${me}`)
 	})
 
 	test.afterAll(async () => {
@@ -35,7 +33,7 @@ test.describe('My tasks (#3441)', () => {
 
 	test('a done card drops out of my tasks', async () => {
 		const doneCardId = (await api.post('/cards', { stackId: state.stackId, title: 'Finish me ' + Math.floor(Date.now() / 1000) })).id
-		await api.put(`/cards/${doneCardId}/assignees/${USER}`)
+		await api.put(`/cards/${doneCardId}/assignees/${me}`)
 		expect((await api.get('/my-cards')).map((c) => c.id)).toContain(doneCardId)
 
 		await api.patch(`/cards/${doneCardId}`, { done: true })

--- a/tests/e2e/my-reviews.spec.js
+++ b/tests/e2e/my-reviews.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 test.describe('My Reviews page', () => {
 	const state = { boardId: 0, stackId: 0, cardId: 0, reviewsUrl: '' }
@@ -24,9 +22,9 @@ test.describe('My Reviews page', () => {
 		const card = await api.post('/cards', { stackId: stack.id, title: 'Review Me Please' })
 		state.cardId = card.id
 
-		// The board owner (admin) requests a review from themselves - produces a
+		// The board owner requests a review from themselves - produces a
 		// pending review row that appears on the My Reviews page.
-		await api.put(`/cards/${card.id}/reviews/${USER}`)
+		await api.put(`/cards/${card.id}/reviews/${me}`)
 
 		state.reviewsUrl = `${BASE}/index.php/apps/kanso#/reviews`
 	})

--- a/tests/e2e/my-work-freshness.spec.js
+++ b/tests/e2e/my-work-freshness.spec.js
@@ -14,9 +14,7 @@
 //     there; unassign → it disappears again.
 //  2. request a review → client-side navigate to My Reviews → request is there.
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 /**
  * Same-document (hash-only) navigation — vue-router handles it client-side,
@@ -71,7 +69,7 @@ test.describe('My Work freshness (#3766)', () => {
 			{ timeout: 10_000 },
 		)
 		await page.locator('.card-modal__popover .card-modal__assign-option').first().click()
-		await expect(page.locator('.card-modal__assignee-pill', { hasText: USER })).toBeVisible({ timeout: 8000 })
+		await expect(page.locator('.card-modal__assignee-pill', { hasText: me })).toBeVisible({ timeout: 8000 })
 		await feedRefetch
 
 		// Client-side navigation to My Tasks — the new assignment is there.
@@ -87,7 +85,7 @@ test.describe('My Work freshness (#3766)', () => {
 			(r) => r.url().includes(`/api/cards/${state.taskCardId}/assignees/`) && r.request().method() === 'DELETE',
 			{ timeout: 10_000 },
 		)
-		await page.locator('.card-modal__assignee-pill', { hasText: USER })
+		await page.locator('.card-modal__assignee-pill', { hasText: me })
 			.locator('.card-modal__pill-x').first().click()
 		await unassignDone
 

--- a/tests/e2e/my-work-live.spec.js
+++ b/tests/e2e/my-work-live.spec.js
@@ -21,8 +21,6 @@
 
 import { test, expect, api, BASE } from './helpers.js'
 
-const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
-
 // Local ncLogin takes POSITIONAL (page, user, pass) and always drives the form
 // for an explicit non-admin identity — kept as-is (the shared ncLogin uses an
 // object arg and short-circuits on an existing session), per the migration
@@ -50,16 +48,16 @@ test.describe('My Work live updates (#3768)', () => {
 	const TASK_TITLE = `Live Assign ${ts}`
 	const state = { boardId: 0, reviewCardId: 0, taskCardId: 0 }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		const board = await api.post('/boards', { title: `MyWork Live E2E ${ts}` })
 		state.boardId = board.id
 		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
 		state.reviewCardId = (await api.post('/cards', { stackId: stack.id, title: REVIEW_TITLE })).id
 		state.taskCardId = (await api.post('/cards', { stackId: stack.id, title: TASK_TITLE })).id
-		// Share with tester (READ|EDIT = 3) so the admin's review request /
-		// assignment lands in the tester's cross-board feeds.
+		// Share with the peer (READ|EDIT = 3) so the current user's review request /
+		// assignment lands in the peer's cross-board feeds.
 		await api.post(`/boards/${board.id}/acl`, {
-			participant: TESTER.user,
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3,
 		})
@@ -69,13 +67,13 @@ test.describe('My Work live updates (#3768)', () => {
 		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
 	})
 
-	test('a review requested by another user appears in the open My Reviews view by itself', async ({ browser }) => {
+	test('a review requested by another user appears in the open My Reviews view by itself', async ({ browser, peer }) => {
 		// Polling budget (60s interval + slow-CI headroom) on top of the default.
 		test.setTimeout(180_000)
 		const ctx = await browser.newContext()
 		try {
 			const page = await ctx.newPage()
-			await ncLogin(page, TESTER.user, TESTER.pass)
+			await ncLogin(page, peer.user, peer.pass)
 
 			// Tester parks on My Reviews — from here on: no navigation, no focus
 			// change, no reload. The marker survives only if that holds.
@@ -85,8 +83,8 @@ test.describe('My Work live updates (#3768)', () => {
 			await expect(row).toBeHidden()
 			await page.evaluate(() => { window.__kansoNoReload = true })
 
-			// The admin — another user, no browser — requests a review FROM the tester.
-			await api.put(`/cards/${state.reviewCardId}/reviews/${TESTER.user}`)
+			// The current user — another user, no browser — requests a review FROM the peer.
+			await api.put(`/cards/${state.reviewCardId}/reviews/${peer.user}`)
 
 			// Push: near-instant. Poll-only (CI): within the 60s interval.
 			await expect(row).toBeVisible({ timeout: 90_000 })
@@ -97,12 +95,12 @@ test.describe('My Work live updates (#3768)', () => {
 		}
 	})
 
-	test('a card assigned by another user appears in the open My Tasks view by itself', async ({ browser }) => {
+	test('a card assigned by another user appears in the open My Tasks view by itself', async ({ browser, peer }) => {
 		test.setTimeout(180_000)
 		const ctx = await browser.newContext()
 		try {
 			const page = await ctx.newPage()
-			await ncLogin(page, TESTER.user, TESTER.pass)
+			await ncLogin(page, peer.user, peer.pass)
 
 			await page.goto(`${BASE}/index.php/apps/kanso#/my-tasks`)
 			await expect(page.locator('.my-cards-view')).toBeVisible({ timeout: 15_000 })
@@ -110,8 +108,8 @@ test.describe('My Work live updates (#3768)', () => {
 			await expect(row).toBeHidden()
 			await page.evaluate(() => { window.__kansoNoReload = true })
 
-			// The admin assigns the tester to the card.
-			await api.put(`/cards/${state.taskCardId}/assignees/${TESTER.user}`)
+			// The current user assigns the peer to the card.
+			await api.put(`/cards/${state.taskCardId}/assignees/${peer.user}`)
 
 			await expect(row).toBeVisible({ timeout: 90_000 })
 			expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)

--- a/tests/e2e/my-work-nav.spec.js
+++ b/tests/e2e/my-work-nav.spec.js
@@ -6,9 +6,7 @@
 // badge counting pending review requests. Closing a card opened from a
 // standalone view returns to that view (#3597 close-to-origin intact).
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 function navItem(page, name) {
 	return page.locator('.app-navigation .app-navigation-entry-link', { hasText: name })
@@ -29,10 +27,10 @@ test.describe('My Work split into three nav items with badges', () => {
 		state.stackId = stack.id
 		const card = await api.post('/cards', { stackId: stack.id, title: 'Nav Split Target Card' })
 		state.cardId = card.id
-		// Assign to admin → surfaces in My Tasks. Request review from admin →
-		// surfaces a pending review (drives the My Reviews badge).
-		await api.put(`/cards/${card.id}/assignees/${USER}`)
-		await api.put(`/cards/${card.id}/reviews/${USER}`)
+		// Assign to the current user → surfaces in My Tasks. Request review from
+		// the current user → surfaces a pending review (drives the My Reviews badge).
+		await api.put(`/cards/${card.id}/assignees/${me}`)
+		await api.put(`/cards/${card.id}/reviews/${me}`)
 	})
 
 	test.afterAll(async () => {

--- a/tests/e2e/my-work-return.spec.js
+++ b/tests/e2e/my-work-return.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 // #3597 — closing a card opened from My Work must return to My Work, not the
 // board; while a card opened from the board (or a pasted deep link) must still
@@ -32,8 +30,8 @@ test.describe('Card close returns to its origin', () => {
 		})
 		state.cardId = card.id
 
-		// Assign to admin so the card surfaces in the "My tasks" feed.
-		await api.put(`/cards/${card.id}/assignees/${USER}`)
+		// Assign to the current user so the card surfaces in the "My tasks" feed.
+		await api.put(`/cards/${card.id}/assignees/${me}`)
 	})
 
 	test.afterAll(async () => {

--- a/tests/e2e/onboarding.spec.js
+++ b/tests/e2e/onboarding.spec.js
@@ -9,33 +9,32 @@
 // persisted PER USER via the shared `dismissed_hints` settings key, so it stays
 // hidden after a reload.
 
-import { test, expect, ncLogin } from './helpers.js'
+import { test, expect, ncLogin, adminAuth } from './helpers.js'
 
 const BASE = 'http://localhost:8891'
-const ADMIN = 'admin'
-const ADMIN_PASS = 'admin'
-const ADMIN_AUTH = 'Basic ' + Buffer.from(ADMIN + ':' + ADMIN_PASS).toString('base64')
 
-// A hermetic, throwaway user so the board list is genuinely empty.
-const UID = 'kanso-onboard-' + Math.floor(Date.now() / 1000)
+// A hermetic, throwaway user so the board list is genuinely empty. The name is
+// made per-worker-unique in beforeAll (worker index) so parallel workers never
+// provision/delete the same account.
+let UID = ''
 const PASS = 'onboard-pass-123'
 
 const OCS = BASE + '/ocs/v2.php/cloud'
 const OCS_HEADERS = { 'OCS-APIREQUEST': 'true', Accept: 'application/json' }
 
 async function provisionUser(uid, password) {
-	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: ADMIN_AUTH } }).catch(() => {})
+	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: adminAuth } }).catch(() => {})
 	const body = new URLSearchParams({ userid: uid, password })
 	const r = await fetch(`${OCS}/users`, {
 		method: 'POST',
-		headers: { ...OCS_HEADERS, Authorization: ADMIN_AUTH, 'Content-Type': 'application/x-www-form-urlencoded' },
+		headers: { ...OCS_HEADERS, Authorization: adminAuth, 'Content-Type': 'application/x-www-form-urlencoded' },
 		body,
 	})
 	if (!r.ok) throw new Error(`provision ${uid} → ${r.status}: ${await r.text()}`)
 }
 
 async function deleteUser(uid) {
-	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: ADMIN_AUTH } }).catch(() => {})
+	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: adminAuth } }).catch(() => {})
 }
 
 test.describe('First-run onboarding (#3413)', () => {
@@ -44,7 +43,8 @@ test.describe('First-run onboarding (#3413)', () => {
 	// storageState — otherwise the page starts as admin and loginAs no-ops.
 	test.use({ storageState: { cookies: [], origins: [] } })
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({}, workerInfo) => {
+		UID = `kanso-onboard-${Math.floor(Date.now() / 1000)}-w${workerInfo.workerIndex}`
 		await provisionUser(UID, PASS)
 	})
 

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -1,18 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect } from './helpers.js'
+import { test, expect, currentAuth, me } from './helpers.js'
 
 const BASE = 'http://localhost:8891'
 const API = BASE + '/index.php/apps/kanso/api'
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
-const AUTH = 'Basic ' + Buffer.from('admin:admin').toString('base64')
 
-// Authenticated API call (as admin, who owns/manages the board).
+// Authenticated API call as the CURRENT user (the board owner/MANAGE user).
+// Reads `currentAuth` at call time so it follows the worker's identity under
+// isolation, not a module-load snapshot.
 async function api(method, path, body) {
 	const r = await fetch(API + path, {
 		method,
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: body === undefined ? undefined : JSON.stringify(body),
 	})
 	const text = await r.text()
@@ -47,7 +48,7 @@ test.describe('Public read-only board share', () => {
 		todoStackId = (await api('POST', '/stacks', { boardId, title: 'To do' })).body.id
 		cardId = (await api('POST', '/cards', { stackId: todoStackId, title: 'Public visible card' })).body.id
 		// Add people/comments that MUST NOT surface on the public view.
-		await api('PUT', `/cards/${cardId}/assignees/admin`)
+		await api('PUT', `/cards/${cardId}/assignees/${me}`)
 		await api('POST', `/cards/${cardId}/comments`, { message: 'internal comment SHOULD NOT LEAK' })
 	})
 
@@ -85,7 +86,7 @@ test.describe('Public read-only board share', () => {
 
 		// No people, no comments, no internal metadata anywhere in the payload.
 		const json = JSON.stringify(res.body)
-		expect(json).not.toContain('admin') // no assignee / owner uid
+		expect(json).not.toContain(me) // no assignee / owner uid
 		expect(json).not.toContain('SHOULD NOT LEAK') // no comments
 		expect(card.assignees).toBeUndefined()
 		expect(card.assigneeIds).toBeUndefined()

--- a/tests/e2e/realtime-card-modal.spec.js
+++ b/tests/e2e/realtime-card-modal.spec.js
@@ -15,8 +15,6 @@
 
 import { test, expect, api, ncLogin, BASE } from './helpers.js'
 
-const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
-
 test.describe('Realtime card modal freshness', () => {
 	// Drives two distinct users (admin + tester) and logs each in explicitly — so
 	// it must NOT inherit the shared authenticated storageState, or every context
@@ -25,7 +23,7 @@ test.describe('Realtime card modal freshness', () => {
 
 	const state = { boardId: 0, cardId: 0, cardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		const boards = await api.get('/boards')
 		for (const b of boards) {
 			if (b.title === 'Realtime Modal Board') {
@@ -37,9 +35,9 @@ test.describe('Realtime card modal freshness', () => {
 		const stack = await api.post('/stacks', { boardId: board.id, title: 'S1' })
 		const card = await api.post('/cards', { stackId: stack.id, title: 'Modal card v1' })
 		state.cardId = card.id
-		// Share with tester (READ|EDIT = 3)
+		// Share with the peer (READ|EDIT = 3)
 		await api.post(`/boards/${board.id}/acl`, {
-			participant: TESTER.user,
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3,
 		})
@@ -52,11 +50,11 @@ test.describe('Realtime card modal freshness', () => {
 		}
 	})
 
-	test('open modal picks up remote title, description and comment without reload', async ({ browser }) => {
+	test('open modal picks up remote title, description and comment without reload', async ({ browser, peer }) => {
 		const testerCtx = await browser.newContext()
 		try {
 			const page = await testerCtx.newPage()
-			await ncLogin(page, { user: TESTER.user, pass: TESTER.pass })
+			await ncLogin(page, { user: peer.user, pass: peer.pass })
 
 			// Tester opens the card modal and keeps it open — no further navigation.
 			await page.goto(state.cardUrl)
@@ -79,11 +77,11 @@ test.describe('Realtime card modal freshness', () => {
 		}
 	})
 
-	test('a remote change never clobbers a dirty description draft', async ({ browser }) => {
+	test('a remote change never clobbers a dirty description draft', async ({ browser, peer }) => {
 		const testerCtx = await browser.newContext()
 		try {
 			const page = await testerCtx.newPage()
-			await ncLogin(page, { user: TESTER.user, pass: TESTER.pass })
+			await ncLogin(page, { user: peer.user, pass: peer.pass })
 
 			await page.goto(state.cardUrl)
 			await expect(page.locator('.card-modal__desc-rendered')).toContainText('remote description v1', { timeout: 15_000 })

--- a/tests/e2e/realtime.spec.js
+++ b/tests/e2e/realtime.spec.js
@@ -7,16 +7,13 @@
 // The fallback test toggles the notify_push app off through occ in the dev
 // container, so this suite assumes the dev/ docker stack.
 
-import { test, expect, api, ncLogin, adminAuth, BASE } from './helpers.js'
+import { test, expect, api, ncLogin, currentAuth, BASE } from './helpers.js'
 import { execSync } from 'node:child_process'
 
 const HEADERS = {
 	'OCS-APIREQUEST': 'true',
 	'Content-Type': 'application/json',
 }
-const ADMIN_AUTH = adminAuth
-
-const TESTER = { user: 'tester', pass: 'kanso-dev-tester!1' }
 
 // The CI runner sets KANSO_SKIP_NOTIFY_PUSH=1: notify_push is never installed
 // there, so the enable/disable dance is both unnecessary and a hard-failure
@@ -49,7 +46,7 @@ test.describe('Realtime sync', () => {
 
 	const state = { boardId: 0, boardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		const boards = await api.get('/boards')
 		for (const b of boards) {
 			if (b.title === 'Realtime Test Board') {
@@ -59,9 +56,9 @@ test.describe('Realtime sync', () => {
 		const board = await api.post('/boards', { title: 'Realtime Test Board' })
 		state.boardId = board.id
 		await api.post('/stacks', { boardId: board.id, title: 'S1' })
-		// Share with tester (READ|EDIT = 3)
+		// Share with the peer (READ|EDIT = 3)
 		await api.post(`/boards/${board.id}/acl`, {
-			participant: TESTER.user,
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3,
 		})
@@ -74,7 +71,7 @@ test.describe('Realtime sync', () => {
 		occSafe('app:enable notify_push')
 	})
 
-	test('push: tester sees a new card near-instantly without interaction', async ({ browser }) => {
+	test('push: tester sees a new card near-instantly without interaction', async ({ browser, user, peer }) => {
 		// This test genuinely requires notify_push; the CI runner without it
 		// (KANSO_SKIP_NOTIFY_PUSH=1) can only exercise the poll fallback below.
 		test.skip(SKIP_NOTIFY_PUSH, 'notify_push not available on this runner')
@@ -83,8 +80,8 @@ test.describe('Realtime sync', () => {
 		try {
 			const adminPage = await adminCtx.newPage()
 			const testerPage = await testerCtx.newPage()
-			await ncLogin(adminPage, { user: 'admin', pass: 'admin' })
-			await ncLogin(testerPage, { user: TESTER.user, pass: TESTER.pass })
+			await ncLogin(adminPage, { user: user.user, pass: user.pass })
+			await ncLogin(testerPage, { user: peer.user, pass: peer.pass })
 
 			await adminPage.goto(state.boardUrl)
 			await testerPage.goto(state.boardUrl)
@@ -103,7 +100,7 @@ test.describe('Realtime sync', () => {
 		}
 	})
 
-	test('fallback: tester sees a new card via the 5s poll when push is off', async ({ browser }) => {
+	test('fallback: tester sees a new card via the 5s poll when push is off', async ({ browser, peer }) => {
 		// Best-effort disable: on KANSO_SKIP_NOTIFY_PUSH runners push is already
 		// off (app never installed), so this is a no-op there and must never
 		// hard-fail the poll-fallback test it guards.
@@ -113,7 +110,7 @@ test.describe('Realtime sync', () => {
 		// could still load with push enabled and take the 60s path).
 		for (let i = 0; i < 20; i++) {
 			const r = await fetch(BASE + '/ocs/v2.php/cloud/capabilities?format=json', {
-				headers: { ...HEADERS, Authorization: ADMIN_AUTH },
+				headers: { ...HEADERS, Authorization: currentAuth },
 			})
 			const caps = (await r.json())?.ocs?.data?.capabilities ?? {}
 			if (!('notify_push' in caps)) break
@@ -122,7 +119,7 @@ test.describe('Realtime sync', () => {
 		const testerCtx = await browser.newContext()
 		try {
 			const testerPage = await testerCtx.newPage()
-			await ncLogin(testerPage, { user: TESTER.user, pass: TESTER.pass })
+			await ncLogin(testerPage, { user: peer.user, pass: peer.pass })
 
 			// Fresh load AFTER disabling: no notify_push capability → the
 			// client falls back to the 5s delta poll.

--- a/tests/e2e/reminders.spec.js
+++ b/tests/e2e/reminders.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, adminAuth, BASE, API } from './helpers.js'
+import { test, expect, api, ncLogin, currentAuth, BASE, API } from './helpers.js'
 import { execSync } from 'node:child_process'
 
 const NOTIF = BASE + '/ocs/v2.php/apps/notifications/api/v2/notifications'
@@ -10,10 +10,9 @@ const HEADERS = {
 	'Content-Type': 'application/json',
 }
 const OCS_HEADERS = { 'OCS-APIREQUEST': 'true', Accept: 'application/json' }
-const AUTH = adminAuth
 
 async function kansoNotifications() {
-	const r = await fetch(NOTIF, { headers: { ...OCS_HEADERS, Authorization: AUTH } })
+	const r = await fetch(NOTIF, { headers: { ...OCS_HEADERS, Authorization: currentAuth } })
 	if (!r.ok) return []
 	const body = await r.json()
 	const data = body?.ocs?.data ?? []
@@ -85,7 +84,7 @@ test.describe('Personal reminders (remind me)', () => {
 	test('a past reminder time is rejected (400)', async () => {
 		const r = await fetch(`${API}/cards/${state.cardId}/reminders`, {
 			method: 'POST',
-			headers: { ...HEADERS, Authorization: AUTH },
+			headers: { ...HEADERS, Authorization: currentAuth },
 			body: JSON.stringify({ remindAt: Math.floor(Date.now() / 1000) - 60 }),
 		})
 		expect(r.status).toBe(400)

--- a/tests/e2e/review-compact.spec.js
+++ b/tests/e2e/review-compact.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 // #3493 — with 3+ reviews the attribute-bar chips must stay compact (one row).
 test.describe('Compact multi-review attribute bar', () => {
@@ -14,11 +12,11 @@ test.describe('Compact multi-review attribute bar', () => {
 		state.boardId = board.id
 		const stackId = (await api.post('/stacks', { boardId: board.id, title: 'Do' })).id
 		const cardId = (await api.post('/cards', { stackId, title: 'Review-heavy card' })).id
-		// Three distinct reviews from admin (one per type) — same reviewer, three
-		// types is a valid multi-review shape and avoids provisioning extra users.
+		// Three distinct reviews from the current user (one per type) — same reviewer,
+		// three types is a valid multi-review shape and avoids provisioning extra users.
 		for (const name of ['QA', 'Security', 'Design']) {
 			const typeId = (await api.post('/review-types', { boardId: board.id, title: name, color: '31CC7C' })).id
-			await api.put(`/cards/${cardId}/reviews/${USER}`, { reviewTypeId: typeId })
+			await api.put(`/cards/${cardId}/reviews/${me}`, { reviewTypeId: typeId })
 		}
 		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${cardId}`
 	})

--- a/tests/e2e/review-gating.spec.js
+++ b/tests/e2e/review-gating.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 test.describe('Review-type stage gating', () => {
 	const state = {
@@ -46,9 +44,9 @@ test.describe('Review-type stage gating', () => {
 	})
 
 	test('QA renders gated while Code is pending, then un-gates once Code is approved', async ({ page }) => {
-		// Request both reviews from admin (one per type is allowed on the same card).
-		await api.put(`/cards/${state.cardId}/reviews/${USER}`, { reviewTypeId: state.codeTypeId })
-		await api.put(`/cards/${state.cardId}/reviews/${USER}`, { reviewTypeId: state.qaTypeId })
+		// Request both reviews from the current user (one per type is allowed on the same card).
+		await api.put(`/cards/${state.cardId}/reviews/${me}`, { reviewTypeId: state.codeTypeId })
+		await api.put(`/cards/${state.cardId}/reviews/${me}`, { reviewTypeId: state.qaTypeId })
 
 		// The server should mark the QA (stage 1) review gated, blocked by the Code
 		// (stage 0) review, and QA's notification should be deferred (notifiedAt null).

--- a/tests/e2e/review-multi.spec.js
+++ b/tests/e2e/review-multi.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api } from './helpers.js'
+import { test, expect, api, me } from './helpers.js'
 
 // #3468 (multiple reviews per card, incl. same reviewer + different type) and
 // #3469 (request-changes reason → comment), driven through the public API.
@@ -23,11 +23,11 @@ test.describe('Multiple reviews + request-changes reason', () => {
 
 	test('same reviewer can hold two review types; request-changes posts a reason comment', async () => {
 		// Two reviews from the SAME reviewer: one untyped, one typed (#3468).
-		await api.put(`/cards/${cardId}/reviews/admin`)
-		await api.put(`/cards/${cardId}/reviews/admin`, { reviewTypeId: typeId })
+		await api.put(`/cards/${cardId}/reviews/${me}`)
+		await api.put(`/cards/${cardId}/reviews/${me}`, { reviewTypeId: typeId })
 
 		let card = await api.get(`/cards/${cardId}`)
-		const mine = card.reviews.filter((r) => r.reviewer === 'admin')
+		const mine = card.reviews.filter((r) => r.reviewer === me)
 		expect(mine).toHaveLength(2)
 		const untyped = mine.find((r) => !r.reviewTypeId)
 		const typed = mine.find((r) => r.reviewTypeId === typeId)
@@ -48,11 +48,11 @@ test.describe('Multiple reviews + request-changes reason', () => {
 		const reasonComment = comments.find((c) => (c.body || '').includes('Please add tests'))
 		expect(reasonComment).toBeTruthy()
 		expect(reasonComment.body).toContain('Requested changes')
-		expect(reasonComment.author).toBe('admin')
+		expect(reasonComment.author).toBe(me)
 
 		// Withdraw one review by id - the other remains.
 		await api.delete(`/cards/${cardId}/reviews/${untyped.id}`)
 		card = await api.get(`/cards/${cardId}`)
-		expect(card.reviews.filter((r) => r.reviewer === 'admin')).toHaveLength(1)
+		expect(card.reviews.filter((r) => r.reviewer === me)).toHaveLength(1)
 	})
 })

--- a/tests/e2e/review-types.spec.js
+++ b/tests/e2e/review-types.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 test.describe('Review types', () => {
 	const state = {
@@ -132,7 +130,7 @@ test.describe('Review types', () => {
 
 		// Pre-create a typed review via API so we can verify the chip without
 		// needing to interact with the popover (avoids participant-picker complexity).
-		await api.raw('PUT', `/cards/${state.cardId}/reviews/${USER}`, { reviewTypeId: state.reviewTypeId })
+		await api.raw('PUT', `/cards/${state.cardId}/reviews/${me}`, { reviewTypeId: state.reviewTypeId })
 
 		await page.goto(state.cardUrl)
 		await page.waitForSelector('.card-modal', { timeout: 12_000 })

--- a/tests/e2e/review.spec.js
+++ b/tests/e2e/review.spec.js
@@ -1,9 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
-
-const USER = 'admin'
+import { test, expect, api, ncLogin, BASE, me } from './helpers.js'
 
 test.describe('Card review flow', () => {
 	const state = { boardId: 0, stackId: 0, cardId: 0, cardUrl: '', boardUrl: '' }
@@ -27,7 +25,7 @@ test.describe('Card review flow', () => {
 
 		// The board owner requests a review from themselves - a valid single-user
 		// path (owner holds READ). Gives the card one pending review to drive the UI.
-		await api.put(`/cards/${card.id}/reviews/${USER}`)
+		await api.put(`/cards/${card.id}/reviews/${me}`)
 	})
 
 	test.afterAll(async () => {

--- a/tests/e2e/share-from-files.spec.js
+++ b/tests/e2e/share-from-files.spec.js
@@ -1,20 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect } from '@playwright/test'
+import { test, expect, currentAuth, me, ncLogin, BASE } from './helpers.js'
 
-const BASE = 'http://localhost:8891'
-const USER = 'admin'
-const PASS = 'admin'
 const API = BASE + '/index.php/apps/kanso/api'
-const DAV = BASE + '/remote.php/dav/files/' + USER
+// DAV path for the CURRENT user's own Files. Built at call time so it reads the
+// live `me` binding (a module-level snapshot would capture 'admin' before the
+// worker rebind).
+const davUrl = () => BASE + '/remote.php/dav/files/' + me
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
-const AUTH = 'Basic ' + Buffer.from(USER + ':' + PASS).toString('base64')
 
 async function api(method, path, body) {
 	const r = await fetch(API + path, {
 		method,
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: body === undefined ? undefined : JSON.stringify(body),
 	})
 	const text = await r.text()
@@ -24,9 +23,9 @@ async function api(method, path, body) {
 // Uploads bytes to the user's Files over WebDAV and returns the numeric fileId
 // (the OC-FileId header, of the form "<id>oc..." - the leading integer is the id).
 async function putFile(name, content) {
-	const put = await fetch(`${DAV}/${name}`, {
+	const put = await fetch(`${davUrl()}/${name}`, {
 		method: 'PUT',
-		headers: { Authorization: AUTH },
+		headers: { Authorization: currentAuth },
 		body: content,
 	})
 	if (!put.ok && put.status !== 204 && put.status !== 201) {
@@ -65,9 +64,9 @@ test.describe('Share from Files', () => {
 
 	test.afterAll(async () => {
 		if (boardId) await api('DELETE', `/boards/${boardId}`)
-		await fetch(`${DAV}/kanso-share-from-files.txt`, {
+		await fetch(`${davUrl()}/kanso-share-from-files.txt`, {
 			method: 'DELETE',
-			headers: { Authorization: AUTH },
+			headers: { Authorization: currentAuth },
 		}).catch(() => {})
 	})
 
@@ -92,7 +91,7 @@ test.describe('Share from Files', () => {
 		const attId = res.body[0].id
 
 		const dl = await fetch(`${API}/cards/${cardId}/attachments/${attId}`, {
-			headers: { Authorization: AUTH, 'OCS-APIREQUEST': 'true' },
+			headers: { Authorization: currentAuth, 'OCS-APIREQUEST': 'true' },
 		})
 		expect(dl.ok).toBe(true)
 		expect(await dl.text()).toBe('from the files app')
@@ -106,16 +105,10 @@ test.describe('Share from Files', () => {
 	})
 
 	test('the Files-integration script registers the action', async ({ page }) => {
-		// Log in, open the Files app (which fires loadAdditionalScripts →
+		// Log in as the current user (detects the worker's live session under
+		// isolation), open the Files app (which fires loadAdditionalScripts →
 		// Kanso's files entry), then assert the action is in the shared registry.
-		await page.goto(BASE + '/index.php/login')
-		const userInput = page.locator('#user')
-		if (await userInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-			await page.fill('#user', USER)
-			await page.fill('#password', PASS)
-			await page.click('button[type=submit]')
-			await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 })
-		}
+		await ncLogin(page)
 		await page.goto(BASE + '/index.php/apps/files')
 		await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {})
 

--- a/tests/e2e/subscription.spec.js
+++ b/tests/e2e/subscription.spec.js
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, api, ncLogin, authFor, adminAuth, API, OCS, BASE } from './helpers.js'
+import { test, expect, api, ncLogin, authFor, currentAuth, adminAuth, API, OCS, BASE } from './helpers.js'
 
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
-const AUTH = adminAuth
 
 async function apiPut(path) {
+	// Owner op — act as the current user (reads the live binding at call time).
 	const r = await fetch(API + path, {
 		method: 'PUT',
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 	})
 	return r
 }
@@ -18,28 +18,31 @@ async function apiPut(path) {
 const OCS_HEADERS = { 'OCS-APIREQUEST': 'true', Accept: 'application/json' }
 
 async function provisionUser(uid, password) {
-	// Hermetic: remove any prior user, then recreate with a known password.
-	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: AUTH } }).catch(() => {})
+	// Genuine admin op: OCS user provisioning. Hermetic: remove any prior user,
+	// then recreate with a known password.
+	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: adminAuth } }).catch(() => {})
 	const body = new URLSearchParams({ userid: uid, password })
 	const r = await fetch(`${OCS}/users`, {
 		method: 'POST',
-		headers: { ...OCS_HEADERS, Authorization: AUTH, 'Content-Type': 'application/x-www-form-urlencoded' },
+		headers: { ...OCS_HEADERS, Authorization: adminAuth, 'Content-Type': 'application/x-www-form-urlencoded' },
 		body,
 	})
 	if (!r.ok) throw new Error(`provision ${uid} → ${r.status}: ${await r.text()}`)
 }
 
 async function deleteUser(uid) {
-	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: AUTH } }).catch(() => {})
+	// Genuine admin op: OCS user deletion.
+	await fetch(`${OCS}/users/${uid}`, { method: 'DELETE', headers: { ...OCS_HEADERS, Authorization: adminAuth } }).catch(() => {})
 }
 
 const authHeader = authFor
 
 // Share a board with a user at the given permission mask (READ=1, EDIT=2, SHARE=4).
 async function shareBoardWith(boardId, uid, permission) {
+	// Owner op — act as the current user (board owner).
 	const r = await fetch(`${API}/boards/${boardId}/acl`, {
 		method: 'POST',
-		headers: { ...HEADERS, Authorization: AUTH },
+		headers: { ...HEADERS, Authorization: currentAuth },
 		body: JSON.stringify({ participant: uid, participantType: 'user', permission }),
 	})
 	if (!r.ok) throw new Error(`share ${boardId}→${uid} → ${r.status}: ${await r.text()}`)
@@ -193,11 +196,13 @@ test.describe('Card Subscriptions / Watchers', () => {
 test.describe('Watchers dropdown UI (caret panel)', () => {
 	// #3654: watchers are managed from a dropdown under the top-right Watch button
 	// (no standalone body section). Drive the panel through the UI.
-	const BOB = 'kanso_watch_ui_bob'
+	// Worker-scoped uid so parallel workers never contend over one shared account.
+	let BOB = 'kanso_watch_ui_bob'
 	const BOB_PASS = 'SubUiWatcher#2026'
 	const state = { boardId: 0, stackId: 0, cardId: 0, cardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({}, workerInfo) => {
+		BOB = `kanso_watch_ui_bob_w${workerInfo.workerIndex}`
 		await provisionUser(BOB, BOB_PASS)
 		for (const b of await api.get('/boards')) {
 			if (b.title === 'Watchers UI E2E Board') await api.delete(`/boards/${b.id}`)
@@ -279,13 +284,16 @@ test.describe('Watchers dropdown UI (caret panel)', () => {
 })
 
 test.describe('Watcher management — add / remove OTHER users', () => {
-	const BOB = 'kanso_watch_bob'
+	// Worker-scoped uids so parallel workers never contend over shared accounts.
+	let BOB = 'kanso_watch_bob'
 	const BOB_PASS = 'Sub2Watcher#2026'
-	const STRANGER = 'kanso_watch_stranger'
+	let STRANGER = 'kanso_watch_stranger'
 	const STRANGER_PASS = 'Sub2Stranger#2026'
 	const state = { boardId: 0, stackId: 0, cardId: 0 }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({}, workerInfo) => {
+		BOB = `kanso_watch_bob_w${workerInfo.workerIndex}`
+		STRANGER = `kanso_watch_stranger_w${workerInfo.workerIndex}`
 		// Second board participant (READ+EDIT) and a non-member.
 		await provisionUser(BOB, BOB_PASS)
 		await provisionUser(STRANGER, STRANGER_PASS)
@@ -330,7 +338,7 @@ test.describe('Watcher management — add / remove OTHER users', () => {
 		await apiPut(`/cards/${state.cardId}/subscription/${BOB}`) // ensure present
 		const del = await fetch(`${API}/cards/${state.cardId}/subscription/${BOB}`, {
 			method: 'DELETE',
-			headers: { ...HEADERS, Authorization: AUTH },
+			headers: { ...HEADERS, Authorization: currentAuth },
 		})
 		expect(del.ok).toBeTruthy()
 		const block = await del.json()

--- a/tests/e2e/visibility-leak-matrix.spec.js
+++ b/tests/e2e/visibility-leak-matrix.spec.js
@@ -1,10 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, makeApi, authFor, adminAuth, API, BASE } from './helpers.js'
+import { test, expect, makeApi, currentAuth, API, BASE } from './helpers.js'
 
-const ADMIN = adminAuth
-const TESTER = authFor('tester', 'kanso-dev-tester!1')
+// Sentinels for the two viewers. They are NOT auth strings themselves — the
+// client dispatch below resolves them at CALL time: ADMIN → the current user
+// (board owner, `currentAuth`), TESTER → the worker-scoped `peer` (captured in
+// beforeAll). This keeps every `api(ADMIN|TESTER, …)` call site byte-for-byte
+// identical while staying parallel-safe under E2E_ISOLATE.
+const ADMIN = Symbol('owner')
+const TESTER = Symbol('peer')
+
+// The worker-scoped peer, captured once in beforeAll so the module-level client
+// dispatch and the `peer.user` participant/assignee literals can reach it.
+let peerRef = null
 
 // #3743 — the endpoint-level leak matrix: two viewers (admin = internal board
 // owner, tester = EXTERNAL member) plus the anonymous token surfaces, asserted
@@ -23,10 +32,18 @@ const TESTER = authFor('tester', 'kanso-dev-tester!1')
 //   tester → PUB, CLI      (never PROV, never PRIV)
 //   anon   → PUB              (public share + ICS feed)
 
-// Per-auth API clients (admin + external tester), cached so the (auth, method,
-// path, body) call sites below stay byte-for-byte identical.
+// Per-viewer API clients (owner + external peer), cached so the (auth, method,
+// path, body) call sites below stay byte-for-byte identical. The ADMIN/TESTER
+// sentinels resolve lazily (after the worker-isolation rebind + peer capture).
 const clients = new Map()
 function clientFor(auth) {
+	if (auth === ADMIN) {
+		// Read the live `currentAuth` binding at call time (a module-level snapshot
+		// would capture the pre-rebind admin auth under E2E_ISOLATE).
+		if (!clients.has(currentAuth)) clients.set(currentAuth, makeApi(currentAuth))
+		return clients.get(currentAuth)
+	}
+	if (auth === TESTER) return peerRef.api
 	if (!clients.has(auth)) clients.set(auth, makeApi(auth))
 	return clients.get(auth)
 }
@@ -51,15 +68,16 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 
 	const title = (name) => `${name} ${token}`
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
+		peerRef = peer
 		const board = await api(ADMIN, 'POST', '/boards', { title: 'Leak Matrix ' + token })
 		state.boardId = board.id
 		const stack = await api(ADMIN, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
 		state.stackId = stack.id
 
-		// Share with tester as an EXTERNAL member holding READ | EDIT.
+		// Share with the peer as an EXTERNAL member holding READ | EDIT.
 		await api(ADMIN, 'POST', `/boards/${board.id}/acl`, {
-			participant: 'tester',
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3,
 			role: 'external',
@@ -136,8 +154,8 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 	})
 
 	test('my-cards: assignment grants no visibility', async () => {
-		await api(ADMIN, 'PUT', `/cards/${state.cards.PUB.id}/assignees/tester`)
-		await api(ADMIN, 'PUT', `/cards/${state.cards.PROV.id}/assignees/tester`)
+		await api(ADMIN, 'PUT', `/cards/${state.cards.PUB.id}/assignees/${peerRef.user}`)
+		await api(ADMIN, 'PUT', `/cards/${state.cards.PROV.id}/assignees/${peerRef.user}`)
 
 		const mine = await api(TESTER, 'GET', '/my-cards')
 		const titles = mine.map((c) => c.title).filter((t) => t.includes(token))
@@ -146,10 +164,10 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 
 	test('reviews: a hidden card is not reviewable across the fence', async () => {
 		// Requesting a review FROM tester on a card tester cannot see → 400.
-		const blocked = await call(ADMIN, 'PUT', `/cards/${state.cards.PROV.id}/reviews/tester`)
+		const blocked = await call(ADMIN, 'PUT', `/cards/${state.cards.PROV.id}/reviews/${peerRef.user}`)
 		expect(blocked.status).toBe(400)
 
-		await api(ADMIN, 'PUT', `/cards/${state.cards.PUB.id}/reviews/tester`)
+		await api(ADMIN, 'PUT', `/cards/${state.cards.PUB.id}/reviews/${peerRef.user}`)
 		const mine = await api(TESTER, 'GET', '/reviews/mine')
 		const titles = mine.map((r) => r.cardTitle).filter((t) => t.includes(token))
 		expect(titles).toEqual([title('PUB')])
@@ -164,7 +182,7 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 		const testerByStack = testerStats.byStack.reduce((n, r) => n + r.count, 0)
 		expect(testerByStack).toBe(2)
 		// Assignee distribution must not count the hidden assignment either.
-		const testerAssignee = (testerStats.byAssignee.find((r) => r.uid === 'tester') || { count: 0 }).count
+		const testerAssignee = (testerStats.byAssignee.find((r) => r.uid === peerRef.user) || { count: 0 }).count
 		expect(testerAssignee).toBe(1) // PUB only — PROV is hidden from this viewer
 
 		const boards = await api(TESTER, 'GET', '/boards')
@@ -201,7 +219,7 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 			['GET', `/cards/${hidden}/checklist`],
 			['POST', `/cards/${hidden}/move`, { targetStackId: state.stackId }],
 			['PUT', `/cards/${hidden}/labels/1`],
-			['PUT', `/cards/${hidden}/assignees/tester`],
+			['PUT', `/cards/${hidden}/assignees/${peerRef.user}`],
 		]
 		for (const [method, path, body] of probes) {
 			const r = await call(TESTER, method, path, body)
@@ -274,7 +292,7 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 		// card keeps the earlier set/count assertions untouched.
 		const card = await api(ADMIN, 'POST', '/cards', { stackId: state.stackId, title: `STEPHOST ${token}` })
 		const item = await api(ADMIN, 'POST', `/cards/${card.id}/checklist`, { title: `step ${token}` })
-		await api(ADMIN, 'POST', `/checklist/${item.id}/assign`, { participant: 'tester' })
+		await api(ADMIN, 'POST', `/checklist/${item.id}/assign`, { participant: peerRef.user })
 
 		// Visible card → the step is in tester's feed.
 		const before = await api(TESTER, 'GET', '/my-steps')

--- a/tests/e2e/waiting-on-client.spec.js
+++ b/tests/e2e/waiting-on-client.spec.js
@@ -12,7 +12,7 @@ import { test, expect, api, ncLogin, BASE } from './helpers.js'
 test.describe.serial('Waiting on client (#3746)', () => {
 	const state = { boardId: 0, waitCardId: 0, plainCardId: 0, itemId: 0, boardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		// Hermetic setup: tear down any prior run's board.
 		const boards = await api.get('/boards')
 		for (const b of boards) {
@@ -25,9 +25,9 @@ test.describe.serial('Waiting on client (#3746)', () => {
 		state.boardId = board.id
 		const stack = await api.post('/stacks', { boardId: board.id, title: 'Doing' })
 
-		// tester joins the CLIENT side (external) with READ | EDIT.
+		// The peer joins the CLIENT side (external) with READ | EDIT.
 		await api.post(`/boards/${board.id}/acl`, {
-			participant: 'tester',
+			participant: peer.user,
 			participantType: 'user',
 			permission: 3,
 			role: 'external',
@@ -42,7 +42,7 @@ test.describe.serial('Waiting on client (#3746)', () => {
 
 		const item = await api.post(`/cards/${waitCard.id}/checklist`, { title: 'Client signs contract' })
 		state.itemId = item.id
-		await api.post(`/checklist/${item.id}/assign`, { participant: 'tester' })
+		await api.post(`/checklist/${item.id}/assign`, { participant: peer.user })
 
 		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
 	})


### PR DESCRIPTION
Follow-up to the e2e helpers PR (#75). That one made the suite parallel-*ready*
but nothing actually consumed the isolation. This one makes it **real** and
turns it on in CI.

## Under `E2E_ISOLATE=1`, each Playwright worker is its own Nextcloud user
- **Browser session:** a per-worker `storageState` — pages start logged in as
  `kansoe2e_w<n>`, not the shared admin.
- **API identity:** `helpers.js` rebinds the live `api` / `me` / `currentAuth`
  bindings per worker, so a spec's `import { api }`, its self-refs
  (`/assignees/${me}`), and its bespoke `fetch` clients all act as the worker
  user — **no per-spec plumbing** for the common case (ES live bindings + an
  `auto` worker fixture that runs before any `beforeAll`).
- **Second identity:** a new `peer` worker fixture (off-isolate = the dev
  `tester`; on-isolate = a per-worker peer) for board-sharing / ACL / peer-login
  specs. Specs that provisioned their own extra users now suffix the worker
  index so parallel workers never collide.

With `E2E_ISOLATE` **unset** (the default) every binding resolves to admin /
tester and behaviour is byte-for-byte the serial suite — dormant, not a code
path specs must reason about.

## CI
The `e2e` job now runs `E2E_ISOLATE=1 E2E_WORKERS=2` — conservative on purpose:
the self-hosted runner hosts the whole stack in-pod and is ~4-5x slower than a
dev box, so over-subscribing php-fpm/postgres would trade wall-clock for timeout
flakiness. `E2E_WORKERS` can be raised once the runner has headroom.

## Validation (local, `E2E_ISOLATE=1 --workers=4`)
Ran every spec category in parallel:

| category | result |
|---|---|
| self-user (`me`) | 40/40 |
| bespoke clients (`currentAuth`) | 42/45 |
| multi-user API (`peer`) | 38/40 → 40 after fix |
| browser-peer login | 17/17 |
| provisioning / anon | 19/19 |

Every non-pass reproduces **identically as admin** on the dev stack (pre-existing
purge-endpoint 500 / contacts indexing / the known `trash` flake) — none are
isolation regressions. Two-user probe confirmed each worker's `beforeAll` API
client *and* browser `whoami` resolve to its own user.

Diff is helpers.js + the isolation fixture, a docs update, the CI env, and
mechanical per-spec swaps (`'admin'`→`me`, tester→`peer`, bespoke-client auth→
`currentAuth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)