### PR TITLE
feat: un-nest sub-cards by dragging, and add columns from list view

### DIFF
--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -126,10 +126,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</p>
 				</div>
 
-				<!-- Card row (top-level only gets DnD; children and composer are inert) -->
+				<!-- Card row. Top-level AND child rows are draggable: the list draws the
+				     indent, so dragging a sub-card out of it is a gesture the user can
+				     see themselves make (the kanban board draws no indent, so a tile
+				     drag there never touches the parent). -->
 				<div
-					v-else-if="rows[vRow.index].type === 'card' && !rows[vRow.index].isChild"
-					v-card-dnd="{ card: rows[vRow.index].card, sortMode: props.sortMode }"
+					v-else-if="rows[vRow.index].type === 'card'"
+					v-card-dnd="{ card: rows[vRow.index].card, sortMode: props.sortMode, rowParentId: rows[vRow.index].isChild ? rows[vRow.index].card.parentCardId : null }"
 					class="board-list-row-wrap"
 					:class="{
 						'board-list-row-wrap--dragging': isDraggingCard === rows[vRow.index].card.id,
@@ -139,10 +142,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					}">
 					<button
 						class="board-list-row"
-						:class="{ 'board-list-row--draggable': props.sortMode === 'manual' }"
+						:class="{
+							'board-list-row--draggable': props.sortMode === 'manual',
+							'board-list-row--child': rows[vRow.index].isChild,
+						}"
 						@click="openCard(rows[vRow.index].card)">
 
-						<!-- Expand/collapse caret for parent cards with children; spacer for all others -->
+						<!-- Expand/collapse caret for parent cards with children; spacer for
+						     all other top-level rows. A child row has neither (its own indent
+						     already carries the hierarchy). -->
 						<span
 							v-if="rows[vRow.index].hasChildren"
 							class="board-list-row__caret"
@@ -164,7 +172,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						</span>
 						<!-- Spacer keeps status dot aligned when there is no caret -->
 						<span
-							v-else
+							v-else-if="!rows[vRow.index].isChild"
 							class="board-list-row__caret-spacer" />
 
 						<span
@@ -259,107 +267,41 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</span>
 						</span>
 					</button>
-					<!-- Drop indicator lines (top / bottom edge) -->
-					<div v-if="dropTargetCardId === rows[vRow.index].card.id && dropEdge === 'top'" class="board-list-drop-indicator board-list-drop-indicator--top" />
-					<div v-if="dropTargetCardId === rows[vRow.index].card.id && dropEdge === 'bottom'" class="board-list-drop-indicator board-list-drop-indicator--bottom" />
-					<!-- Nest hint (#5885): centre-band drop makes the dragged card a sub-card -->
+					<!-- Drop indicator lines (top / bottom edge). The line is indented to
+					     the level the card would land at, so leaving a parent is visible
+					     as the line jumping back to the left margin; an un-nesting drop
+					     also switches it to the dashed detach style. -->
+					<div
+						v-if="dropTargetCardId === rows[vRow.index].card.id && dropEdge === 'top'"
+						class="board-list-drop-indicator board-list-drop-indicator--top"
+						:class="{
+							'board-list-drop-indicator--nested': dropNested,
+							'board-list-drop-indicator--unnest': dropIntent === 'unnest',
+						}" />
+					<div
+						v-if="dropTargetCardId === rows[vRow.index].card.id && dropEdge === 'bottom'"
+						class="board-list-drop-indicator board-list-drop-indicator--bottom"
+						:class="{
+							'board-list-drop-indicator--nested': dropNested,
+							'board-list-drop-indicator--unnest': dropIntent === 'unnest',
+						}" />
+					<!-- Nest hint (#5885): centre-band drop makes the dragged card a
+					     sub-card. A reorder drop that lands among ANOTHER card's children
+					     adopts it into that parent, so it carries the same label. -->
 					<span
-						v-if="dropTargetCardId === rows[vRow.index].card.id && dropMode === 'nest'"
+						v-if="dropTargetCardId === rows[vRow.index].card.id && (dropMode === 'nest' || dropIntent === 'reparent')"
 						class="board-list-nest-hint">
 						{{ t('kanso', 'Drop to nest as sub-card') }}
 					</span>
+					<!-- Un-nest hint: this reorder position is outside the dragged card's
+					     parent, so the drop takes it out. Deliberately worded as the
+					     action, and styled apart from the nest hint. -->
+					<span
+						v-else-if="dropTargetCardId === rows[vRow.index].card.id && dropIntent === 'unnest'"
+						class="board-list-nest-hint board-list-nest-hint--unnest">
+						{{ t('kanso', 'Drop to remove from parent') }}
+					</span>
 				</div>
-
-				<!-- Child card row (inert for DnD — never draggable/droppable) -->
-				<button
-					v-else-if="rows[vRow.index].type === 'card' && rows[vRow.index].isChild"
-					class="board-list-row board-list-row--child"
-					@click="openCard(rows[vRow.index].card)">
-
-					<span
-						class="board-list-row__status"
-						:class="`board-list-row__status--${statusOf(rows[vRow.index].card)}`"
-						:title="statusLabel(rows[vRow.index].card)" />
-
-					<span
-						v-if="cardHumanId(rows[vRow.index].card)"
-						class="board-list-row__id">
-						{{ cardHumanId(rows[vRow.index].card) }}
-					</span>
-
-					<span
-						v-if="(rows[vRow.index].card.labelIds || []).length"
-						class="board-list-row__labels">
-						<span
-							v-for="labelId in (rows[vRow.index].card.labelIds || []).slice(0, 4)"
-							:key="labelId"
-							class="board-list-row__label-dot"
-							:title="labelTitle(labelId)"
-							:style="{ background: labelColor(labelId) }" />
-					</span>
-
-					<span
-						class="board-list-row__title"
-						:class="{ 'board-list-row__title--done': isDone(rows[vRow.index].card) }">
-						{{ rows[vRow.index].card.title }}
-					</span>
-
-					<span class="board-list-row__meta">
-						<span
-							v-if="rows[vRow.index].card.priority > 0"
-							class="board-list-row__priority"
-							:class="`board-list-row__priority--${rows[vRow.index].card.priority}`">
-							{{ priorityLabel(rows[vRow.index].card.priority) }}
-						</span>
-
-						<span
-							v-if="cardProgress(rows[vRow.index].card)"
-							class="board-list-row__count">
-							<CheckboxMarkedOutlineIcon :size="14" />
-							{{ cardProgress(rows[vRow.index].card).done }}/{{ cardProgress(rows[vRow.index].card).total }}
-						</span>
-
-						<span
-							v-if="rows[vRow.index].card.duedate"
-							class="board-list-row__due"
-							:class="{ 'board-list-row__due--overdue': isOverdue(rows[vRow.index].card) }">
-							<CalendarIcon :size="14" />
-							{{ formatDue(rows[vRow.index].card) }}
-						</span>
-
-						<span v-if="rows[vRow.index].card.commentCount > 0" class="board-list-row__count">
-							<CommentOutlineIcon :size="14" />
-							{{ rows[vRow.index].card.commentCount }}
-						</span>
-
-						<CheckDecagramIcon
-							v-if="rows[vRow.index].card.reviewState === 'approved'"
-							:size="15"
-							class="board-list-row__review board-list-row__review--approved" />
-						<AlertDecagramIcon
-							v-else-if="rows[vRow.index].card.reviewState === 'changes_requested'"
-							:size="15"
-							class="board-list-row__review board-list-row__review--changes" />
-
-						<!-- Timer running (#73) -->
-						<TimerOutlineIcon
-							v-if="rows[vRow.index].card.timerRunning && cardFeatures.timeTracking"
-							:size="15"
-							class="board-list-row__timer-running"
-							:title="t('kanso', 'Timer running')" />
-
-						<span
-							v-if="(rows[vRow.index].card.assigneeIds || []).length"
-							class="board-list-row__assignees">
-							<NcAvatar
-								v-for="uid in (rows[vRow.index].card.assigneeIds || []).slice(0, 3)"
-								:key="uid"
-								:user="uid"
-								:size="24"
-								:hide-status="true" />
-						</span>
-					</span>
-				</button>
 
 				<!-- Group-level column drop target for empty groups (appends to end).
 				     Rendered as the last slot inside each header vrow so it occupies the
@@ -480,6 +422,17 @@ const isDraggingCard = ref(null)    // cardId currently being dragged (for opaci
 const dropTargetCardId = ref(null)  // cardId the pointer is hovering over
 const dropEdge = ref(null)          // 'top' | 'bottom' | null
 const dropMode = ref(null)          // 'reorder' | 'nest' | null (#5885)
+// What a reorder drop would do to the dragged card's PARENT: 'unnest' (it
+// leaves its parent), 'reparent' (it joins another card's children) or
+// 'reorder' (parent untouched). Drives the drop affordance so the two are never
+// confusable before the pointer is released.
+const dropIntent = ref('reorder')
+// Whether the dragged card would land INSIDE a parent at the hovered position.
+// Read from the drop data rather than from the hovered row's own level, so the
+// indicator is drawn at the indent the card actually takes — a refused adoption
+// (a card that has children of its own cannot become one) lands top-level even
+// though the row under the pointer is indented.
+const dropNested = ref(false)
 
 // Whether this surface offers drag-to-nest (#5885). Provided as true only by a
 // board that owns the card drag monitor and is in manual sort; a cross-board
@@ -540,7 +493,11 @@ function setGroupDropRef(stackId, el) {
 		element: el,
 		canDrop: ({ source }) => source.data.type === 'card',
 		// Match StackColumn's column drop-target data shape exactly so the BoardView
-		// card monitor's `columnTarget` branch resolves it correctly.
+		// card monitor's `columnTarget` branch resolves it correctly. Deliberately
+		// no `parentChange`: this overlay covers a whole group header and paints
+		// only a generic highlight, so a drop here must stay a plain move. Taking a
+		// card out of its parent needs the visible gesture — dragging the row out
+		// of the indent onto another top-level row.
 		getData: () => ({ type: 'column', stackId, laneKey: '' }),
 		onDragEnter: () => el.classList.add(DROP_OVER_CLASS),
 		onDragLeave: () => el.classList.remove(DROP_OVER_CLASS),
@@ -552,37 +509,45 @@ function setGroupDropRef(stackId, el) {
 }
 
 // ── vCardDnd custom directive ──────────────────────────────────────────────────
-// Attaches draggable + dropTarget (identical data contract as CardTile) to each
-// top-level card row wrapper. The directive lives on the outermost <div
-// class="board-list-row-wrap"> so the full row area is the drag handle and
-// drop target. Because virtualizer recycles DOM nodes, we use mounted/updated/
-// unmounted to always re-sync the registration with the current card binding.
+// Attaches draggable + dropTarget (identical data contract as CardTile) to EVERY
+// card row wrapper — top-level and indented child rows alike. The directive
+// lives on the outermost <div class="board-list-row-wrap"> so the full row area
+// is the drag handle and drop target. Because virtualizer recycles DOM nodes, we
+// use mounted/updated/unmounted to always re-sync the registration with the
+// current card binding.
 //
 // Data contract (built by buildCardDragData, so it cannot drift from CardTile):
 //   draggable getInitialData: { type:'card', cardId, stackId, sortKey, laneKey:null,
 //                               parentCardId, hasChildren }
 //   dropTarget getData:       buildCardDropData(…) → either
 //                               { same fields, dropMode:'nest' }               (centre band)
-//                             or attachClosestEdge({ … , dropMode:'reorder' }) (edges)
+//                             or attachClosestEdge({ … , dropMode:'reorder',
+//                                                    parentChange })           (edges)
 //   dropTarget canDrop:       source.data.type === 'card' && source.data.cardId !== cardId
 //
 // laneKey is null (not '') because the list view is always the flat/no-swimlane
 // path; the BoardView monitor's swimlane guard checks `laneKey ?? ''` so null
 // collapses to '' and cross-lane drops are correctly rejected.
 //
-// A 'reorder' drop still only changes stackId + sortKey — it never touches
-// parentCardId. A 'nest' drop (#5885) makes the dragged card a sub-card of the
-// hovered one; the BoardView monitor owns that mutation. Child rows stay inert
-// (they never receive this directive); a sub-card is detached from the card's
-// own detail panel.
+// `rowParentId` is what makes drag-OUT possible here and nowhere else: it is the
+// level the row sits at (null for a top-level row, the parent's id for an
+// indented child row), so a reorder drop resolves the parent the card takes at
+// that position — dropping a sub-card among its own siblings keeps it a
+// sub-card, dropping it at a top-level position takes it out. The kanban tile
+// passes no rowParentId at all, so a tile reorder or column move can never
+// change a parent the board does not draw. Detaching also stays available from
+// the card's own detail panel (the keyboard-accessible path).
 
-function makeCardDndBinding(el, { card, sortMode: mode }) {
+function makeCardDndBinding(el, { card, sortMode: mode, rowParentId }) {
 	// Only wire DnD when we are in the classic per-stack path (card has a real
 	// stackId) and the display sort is manual.
 	if (!card?.id || !card?.stackId || mode !== 'manual') return () => {}
 
 	const cardId = card.id
-	const base = buildCardDragData(card, null)
+	// The row's rendered level rides BOTH payloads: as a drag source it says what
+	// indent the card is being dragged out of, as a drop target what indent the
+	// position offers.
+	const base = buildCardDragData(card, null, rowParentId ?? null)
 
 	return combine(
 		draggable({
@@ -600,12 +565,17 @@ function makeCardDndBinding(el, { card, sortMode: mode }) {
 				element: el2,
 				source,
 				nestEnabled: nestEnabled.value === true,
+				rowParentId: rowParentId ?? null,
 			}),
 			onDrag: ({ self }) => {
 				if (dropTargetCardId.value !== cardId) dropTargetCardId.value = cardId
 				const nesting = self.data.dropMode === 'nest'
 				const nextMode = nesting ? 'nest' : 'reorder'
 				if (dropMode.value !== nextMode) dropMode.value = nextMode
+				const intent = nesting ? 'reorder' : (self.data.parentChange?.intent ?? 'reorder')
+				if (dropIntent.value !== intent) dropIntent.value = intent
+				const nested = !nesting && self.data.landsNested === true
+				if (dropNested.value !== nested) dropNested.value = nested
 				// Edge line and nest highlight are mutually exclusive, so the user
 				// can always tell which drop is pending before releasing.
 				const edge = nesting ? null : extractClosestEdge(self.data)
@@ -616,12 +586,16 @@ function makeCardDndBinding(el, { card, sortMode: mode }) {
 					dropTargetCardId.value = null
 					dropEdge.value = null
 					dropMode.value = null
+					dropIntent.value = 'reorder'
+					dropNested.value = false
 				}
 			},
 			onDrop: () => {
 				dropTargetCardId.value = null
 				dropEdge.value = null
 				dropMode.value = null
+				dropIntent.value = 'reorder'
+				dropNested.value = false
 			},
 		}),
 	)
@@ -670,6 +644,9 @@ const vCardDnd = {
 			// gained/lost a parent or a child must be re-registered too.
 			&& (prev?.card?.parentCardId ?? null) === (next?.card?.parentCardId ?? null)
 			&& Number(prev?.card?.childProgress?.total ?? 0) === Number(next?.card?.childProgress?.total ?? 0)
+			// The row's own level decides what a reorder drop does to the parent,
+			// so a row that moved between the indent and the margin must re-register.
+			&& (prev?.rowParentId ?? null) === (next?.rowParentId ?? null)
 		if (sameCard) {
 			pendingRebinds.delete(el)
 			return
@@ -1360,8 +1337,7 @@ body.theme--dark .board-list-table,
    matching the kanban card tile's closest-edge indicator style. */
 .board-list-drop-indicator {
 	position: absolute;
-	left: 0;
-	right: 0;
+	inset-inline: 0;
 	height: 2px;
 	background: var(--color-primary-element);
 	border-radius: 1px;
@@ -1375,6 +1351,24 @@ body.theme--dark .board-list-table,
 
 .board-list-drop-indicator--bottom {
 	bottom: 0;
+}
+
+/* The line is drawn at the INDENT of the position it marks: flush left for a
+   top-level slot, inset to the child gutter for a slot inside a parent's
+   children. Dragging a sub-card out of its parent is then visible as the line
+   snapping back to the margin, before anything is committed. */
+.board-list-drop-indicator--nested {
+	/* Logical, so it matches the child row's own padding-inline-start under RTL. */
+	inset-inline-start: 46px;
+}
+
+/* …and an un-nesting drop (the card leaves its parent) is drawn apart from a
+   plain reorder: a thicker dashed rule in the warning tone, so "this changes
+   the hierarchy" never reads as "this just moves the row". */
+.board-list-drop-indicator--unnest {
+	height: 0;
+	background: none;
+	border-top: 3px dashed var(--kanso-warning-legible);
 }
 
 /* ── Nest drop affordance (#5885) ─────────────────────────────────────────────
@@ -1408,6 +1402,14 @@ body.theme--dark .board-list-table,
 	font-size: 0.68rem;
 	font-weight: 600;
 	white-space: nowrap;
+}
+
+/* The opposite move: this drop takes the dragged card OUT of its parent. Same
+   pill, the warning tone of the un-nest rule — never the primary colour the
+   nest affordance owns. */
+.board-list-nest-hint--unnest {
+	border-color: var(--kanso-warning-legible);
+	color: var(--kanso-warning-legible);
 }
 
 /* ── Card rows ──────────────────────────────────────────────────────────────── */

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -313,11 +313,45 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:data-stack-id="rows[vRow.index].stackId" />
 			</div>
 		</div>
+
+		<!-- Column composer (#9853). List view had no way to create a column: the
+		     ⋯ More → "Add column" action revealed a composer that only exists on the
+		     kanban track, so in list view it silently did nothing. This is the list's
+		     own target for that action, and a standing affordance in its own right —
+		     the same shape as the per-group "Add card…" composer, at the end of the
+		     group list.
+
+		     Deliberately rendered OUTSIDE the virtualizer (a sibling of the row host,
+		     not a virtual row): the list recycles row elements as it scrolls, which
+		     would blow away the input's focus and half-typed draft. Out here it is a
+		     plain, stable DOM node.
+
+		     Editors only — BoardView passes the callback only when the user may edit
+		     the board, so a viewer gets no affordance at all. The cross-board Views
+		     path (props.groups, whose rows have no stack behind them) never passes
+		     one either. -->
+		<form
+			v-if="addColumnEnabled"
+			class="add-column-composer"
+			@submit.prevent="submitNewColumn">
+			<input
+				ref="addColumnInputRef"
+				v-model="addColumnTitle"
+				class="add-column-composer__input"
+				type="text"
+				maxlength="100"
+				data-test="list-add-column"
+				:aria-label="t('kanso', 'Add column…')"
+				:placeholder="t('kanso', 'Add column…')"
+				:disabled="addColumnPending"
+				@keydown.enter.prevent="submitNewColumn">
+			<p v-if="addColumnError" class="add-column-composer__error">{{ addColumnError }}</p>
+		</form>
 	</div>
 </template>
 
 <script setup>
-import { ref, computed, inject, reactive, watch, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { ref, computed, inject, nextTick, reactive, watch, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
 import { useRouter } from 'vue-router'
 import { translate as t } from '@nextcloud/l10n'
 import { useVirtualizer } from '@tanstack/vue-virtual'
@@ -386,6 +420,14 @@ const props = defineProps({
 	 * Async fn (stackId, templateId) → Promise - creates a card from a template.
 	 */
 	onCreateFromTemplate: { type: Function, default: null },
+	/**
+	 * Async fn (title) → Promise - creates a column (#9853). When provided (and
+	 * props.groups is absent) an "Add column…" composer renders at the end of the
+	 * group list, and `focusAddColumn()` (exposed below) is what the board's
+	 * ⋯ More → "Add column" action targets while list view is active. BoardView
+	 * passes it only to editors, so a viewer sees no add-column affordance.
+	 */
+	onCreateStack: { type: Function, default: null },
 	/**
 	 * Board's "new cards on top" preference. When true, multi-line pastes are
 	 * submitted in reverse order so the first pasted line appears topmost.
@@ -1072,6 +1114,60 @@ async function createFromTemplate(stackId, templateId) {
 		isPendingByStack[stackId] = false
 	}
 }
+
+// ── Column composer (#9853) ──────────────────────────────────────────────────
+// Only on the classic per-stack path: the cross-board Views path renders
+// arbitrary groups with no stack behind them, so "add column" is meaningless
+// there (the same reason setGroupDropRef skips a null stackId). Non-manual sort
+// modes are NOT gated: unlike a drag, creating a column doesn't touch any sort
+// key, and kanban offers it in every sort mode.
+const addColumnEnabled = computed(() => !props.groups && typeof props.onCreateStack === 'function')
+
+const addColumnTitle = ref('')
+const addColumnError = ref('')
+const addColumnPending = ref(false)
+const addColumnInputRef = ref(null)
+
+// A failure message describes the title that failed, so it goes stale the moment
+// that title is edited — otherwise the user retypes and still stares at the old
+// error next to text that is now fine.
+watch(addColumnTitle, () => { addColumnError.value = '' })
+
+async function submitNewColumn() {
+	const title = addColumnTitle.value.trim()
+	if (!title || addColumnPending.value || !props.onCreateStack) return
+	addColumnError.value = ''
+	addColumnPending.value = true
+	try {
+		await props.onCreateStack(title)
+		addColumnTitle.value = ''
+	} catch (err) {
+		addColumnError.value = err?.response?.data?.error || t('kanso', 'Failed to create column.')
+	} finally {
+		addColumnPending.value = false
+	}
+	// Re-focus for rapid entry, mirroring the card composer — and after a failure
+	// too, so the title can be corrected and retried. Must come after the pending
+	// flag clears: a disabled input cannot take focus.
+	await nextTick()
+	addColumnInputRef.value?.focus()
+}
+
+/**
+ * Reveal + focus the column composer. This is what the board's ⋯ More →
+ * "Add column" action calls while list view is active — one menu action, two
+ * targets, instead of one that quietly aims at the hidden kanban track.
+ */
+function focusAddColumn() {
+	if (!addColumnEnabled.value) return
+	addColumnError.value = ''
+	nextTick(() => {
+		addColumnInputRef.value?.scrollIntoView?.({ block: 'nearest' })
+		addColumnInputRef.value?.focus()
+	})
+}
+
+defineExpose({ focusAddColumn })
 </script>
 
 <style scoped>
@@ -1314,6 +1410,52 @@ body.theme--dark .board-list-table,
 	color: var(--kanso-error-legible);
 	margin: 0;
 	white-space: nowrap;
+}
+
+/* ── Column composer ────────────────────────────────────────────────────────── */
+
+/* Sits after the virtualized row host (outside the virtualizer), so it reads as
+   the end of the group list. Same max-width as the host so its input lines up
+   with the rows above it. */
+.add-column-composer {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 1100px;
+	padding: 10px 8px 0;
+}
+
+.add-column-composer__input {
+	flex: 1;
+	min-width: 0;
+	max-width: 320px;
+	height: 28px;
+	padding: 0 8px;
+	border: 1px dashed var(--color-border-dark);
+	border-radius: var(--border-radius, 3px);
+	background: transparent;
+	color: var(--color-main-text);
+	font-size: 0.875rem;
+}
+
+.add-column-composer__input:focus {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -1px;
+	border-color: transparent;
+	background: var(--color-main-background);
+}
+
+.add-column-composer__input::placeholder {
+	color: var(--color-text-maxcontrast);
+}
+
+.add-column-composer__error {
+	flex: 0 0 auto;
+	font-size: 0.75rem;
+	color: var(--kanso-error-legible);
+	margin: 0;
 }
 
 /* ── Card row wrapper (DnD host) ────────────────────────────────────────────── */

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -49,8 +49,21 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<span class="card-tile__title" :class="{ 'card-tile__title--done': isDone }">{{ card.title }}</span>
 			<!-- Single meta row: all badges inline, assignees pushed to the right -->
 			<div
-				v-if="isInProgress || card.blocked || card.waitingOnExternal || card.recurring || (card.timerRunning && cardFeatures.timeTracking) || card.duedate || (card.checklist && card.checklist.total > 0) || (card.childProgress && card.childProgress.total > 0) || card.commentCount > 0 || card.priority > 0 || cardType || (card.assigneeIds && card.assigneeIds.length) || card.reviewState || card.estimate || isRestricted"
+				v-if="card.parentCardId || isInProgress || card.blocked || card.waitingOnExternal || card.recurring || (card.timerRunning && cardFeatures.timeTracking) || card.duedate || (card.checklist && card.checklist.total > 0) || (card.childProgress && card.childProgress.total > 0) || card.commentCount > 0 || card.priority > 0 || cardType || (card.assigneeIds && card.assigneeIds.length) || card.reviewState || card.estimate || isRestricted"
 				class="card-tile__meta">
+				<!-- Sub-card marker: this card hangs under another one. The board draws
+				     no indent (columns are flat), so without this a sub-card is
+				     indistinguishable from any other card. The parent's title is not in
+				     the board summary and is deliberately not fetched for it — the
+				     board payload stays summary-only, and the panel names the parent. -->
+				<span
+					v-if="card.parentCardId"
+					class="card-tile__subcard"
+					role="img"
+					:aria-label="t('kanso', 'Sub-card')"
+					:title="t('kanso', 'Sub-card')">
+					<SubdirectoryArrowRightIcon :size="14" />
+				</span>
 				<!-- In-progress status chip -->
 				<span
 					v-if="isInProgress"
@@ -221,6 +234,7 @@ import ProgressClockIcon from 'vue-material-design-icons/ProgressClock.vue'
 import CheckboxMarkedOutlineIcon from 'vue-material-design-icons/CheckboxMarkedOutline.vue'
 import CommentMultipleOutlineIcon from 'vue-material-design-icons/CommentMultipleOutline.vue'
 import SitemapIcon from 'vue-material-design-icons/Sitemap.vue'
+import SubdirectoryArrowRightIcon from 'vue-material-design-icons/SubdirectoryArrowRight.vue'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'
 import ArrowUpBoldIcon from 'vue-material-design-icons/ArrowUpBold.vue'
 import SignalCellular2Icon from 'vue-material-design-icons/SignalCellular2.vue'
@@ -905,6 +919,15 @@ body.theme--dark .card-tile,
 	background: rgba(240, 168, 68, 0.1);
 }
 
+/* Sub-card marker - a muted ↳ glyph in the same neutral vocabulary as the
+ * recurring badge: an attribute of the card, not an alert. It leads the meta
+ * row so "this belongs under another card" is the first thing read. */
+.card-tile__subcard {
+	display: inline-flex;
+	align-items: center;
+	color: var(--color-text-maxcontrast);
+}
+
 /* Recurring badge (#61) - a muted repeat glyph; neutral so it reads as an
  * attribute of the card, not an alert. */
 .card-tile__recurring {
@@ -1045,6 +1068,12 @@ body.theme--dark .card-tile,
 
 /* Compact: match the timer-running icon size to the recurring badge. */
 .card-tile--compact .card-tile__timer-running :deep(svg) {
+	width: 12px;
+	height: 12px;
+}
+
+/* Compact: same treatment for the sub-card marker. */
+.card-tile--compact .card-tile__subcard :deep(svg) {
 	width: 12px;
 	height: 12px;
 }

--- a/src/services/cardNesting.js
+++ b/src/services/cardNesting.js
@@ -28,6 +28,22 @@
  *
  * The BoardView card monitor reads `dropMode` to decide between setParent and
  * the plain move mutation.
+ *
+ * Drag-out (un-nest) rides the SAME reorder edges, but only on a surface that
+ * renders the hierarchy. A reorder drop carries `parentChange` — the parent the
+ * dropped card takes at that position — computed by {@see reorderParentChange}
+ * from the row's own level (`rowParentId`):
+ *
+ *   rowParentId === undefined  the view has no levels (kanban): parentChange is
+ *                              always null, so a column move or a reorder can
+ *                              never break a sub-card relation the board does
+ *                              not even draw.
+ *   rowParentId === null       a top-level position: dropping a sub-card here
+ *                              clears its parent (the user literally dragged it
+ *                              out of the indent).
+ *   rowParentId === <id>       inside <id>'s children: reordering a sub-card
+ *                              among its siblings keeps its parent; dropping a
+ *                              card from elsewhere adopts it into that parent.
  */
 
 import { attachClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
@@ -107,15 +123,95 @@ export function isInNestBand(input, element) {
 }
 
 /**
+ * The parent a dragged card is DRAWN under right now: its row's own level when
+ * the view draws levels, else its stored parent.
+ *
+ * The two differ for a sub-card whose parent lives in another column — the list
+ * only indents a child under a parent in the same group, so that card renders
+ * flush-left even though it stores a parent.
+ *
+ * @param {object} sourceData drag payload (`source.data`) of the dragged card
+ * @return {?number} the rendered parent id, or null for a top-level row
+ */
+export function renderedParentOf(sourceData) {
+	if (!sourceData) return null
+	return sourceData.rowParentId !== undefined
+		? (sourceData.rowParentId ?? null)
+		: (sourceData.parentCardId ?? null)
+}
+
+/**
+ * The parent change a plain REORDER drop at a given row implies, or null when
+ * the drop leaves the card's parent exactly as it is.
+ *
+ * This is the inverse of the centre-band nest: dragging an indented sub-card row
+ * out to a top-level position takes it out of its parent. It is offered ONLY on
+ * a surface that draws the hierarchy (list view), which is why `rowParentId`
+ * defaults to undefined — a kanban tile renders a sub-card exactly like any
+ * other card, so a column move or reorder there must never silently detach it.
+ *
+ * Levels are compared as RENDERED, never as stored: the source's own drawn level
+ * rides the drag payload as `rowParentId`. A sub-card whose parent sits in
+ * another column is drawn flush-left (the list only indents a child under a
+ * parent in the SAME group), and reordering it there must not take its parent
+ * away — the user is not dragging it out of any indent they can see. Only the
+ * stored parent is consulted to skip a write that would change nothing.
+ *
+ * Dropping onto the card's OWN parent row is never an un-nest either: the
+ * pointer is still on the parent, and the slot right under a parent row is
+ * where its first child goes — the pixel boundary it shares with the first
+ * child row's top edge must not mean two opposite things.
+ *
+ * The server's rules are mirrored, so an offered change is never one that 400s:
+ * no self-parent, and a card that has children of its own cannot become a child
+ * (one level deep). The third server rule — the prospective parent must not
+ * itself be a child — holds by construction here: `rowParentId` is only ever
+ * taken from a row the list drew as top-level. A blocked adoption degrades to a
+ * plain reorder rather than to an un-nest, never to a surprise.
+ *
+ * @param {object} sourceData drag payload (`source.data`) of the dragged card
+ * @param {number|null|undefined} rowParentId parent of the row being dropped on
+ *   (null = top-level row, undefined = this view has no hierarchy)
+ * @param {?number} [rowCardId] the hovered row's own card id
+ * @return {?{parentCardId: ?number, intent: 'unnest'|'reparent'}} null when the parent stays put
+ */
+export function reorderParentChange(sourceData, rowParentId, rowCardId = null) {
+	if (rowParentId === undefined) return null
+	if (!sourceData || sourceData.type !== 'card') return null
+	const from = renderedParentOf(sourceData)
+	const stored = sourceData.parentCardId ?? null
+	const to = rowParentId ?? null
+	if (from === null && to === null) return null
+	if (from !== null && to !== null && Number(from) === Number(to)) return null
+	if (to === null) {
+		if (stored === null) return null // not a sub-card: nothing to take it out of
+		// Still on its own parent's row — that is not "out".
+		if (rowCardId != null && Number(rowCardId) === Number(stored)) return null
+		return { parentCardId: null, intent: 'unnest' }
+	}
+	// Already stored under this parent (only the indent was missing) — no write.
+	if (stored !== null && Number(stored) === Number(to)) return null
+	// Becoming (or changing) a parent: same guards as canNestInto.
+	if (Number(to) === Number(sourceData.cardId)) return null
+	if (sourceData.hasChildren === true) return null
+	return { parentCardId: Number(to), intent: 'reparent' }
+}
+
+/**
  * The identity fields a card carries as BOTH a drag source and a drop target.
  * Built here so the kanban tile and the list row cannot drift apart: the
  * BoardView monitor reads the same keys from either view.
  *
+ * `rowParentId` is the level the row is DRAWN at, which is not always the stored
+ * parent (a sub-card whose parent is in another column renders flush-left). Only
+ * a view that draws levels passes it; everywhere else it stays undefined.
+ *
  * @param {object} card the card summary
  * @param {?string} laneKey swimlane key ('' when swimlanes are off, null in list view)
+ * @param {number|null|undefined} [rowParentId] the rendered level of this card's row
  * @return {object} the shared drag/drop payload
  */
-export function buildCardDragData(card, laneKey) {
+export function buildCardDragData(card, laneKey, rowParentId = undefined) {
 	return {
 		type: 'card',
 		cardId: card.id,
@@ -123,6 +219,7 @@ export function buildCardDragData(card, laneKey) {
 		sortKey: card.sortKey,
 		laneKey,
 		parentCardId: card.parentCardId ?? null,
+		rowParentId,
 		hasChildren: Number(card.childProgress?.total ?? 0) > 0,
 	}
 }
@@ -137,14 +234,32 @@ export function buildCardDragData(card, laneKey) {
  * @param {Element} args.element the drop target's element
  * @param {{ data: object }} args.source the drag source
  * @param {boolean} [args.nestEnabled] whether nesting is offered at all
+ * @param {number|null|undefined} [args.rowParentId] the row's own level — see
+ *   {@see reorderParentChange}. Omitted on a view that has no hierarchy.
  * @return {object} the data to return from `getData()`
  */
-export function buildCardDropData({ base, input, element, source, nestEnabled = true }) {
+export function buildCardDropData({ base, input, element, source, nestEnabled = true, rowParentId }) {
 	if (nestEnabled && canNestInto(source?.data, base) && isInNestBand(input, element)) {
-		return { ...base, dropMode: 'nest' }
+		return { ...base, dropMode: 'nest', parentChange: null, landsNested: true }
 	}
+	// Changing a card's level by drag is gated on the same flag as nesting: only a
+	// surface that owns the card monitor and is in manual sort can carry it out,
+	// so nowhere else may show an affordance promising it.
+	const parentChange = nestEnabled
+		? reorderParentChange(source?.data, rowParentId, base?.cardId ?? null)
+		: null
 	return attachClosestEdge(
-		{ ...base, dropMode: 'reorder' },
+		{
+			...base,
+			dropMode: 'reorder',
+			parentChange,
+			// The level the card ACTUALLY lands at, so the drop indicator can be
+			// drawn at the indent the card will take — including when an adoption
+			// was refused and the drop quietly stays a plain top-level reorder.
+			landsNested: parentChange
+				? parentChange.parentCardId !== null
+				: renderedParentOf(source?.data) !== null,
+		},
 		{ input, element, allowedEdges: ['top', 'bottom'] },
 	)
 }

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -978,6 +978,76 @@ async function nestCard(cardId, targetData, sourceStackId, sourceParentId) {
 	expandStack(targetData.stackId)
 	enqueueMove({ cardId, targetStackId: targetData.stackId, afterCardId: parentCard.id, optimisticKey })
 }
+
+/**
+ * Apply a plain (edge / column) card drop: the optional parent change the drop
+ * position implies, then the move itself.
+ *
+ * `parentChange` is non-null only in list view, which renders children indented
+ * under their parent — so "drag the row out of the indent" is a gesture the user
+ * can see themselves perform. Dropping a sub-card at a top-level position clears
+ * its parent; reordering it among its own siblings does not (the row stays at
+ * the same level, so no change is produced at all).
+ *
+ * The re-parent is AWAITED before the move is queued, for the same two reasons
+ * nestCard does it: setParent's onSettled invalidates the board, which must not
+ * land on top of an in-flight optimistic move, and a rejected re-parent must not
+ * leave the card in a column the user never asked for.
+ *
+ * @param {object} args arguments
+ * @param {number} args.cardId the dragged card
+ * @param {?number} args.sourceParentId the dragged card's parent before the drop
+ * @param {?{parentCardId: ?number, intent: string}} args.parentChange the level change, if any
+ * @param {?object} args.move the enqueueMove payload, or null when the position is unchanged
+ */
+async function applyCardDrop({ cardId, sourceParentId, parentChange, move }) {
+	// The drop data was built when the row registered its drop target, which a
+	// realtime delta can outdate mid-drag (row registrations are deliberately
+	// held back for the duration of a drag). Re-read the card's parent from the
+	// cache so a change someone else already made is not written a second time.
+	const storedParentId = allVisibleCards.value.find((c) => c.id === Number(cardId))?.parentCardId ?? null
+	if (parentChange !== null && Number(storedParentId ?? 0) === Number(parentChange.parentCardId ?? 0)) {
+		parentChange = null
+	}
+
+	if (parentChange !== null) {
+		const movedTitle = cardTitleById(cardId)
+		try {
+			await setCardParent(
+				Number(cardId),
+				parentChange.parentCardId,
+				storedParentId != null ? Number(storedParentId) : (sourceParentId != null ? Number(sourceParentId) : null),
+			)
+		} catch (err) {
+			showWarning(err?.response?.data?.error
+				|| (parentChange.parentCardId === null
+					? t('kanso', 'Couldn\'t remove this card from its parent.')
+					: t('kanso', 'Couldn\'t make this card a sub-card.')))
+			return
+		}
+		announce(parentChange.parentCardId === null
+			? t('kanso', '{card} is no longer a sub-card', { card: movedTitle })
+			: t('kanso', '{card} is now a sub-card of {parent}', {
+				card: movedTitle,
+				parent: cardTitleById(parentChange.parentCardId),
+			}))
+	}
+
+	if (!move) return
+
+	// A card dropped onto a collapsed column's rail lands at the end of that
+	// stack; expand it so the moved card is visible rather than silently
+	// disappearing into a collapsed rail.
+	expandStack(move.targetStackId)
+	enqueueMove(move)
+
+	// Announce the user's own move to assistive tech.
+	announce(t('kanso', '{card} moved to {stack}', {
+		card: (cardsByStack.value.get(move.targetStackId) ?? []).find((c) => c.id === cardId)?.title
+			|| cardTitleById(cardId),
+		stack: stackTitleById(move.targetStackId),
+	}))
+}
 const { toggle: boardWatchToggle } = useBoardSubscription(boardId)
 // The chosen background preset resolved to its CSS gradient (null = none). The
 // key → CSS mapping lives client-side; an unknown key resolves to null.
@@ -1755,32 +1825,39 @@ onMounted(() => {
 					return // No valid target
 				}
 
-				// No-op guard: check if card is already in this position
+				// No-op guard: check if card is already in this position. A drop that
+				// only changes the LEVEL (dragging a sub-card out onto the very slot
+				// it already occupies) still has work to do, so this suppresses the
+				// move, not the whole drop.
+				let samePosition = false
 				if (targetStackId === sourceStackId) {
 					const stackCards = cardsByStack.value.get(targetStackId) ?? []
 					const draggedIdx = stackCards.findIndex((c) => c.id === cardId)
 					const cardBefore = draggedIdx > 0 ? stackCards[draggedIdx - 1] : null
 					const currentAfterCardId = cardBefore?.id ?? null
-					if (currentAfterCardId === afterCardId) return // already in this position
+					samePosition = currentAfterCardId === afterCardId
 				}
 
-				// A card dropped onto a collapsed column's rail lands at the end of
-				// that stack (columnTarget branch above); expand it so the moved card
-				// is visible rather than silently disappearing into a collapsed rail.
-				expandStack(targetStackId)
+				// The parent the drop position implies, when the view renders the
+				// hierarchy (list view only — see reorderParentChange). On the kanban
+				// board this is always null: a sub-card is an ordinary-looking tile
+				// there, so a reorder or a column move must never silently break the
+				// relation. Detaching stays an explicit action in the card's detail
+				// panel on both surfaces.
+				const parentChange = (cardTarget ?? columnTarget)?.data.parentChange ?? null
+				if (parentChange === null && samePosition) return
 
-				enqueueMove({ cardId, targetStackId, afterCardId, optimisticKey })
-
-				// Announce the user's own move to assistive tech. A reorder never
-				// touches parentCardId (#5885): on a kanban board a sub-card is an
-				// ordinary-looking tile, so moving one between columns must not
-				// silently break the relation. Detaching stays an explicit action in
-				// the card's detail panel.
-				announce(t('kanso', '{card} moved to {stack}', {
-					card: (cardsByStack.value.get(targetStackId) ?? []).find((c) => c.id === cardId)?.title
-						|| cardTitleById(cardId),
-					stack: stackTitleById(targetStackId),
-				}))
+				applyCardDrop({
+					cardId,
+					sourceParentId,
+					parentChange,
+					move: samePosition ? null : { cardId, targetStackId, afterCardId, optimisticKey },
+				}).catch(() => {
+					// The mutation surfaces its own failure; this only keeps an
+					// unexpected throw from escaping the drag callback as an
+					// unhandled rejection.
+					showWarning(t('kanso', 'Failed to move card. Please try again.'))
+				})
 			},
 		}),
 		// Stack reordering: header-dragged columns dropped on another column's

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -417,6 +417,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		     cards. Read-oriented: rows open the card modal. -->
 		<BoardListView
 			v-if="viewMode === 'list' && boardData"
+			ref="listViewRef"
 			:stacks="sortedStacks"
 			:cards-by-stack="cardsByStack"
 			:labels-by-id="labelsById"
@@ -426,6 +427,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			:on-create-card="handleCreateCard"
 			:on-fetch-templates="handleFetchTemplates"
 			:on-create-from-template="handleCreateFromTemplate"
+			:on-create-stack="canEditBoard ? handleCreateStack : null"
 			:sort-mode="sortMode" />
 
 		<!-- Timeline (Gantt) view - cards on a date axis by start→due. -->
@@ -1991,12 +1993,20 @@ function goToTrash() {
 	router.push({ name: 'board-trash', params: { id: props.id } })
 }
 
+// The single, view-agnostic column create. The kanban composer below and the
+// list view's own composer (#9853) both go through it, so a column created from
+// either surface is the same single-row insert reconciled by the same board
+// invalidation — and appears (and becomes a drop target) without a reload.
+async function handleCreateStack(title) {
+	await createStack.mutateAsync({ boardId: Number(props.id), title })
+}
+
 async function submitNewStack() {
 	const title = newStackTitle.value.trim()
 	if (!title) return
 	stackError.value = ''
 	try {
-		await createStack.mutateAsync({ boardId: Number(props.id), title })
+		await handleCreateStack(title)
 		newStackTitle.value = ''
 	} catch (err) {
 		stackError.value =
@@ -2009,9 +2019,20 @@ async function submitNewStack() {
 // board is empty (onboarding). Esc / empty-blur collapses it.
 const showAddColumn = ref(false)
 const addColumnInputRef = ref(null)
+// The mounted BoardListView, when list view is the active one. Its composer is
+// the other target of the single "Add column" menu action (#9853).
+const listViewRef = ref(null)
 
 function revealAddColumn() {
 	stackError.value = ''
+	// ONE menu action, two targets. The composer below lives at the end of the
+	// kanban track, which list view doesn't render — aiming at it there focused
+	// nothing and the action silently did nothing. In list view, hand off to the
+	// list's own composer instead.
+	if (viewMode.value === 'list') {
+		listViewRef.value?.focusAddColumn()
+		return
+	}
 	showAddColumn.value = true
 	nextTick(() => {
 		// Scroll the composer into view (it sits at the far right of the columns row)

--- a/tests/e2e/dnd-unnest.spec.js
+++ b/tests/e2e/dnd-unnest.spec.js
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Drag a sub-card OUT of its parent — the inverse of the centre-band nest.
+//
+// It is offered in LIST view only, because that is the only surface that draws
+// the hierarchy: children render indented under their parent, so "drag the row
+// out of the indent" is a gesture the user can see themselves perform. The crux
+// is the distinction the tests below pin down:
+//
+//   drop among the parent's OWN children  → plain reorder, parent untouched
+//   drop at a TOP-LEVEL position          → the parent is cleared
+//
+// On the kanban board a sub-card is an ordinary tile in a flat column, so a
+// drag there never changes the parent (guarded in dnd-nest.spec.js). It does
+// now carry a ↳ marker so it is at least recognisable, and the card's own
+// detail panel keeps the explicit, keyboard-reachable detach.
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+/**
+ * Real-pointer drag (Pragmatic DnD uses the native HTML5 drag adapter, so
+ * synthetic events are not enough). Same helper as dnd-nest.spec.js, including
+ * the hook that asserts the drop affordance while the pointer is still held.
+ *
+ * @param {import('@playwright/test').Page} page - the page under test
+ * @param {import('@playwright/test').Locator} source - element to pick up
+ * @param {import('@playwright/test').Locator} target - element to drop onto
+ * @param {object} [options] - drag options
+ * @param {'top'|'middle'|'bottom'} [options.position] - where in the target to aim
+ * @param {Function} [options.whileHovering] - async assertion run before mouse-up
+ * @return {Promise<void>}
+ */
+async function dragWithMouse(page, source, target, { position = 'middle', whileHovering } = {}) {
+	const srcBox = await source.boundingBox()
+	const tgtBox = await target.boundingBox()
+	if (!srcBox || !tgtBox) throw new Error('Could not get bounding boxes for drag')
+
+	const srcX = srcBox.x + srcBox.width / 2
+	const srcY = srcBox.y + srcBox.height / 2
+	const tgtX = tgtBox.x + tgtBox.width / 2
+	const frac = position === 'top' ? 0.15 : position === 'bottom' ? 0.85 : 0.5
+	const tgtY = tgtBox.y + tgtBox.height * frac
+
+	await page.mouse.move(srcX, srcY)
+	await page.mouse.down()
+	const steps = 15
+	for (let i = 1; i <= steps; i++) {
+		await page.mouse.move(
+			srcX + (tgtX - srcX) * (i / steps),
+			srcY + (tgtY - srcY) * (i / steps),
+			{ steps: 1 },
+		)
+		await page.waitForTimeout(20)
+	}
+	// Settle on the target with a 1px jiggle: Pragmatic's element adapter only
+	// re-evaluates a drop target on a native dragover, so a perfectly still
+	// pointer on a freshly registered target never gets one.
+	for (let i = 0; i < 4; i++) {
+		await page.mouse.move(tgtX + (i % 2 ? 1 : -1), tgtY, { steps: 1 })
+		await page.waitForTimeout(60)
+	}
+	await page.waitForTimeout(200)
+	if (whileHovering) await whileHovering()
+	await page.mouse.move(tgtX, tgtY, { steps: 1 })
+	await page.waitForTimeout(60)
+	await page.mouse.up()
+	await page.waitForTimeout(600)
+}
+
+/** Switch the board to List view via the Display popover. */
+async function pickListView(page) {
+	await page.locator('.board-view__display-menu button').first().click()
+	await page.waitForTimeout(400)
+	await page.locator('.action-radio__text', { hasText: /^List$/ }).click()
+	await page.waitForTimeout(150)
+	await page.keyboard.press('Escape')
+	await page.waitForTimeout(200)
+	await expect(page.locator('.board-list-row').first()).toBeVisible({ timeout: 8_000 })
+	// The virtualizer lays rows out absolutely and re-positions them once the
+	// group heights settle; take bounding boxes only after that.
+	await page.waitForTimeout(600)
+}
+
+test.describe('Drag a sub-card out of its parent (list view)', () => {
+	const state = { boardId: 0, u1Id: 0, u2Id: 0, ids: {}, boardUrl: '' }
+
+	/** The stored parent of a card, straight from the server (no cache in between). */
+	const parentOf = async (title) => {
+		const card = await api.get(`/cards/${state.ids[title]}`)
+		return card.parentCardId ?? null
+	}
+
+	const row = (page, title) => page
+		.locator('.board-list-row-wrap')
+		.filter({ hasText: title })
+
+	const rowTitles = async (page) => (await page.locator('.board-list-row__title').allTextContents())
+		.map((s) => s.trim())
+
+	/**
+	 * Put the fixture back the way each test expects to find it. Called at the top
+	 * of every test so the file is retry-safe: Playwright retries a failed test in
+	 * place, and these tests deliberately mutate shared board state.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async function resetFixture() {
+		for (const title of ['UA', 'UB', 'UX']) {
+			await api.put(`/cards/${state.ids[title]}/parent`, { parentCardId: state.ids.UP })
+		}
+	}
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'UnnestDnD ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const u1 = await api.post('/stacks', { boardId: board.id, title: 'U1' })
+		const u2 = await api.post('/stacks', { boardId: board.id, title: 'U2' })
+		state.u1Id = u1.id
+		state.u2Id = u2.id
+		// Created in order, so the column's sort keys run UP, UA, UB, UT — and the
+		// list renders UP with UA + UB indented under it, then UT at top level.
+		for (const title of ['UP', 'UA', 'UB', 'UT']) {
+			const card = await api.post('/cards', { stackId: u1.id, title })
+			state.ids[title] = card.id
+		}
+		// UX lives in the OTHER column as a sub-card of UP: a card that stores a
+		// parent but renders flush-left, because the list only indents a child
+		// under a parent in the same group. UZ gives it something to reorder against.
+		for (const title of ['UX', 'UZ']) {
+			const card = await api.post('/cards', { stackId: u2.id, title })
+			state.ids[title] = card.id
+		}
+		await api.put(`/cards/${state.ids.UA}/parent`, { parentCardId: state.ids.UP })
+		await api.put(`/cards/${state.ids.UB}/parent`, { parentCardId: state.ids.UP })
+		await api.put(`/cards/${state.ids.UX}/parent`, { parentCardId: state.ids.UP })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('reordering a child among its siblings does NOT take it out of its parent', async ({ page }) => {
+		await resetFixture()
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await pickListView(page)
+
+		// UA and UB are UP's children; U1 therefore renders UP with two indented
+		// rows under it, then UT. (The exact sibling order is whatever the previous
+		// run left, so it is asserted after the drag, not before.)
+		await expect(page.locator('.board-list-row--child')).toHaveCount(2, { timeout: 8_000 })
+		expect(await parentOf('UB')).toBe(state.ids.UP)
+
+		// UB onto UA's TOP edge: still inside UP's children, so this is an ordinary
+		// reorder — the indicator is indented to the child level and carries none of
+		// the detach styling or wording.
+		await dragWithMouse(page, row(page, 'UB'), row(page, 'UA'), {
+			position: 'top',
+			whileHovering: async () => {
+				await expect(page.locator('.board-list-drop-indicator')).toHaveCount(1)
+				await expect(page.locator('.board-list-drop-indicator--nested')).toHaveCount(1)
+				await expect(page.locator('.board-list-drop-indicator--unnest')).toHaveCount(0)
+				await expect(page.locator('.board-list-nest-hint--unnest')).toHaveCount(0)
+			},
+		})
+
+		await expect.poll(async () => (await rowTitles(page)).slice(0, 4), { timeout: 10_000 })
+			.toEqual(['UP', 'UB', 'UA', 'UT'])
+		// The whole point: the relation survived the reorder.
+		expect(await parentOf('UB')).toBe(state.ids.UP)
+		expect(await parentOf('UA')).toBe(state.ids.UP)
+		// Both are still drawn indented under UP.
+		await expect(page.locator('.board-list-row--child')).toHaveCount(2)
+	})
+
+	test('dragging a child row out to a top-level position clears its parent', async ({ page }) => {
+		await resetFixture()
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await pickListView(page)
+
+		expect(await parentOf('UA')).toBe(state.ids.UP)
+		await expect(page.locator('.board-list-row--child').filter({ hasText: 'UA' }))
+			.toBeVisible({ timeout: 8_000 })
+
+		// UA onto UT's BOTTOM edge — a top-level slot, so UA leaves UP.
+		await dragWithMouse(page, row(page, 'UA'), row(page, 'UT'), {
+			position: 'bottom',
+			whileHovering: async () => {
+				// Distinct from both a plain reorder line and the nest highlight.
+				await expect(page.locator('.board-list-drop-indicator--unnest')).toHaveCount(1)
+				await expect(page.locator('.board-list-drop-indicator--nested')).toHaveCount(0)
+				await expect(page.locator('.board-list-nest-hint--unnest')).toBeVisible()
+				await expect(page.locator('.board-list-row-wrap--nest-target')).toHaveCount(0)
+			},
+		})
+
+		await expect.poll(async () => await parentOf('UA'), { timeout: 10_000 }).toBeNull()
+
+		// The row un-indents and lands where it was dropped.
+		await expect(page.locator('.board-list-row--child').filter({ hasText: 'UA' }))
+			.toHaveCount(0, { timeout: 10_000 })
+		await expect.poll(async () => (await rowTitles(page)).slice(0, 4), { timeout: 10_000 })
+			.toEqual(['UP', 'UB', 'UT', 'UA'])
+
+		// Server is the source of truth — it survives a reload.
+		await page.reload()
+		await expect(page.locator('.board-list-row').first()).toBeVisible({ timeout: 15_000 })
+		expect(await parentOf('UA')).toBeNull()
+		await expect(page.locator('.board-list-row--child').filter({ hasText: 'UA' }))
+			.toHaveCount(0, { timeout: 8_000 })
+		// UB is untouched by all of this.
+		expect(await parentOf('UB')).toBe(state.ids.UP)
+	})
+
+	test('a sub-card whose parent is in another column reorders without losing it', async ({ page }) => {
+		// It renders flush-left (the list only indents a child under a parent in the
+		// SAME group), so there is no indent to drag it out of — and every position
+		// open to it is a top-level one. Levels are therefore compared as RENDERED,
+		// never as stored, or this card could never be reordered at all.
+		await resetFixture()
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await pickListView(page)
+
+		expect(await parentOf('UX')).toBe(state.ids.UP)
+		await expect(page.locator('.board-list-row--child').filter({ hasText: 'UX' }))
+			.toHaveCount(0)
+
+		await dragWithMouse(page, row(page, 'UX'), row(page, 'UZ'), {
+			position: 'bottom',
+			whileHovering: async () => {
+				// An ordinary reorder: no detach rule, no detach pill.
+				await expect(page.locator('.board-list-drop-indicator--unnest')).toHaveCount(0)
+				await expect(page.locator('.board-list-nest-hint--unnest')).toHaveCount(0)
+			},
+		})
+
+		// Reordered inside U2, and still a sub-card of UP over in U1.
+		await expect.poll(async () => (await rowTitles(page)).slice(-2), { timeout: 10_000 })
+			.toEqual(['UZ', 'UX'])
+		expect(await parentOf('UX')).toBe(state.ids.UP)
+	})
+
+	test('a kanban tile marks a sub-card; a top-level card carries no marker', async ({ page }) => {
+		await resetFixture()
+		// The board draws no indent, so without this marker a sub-card is
+		// indistinguishable from any other tile — which is exactly why a kanban
+		// drag must not be allowed to detach one.
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.stack-column', { timeout: 15_000 })
+
+		const tile = (title) => page.locator('.card-tile').filter({ hasText: title })
+		await expect(tile('UP')).toBeVisible({ timeout: 8_000 })
+
+		expect(await parentOf('UB')).toBe(state.ids.UP)
+		await expect(tile('UB').locator('.card-tile__subcard')).toBeVisible({ timeout: 8_000 })
+		// …including one whose parent lives in another column — the tile is all the
+		// board has to go on there.
+		await expect(tile('UX').locator('.card-tile__subcard')).toBeVisible({ timeout: 8_000 })
+		// UT and UZ never had a parent; UP is one.
+		await expect(tile('UT').locator('.card-tile__subcard')).toHaveCount(0)
+		await expect(tile('UZ').locator('.card-tile__subcard')).toHaveCount(0)
+		await expect(tile('UP').locator('.card-tile__subcard')).toHaveCount(0)
+	})
+
+	test('the card panel still detaches a sub-card without any dragging', async ({ page }) => {
+		// Drag must never be the only way out: the panel action is the accessible
+		// path, and it is one click from the sub-card itself.
+		await resetFixture()
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.stack-column', { timeout: 15_000 })
+
+		await page.locator('.card-tile').filter({ hasText: 'UB' }).click()
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const parentLink = page.locator('.card-modal__parent-link')
+		await expect(parentLink).toHaveText('UP', { timeout: 8_000 })
+
+		await page.getByTitle('Detach from parent').click()
+
+		await expect.poll(async () => await parentOf('UB'), { timeout: 10_000 }).toBeNull()
+		await expect(parentLink).toHaveCount(0, { timeout: 8_000 })
+	})
+})

--- a/tests/e2e/list-view.spec.js
+++ b/tests/e2e/list-view.spec.js
@@ -12,9 +12,8 @@ async function dragWithMouse(page, sourceLocator, targetLocator, targetPosition 
 	const srcX = srcBox.x + srcBox.width / 2
 	const srcY = srcBox.y + srcBox.height / 2
 	const tgtX = tgtBox.x + tgtBox.width / 2
-	const tgtY = targetPosition === 'top'
-		? tgtBox.y + tgtBox.height * 0.2
-		: tgtBox.y + tgtBox.height * 0.8
+	const frac = targetPosition === 'top' ? 0.2 : targetPosition === 'middle' ? 0.5 : 0.8
+	const tgtY = tgtBox.y + tgtBox.height * frac
 
 	await page.mouse.move(srcX, srcY)
 	await page.mouse.down()
@@ -456,5 +455,212 @@ test.describe('List view — drag-and-drop reorder', () => {
 
 		// Cleanup
 		await api.delete(`/boards/${board2.id}`).catch(() => {})
+	})
+})
+
+// ── Column composer (#9853) ───────────────────────────────────────────────────
+// List view had no way to create a column. The ⋯ More → "Add column" action is
+// not kanban-gated (it only checks edit permission), but it revealed a composer
+// that lives at the end of the KANBAN track — never rendered in list view — so
+// in list view the menu item silently did nothing. The list now owns a composer
+// of its own, at the end of the group list, and the same single menu action
+// targets it while list view is active.
+
+test.describe('List view — column composer (#9853)', () => {
+	// Roomy enough that the ⋯ More menu keeps its visible "More" label.
+	test.use({ viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, stackId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'List Add Column ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		state.stackId = stack.id
+		await api.post('/cards', { stackId: stack.id, title: 'Movable card' })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	const composer = (page) => page.locator('[data-test="list-add-column"]')
+	const groupCount = (page, title) => page
+		.locator('.board-list-group')
+		.filter({ hasText: title })
+		.locator('.board-list-group__count')
+
+	async function openListView(page) {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		await page.locator('.board-view__display-menu button').first().click()
+		await page.getByRole('menuitemradio', { name: 'List', exact: true }).click()
+		await page.keyboard.press('Escape')
+		await page.waitForSelector('.board-list-group', { timeout: 10_000 })
+	}
+
+	test('creates a column in place, and the new column takes a dragged card with no reload', async ({ page }) => {
+		await openListView(page)
+
+		const input = composer(page)
+		await expect(input).toBeVisible({ timeout: 8_000 })
+		await input.fill('In review')
+		await input.press('Enter')
+
+		// The column appears in the list itself — no switch to Board view.
+		await expect(page.locator('.board-list-group', { hasText: 'In review' }))
+			.toBeVisible({ timeout: 10_000 })
+		// …and the composer clears + stays focused for a second column.
+		await expect(input).toHaveValue('', { timeout: 8_000 })
+		await expect(input).toBeFocused()
+
+		// The server is the source of truth; grab the new column's real id.
+		let newStackId = 0
+		await expect.poll(async () => {
+			const { stacks } = await api.get(`/boards/${state.boardId}`)
+			newStackId = (stacks ?? []).find((s) => s.title === 'In review')?.id ?? 0
+			return newStackId
+		}, { timeout: 8_000 }).toBeGreaterThan(0)
+
+		// A brand-new (empty) column must be a live drop target immediately — its
+		// only drop target is the group-header overlay (there is no card row to
+		// aim at), so this is the b5edae1 empty-column path on a fresh column.
+		const card = page.locator('.board-list-row-wrap').filter({ hasText: 'Movable card' })
+		const drop = page.locator(`.board-list-group-drop[data-stack-id="${newStackId}"]`)
+		await expect(drop).toHaveCount(1, { timeout: 8_000 })
+		await dragWithMouse(page, card, drop, 'middle')
+
+		await expect(groupCount(page, 'In review')).toHaveText('1', { timeout: 8_000 })
+		await expect(groupCount(page, 'Inbox')).toHaveText('0')
+
+		// Both the column and the move survive a reload.
+		await page.reload()
+		await page.waitForSelector('.board-list-group', { timeout: 15_000 })
+		await expect(groupCount(page, 'In review')).toHaveText('1', { timeout: 10_000 })
+		await expect(groupCount(page, 'Inbox')).toHaveText('0')
+	})
+
+	test('⋯ More → "Add column" focuses the list composer instead of doing nothing', async ({ page }) => {
+		await openListView(page)
+
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: 'Add column' }).click()
+
+		const input = composer(page)
+		// Let the menu finish closing first: NcActions restores focus to its
+		// trigger on close, so asserting only on an early poll could hide a steal.
+		// This asserts the STEADY state after that restore would have happened.
+		await page.waitForTimeout(600)
+		await expect(input).toBeFocused({ timeout: 8_000 })
+		// The kanban track's own composer stays unrevealed — one action, one target.
+		await expect(page.locator('.add-stack')).toHaveCount(0)
+
+		await input.fill('From the menu')
+		await input.press('Enter')
+		await expect(page.locator('.board-list-group', { hasText: 'From the menu' }))
+			.toBeVisible({ timeout: 10_000 })
+		await expect.poll(async () => {
+			const { stacks } = await api.get(`/boards/${state.boardId}`)
+			return (stacks ?? []).some((s) => s.title === 'From the menu')
+		}, { timeout: 8_000 }).toBe(true)
+	})
+
+	test('the composer keeps its focus and half-typed draft while the list recycles rows', async ({ page }) => {
+		// This is the whole reason the composer is rendered OUTSIDE the virtualizer:
+		// as a virtual row it would be unmounted and recycled onto another card the
+		// moment the list scrolled, taking the focus and the draft with it. Needs
+		// its own board — long enough that scrolling really does recycle rows.
+		const board = await api.post('/boards', { title: 'List Column Scroll ' + Math.floor(Date.now() / 1000) })
+		try {
+			const stack = await api.post('/stacks', { boardId: board.id, title: 'Long' })
+			for (let i = 1; i <= 50; i++) {
+				await api.post('/cards', { stackId: stack.id, title: `Row ${String(i).padStart(2, '0')}` })
+			}
+
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/board/${board.id}`)
+			await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+			await page.locator('.board-view__display-menu button').first().click()
+			await page.getByRole('menuitemradio', { name: 'List', exact: true }).click()
+			await page.keyboard.press('Escape')
+			await page.waitForSelector('.board-list-row', { timeout: 10_000 })
+
+			const input = composer(page)
+			await input.click()
+			await input.fill('Half typed')
+			await expect(input).toBeFocused()
+
+			// Scroll to the very top and back down: every row element rendered a
+			// moment ago is now bound to a different card.
+			const list = page.locator('.board-list-table')
+			await list.evaluate((el) => { el.scrollTop = 0 })
+			await page.waitForTimeout(400)
+			await expect(page.locator('.board-list-row', { hasText: 'Row 01' })).toBeVisible({ timeout: 8_000 })
+			await list.evaluate((el) => { el.scrollTop = el.scrollHeight })
+			await page.waitForTimeout(400)
+			await expect(page.locator('.board-list-row', { hasText: 'Row 50' })).toBeVisible({ timeout: 8_000 })
+
+			// Neither the draft nor the focus was recycled away with the rows.
+			await expect(input).toHaveValue('Half typed')
+			await expect(input).toBeFocused()
+		} finally {
+			await api.delete(`/boards/${board.id}`).catch(() => {})
+		}
+	})
+})
+
+test.describe('List view — add-column is editors only (#9853)', () => {
+	// A second identity logs in explicitly, so this describe must NOT inherit the
+	// shared admin storageState (it would silently stay admin and false-pass).
+	test.use({ storageState: { cookies: [], origins: [] }, viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, boardUrl: '' }
+
+	test.beforeAll(async ({ peer }) => {
+		const board = await api.post('/boards', { title: 'List Column ACL ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		await api.post('/cards', { stackId: stack.id, title: 'Read-only card' })
+		// READ only (1) — no EDIT bit, so canEditBoard is false for the peer.
+		await api.post(`/boards/${board.id}/acl`, {
+			participant: peer.user,
+			participantType: 'user',
+			permission: 1,
+		})
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('a viewer sees no add-column affordance in list view', async ({ browser, peer }) => {
+		const ctx = await browser.newContext({ viewport: { width: 1600, height: 900 } })
+		try {
+			const page = await ctx.newPage()
+			await ncLogin(page, { user: peer.user, pass: peer.pass })
+			await page.goto(state.boardUrl)
+			await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+			await page.locator('.board-view__display-menu button').first().click()
+			await page.getByRole('menuitemradio', { name: 'List', exact: true }).click()
+			await page.keyboard.press('Escape')
+			await page.waitForSelector('.board-list-group', { timeout: 10_000 })
+
+			// The list renders for them…
+			await expect(page.locator('.board-list-row', { hasText: 'Read-only card' }))
+				.toBeVisible({ timeout: 8_000 })
+			// …but neither the composer nor the menu action is offered.
+			await expect(page.locator('[data-test="list-add-column"]')).toHaveCount(0)
+			await page.getByRole('button', { name: 'More' }).click()
+			// Prove the menu actually opened before asserting an absence — a
+			// not-yet-rendered popover satisfies toHaveCount(0) for free.
+			await expect(page.getByRole('menuitem', { name: /deleted cards/i }))
+				.toBeVisible({ timeout: 8_000 })
+			await expect(page.getByRole('menuitem', { name: 'Add column' })).toHaveCount(0)
+		} finally {
+			await ctx.close()
+		}
 	})
 })

--- a/tests/e2e/list-view.spec.js
+++ b/tests/e2e/list-view.spec.js
@@ -425,12 +425,12 @@ test.describe('List view — drag-and-drop reorder', () => {
 		await expect(afterRows.nth(2)).toContainText('L2')
 	})
 
-	test('child rows are inert — dragging a child row does not move it', async ({ page }) => {
-		// Regression guard: child rows must not participate in DnD. We verify that
-		// a child row element does not carry the vCardDnd directive by checking that
-		// it does NOT have the board-list-row-wrap container (that wrapper is only
-		// rendered for top-level cards). Children render as bare board-list-row--child
-		// buttons, not inside board-list-row-wrap.
+	test('child rows are draggable — a child row is its own DnD host', async ({ page }) => {
+		// Child rows used to be inert, which made dragging a sub-card back out of
+		// its parent impossible. They now carry the same DnD host (board-list-row-wrap
+		// + the vCardDnd directive) as a top-level row, while still rendering
+		// indented. Which drop position keeps the parent and which clears it is
+		// covered in dnd-unnest.spec.js.
 		const board2 = await api.post('/boards', { title: 'List DnD Child Guard ' + Date.now() })
 		const stack2 = await api.post('/stacks', { boardId: board2.id, title: 'Tasks' })
 		const parent = await api.post('/cards', { stackId: stack2.id, title: 'Parent' })
@@ -445,13 +445,14 @@ test.describe('List view — drag-and-drop reorder', () => {
 		await page.keyboard.press('Escape')
 		await page.waitForSelector('.board-list-row', { timeout: 10_000 })
 
-		// The child row should be a .board-list-row--child element and must NOT be
-		// wrapped inside a .board-list-row-wrap (which is the DnD host element).
+		// The child row still renders indented…
 		const childRow = page.locator('.board-list-row--child', { hasText: 'Child' })
 		await expect(childRow).toBeVisible({ timeout: 8_000 })
 
-		const wrapCount = await page.locator('.board-list-row-wrap', { hasText: 'Child' }).count()
-		expect(wrapCount).toBe(0)
+		// …and now sits inside the DnD host, marked draggable like any other row.
+		const childWrap = page.locator('.board-list-row-wrap', { hasText: 'Child' })
+		await expect(childWrap).toHaveCount(1)
+		await expect(childWrap.locator('.board-list-row--child.board-list-row--draggable')).toHaveCount(1)
 
 		// Cleanup
 		await api.delete(`/boards/${board2.id}`).catch(() => {})

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -374,6 +374,7 @@ msgstr ""
 msgid "Add column"
 msgstr ""
 
+#: src/components/BoardListView.vue
 #: src/views/BoardView.vue
 msgid "Add column…"
 msgstr ""
@@ -2128,6 +2129,10 @@ msgstr ""
 #: src/components/BoardSettingsModal.vue
 #: src/components/StackColumn.vue
 msgid "Failed to create card."
+msgstr ""
+
+#: src/components/BoardListView.vue
+msgid "Failed to create column."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -91,6 +91,10 @@ msgid "{card} is due tomorrow"
 msgstr ""
 
 #: src/views/BoardView.vue
+msgid "{card} is no longer a sub-card"
+msgstr ""
+
+#: src/views/BoardView.vue
 msgid "{card} is now a sub-card of {parent}"
 msgstr ""
 
@@ -1410,6 +1414,10 @@ msgstr ""
 msgid "Couldn't make this card a sub-card."
 msgstr ""
 
+#: src/views/BoardView.vue
+msgid "Couldn't remove this card from its parent."
+msgstr ""
+
 #: src/components/BoardSettingsModal.vue
 msgid "Count"
 msgstr ""
@@ -1802,6 +1810,10 @@ msgstr ""
 #: src/components/BoardListView.vue
 #: src/components/CardTile.vue
 msgid "Drop to nest as sub-card"
+msgstr ""
+
+#: src/components/BoardListView.vue
+msgid "Drop to remove from parent"
 msgstr ""
 
 #: src/views/PublicBoard.vue
@@ -2295,6 +2307,7 @@ msgid "Failed to move card."
 msgstr ""
 
 #: src/composables/useCardMove.js
+#: src/views/BoardView.vue
 msgid "Failed to move card. Please try again."
 msgstr ""
 
@@ -4512,6 +4525,7 @@ msgstr ""
 msgid "Strikethrough"
 msgstr ""
 
+#: src/components/CardTile.vue
 #: src/composables/useBoardFilters.js
 msgid "Sub-card"
 msgstr ""


### PR DESCRIPTION
Follow-on to #89 (merged, released as `v0.17.0`). Two cards the board owner asked for directly while reviewing that work.

## What's in here

| Commit | Card | What it does |
| --- | --- | --- |
| `35e9153` | #9850 | Drag a sub-card out of its parent in list view to make it top-level again — the inverse of the nesting that shipped in #89. |
| `9fc0287` | #9853 | Add a column from list view, instead of switching back to the board first. |

## Why un-nesting is list-view-only

#89 shipped drag-to-**nest** but deliberately not the inverse, because the obvious rule ("any reorder-mode drop of a sub-card clears its parent") is silent data loss on a kanban board: a sub-card renders as an ordinary tile, so a routine "move this subtask to the next column" would break the relation with no signal and no undo.

This PR resolves that properly rather than by loosening the rule:
- **List view** gets real drag-out un-nesting — children render indented there, so dragging out of the indent is a gesture you can see yourself performing. Distinct dashed "Drop to remove from parent" affordance; reordering among siblings does not detach.
- **Kanban tiles** gain a `↳` sub-card marker, so nesting stops being invisible — but kanban drag stays non-destructive. Both #89 guard tests still pass.
- The explicit "Detach from parent" panel action remains the accessible path.

### A review pass caught three real bugs here, all fixed and covered

1. **Levels are compared as RENDERED, not stored.** A sub-card whose parent sits in another column renders flush-left — under the naive rule an ordinary reorder would have detached it. That's the same data-loss failure mode #89 rejected, hiding inside the "safe" view.
2. The group-header / column drop no longer changes a parent at all (it had no affordance suggesting it would).
3. Parent-by-drag is gated on `NEST_ENABLED`, so cross-board Views don't render dead pills.

Dropping onto a card's *own parent row* is never a detach either — that pixel boundary is shared with the first child row's top edge.

## Add column in list view

The ⋯ More → "Add column" action was never kanban-gated — it rendered in list view and **silently did nothing**, because it reveals a composer that only exists in the kanban track. Now the one action reveals and focuses whichever composer belongs to the active view. The list composer is rendered **outside the virtualiser**, so scrolling can't recycle away focus or a half-typed draft (there's a test for exactly that, across a 50-row recycle).

## Behaviour change worth knowing

`list-view.spec.js`'s "child rows are inert" spec encoded the old rule and was **rewritten** to assert the new one. That's a deliberate semantic change, not a test being loosened to pass.

## Verification

`35e9153`: 5 new e2e + 29 regression specs green, including both #89 nesting guards.
`9fc0287`: 4 new e2e (create-in-place + drag into the new column + reload; menu action focuses the list composer; focus/draft survive a virtual-list recycle; a read-only peer sees neither composer nor menu item) + 32 regression specs green.
`npm run build` clean; l10n extract/compile/lint run last in both. No `<version>` change.
