### PR TITLE
feat: create and manage repeating cards from the MCP server

### DIFF
--- a/lib/Controller/RecurRuleController.php
+++ b/lib/Controller/RecurRuleController.php
@@ -19,7 +19,7 @@ use OCP\IUserSession;
  * Recurring-card rule endpoints. Rules are board-automation config, so
  * mutations require MANAGE and listing requires READ (enforced in
  * {@see RecurrenceService}). create-now spawns one card immediately. Errors
- * map through ApiErrorTrait (bad RRULE / mode / policy → 400).
+ * map through ApiErrorTrait (bad RRULE / mode / policy / timezone → 400).
  */
 class RecurRuleController extends Controller {
 	use ApiErrorTrait;
@@ -52,8 +52,9 @@ class RecurRuleController extends Controller {
 		int $duedatePolicy = 0,
 		int $duedateOffsetSeconds = 0,
 		bool $skipWhileOpen = false,
+		?string $timezone = null,
 	): JSONResponse {
-		return $this->respond(function () use ($id, $templateCardId, $targetStackId, $mode, $rrule, $duedatePolicy, $duedateOffsetSeconds, $skipWhileOpen): JSONResponse {
+		return $this->respond(function () use ($id, $templateCardId, $targetStackId, $mode, $rrule, $duedatePolicy, $duedateOffsetSeconds, $skipWhileOpen, $timezone): JSONResponse {
 			return new JSONResponse(
 				$this->recurrenceService->create(
 					$id,
@@ -65,6 +66,7 @@ class RecurRuleController extends Controller {
 					$duedateOffsetSeconds,
 					$skipWhileOpen,
 					$this->currentUserId(),
+					$timezone,
 				)
 			);
 		});
@@ -81,8 +83,9 @@ class RecurRuleController extends Controller {
 		?int $duedateOffsetSeconds = null,
 		?bool $skipWhileOpen = null,
 		?bool $enabled = null,
+		?string $timezone = null,
 	): JSONResponse {
-		return $this->respond(function () use ($id, $templateCardId, $targetStackId, $mode, $rrule, $duedatePolicy, $duedateOffsetSeconds, $skipWhileOpen, $enabled): JSONResponse {
+		return $this->respond(function () use ($id, $templateCardId, $targetStackId, $mode, $rrule, $duedatePolicy, $duedateOffsetSeconds, $skipWhileOpen, $enabled, $timezone): JSONResponse {
 			return new JSONResponse(
 				$this->recurrenceService->update(
 					$id,
@@ -95,6 +98,7 @@ class RecurRuleController extends Controller {
 					$skipWhileOpen,
 					$enabled,
 					$this->currentUserId(),
+					$timezone,
 				)
 			);
 		});

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -172,6 +172,27 @@ class RecurrenceService {
 		return date_default_timezone_get() ?: 'UTC';
 	}
 
+	/**
+	 * The timezone a create/update should store: an explicitly supplied IANA id
+	 * when the caller sent one (API clients scheduling on someone else's behalf),
+	 * otherwise the owner's personal timezone. Unlike {@see self::timezoneFor},
+	 * which is lenient about already-stored values for back-compat, an explicit
+	 * bad id is a client error and is rejected.
+	 *
+	 * @throws InvalidInputException if $timezone is a non-empty, unparseable id
+	 */
+	private function resolveTimezone(?string $timezone, string $uid): string {
+		if ($timezone === null || $timezone === '') {
+			return $this->defaultTimezoneFor($uid);
+		}
+		try {
+			new \DateTimeZone($timezone);
+		} catch (\Exception $e) {
+			throw new InvalidInputException('Invalid timezone');
+		}
+		return $timezone;
+	}
+
 	// ---- rule CRUD --------------------------------------------------------
 
 	/**
@@ -210,7 +231,7 @@ class RecurrenceService {
 	 *
 	 * @throws DoesNotExistException if the board, template card or target stack does not exist or is deleted
 	 * @throws NotPermittedException if the user may not manage the board
-	 * @throws InvalidInputException on invalid mode, policy, offset, RRULE or cross-board references
+	 * @throws InvalidInputException on invalid mode, policy, offset, RRULE, timezone or cross-board references
 	 */
 	public function create(
 		int $boardId,
@@ -222,6 +243,7 @@ class RecurrenceService {
 		int $duedateOffsetSeconds,
 		bool $skipWhileOpen,
 		string $uid,
+		?string $timezone = null,
 	): RecurRule {
 		$board = $this->loadBoard($boardId);
 		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
@@ -248,10 +270,10 @@ class RecurrenceService {
 		$rule->setLastSpawnedAt(0);
 		$rule->setOccurrencesSpawned(0);
 		$rule->setCreatedAt($now);
-		// Default the rule's timezone to the owner's personal timezone (server
-		// default fallback); the schedule is expanded as floating wall-clock time
-		// in this zone.
-		$rule->setTimezone($this->defaultTimezoneFor($uid));
+		// The schedule is expanded as floating wall-clock time in this zone: an
+		// explicit IANA id from the caller wins, otherwise the owner's personal
+		// timezone (server default fallback).
+		$rule->setTimezone($this->resolveTimezone($timezone, $uid));
 		// Work out when this rule should fire for the FIRST time.
 		//
 		// The schedule is anchored at the card's Start date (its due date, then the
@@ -271,14 +293,14 @@ class RecurrenceService {
 	/**
 	 * Updates the given fields of a rule (null = leave unchanged). The cached
 	 * `next_occurrence_at` is re-armed only when the schedule actually changes (a
-	 * different RRULE) or the rule is re-enabled (disabled → enabled), and even
-	 * then it is never rewound onto an occurrence the cron already spawned - a
+	 * different RRULE or timezone) or the rule is re-enabled (disabled → enabled),
+	 * and even then it is never rewound onto an occurrence the cron already spawned - a
 	 * no-op edit leaves the cursor exactly where it was, so editing a rule can no
 	 * longer duplicate an already-fired occurrence dated today (#65).
 	 *
 	 * @throws DoesNotExistException if the rule, its board, the template card or the target stack does not exist or is deleted
 	 * @throws NotPermittedException if the user may not manage the board
-	 * @throws InvalidInputException on invalid mode, policy, offset, RRULE or cross-board references
+	 * @throws InvalidInputException on invalid mode, policy, offset, RRULE, timezone or cross-board references
 	 */
 	public function update(
 		int $id,
@@ -291,6 +313,7 @@ class RecurrenceService {
 		?bool $skipWhileOpen,
 		?bool $enabled,
 		string $uid,
+		?string $timezone = null,
 	): RecurRule {
 		$rule = $this->ruleMapper->find($id);
 		$board = $this->loadBoard($rule->getBoardId());
@@ -312,8 +335,16 @@ class RecurrenceService {
 		// cursor may only be re-armed when the schedule really changed, and never
 		// rewound onto an occurrence the cron has already spawned.
 		$originalRrule = $rule->getRrule();
+		$originalTimezone = $rule->getTimezone();
 		$wasEnabled = $rule->getEnabled();
+		// A null/empty timezone means "leave the zone alone"; there is no way to
+		// clear it (a rule always expands in SOME zone, cleared just means the
+		// server default). An explicit bad id is rejected by resolveTimezone().
+		$newTimezone = ($timezone === null || $timezone === '')
+			? $originalTimezone
+			: $this->resolveTimezone($timezone, $uid);
 
+		$rule->setTimezone($newTimezone);
 		$rule->setTemplateCardId($newTemplate);
 		$rule->setTargetStackId($newStack);
 		$rule->setMode($newMode);
@@ -347,7 +378,10 @@ class RecurrenceService {
 		//      "Daily" did nothing for up to a week. It's also safe: a date after now
 		//      is always in the future, so it can never be one we already fired -
 		//      meaning no duplicate card (still safe for #65).
-		$scheduleChanged = $newRrule !== $originalRrule;
+		//
+		// A timezone change counts as a schedule change too: re-anchoring the same
+		// repeat rule in a different zone shifts every future occurrence.
+		$scheduleChanged = $newRrule !== $originalRrule || $newTimezone !== $originalTimezone;
 		$reEnabled = $rule->getEnabled() && !$wasEnabled;
 		if ($rule->getEnabled() && ($scheduleChanged || $reEnabled)) {
 			$rule->setNextOccurrenceAt($this->firstFireFor($rule, $this->anchorFor($template, $rule)));

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -173,6 +173,19 @@ claude mcp add --transport http kanso http://127.0.0.1:7654/mcp
 - `kanso_add_checklist_item` — add a checklist item to a card
 - `kanso_toggle_checklist_item` — mark an item done / not done
 
+**Recurrence (repeating cards)**
+
+Recurrence is board automation, not a card field: a rule is anchored on a
+*template* card and spawns into a target stack on an RFC 5545 `RRULE`. To make a
+card repeat, create the card first, then create a rule with its id as the
+template. Mutations need MANAGE on the board.
+
+- `kanso_list_recur_rules` — a board's repeat schedules (+ next occurrence)
+- `kanso_create_recur_rule` — repeat a template card (rrule, CLONE/RESET mode, due-date policy, timezone)
+- `kanso_update_recur_rule` — edit a rule; `enabled=false` pauses it
+- `kanso_delete_recur_rule` — drop the schedule (template + spawned cards stay)
+- `kanso_recur_rule_create_now` — fire once now without touching the schedule
+
 **My work**
 
 - `kanso_list_my_cards` — open cards assigned to you across all boards (never

--- a/mcp/kanso_mcp/client.py
+++ b/mcp/kanso_mcp/client.py
@@ -25,6 +25,7 @@ from kanso_mcp.models import (
     ChecklistItem,
     Comment,
     Label,
+    RecurRule,
     Stack,
 )
 
@@ -364,6 +365,88 @@ class KansoClient:
                 response.status_code, "PUT", f"/cards/{card_id}/parent", response.text
             )
         return Card.model_validate(response.json())
+
+    # ------------------------------------------------------------- recurrence
+    async def list_recur_rules(self, board_id: int) -> List[RecurRule]:
+        data = await self._request("GET", f"/boards/{board_id}/recur-rules")
+        return [RecurRule.model_validate(r) for r in (data or [])]
+
+    async def create_recur_rule(
+        self,
+        board_id: int,
+        template_card_id: int,
+        target_stack_id: int,
+        rrule: str,
+        *,
+        mode: int = 0,
+        duedate_policy: int = 0,
+        duedate_offset_seconds: int = 0,
+        skip_while_open: bool = False,
+        timezone: Optional[str] = None,
+    ) -> RecurRule:
+        # The board id rides in the PATH; the rest is the body. mode/policy/
+        # offset/skip are sent explicitly (not dropped when 0/False) so the rule
+        # is created with exactly what the caller asked for rather than with
+        # whatever the controller defaults happen to be.
+        data = await self._request(
+            "POST",
+            f"/boards/{board_id}/recur-rules",
+            json={
+                "templateCardId": template_card_id,
+                "targetStackId": target_stack_id,
+                "mode": mode,
+                "rrule": rrule,
+                "duedatePolicy": duedate_policy,
+                "duedateOffsetSeconds": duedate_offset_seconds,
+                "skipWhileOpen": skip_while_open,
+                "timezone": timezone,
+            },
+        )
+        return RecurRule.model_validate(data)
+
+    async def update_recur_rule(
+        self,
+        rule_id: int,
+        *,
+        template_card_id: Optional[int] = None,
+        target_stack_id: Optional[int] = None,
+        mode: Optional[int] = None,
+        rrule: Optional[str] = None,
+        duedate_policy: Optional[int] = None,
+        duedate_offset_seconds: Optional[int] = None,
+        skip_while_open: Optional[bool] = None,
+        enabled: Optional[bool] = None,
+        timezone: Optional[str] = None,
+    ) -> RecurRule:
+        # PATCH targets the rule id directly (/recur-rules/{id}), NOT nested
+        # under the board. None fields are dropped => left unchanged.
+        data = await self._request(
+            "PATCH",
+            f"/recur-rules/{rule_id}",
+            json={
+                "templateCardId": template_card_id,
+                "targetStackId": target_stack_id,
+                "mode": mode,
+                "rrule": rrule,
+                "duedatePolicy": duedate_policy,
+                "duedateOffsetSeconds": duedate_offset_seconds,
+                "skipWhileOpen": skip_while_open,
+                "enabled": enabled,
+                "timezone": timezone,
+            },
+        )
+        return RecurRule.model_validate(data)
+
+    async def delete_recur_rule(self, rule_id: int) -> Any:
+        return await self._request("DELETE", f"/recur-rules/{rule_id}")
+
+    async def recur_rule_create_now(self, rule_id: int) -> Optional[Card]:
+        # Returns {"card": {...}}: an explicit create-now always spawns (it
+        # ignores skipWhileOpen), but the payload is typed nullable server-side,
+        # so tolerate a null card rather than blowing up on validation.
+        data = await self._request("POST", f"/recur-rules/{rule_id}/create-now")
+        card = (data or {}).get("card")
+        return Card.model_validate(card) if card else None
 
     # ----------------------------------------------------------------- my work
     async def list_my_cards(self) -> List[CardSummary]:

--- a/mcp/kanso_mcp/models.py
+++ b/mcp/kanso_mcp/models.py
@@ -169,6 +169,37 @@ class Card(CardSummary):
     relations: Optional[Any] = None
 
 
+class RecurRule(_Base):
+    """A recurring-card rule from ``/api/boards/{id}/recur-rules``.
+
+    Board automation, NOT a card field: the rule is anchored on a *template*
+    card (``templateCardId``) and spawns into ``targetStackId`` on an RFC 5545
+    ``rrule`` schedule, expanded as floating wall-clock time in ``timezone``.
+    ``mode`` is 0 (CLONE — a fresh card per occurrence) or 1 (RESET — move the
+    template back and clear its done state). ``duedatePolicy`` is 0 (due at the
+    occurrence), 1 (occurrence + ``duedateOffsetSeconds``) or 2 (no due date).
+    The bookkeeping fields (``lastSpawnedAt``, ``nextOccurrenceAt``,
+    ``occurrencesSpawned``) are server-maintained unix timestamps/counters.
+    """
+
+    id: int
+    boardId: Optional[int] = None
+    templateCardId: Optional[int] = None
+    targetStackId: Optional[int] = None
+    mode: int = 0
+    rrule: Optional[str] = None
+    duedatePolicy: int = 0
+    duedateOffsetSeconds: int = 0
+    skipWhileOpen: bool = False
+    enabled: bool = False
+    owner: Optional[str] = None
+    lastSpawnedAt: int = 0
+    nextOccurrenceAt: int = 0
+    occurrencesSpawned: int = 0
+    createdAt: int = 0
+    timezone: Optional[str] = None
+
+
 class BoardDetail(_Base):
     """The full ``GET /boards/{id}`` payload: board + stacks + card summaries + labels."""
 

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -539,6 +539,170 @@ def register_tools(mcp: FastMCP, client: KansoClient) -> None:
         """
         return (await client.create_label(board_id, title, color)).model_dump()
 
+    # ------------------------------------------------------------- recurrence
+    @mcp.tool(
+        title="List a Kanso board's recurring-card rules",
+        annotations={"readOnlyHint": True},
+    )
+    async def kanso_list_recur_rules(board_id: int) -> List[dict]:
+        """List a board's recurring-card rules (its repeat schedules).
+
+        Recurrence in Kanso is BOARD AUTOMATION, not a card field: a rule is
+        anchored on a *template* card and spawns work into a target stack on a
+        schedule. Rules whose template card is in the trash are hidden.
+
+        Each rule carries `templateCardId`, `targetStackId`, `rrule`, `mode`,
+        `duedatePolicy`, `timezone`, `enabled` and the server-maintained
+        `nextOccurrenceAt` / `lastSpawnedAt` / `occurrencesSpawned` counters
+        (unix timestamps).
+
+        Args:
+            board_id: The numeric board id.
+        """
+        rules = await client.list_recur_rules(board_id)
+        return [r.model_dump() for r in rules]
+
+    @mcp.tool(title="Create a Kanso recurring-card rule")
+    async def kanso_create_recur_rule(
+        board_id: int,
+        template_card_id: int,
+        target_stack_id: int,
+        rrule: str,
+        mode: int = 0,
+        duedate_policy: int = 0,
+        duedate_offset_seconds: int = 0,
+        skip_while_open: bool = False,
+        timezone: Optional[str] = None,
+    ) -> dict:
+        """Make a card recur on a schedule. Requires MANAGE on the board.
+
+        There is no "recurrence" field on a card — to make a card repeat, create
+        it first (`kanso_create_card`) and then pass its id here as the
+        `template_card_id`. The template card and the target stack must both
+        belong to `board_id`.
+
+        `rrule` is an RFC 5545 recurrence rule WITHOUT the "RRULE:" prefix, e.g.
+        "FREQ=DAILY", "FREQ=WEEKLY;BYDAY=MO,WE,FR", "FREQ=MONTHLY;BYMONTHDAY=1",
+        "FREQ=DAILY;COUNT=10", "FREQ=WEEKLY;UNTIL=20261231T000000Z". It is
+        anchored at the rule's creation time, so a daily rule created at 09:00
+        fires at 09:00. Unparseable rules are rejected with an API error.
+
+        Args:
+            board_id: The board the rule lives on.
+            template_card_id: The card to repeat (the template).
+            target_stack_id: The stack each occurrence lands in.
+            rrule: The RFC 5545 schedule, e.g. "FREQ=WEEKLY;BYDAY=MO".
+            mode: 0 = CLONE (default) — each occurrence creates a FRESH card in
+                the target stack, copying the template's title, description,
+                labels and assignees. 1 = RESET — move the template card ITSELF
+                back to the target stack and clear its done state (chore style;
+                there is only ever one card).
+            duedate_policy: 0 = due at the occurrence time (default),
+                1 = due at the occurrence + `duedate_offset_seconds`,
+                2 = spawned cards get no due date.
+            duedate_offset_seconds: Offset for policy 1, in seconds (0 to ten
+                years); ignored by the other policies.
+            skip_while_open: CLONE mode only — skip a scheduled spawn while the
+                previously spawned card is still open (no pile-up of undone
+                copies). Manual `kanso_recur_rule_create_now` ignores this.
+            timezone: IANA timezone id the schedule is expanded in, e.g.
+                "Europe/Istanbul". Occurrences are floating wall-clock times, so
+                "daily at 09:00" stays 09:00 local across DST. Omit to use the
+                calling user's personal Nextcloud timezone.
+        """
+        return (
+            await client.create_recur_rule(
+                board_id,
+                template_card_id,
+                target_stack_id,
+                rrule,
+                mode=mode,
+                duedate_policy=duedate_policy,
+                duedate_offset_seconds=duedate_offset_seconds,
+                skip_while_open=skip_while_open,
+                timezone=timezone,
+            )
+        ).model_dump()
+
+    @mcp.tool(title="Update a Kanso recurring-card rule")
+    async def kanso_update_recur_rule(
+        rule_id: int,
+        template_card_id: Optional[int] = None,
+        target_stack_id: Optional[int] = None,
+        mode: Optional[int] = None,
+        rrule: Optional[str] = None,
+        duedate_policy: Optional[int] = None,
+        duedate_offset_seconds: Optional[int] = None,
+        skip_while_open: Optional[bool] = None,
+        enabled: Optional[bool] = None,
+        timezone: Optional[str] = None,
+    ) -> dict:
+        """Change a recurring-card rule. Only the fields you pass are changed.
+        Requires MANAGE on the rule's board.
+
+        Note `rule_id` is the RULE's own id (from `kanso_list_recur_rules`), NOT
+        a card id. Pause a schedule with `enabled=false` and resume it with
+        `enabled=true` (resuming re-arms it to the next future occurrence).
+
+        Args:
+            rule_id: The numeric rule id.
+            template_card_id: Re-anchor the rule on a different template card
+                (same board).
+            target_stack_id: Spawn into a different stack (same board).
+            mode: 0 = CLONE, 1 = RESET (see `kanso_create_recur_rule`).
+            rrule: A new RFC 5545 schedule, e.g. "FREQ=WEEKLY;BYDAY=MO".
+            duedate_policy: 0 = at occurrence, 1 = occurrence + offset, 2 = none.
+            duedate_offset_seconds: Offset in seconds for policy 1.
+            skip_while_open: Skip a spawn while the last card is still open.
+            enabled: false pauses the rule, true resumes it.
+            timezone: New IANA timezone id for the schedule; omit to leave the
+                rule's zone unchanged (it cannot be cleared).
+        """
+        return (
+            await client.update_recur_rule(
+                rule_id,
+                template_card_id=template_card_id,
+                target_stack_id=target_stack_id,
+                mode=mode,
+                rrule=rrule,
+                duedate_policy=duedate_policy,
+                duedate_offset_seconds=duedate_offset_seconds,
+                skip_while_open=skip_while_open,
+                enabled=enabled,
+                timezone=timezone,
+            )
+        ).model_dump()
+
+    @mcp.tool(
+        title="Delete a Kanso recurring-card rule",
+        annotations={"destructiveHint": True},
+    )
+    async def kanso_delete_recur_rule(rule_id: int) -> dict:
+        """Delete a recurring-card rule. The template card and any cards it
+        already spawned are left alone — only the schedule goes away. To stop a
+        schedule reversibly, use `kanso_update_recur_rule(enabled=false)`.
+
+        Args:
+            rule_id: The numeric rule id (NOT a card id).
+        """
+        result = await client.delete_recur_rule(rule_id)
+        return {"deleted": True, "result": result}
+
+    @mcp.tool(title="Spawn a Kanso recurring-card rule now")
+    async def kanso_recur_rule_create_now(rule_id: int) -> dict:
+        """Fire a recurring-card rule once immediately, ignoring its schedule
+        (and ignoring `skipWhileOpen` — an explicit run always spawns).
+
+        This does NOT bring the schedule forward: the next scheduled occurrence
+        still fires as planned, so this just stamps one extra card now. Returns
+        the spawned card (CLONE mode) or the reset template card (RESET mode).
+
+        Args:
+            rule_id: The numeric rule id (NOT a card id).
+        """
+        card = await client.recur_rule_create_now(rule_id)
+        return {"spawned": card is not None, "card": card.model_dump() if card else None}
+
     # ----------------------------------------------------------------- my work
     @mcp.tool(
         title="List my Kanso cards",

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -565,6 +565,185 @@ async def test_list_board_members_forwards_q():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_recur_rules_parses():
+    route = respx.get(f"{BASE}/boards/7/recur-rules").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 3,
+                    "boardId": 7,
+                    "templateCardId": 100,
+                    "targetStackId": 11,
+                    "mode": 0,
+                    "rrule": "FREQ=WEEKLY;BYDAY=MO",
+                    "duedatePolicy": 1,
+                    "duedateOffsetSeconds": 86400,
+                    "skipWhileOpen": True,
+                    "enabled": True,
+                    "owner": "alice",
+                    "lastSpawnedAt": 0,
+                    "nextOccurrenceAt": 1800000000,
+                    "occurrencesSpawned": 0,
+                    "createdAt": 1799000000,
+                    "timezone": "Europe/Istanbul",
+                }
+            ],
+        )
+    )
+    async with _client() as c:
+        rules = await c.list_recur_rules(7)
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/boards/7/recur-rules"
+    assert rules[0].id == 3
+    assert rules[0].templateCardId == 100
+    assert rules[0].rrule == "FREQ=WEEKLY;BYDAY=MO"
+    assert rules[0].duedatePolicy == 1
+    assert rules[0].skipWhileOpen is True
+    assert rules[0].timezone == "Europe/Istanbul"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_create_recur_rule_body():
+    route = respx.post(f"{BASE}/boards/7/recur-rules").mock(
+        return_value=httpx.Response(200, json={"id": 3, "boardId": 7, "rrule": "FREQ=DAILY"})
+    )
+    async with _client() as c:
+        rule = await c.create_recur_rule(
+            7,
+            100,
+            11,
+            "FREQ=DAILY",
+            mode=1,
+            duedate_policy=1,
+            duedate_offset_seconds=3600,
+            skip_while_open=True,
+            timezone="Europe/Istanbul",
+        )
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    # boardId rides in the PATH, everything else is camelCase in the body.
+    assert _json.loads(req.content) == {
+        "templateCardId": 100,
+        "targetStackId": 11,
+        "mode": 1,
+        "rrule": "FREQ=DAILY",
+        "duedatePolicy": 1,
+        "duedateOffsetSeconds": 3600,
+        "skipWhileOpen": True,
+        "timezone": "Europe/Istanbul",
+    }
+    assert rule.id == 3
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_create_recur_rule_sends_zero_and_false_defaults():
+    route = respx.post(f"{BASE}/boards/7/recur-rules").mock(
+        return_value=httpx.Response(200, json={"id": 4, "boardId": 7})
+    )
+    async with _client() as c:
+        await c.create_recur_rule(7, 100, 11, "FREQ=DAILY")
+    import json as _json
+
+    # 0 / False are meaningful values and must survive the None-filter; only the
+    # unset timezone is dropped (=> the owner's personal timezone server-side).
+    assert _json.loads(route.calls.last.request.content) == {
+        "templateCardId": 100,
+        "targetStackId": 11,
+        "mode": 0,
+        "rrule": "FREQ=DAILY",
+        "duedatePolicy": 0,
+        "duedateOffsetSeconds": 0,
+        "skipWhileOpen": False,
+    }
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_update_recur_rule_drops_none():
+    route = respx.patch(f"{BASE}/recur-rules/3").mock(
+        return_value=httpx.Response(200, json={"id": 3, "boardId": 7, "enabled": False})
+    )
+    async with _client() as c:
+        rule = await c.update_recur_rule(3, enabled=False)
+    import json as _json
+
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    # PATCH targets the rule id directly, NOT nested under the board.
+    assert req.url.path == "/index.php/apps/kanso/api/recur-rules/3"
+    # enabled=False must survive; every unset field is dropped.
+    assert _json.loads(req.content) == {"enabled": False}
+    assert rule.enabled is False
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_update_recur_rule_forwards_timezone_and_rrule():
+    route = respx.patch(f"{BASE}/recur-rules/3").mock(
+        return_value=httpx.Response(200, json={"id": 3, "timezone": "Asia/Tokyo"})
+    )
+    async with _client() as c:
+        await c.update_recur_rule(3, rrule="FREQ=MONTHLY", timezone="Asia/Tokyo")
+    import json as _json
+
+    assert _json.loads(route.calls.last.request.content) == {
+        "rrule": "FREQ=MONTHLY",
+        "timezone": "Asia/Tokyo",
+    }
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_delete_recur_rule_path():
+    route = respx.delete(f"{BASE}/recur-rules/3").mock(
+        return_value=httpx.Response(200, json={"id": 3})
+    )
+    async with _client() as c:
+        await c.delete_recur_rule(3)
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.method == "DELETE"
+    assert req.url.path == "/index.php/apps/kanso/api/recur-rules/3"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_recur_rule_create_now_unwraps_card():
+    route = respx.post(f"{BASE}/recur-rules/3/create-now").mock(
+        return_value=httpx.Response(
+            200, json={"card": {"id": 500, "title": "Water the plants", "stackId": 11}}
+        )
+    )
+    async with _client() as c:
+        card = await c.recur_rule_create_now(3)
+    req = route.calls.last.request
+    _assert_api_headers(req)
+    assert req.url.path == "/index.php/apps/kanso/api/recur-rules/3/create-now"
+    assert card is not None
+    assert card.id == 500
+    assert card.title == "Water the plants"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_recur_rule_create_now_null_card_is_none():
+    respx.post(f"{BASE}/recur-rules/3/create-now").mock(
+        return_value=httpx.Response(200, json={"card": None})
+    )
+    async with _client() as c:
+        card = await c.recur_rule_create_now(3)
+    # A null card must come back as None, not blow up model validation.
+    assert card is None
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_error_raises_kanso_api_error():
     respx.post(f"{BASE}/boards").mock(
         return_value=httpx.Response(412, text="CSRF check failed")

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -145,6 +145,97 @@ async def test_get_board_schema_exposes_optional_include_archived():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_create_recur_rule_tool_sends_its_defaults():
+    route = respx.post(f"{BASE}/boards/7/recur-rules").mock(
+        return_value=httpx.Response(200, json={"id": 3, "boardId": 7, "rrule": "FREQ=DAILY"})
+    )
+    tools, client = _tools()
+    async with client:
+        rule = await tools["kanso_create_recur_rule"](7, 100, 10, "FREQ=DAILY")
+    import json as _json
+
+    # The tool's own defaults (CLONE, due-at-occurrence, no offset, no skip) must
+    # reach the API rather than being dropped as "unset".
+    assert _json.loads(route.calls.last.request.content) == {
+        "templateCardId": 100,
+        "targetStackId": 10,
+        "mode": 0,
+        "rrule": "FREQ=DAILY",
+        "duedatePolicy": 0,
+        "duedateOffsetSeconds": 0,
+        "skipWhileOpen": False,
+    }
+    assert rule["id"] == 3
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_update_recur_rule_tool_sends_only_what_changed():
+    route = respx.patch(f"{BASE}/recur-rules/3").mock(
+        return_value=httpx.Response(200, json={"id": 3, "enabled": False})
+    )
+    tools, client = _tools()
+    async with client:
+        rule = await tools["kanso_update_recur_rule"](3, enabled=False)
+    import json as _json
+
+    assert _json.loads(route.calls.last.request.content) == {"enabled": False}
+    assert rule["enabled"] is False
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_recur_rule_create_now_tool_unwraps_the_card():
+    respx.post(f"{BASE}/recur-rules/3/create-now").mock(
+        return_value=httpx.Response(
+            200, json={"card": {"id": 500, "title": "Water the plants", "stackId": 10}}
+        )
+    )
+    tools, client = _tools()
+    async with client:
+        result = await tools["kanso_recur_rule_create_now"](3)
+
+    # The tool flattens the {"card": ...} envelope into a spawned flag + card.
+    assert result["spawned"] is True
+    assert result["card"]["id"] == 500
+
+
+@pytest.mark.asyncio
+async def test_create_recur_rule_schema_only_requires_the_essentials():
+    # An agent must be able to set up a repeat with just the anchor + schedule;
+    # mode / policy / offset / skip / timezone all have to stay optional or the
+    # simple call becomes an argument error.
+    from mcp.server.fastmcp import FastMCP
+
+    client = KansoClient(
+        KansoConfig(host="http://nc.test", username="admin", password="pw")
+    )
+    server = FastMCP("kanso-test")
+    register_tools(server, client)
+    async with client:
+        tools = {t.name: t for t in await server.list_tools()}
+
+    schema = tools["kanso_create_recur_rule"].inputSchema
+    assert set(schema["required"]) == {
+        "board_id",
+        "template_card_id",
+        "target_stack_id",
+        "rrule",
+    }
+    assert schema["properties"]["mode"]["default"] == 0
+    assert schema["properties"]["duedate_policy"]["default"] == 0
+    assert schema["properties"]["skip_while_open"]["default"] is False
+    # The whole recurrence surface must be registered, not just create.
+    assert {
+        "kanso_list_recur_rules",
+        "kanso_update_recur_rule",
+        "kanso_delete_recur_rule",
+        "kanso_recur_rule_create_now",
+    } <= set(tools)
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_get_board_with_no_archived_cards_is_unchanged():
     respx.get(f"{BASE}/boards/8").mock(
         return_value=httpx.Response(

--- a/tests/unit/Controller/RecurRuleControllerTest.php
+++ b/tests/unit/Controller/RecurRuleControllerTest.php
@@ -91,6 +91,16 @@ class RecurRuleControllerTest extends TestCase {
 		self::assertSame($rule, $response->getData());
 	}
 
+	public function testCreateForwardsTimezone(): void {
+		$this->recurrenceService->expects(self::once())
+			->method('create')
+			->with(1, 10, 5, RecurRule::MODE_CLONE, 'FREQ=DAILY', 0, 0, false, 'alice', 'Europe/Istanbul')
+			->willReturn($this->rule());
+
+		$response = $this->controller->create(1, 10, 5, RecurRule::MODE_CLONE, 'FREQ=DAILY', 0, 0, false, 'Europe/Istanbul');
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
 	public function testCreateMapsInvalidRruleTo400(): void {
 		$this->recurrenceService->method('create')->willThrowException(new InvalidInputException('Invalid recurrence rule'));
 
@@ -113,6 +123,16 @@ class RecurRuleControllerTest extends TestCase {
 			->willReturn($this->rule());
 
 		$response = $this->controller->update(3, null, null, null, 'FREQ=WEEKLY', null, null, null, false);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testUpdateForwardsTimezone(): void {
+		$this->recurrenceService->expects(self::once())
+			->method('update')
+			->with(3, null, null, null, null, null, null, null, null, 'alice', 'Europe/Istanbul')
+			->willReturn($this->rule());
+
+		$response = $this->controller->update(3, null, null, null, null, null, null, null, null, 'Europe/Istanbul');
 		self::assertSame(Http::STATUS_OK, $response->getStatus());
 	}
 

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -1480,4 +1480,130 @@ class RecurrenceServiceTest extends TestCase {
 		// Must not throw despite the rule write failing.
 		$this->service->rearmForTemplateCard($card);
 	}
+
+	// ---- explicit timezone -------------------------------------------------
+
+	/**
+	 * An explicit IANA timezone from the caller (API/MCP clients scheduling for a
+	 * zone that is not the creator's own) wins over the owner's personal timezone.
+	 */
+	public function testCreateHonoursAnExplicitTimezoneOverTheOwnerDefault(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')->willReturn('America/New_York');
+		$service = new RecurrenceService(
+			$this->ruleMapper, $this->cardMapper, $this->stackMapper, $this->boardMapper,
+			$this->cardLabelMapper, $this->cardAssigneeMapper, $this->cardService,
+			$this->changeNotifier, $this->permissionService, $this->visibilityGuard,
+			$this->time, $this->db, $config, $this->logger,
+		);
+
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->method('insert')->willReturnCallback(static function (RecurRule $r): RecurRule {
+			self::assertSame('Europe/Istanbul', $r->getTimezone());
+			$r->setId(9);
+			return $r;
+		});
+
+		$service->create(1, 10, 5, RecurRule::MODE_CLONE, 'FREQ=DAILY', RecurRule::POLICY_AT_OCCURRENCE, 0, false, 'alice', 'Europe/Istanbul');
+	}
+
+	/**
+	 * An empty timezone means "not supplied" - it falls back to the owner default
+	 * rather than storing a blank zone.
+	 */
+	public function testCreateWithEmptyTimezoneFallsBackToTheOwnerDefault(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')->willReturn('America/New_York');
+		$service = new RecurrenceService(
+			$this->ruleMapper, $this->cardMapper, $this->stackMapper, $this->boardMapper,
+			$this->cardLabelMapper, $this->cardAssigneeMapper, $this->cardService,
+			$this->changeNotifier, $this->permissionService, $this->visibilityGuard,
+			$this->time, $this->db, $config, $this->logger,
+		);
+
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->method('insert')->willReturnCallback(static function (RecurRule $r): RecurRule {
+			self::assertSame('America/New_York', $r->getTimezone());
+			$r->setId(9);
+			return $r;
+		});
+
+		$service->create(1, 10, 5, RecurRule::MODE_CLONE, 'FREQ=DAILY', RecurRule::POLICY_AT_OCCURRENCE, 0, false, 'alice', '');
+	}
+
+	/**
+	 * A garbage zone id is a client error (400), NOT a silent fall-back to the
+	 * server default - a schedule quietly expanded in the wrong zone fires at the
+	 * wrong wall-clock hour forever.
+	 */
+	public function testCreateRejectsAnInvalidTimezone(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->create(1, 10, 5, RecurRule::MODE_CLONE, 'FREQ=DAILY', 0, 0, false, 'alice', 'Mars/Olympus_Mons');
+	}
+
+	/**
+	 * Re-anchoring the same RRULE in a DIFFERENT zone shifts every future
+	 * occurrence, so it counts as a schedule change and re-arms the cursor.
+	 */
+	public function testUpdateWithChangedTimezoneReArmsCursor(): void {
+		// Cursor parked on a stale value that is NOT a daily occurrence, so a
+		// re-arm is observable (a no-op edit would leave it exactly as-is).
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 50_000);
+		$this->wireUpdate($rule);
+
+		$this->service->update(3, null, null, null, null, null, null, null, null, 'alice', 'Europe/Istanbul');
+
+		self::assertSame('Europe/Istanbul', $rule->getTimezone());
+		self::assertSame(self::NOW + 86400, $rule->getNextOccurrenceAt());
+	}
+
+	/**
+	 * Re-sending the zone the rule already carries is a no-op edit: it must not
+	 * re-arm the cursor (same duplicate-clone risk as an unchanged RRULE, #65).
+	 */
+	public function testUpdateWithUnchangedTimezoneDoesNotReArmCursor(): void {
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 50_000);
+		$rule->setTimezone('Europe/Istanbul');
+		$this->wireUpdate($rule);
+
+		$this->service->update(3, null, null, null, null, null, null, null, null, 'alice', 'Europe/Istanbul');
+
+		self::assertSame(self::NOW + 50_000, $rule->getNextOccurrenceAt());
+	}
+
+	/**
+	 * A null timezone leaves the rule's zone alone (it is not clearable - a rule
+	 * always expands in some zone).
+	 */
+	public function testUpdateWithNullTimezoneLeavesTheZoneUntouched(): void {
+		$rule = $this->rule(rrule: 'FREQ=DAILY', nextOccurrenceAt: self::NOW + 50_000);
+		$rule->setTimezone('Europe/Istanbul');
+		$this->wireUpdate($rule);
+
+		$this->service->update(3, null, null, null, null, null, null, null, null, 'alice', null);
+
+		self::assertSame('Europe/Istanbul', $rule->getTimezone());
+		self::assertSame(self::NOW + 50_000, $rule->getNextOccurrenceAt());
+	}
+
+	public function testUpdateRejectsAnInvalidTimezone(): void {
+		$rule = $this->rule();
+		$this->ruleMapper->method('find')->with(3)->willReturn($rule);
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(3, null, null, null, null, null, null, null, null, 'alice', 'Mars/Olympus_Mons');
+	}
 }


### PR DESCRIPTION
## What

The MCP server could read and write nearly every card property but had **no access to recurrence at all**, so an assistant could not set a card up to repeat. This adds the full rule surface, plus the one API gap that blocked using it properly.

### MCP tools

| Tool | Endpoint |
| --- | --- |
| `kanso_list_recur_rules` | `GET /boards/{id}/recur-rules` |
| `kanso_create_recur_rule` | `POST /boards/{id}/recur-rules` |
| `kanso_update_recur_rule` | `PATCH /recur-rules/{id}` |
| `kanso_delete_recur_rule` | `DELETE /recur-rules/{id}` |
| `kanso_recur_rule_create_now` | `POST /recur-rules/{id}/create-now` |

Recurrence is board automation rather than a card field, so it can't ride along in `kanso_update_card`. The tool docs spell out the actual flow — create the card, then anchor a rule on it as the template — along with the RRULE examples, CLONE vs RESET mode, and the due-date policy values an assistant has to pick from.

### API: a settable schedule timezone

`RecurrenceService::create` hard-defaulted the rule's timezone to the personal timezone of whoever created it, with no override. A rule set up for a team in another zone therefore fired at the wrong local hour, and an MCP client had no way to correct it. `POST`/`PATCH` now accept an optional IANA `timezone`:

- an unparseable id is a **400**, not a silent fallback — a schedule quietly expanded in the wrong zone fires at the wrong wall-clock hour forever;
- null/empty means "leave it alone" (a rule always expands in *some* zone, so it isn't clearable);
- a zone change counts as a schedule change and re-arms the cursor, since re-anchoring the same RRULE elsewhere shifts every future occurrence. It goes through the existing `firstFireFor`/`anchorFor` path, so the #65 and #80 protections still hold.

## Testing

- `mcp`: **46 pytest tests pass** — client-level coverage for all five endpoints (body shape, `0`/`false` surviving the None-filter, the `{"card": ...}` unwrap) plus tool-level tests, including a schema check that only `board_id` / `template_card_id` / `target_stack_id` / `rrule` are required.
- PHP: **1497 PHPUnit tests pass**, 9 of them new (explicit zone wins over the owner default, empty falls back, garbage rejected on both create and update, changed zone re-arms, unchanged zone does not).
- `psalm` clean, `php-cs-fixer` clean, l10n extract/compile produces no drift.

Not verified: a live HTTP round-trip. The local dev stack is bind-mounted to a different worktree, so it can't serve this branch. The only seam that leaves untested is the app framework binding a `?string $timezone = null` body param — which the `?string $rrule = null` param on these same two endpoints already exercises.

## Note for reviewers

CI has **no Python job**, so `mcp/tests` never gates a PR. Happy to add one in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)