### PR TITLE
chore: nudge sponsorships in the release bot's issue-close comment

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -51,6 +51,21 @@ export default {
 					{ path: 'build/kanso.tar.gz', label: 'kanso.tar.gz' },
 					{ path: 'build/kanso.tar.gz.sig.base64', label: 'kanso.tar.gz.sig.base64' },
 				],
+				// Comment posted on each released issue/PR. Kept close to the
+				// plugin default, plus one soft sponsor nudge — this fires at
+				// the moment a reporter learns their fix shipped, the highest-
+				// goodwill point we get with a user.
+				// NOTE: single-quoted so ${...} reaches the plugin as a Lodash
+				// template (evaluated at release time), not interpolated by this
+				// JS module at load time — a backtick literal would crash here.
+				successComment:
+					':tada: This ${issue.pull_request ? "pull request is included" : "issue is fixed"} ' +
+					'in version ${nextRelease.version} :tada:\n\n' +
+					'The release notes are on [GitHub](${releases.filter(release => !!release.name)[0].url}).\n\n' +
+					'If Kanso saves you time, consider [sponsoring its development]' +
+					'(https://github.com/sponsors/aktasfatih) — it’s an AGPL solo project ' +
+					'and sponsorships keep it maintained. 💜\n\n' +
+					'Your semantic-release bot :package::rocket:',
 			},
 		],
 		[


### PR DESCRIPTION
## What

Overrides the `@semantic-release/github` plugin's `successComment` in `release.config.js` so the comment the release bot auto-posts on released issues/PRs carries a single soft GitHub Sponsors line, alongside the existing "your fix shipped" note.

We recently enabled sponsorship (Sponsor button + PR sponsor links via `FUNDING.yml`). This adds the one channel that actively reaches the reporter — and it fires at the highest-goodwill moment: right when they learn their bug is fixed and shipped.

## Notes

- Kept close to the plugin default; **one** soft line, no guilt-tripping, no repetition elsewhere in the comment.
- `successComment` is single-quoted so `${...}` reaches the plugin as a Lodash template evaluated **at release time** — a backtick literal would be interpolated at config load and crash the release.
- `failComment`/`failTitle` left untouched — a sponsor pitch on a failed-release comment would read badly.
- `node --check release.config.js` passes.

## Merging

Config-only, no runtime/test impact — intended for **admin merge** without waiting on the full CI suite (the ~1.5h e2e in particular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)