### PR TITLE
fix: read-only affordances, cross-board feed cadence, Views filter correctness + parity/wire guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,41 @@ jobs:
       - name: Run unit tests
         run: vendor/bin/phpunit -c phpunit.xml
 
+  # The in-repo Python MCP server (mcp/) ships its own pytest suite, and until
+  # now nothing in the repo ran it — mcp/Dockerfile only `pip install .`s the
+  # package, so every MCP change was verified purely by whoever happened to run
+  # pytest locally.
+  #
+  # Why its own job rather than a step bolted onto build-frontend (as the
+  # info.xml and l10n guards were): those are Node-toolchain checks with a
+  # natural host job. Python has no such host here, and wiring uv into the Node
+  # job purely to keep the job count at six is a contortion, not a saving.
+  # Likewise no `paths:` filter — paths-scoping a *required* check drags in
+  # required-check semantics (a skipped job never reports) for a job that costs
+  # seconds. The project's aversion was to CI cost and flakiness, not to a
+  # number.
+  #
+  # `--frozen` + the committed mcp/uv.lock make the run hermetic: pyproject
+  # pins only floors, so without the lock every run would resolve fresh from
+  # PyPI and an upstream release could redden an unrelated PHP-only PR.
+  unit-mcp:
+    runs-on: kanso-runners
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10
+        with:
+          # Don't depend on whatever Python the runner image happens to ship —
+          # uv fetches its own managed interpreter (pyproject needs >=3.11).
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: mcp/uv.lock
+      - name: Run MCP server unit tests
+        run: uv run --frozen --extra dev pytest
+
   build-frontend:
     runs-on: kanso-runners
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        # setup-uv stopped publishing floating major tags after v7, so this is
+        # pinned to an exact release deliberately and needs a manual bump.
+        # Do not "simplify" it to @v10 — that tag does not exist and the job
+        # then fails to start with "unable to find version".
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           # Don't depend on whatever Python the runner image happens to ship —
           # uv fetches its own managed interpreter (pyproject needs >=3.11).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,15 @@ jobs:
   # seconds. The project's aversion was to CI cost and flakiness, not to a
   # number.
   #
-  # `--frozen` + the committed mcp/uv.lock make the run hermetic: pyproject
+  # `--locked` + the committed mcp/uv.lock make the run hermetic: pyproject
   # pins only floors, so without the lock every run would resolve fresh from
   # PyPI and an upstream release could redden an unrelated PHP-only PR.
+  #
+  # `--locked`, NOT `--frozen`. Both install strictly from the lock, but only
+  # `--locked` first ASSERTS the lock is in sync with pyproject and fails if it
+  # is not. Under `--frozen` a contributor who bumps a dependency and forgets
+  # `uv lock` gets a green run that quietly tested the OLD resolution — which
+  # defeats the point of committing the lockfile at all.
   unit-mcp:
     runs-on: kanso-runners
     defaults:
@@ -106,7 +112,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: mcp/uv.lock
       - name: Run MCP server unit tests
-        run: uv run --frozen --extra dev pytest
+        run: uv run --locked --extra dev pytest
 
   build-frontend:
     runs-on: kanso-runners

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ php-cs-fixer). Before opening a PR:
 
 `main` is a protected branch: every change lands through a pull request and can
 only be merged once **all** CI checks pass — `cs-check`, `psalm`, `unit-php` (on
-PHP 8.2 and 8.3), `build-frontend`, and the full `e2e` suite. Open your PR
+PHP 8.2 and 8.3), `unit-mcp` (the `mcp/` Python server's pytest suite),
+`build-frontend`, and the full `e2e` suite. Open your PR
 against `main`; CI runs automatically on push.
 
 ## Translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,15 @@ php-cs-fixer). Before opening a PR:
   the `kanso_changes` delta log, ETags) — don't regress these.
 
 `main` is a protected branch: every change lands through a pull request and can
-only be merged once **all** CI checks pass — `cs-check`, `psalm`, `unit-php` (on
-PHP 8.2 and 8.3), `unit-mcp` (the `mcp/` Python server's pytest suite),
-`build-frontend`, and the full `e2e` suite. Open your PR
-against `main`; CI runs automatically on push.
+only be merged once **all** required CI checks pass — `cs-check`, `psalm`,
+`unit-php` (on PHP 8.2 and 8.3), `build-frontend`, and the full `e2e` suite.
+Open your PR against `main`; CI runs automatically on push.
+
+`unit-mcp` (the `mcp/` Python server's pytest suite) also runs on every PR, but
+it is **advisory for now** — it is not yet in the branch-protection required
+list, so a red `unit-mcp` will not block a merge. Adding it there is a
+maintainer action in the repository settings that has not happened yet. Please
+treat it as required anyway: don't merge on a red `unit-mcp`.
 
 ## Translations
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,6 +11,7 @@ path = [
     "package.json",
     "package-lock.json",
     "tests/psalm-baseline.xml",
+    "tests/fixtures/**",
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Fatih AKTAS <akfatih2@gmail.com>"

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -9,6 +9,7 @@ namespace OCA\Kanso\Controller;
 
 use OCA\Kanso\Service\InvalidInputException;
 use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\ViewFilter;
 use OCA\Kanso\Service\ViewService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -39,9 +40,11 @@ use OCP\IUserSession;
  * it is applied server-side before the feed's cap.
  *
  * The cross-board card feed itself is served by {@see self::cards()} via
- * {@see ViewService::findMine()} - the server stays filter-agnostic and returns
- * the whole readable-set summaries; the client applies the View's filter and
- * grouping. ACL lives entirely in ViewService (readable-set one-query).
+ * {@see ViewService::findMine()}. The stored `filter` blob stays opaque to the
+ * CRUD above, but the FEED does act on it (#9862): the client sends the active
+ * filter as flat query params and the server applies a mirrored predicate before
+ * the feed's cap, so the cap slices the matching set. Grouping stays entirely
+ * client-side. ACL lives entirely in ViewService (readable-set one-query).
  */
 class ViewController extends Controller {
 	use ApiErrorTrait;
@@ -217,28 +220,60 @@ class ViewController extends Controller {
 
 	/**
 	 * The cross-board card feed a View renders over: enriched card summaries from
-	 * every board the user can read (ACL enforced in {@see ViewService}). The
-	 * server stays filter-agnostic - the client applies the View's saved filter
-	 * and group-by client-side, reusing the board filter predicate.
+	 * every board the user can read (ACL enforced in {@see ViewService}).
 	 *
-	 * Returns an envelope `{cards, capped, total, limit}` (see
+	 * Returns an envelope `{cards, labels, participants, capped, total, limit}` (see
 	 * {@see ViewService::findMine()}): `cards` is hard-capped to keep this single
 	 * unbounded feed bounded, and `capped`/`total` let the client honestly report
-	 * when it is showing only the first N of M readable cards.
+	 * when it is showing only the first N of M MATCHING cards.
 	 *
 	 * The caller passes the View's saved sort, which is applied server-side BEFORE
-	 * that cap so a sorted View starts at the true first row. Unknown values are
-	 * ignored and defaulted here (never rejected) - this is a read path an older or
-	 * newer client must never be able to hard-fail. The params are typed `mixed`
-	 * for the same reason: a malformed query string (`?sortMode[]=due` hands the
-	 * dispatcher an array) would otherwise be a TypeError thrown before the error
-	 * wrapper can turn it into a response.
+	 * that cap so a sorted View starts at the true first row, and the View's active
+	 * filter in the SAME flat short-key form the board's shareable filter links
+	 * already use (`filterToQuery()`: fl/fa/fp/ft/fe/fo/fr/fd/fs/fw/fb/fk/fsd/fsc/fcm).
+	 * The filter runs before the cap too (#9862) - the client still re-filters the
+	 * rows it receives, so this is a superset guard whose job is to make the cap
+	 * slice the matching set.
+	 *
+	 * Unknown values are ignored and defaulted here (never rejected) - this is a
+	 * read path an older or newer client must never be able to hard-fail. Every
+	 * param is typed `mixed` for the same reason: a malformed query string
+	 * (`?sortMode[]=due` hands the dispatcher an array) would otherwise be a
+	 * TypeError thrown before the error wrapper can turn it into a response.
 	 */
 	#[NoAdminRequired]
-	public function cards(mixed $sortMode = 'default', mixed $sortDir = 'asc'): JSONResponse {
-		return $this->respond(function () use ($sortMode, $sortDir): JSONResponse {
+	public function cards(
+		mixed $sortMode = 'default',
+		mixed $sortDir = 'asc',
+		mixed $fl = null,
+		mixed $fa = null,
+		mixed $fp = null,
+		mixed $ft = null,
+		mixed $fe = null,
+		mixed $fo = null,
+		mixed $fr = null,
+		mixed $fd = null,
+		mixed $fs = null,
+		mixed $fw = null,
+		mixed $fb = null,
+		mixed $fk = null,
+		mixed $fsd = null,
+		mixed $fsc = null,
+		mixed $fcm = null,
+	): JSONResponse {
+		$query = [
+			'fl' => $fl, 'fa' => $fa, 'fp' => $fp, 'ft' => $ft, 'fe' => $fe,
+			'fo' => $fo, 'fr' => $fr, 'fd' => $fd, 'fs' => $fs, 'fw' => $fw,
+			'fb' => $fb, 'fk' => $fk, 'fsd' => $fsd, 'fsc' => $fsc, 'fcm' => $fcm,
+		];
+		return $this->respond(function () use ($sortMode, $sortDir, $query): JSONResponse {
 			$sort = $this->normalizeSort(['mode' => $sortMode, 'dir' => $sortDir]);
-			return new JSONResponse($this->viewService->findMine($this->currentUserId(), $sort['mode'], $sort['dir']));
+			return new JSONResponse($this->viewService->findMine(
+				$this->currentUserId(),
+				$sort['mode'],
+				$sort['dir'],
+				ViewFilter::fromQuery($query),
+			));
 		});
 	}
 

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -44,6 +44,13 @@ use OCP\IUserManager;
  * appended to the board's change log, and a single realtime push fires after the
  * commit so the board updates live.
  *
+ * Because the block is anchored past the stack's CURRENT tail key, a long-lived
+ * stack whose keys have already grown to the varchar(64) wall would otherwise
+ * fail the whole import with a 409 `rebalance_required` that only an `occ`
+ * command could clear. Instead the import self-heals: the overflow is caught,
+ * the target stack is rebalanced to short keys ({@see CardService::rebalanceStack})
+ * and the import is replayed ONCE - see {@see self::import}.
+ *
  * Column mapping (0-based source column indexes chosen by the caller):
  *   - title       REQUIRED. A row with a blank title is skipped, not fatal.
  *   - description optional.
@@ -88,6 +95,9 @@ class CsvImportService {
 		private SortKeyService $sortKeyService,
 		private ChangeNotifier $changeNotifier,
 		private PermissionService $permissionService,
+		// Only for rebalanceStack(): the recovery when the target stack's tail
+		// sort key is already at the varchar(64) wall (see import()).
+		private CardService $cardService,
 		private IUserManager $userManager,
 		private IDBConnection $db,
 	) {
@@ -101,10 +111,15 @@ class CsvImportService {
 	 * that field is not mapped); `title` MUST be mapped. When $hasHeader is true
 	 * the first parsed row is treated as headers and skipped.
 	 *
+	 * If the target stack's existing keys are already at the sort-key wall the
+	 * first attempt overflows before writing anything; the stack is then
+	 * rebalanced and the import replayed once (see below).
+	 *
 	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
 	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
 	 * @throws InvalidInputException on an oversized/malformed CSV, a missing title mapping, or too many rows
 	 * @throws NotPermittedException if the actor lacks EDIT on the board
+	 * @throws \OverflowException if the sort keys still overflow after the rebalance
 	 */
 	public function import(
 		string $rawDocument,
@@ -141,13 +156,22 @@ class CsvImportService {
 			}
 
 			rewind($handle);
-			$this->db->beginTransaction();
 			try {
-				$result = $this->rebuild($handle, $hasHeader, $board, $stack, $mapping, $actorUid, $dataRows);
-				$this->db->commit();
-			} catch (\Throwable $e) {
-				$this->db->rollBack();
-				throw $e;
+				$result = $this->attempt($handle, $hasHeader, $board, $stack, $mapping, $actorUid, $dataRows);
+			} catch (\OverflowException) {
+				// The stack's tail key is already at MAX_KEY_LENGTH, so no block of
+				// keys fits past it: appendSequence() threw BEFORE the first insert
+				// and attempt() has already rolled its transaction back - nothing was
+				// written and, critically, NO transaction is open at this point.
+				// That is what makes the recovery safe: rebalanceStack() opens its
+				// OWN transaction and takes SELECT ... FOR UPDATE locks on the
+				// stack's rows, so it must never be called from inside the import's
+				// transaction. Reset the stack to short keys here, between attempts,
+				// then replay the import ONCE (still all-or-nothing). A second
+				// overflow is genuine and propagates as the 409 it always was.
+				$this->cardService->rebalanceStack($stackId);
+				rewind($handle);
+				$result = $this->attempt($handle, $hasHeader, $board, $stack, $mapping, $actorUid, $dataRows);
 			}
 		} finally {
 			fclose($handle);
@@ -159,6 +183,30 @@ class CsvImportService {
 			$this->changeNotifier->pushBoardChanged($boardId);
 		}
 		return $result;
+	}
+
+	/**
+	 * ONE all-or-nothing import attempt: {@see rebuild} wrapped in a single
+	 * transaction that is rolled back completely on any failure.
+	 *
+	 * It always returns with NO transaction open - committed on success, rolled
+	 * back on failure - which is precisely what lets {@see import} rebalance the
+	 * target stack between attempts without nesting inside this transaction.
+	 *
+	 * @param resource $handle a rewound CSV stream positioned at the first record
+	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
+	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
+	 */
+	private function attempt($handle, bool $hasHeader, Board $board, Stack $stack, array $mapping, string $actorUid, int $dataRows): array {
+		$this->db->beginTransaction();
+		try {
+			$result = $this->rebuild($handle, $hasHeader, $board, $stack, $mapping, $actorUid, $dataRows);
+			$this->db->commit();
+			return $result;
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
 	}
 
 	/**

--- a/lib/Service/ViewFilter.php
+++ b/lib/Service/ViewFilter.php
@@ -78,6 +78,14 @@ final class ViewFilter {
 	 * match is an O(1) isset() rather than an in_array() scan per row - the
 	 * predicate runs once per card over a set that can reach the cap.
 	 *
+	 * THIS SIGNATURE IS A WIRE CONTRACT, not just an argument list. ViewFilterTest
+	 * derives the filter's dimension list from these parameter NAMES and asserts it
+	 * against the emit ORDER of the client's `filterToQuery()`, which is what pins
+	 * the two predicates to the same set of dimensions. So renaming a param, or
+	 * swapping two of them here and in fromQuery() below - behaviour-preserving as
+	 * that is - turns the PHP runner red until the client's emit order matches
+	 * again. Add a dimension in both places, in the same position, or not at all.
+	 *
 	 * @param array<int, true> $labels
 	 * @param array<string, true> $assignees
 	 * @param array<int, true> $priorities

--- a/lib/Service/ViewFilter.php
+++ b/lib/Service/ViewFilter.php
@@ -1,0 +1,504 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+/**
+ * The server-side half of the View filter (#9862) - a PHP mirror of the client's
+ * `makePredicate` (src/composables/useBoardFilters.js).
+ *
+ * WHY it exists. The cross-board feed ({@see ViewService::findMine()}) is hard-
+ * capped at {@see ViewService::MAX_CARDS}. While the filter ran only in the
+ * browser, that cap sliced the whole READABLE set before the filter ever saw it,
+ * so on an account with more readable cards than the cap a narrow filter searched
+ * only the first N rows of the sorted order and silently missed every match past
+ * them. Applying the same predicate server-side, BEFORE the cap, makes the cap
+ * slice the MATCHING set instead. This is a correctness fix, not a speedup: the
+ * per-board enrichment queries are unchanged, only the payload shrinks.
+ *
+ * HYBRID, not a replacement. The client keeps applying `makePredicate` over
+ * whatever rows arrive, so this predicate is a SUPERSET GUARD: its only job is to
+ * make the cap slice the right pool. Chip editing therefore stays instant (the
+ * cached rows re-filter locally on the same tick; the refetch only widens the
+ * pool), and a PHP/JS drift can never be a silent correctness bug - a PHP
+ * predicate that is LOOSER than the JS one merely ships harmless extra rows the
+ * client drops. So the rule throughout this class is: **when in doubt, pass the
+ * row through, never drop it.** An unrecognised dimension key, or an
+ * unrecognised value inside a known dimension, is IGNORED - never a rejection,
+ * never a drop. That is the same tolerance {@see \OCA\Kanso\Controller\ViewController::normalizeSort()}
+ * already gives the sort: a read path an older or newer client must not be able
+ * to hard-fail.
+ *
+ * WIRE FORMAT. Exactly the short keys `filterToQuery()` already emits for the
+ * board's shareable filter links - `fl/fa/fp/ft/fe/fo/fr/fd/fs/fw/fb/fk/fsd/fsc/fcm`,
+ * multi-value dimensions comma-joined. No new encoding, no query language.
+ *
+ * The predicate reads ONLY fields already present on a serialized card summary
+ * ({@see CardSummaryService::serialize()} + {@see \OCA\Kanso\Db\Card::jsonSerializeSummary()}),
+ * so it costs no extra query. Parity with the JS predicate is pinned by a golden
+ * fixture asserted from BOTH runners (tests/fixtures/board-filter-parity.json,
+ * read by ViewFilterTest.php and tests/unit/boardFilters.test.mjs).
+ */
+final class ViewFilter {
+	/** Sentinel assignee uid meaning "no assignee" (JS: UNASSIGNED). */
+	public const UNASSIGNED = '__none__';
+
+	/** Sentinel estimate token meaning "no estimate" (JS: UNESTIMATED). */
+	public const UNESTIMATED = '__none__';
+
+	/** Sentinel review value meaning "no review requested" (JS: REVIEW_NONE). */
+	public const REVIEW_NONE = 'none';
+
+	/**
+	 * The accepted values per single-select / whitelisted dimension, mirroring the
+	 * JS option constants. A value outside its list is dropped on decode, which
+	 * leaves that dimension unconstrained - exactly what `applyFilter()` does with
+	 * a hand-edited URL on the client.
+	 */
+	private const TYPES = ['bug', 'feature', 'task', 'chore'];
+	private const REVIEWS = ['pending', 'approved', 'changes_requested', self::REVIEW_NONE];
+	private const DUE = ['overdue', 'week', 'none'];
+	private const DONE = ['open', 'done'];
+	private const WAITING = ['waiting', 'not_waiting'];
+	private const BLOCKED = ['blocked', 'not_blocked'];
+	private const CHECKLIST = ['has', 'incomplete', 'complete', 'none'];
+	private const START = ['started', 'upcoming', 'none'];
+	private const SUBCARD = ['top_level', 'parent', 'child'];
+	private const COMMENTS = ['has', 'none'];
+
+	/** "This week" = now .. end of the 7th day ahead, in milliseconds (JS parity). */
+	private const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+	/**
+	 * Multi-select dimensions are kept as membership MAPS (value => true) so a
+	 * match is an O(1) isset() rather than an in_array() scan per row - the
+	 * predicate runs once per card over a set that can reach the cap.
+	 *
+	 * @param array<int, true> $labels
+	 * @param array<string, true> $assignees
+	 * @param array<int, true> $priorities
+	 * @param array<string, true> $types
+	 * @param array<string, true> $estimates
+	 * @param array<string, true> $owners
+	 * @param array<string, true> $reviews
+	 */
+	private function __construct(
+		private array $labels,
+		private array $assignees,
+		private array $priorities,
+		private array $types,
+		private array $estimates,
+		private array $owners,
+		private array $reviews,
+		private ?string $due,
+		private ?string $done,
+		private ?string $waiting,
+		private ?string $blocked,
+		private ?string $checklist,
+		private ?string $startDate,
+		private ?string $subcard,
+		private ?string $comments,
+	) {
+	}
+
+	/**
+	 * Decode the flat short-key query params into a filter. NEVER throws and never
+	 * rejects: every value is `mixed` (a malformed query string like `?fl[]=1`
+	 * hands the dispatcher an array), unknown keys are simply absent from the map
+	 * this reads, and an unrecognised value inside a known dimension is dropped so
+	 * the dimension imposes no constraint.
+	 *
+	 * @param array<string, mixed> $query the raw `fl/fa/fp/…` params
+	 */
+	public static function fromQuery(array $query): self {
+		return new self(
+			self::intSet($query['fl'] ?? null),
+			self::stringSet($query['fa'] ?? null),
+			self::prioritySet($query['fp'] ?? null),
+			self::stringSet($query['ft'] ?? null, self::TYPES),
+			self::stringSet($query['fe'] ?? null),
+			self::stringSet($query['fo'] ?? null),
+			self::stringSet($query['fr'] ?? null, self::REVIEWS),
+			self::oneOf($query['fd'] ?? null, self::DUE),
+			self::oneOf($query['fs'] ?? null, self::DONE),
+			self::oneOf($query['fw'] ?? null, self::WAITING),
+			self::oneOf($query['fb'] ?? null, self::BLOCKED),
+			self::oneOf($query['fk'] ?? null, self::CHECKLIST),
+			self::oneOf($query['fsd'] ?? null, self::START),
+			self::oneOf($query['fsc'] ?? null, self::SUBCARD),
+			self::oneOf($query['fcm'] ?? null, self::COMMENTS),
+		);
+	}
+
+	/**
+	 * True when no dimension carries a constraint - i.e. the filter would keep
+	 * every row, so the caller can skip the pass entirely. Mirrors the client's
+	 * `filterIsEmpty()`.
+	 */
+	public function isEmpty(): bool {
+		return $this->labels === []
+			&& $this->assignees === []
+			&& $this->priorities === []
+			&& $this->types === []
+			&& $this->estimates === []
+			&& $this->owners === []
+			&& $this->reviews === []
+			&& $this->due === null
+			&& $this->done === null
+			&& $this->waiting === null
+			&& $this->blocked === null
+			&& $this->checklist === null
+			&& $this->startDate === null
+			&& $this->subcard === null
+			&& $this->comments === null;
+	}
+
+	/**
+	 * Evaluate one serialized card summary. AND across dimensions, OR within each;
+	 * an empty dimension imposes no constraint. Line-for-line the JS predicate.
+	 *
+	 * `$nowMs` is a Unix timestamp in MILLISECONDS, injected so the relative due /
+	 * start-date windows are stable across a whole pass (and testable) - the same
+	 * reason `makePredicate` takes `now`.
+	 *
+	 * @param array<string, mixed> $card
+	 */
+	public function matches(array $card, int $nowMs): bool {
+		$weekAhead = $nowMs + self::WEEK_MS;
+
+		// Labels (OR within): card must carry at least one selected label.
+		if ($this->labels !== []) {
+			$hit = false;
+			foreach (self::listOf($card['labelIds'] ?? null) as $id) {
+				if (is_int($id) || is_string($id) || is_float($id)) {
+					if (isset($this->labels[(int)$id])) {
+						$hit = true;
+						break;
+					}
+				}
+			}
+			if (!$hit) {
+				return false;
+			}
+		}
+
+		// Assignees (OR within): any selected uid, or the UNASSIGNED sentinel for
+		// cards with no assignee at all.
+		if ($this->assignees !== []) {
+			$ids = self::listOf($card['assigneeIds'] ?? null);
+			$matchesUid = false;
+			foreach ($ids as $uid) {
+				if (is_string($uid) && isset($this->assignees[$uid])) {
+					$matchesUid = true;
+					break;
+				}
+			}
+			$matchesNone = isset($this->assignees[self::UNASSIGNED]) && $ids === [];
+			if (!$matchesUid && !$matchesNone) {
+				return false;
+			}
+		}
+
+		// Priorities (OR within): card.priority (0..4) in the selected set.
+		if ($this->priorities !== [] && !isset($this->priorities[(int)($card['priority'] ?? 0)])) {
+			return false;
+		}
+
+		// Types (OR within): the built-in card type. A typeless card ('') never
+		// matches a type facet.
+		if ($this->types !== []) {
+			$type = $card['type'] ?? '';
+			if (!is_string($type) || !isset($this->types[$type])) {
+				return false;
+			}
+		}
+
+		// Estimates (OR within): the card's raw scale token, or the UNESTIMATED
+		// sentinel for cards with no estimate. An off-scale legacy token still
+		// matches if explicitly selected.
+		if ($this->estimates !== []) {
+			$estimate = $card['estimate'] ?? '';
+			$estimate = is_string($estimate) ? $estimate : '';
+			$matchesToken = $estimate !== '' && isset($this->estimates[$estimate]);
+			$matchesNone = $estimate === '' && isset($this->estimates[self::UNESTIMATED]);
+			if (!$matchesToken && !$matchesNone) {
+				return false;
+			}
+		}
+
+		// Owners (OR within): the card's owner uid. Owner is always set, so there
+		// is no "none" sentinel here.
+		if ($this->owners !== []) {
+			$owner = $card['owner'] ?? null;
+			if (!is_string($owner) || !isset($this->owners[$owner])) {
+				return false;
+			}
+		}
+
+		// Review state (OR within): the derived review flag, or the 'none' sentinel
+		// for a card with no review requested (reviewState == null).
+		if ($this->reviews !== []) {
+			$review = $card['reviewState'] ?? null;
+			$ok = $review === null
+				? isset($this->reviews[self::REVIEW_NONE])
+				: (is_string($review) && isset($this->reviews[$review]));
+			if (!$ok) {
+				return false;
+			}
+		}
+
+		// Due (single-select): overdue / this-week / no-due-date.
+		if ($this->due !== null) {
+			$raw = self::str($card['duedate'] ?? null);
+			if ($this->due === 'none') {
+				if ($raw !== '') {
+					return false;
+				}
+			} else {
+				if ($raw === '') {
+					return false;
+				}
+				$ts = self::toMillis($raw);
+				if ($ts === null) {
+					return false;
+				}
+				if ($this->due === 'overdue' && !($ts < $nowMs)) {
+					return false;
+				}
+				if ($this->due === 'week' && !($ts >= $nowMs && $ts <= $weekAhead)) {
+					return false;
+				}
+			}
+		}
+
+		// Done state (tri-state): doneAt > 0 means done.
+		if ($this->done !== null) {
+			$isDone = ((int)($card['doneAt'] ?? 0)) > 0;
+			if ($this->done === 'done' && !$isDone) {
+				return false;
+			}
+			if ($this->done === 'open' && $isDone) {
+				return false;
+			}
+		}
+
+		// Waiting on client (#3746, tri-state): the derived summary flag.
+		if ($this->waiting !== null) {
+			$isWaiting = !empty($card['waitingOnExternal']);
+			if ($this->waiting === 'waiting' && !$isWaiting) {
+				return false;
+			}
+			if ($this->waiting === 'not_waiting' && $isWaiting) {
+				return false;
+			}
+		}
+
+		// Blocked (single-select): the derived summary flag.
+		if ($this->blocked !== null) {
+			$isBlocked = !empty($card['blocked']);
+			if ($this->blocked === 'blocked' && !$isBlocked) {
+				return false;
+			}
+			if ($this->blocked === 'not_blocked' && $isBlocked) {
+				return false;
+			}
+		}
+
+		// Checklist (single-select), off the derived {total,done} progress.
+		if ($this->checklist !== null) {
+			$progress = is_array($card['checklist'] ?? null) ? $card['checklist'] : [];
+			$total = (int)($progress['total'] ?? 0);
+			$cdone = (int)($progress['done'] ?? 0);
+			if ($this->checklist === 'has' && !($total > 0)) {
+				return false;
+			}
+			if ($this->checklist === 'incomplete' && !($total > 0 && $cdone < $total)) {
+				return false;
+			}
+			if ($this->checklist === 'complete' && !($total > 0 && $cdone === $total)) {
+				return false;
+			}
+			if ($this->checklist === 'none' && $total !== 0) {
+				return false;
+			}
+		}
+
+		// Start date (single-select): none / started (<= now) / upcoming (> now),
+		// mirroring the due-date now handling.
+		if ($this->startDate !== null) {
+			$raw = self::str($card['startDate'] ?? null);
+			if ($this->startDate === 'none') {
+				if ($raw !== '') {
+					return false;
+				}
+			} else {
+				if ($raw === '') {
+					return false;
+				}
+				$ts = self::toMillis($raw);
+				if ($ts === null) {
+					return false;
+				}
+				if ($this->startDate === 'started' && !($ts <= $nowMs)) {
+					return false;
+				}
+				if ($this->startDate === 'upcoming' && !($ts > $nowMs)) {
+					return false;
+				}
+			}
+		}
+
+		// Sub-card relationship, off parentCardId + the derived childProgress.
+		if ($this->subcard !== null) {
+			$parentId = $card['parentCardId'] ?? null;
+			$childProgress = is_array($card['childProgress'] ?? null) ? $card['childProgress'] : [];
+			$childTotal = (int)($childProgress['total'] ?? 0);
+			if ($this->subcard === 'top_level' && $parentId !== null) {
+				return false;
+			}
+			if ($this->subcard === 'parent' && !($childTotal > 0)) {
+				return false;
+			}
+			if ($this->subcard === 'child' && $parentId === null) {
+				return false;
+			}
+		}
+
+		// Comments (single-select): has / none, off the derived count.
+		if ($this->comments !== null) {
+			$n = (int)($card['commentCount'] ?? 0);
+			if ($this->comments === 'has' && !($n > 0)) {
+				return false;
+			}
+			if ($this->comments === 'none' && $n !== 0) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Split one comma-joined query value into trimmed, non-empty tokens. Mirrors
+	 * the client's `csv()` in `queryToFilter()`, including taking the FIRST value
+	 * when the dispatcher hands us an array (`?fl[]=1&fl[]=2`).
+	 *
+	 * @return list<string>
+	 */
+	private static function tokens(mixed $raw): array {
+		if (is_array($raw)) {
+			$raw = $raw === [] ? null : reset($raw);
+		}
+		if ($raw === null || is_array($raw) || is_object($raw) || is_bool($raw)) {
+			return [];
+		}
+		$parts = explode(',', (string)$raw);
+		$out = [];
+		foreach ($parts as $part) {
+			$part = trim($part);
+			if ($part !== '') {
+				$out[] = $part;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Numeric-id membership map (labels). A non-numeric token is dropped, matching
+	 * the client's `Number.isFinite` guard.
+	 *
+	 * @return array<int, true>
+	 */
+	private static function intSet(mixed $raw): array {
+		$out = [];
+		foreach (self::tokens($raw) as $token) {
+			if (is_numeric($token)) {
+				$out[(int)$token] = true;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * String membership map, optionally whitelisted against the dimension's known
+	 * values (an unknown value is dropped, leaving the dimension unconstrained).
+	 *
+	 * @param list<string>|null $allowed
+	 * @return array<string, true>
+	 */
+	private static function stringSet(mixed $raw, ?array $allowed = null): array {
+		$out = [];
+		foreach (self::tokens($raw) as $token) {
+			if ($allowed !== null && !in_array($token, $allowed, true)) {
+				continue;
+			}
+			$out[$token] = true;
+		}
+		return $out;
+	}
+
+	/**
+	 * Priority membership map: integers 0..4 only, matching the client's range
+	 * guard. Anything else is dropped.
+	 *
+	 * @return array<int, true>
+	 */
+	private static function prioritySet(mixed $raw): array {
+		$out = [];
+		foreach (self::tokens($raw) as $token) {
+			if (!is_numeric($token)) {
+				continue;
+			}
+			// Integer-VALUED (not integer-spelled), so '03' and '3.0' are accepted
+			// exactly as the client's Number()/Number.isInteger() pair accepts them.
+			$n = (float)$token;
+			if ($n === floor($n) && $n >= 0 && $n <= 4) {
+				$out[(int)$n] = true;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * A single-select value, or null when it is missing or not one this version
+	 * knows - so an older/newer client's value silently imposes no constraint
+	 * rather than dropping every row.
+	 *
+	 * @param list<string> $allowed
+	 */
+	private static function oneOf(mixed $raw, array $allowed): ?string {
+		$tokens = self::tokens($raw);
+		if ($tokens === []) {
+			return null;
+		}
+		return in_array($tokens[0], $allowed, true) ? $tokens[0] : null;
+	}
+
+	/** A scalar card field as a string; anything else reads as absent. */
+	private static function str(mixed $value): string {
+		return is_string($value) ? $value : '';
+	}
+
+	/**
+	 * A card list field as a genuine list; anything else reads as empty.
+	 *
+	 * @return list<mixed>
+	 */
+	private static function listOf(mixed $value): array {
+		return is_array($value) ? array_values($value) : [];
+	}
+
+	/**
+	 * Parse a summary date field (always ATOM in the payload) to Unix
+	 * MILLISECONDS, matching the client's `new Date(raw).getTime()`. Unparseable
+	 * reads as null - the same NaN branch the JS predicate rejects on.
+	 */
+	private static function toMillis(string $raw): ?int {
+		$ts = strtotime($raw);
+		return $ts === false ? null : $ts * 1000;
+	}
+}

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -15,11 +15,18 @@ use OCA\Kanso\Db\LabelMapper;
 /**
  * The cross-board feed behind saved "Views" (#3815) - every non-deleted card
  * across all the boards the current user can read, each carrying its board id +
- * title. The server stays filter-AGNOSTIC: it returns the whole readable-set
- * card summaries and the CLIENT applies the saved View's opaque filter predicate
- * and group-by. That keeps the query engine to exactly ONE readable-set path
- * (no new query language) - identical to how {@see MyCardsService::findMine()}
- * and {@see InboxService::findMine()} enforce ACL.
+ * title. There is still exactly ONE readable-set path and no query language -
+ * identical to how {@see MyCardsService::findMine()} and
+ * {@see InboxService::findMine()} enforce ACL.
+ *
+ * The View's filter is applied on BOTH sides (#9862). The client keeps running
+ * its own predicate over whatever rows arrive - that is what keeps chip editing
+ * instant - and the server runs the mirrored {@see ViewFilter} as a SUPERSET
+ * GUARD so the hard cap below slices the MATCHING set rather than the whole
+ * readable set. Without it, an account with more readable cards than the cap
+ * searched only the first N rows of the sorted order and silently missed every
+ * match past them. The filter still consumes only already-serialized summary
+ * fields - no new query, no SQL shortcut.
  *
  * ACL is enforced by restricting to the boards {@see BoardService::findAll()}
  * returns (the readable set) and running each board's summary query under the
@@ -33,9 +40,12 @@ class ViewService {
 	 * Hard cap on the cross-board feed payload. The readable-set + #3743 masking
 	 * still gate every row BEFORE this slice (leak-safety unchanged); the cap only
 	 * bounds how many summaries a single unbounded feed can ship, no matter how
-	 * many boards/cards the user can read. When the readable set exceeds it the
-	 * envelope's `capped` flag is set so the client surfaces an honest "showing
-	 * the first N of M" hint rather than silently truncating.
+	 * many boards/cards the user can read. The View's filter also runs before it
+	 * (#9862), so what the cap slices is the MATCHING set - a narrow filter reaches
+	 * matches anywhere in the readable set, not just within the first N sorted
+	 * rows. When the matching set still exceeds the cap the envelope's `capped`
+	 * flag is set so the client surfaces an honest "showing the first N of M
+	 * matching cards" hint rather than silently truncating.
 	 */
 	public const MAX_CARDS = 5000;
 
@@ -57,10 +67,18 @@ class ViewService {
 	 * run over them with no extra request.
 	 *
 	 * Returned as an envelope so the client can honestly report truncation:
-	 *   ['cards' => list<array>, 'labels' => list<array>, 'capped' => bool, 'total' => int, 'limit' => int]
-	 * where `total` is the pre-cap readable-set count and `cards` is capped to at
-	 * most {@see self::MAX_CARDS} rows. The cap is applied AFTER the per-board ACL
-	 * + #3743 masking loop, so every row is still gated before the slice.
+	 *   ['cards' => …, 'labels' => …, 'participants' => …, 'capped' => bool, 'total' => int, 'limit' => int]
+	 * where `total` is the pre-cap count of MATCHING rows (#9862 - the filter runs
+	 * before the cap) and `cards` is capped to at most {@see self::MAX_CARDS} rows.
+	 * The cap is applied AFTER the per-board ACL + #3743 masking loop, so every row
+	 * is still gated before the slice.
+	 *
+	 * `participants` is the union of assignee uids + card owners across the readable
+	 * boards, accumulated in the per-board loop BEFORE the filter and BEFORE the cap.
+	 * It ships SEPARATELY from the rows on purpose: the client's assignee/owner facets
+	 * are built from it, so filtering to one person must not collapse the facet to the
+	 * survivors (which would make the facet vanish at zero matches and leave no way to
+	 * add a second person). Accumulating it in the existing loop costs no extra query.
 	 *
 	 * Each card additionally carries `boardPrefix` (its board's human-id prefix) and
 	 * `labels` is the union of each readable board's serialized labels (the label's
@@ -75,13 +93,14 @@ class ViewService {
 	 * row of an arbitrary window. `default` keeps the historical stable
 	 * (boardId, id) order, so a View saved before the sort control looks unchanged.
 	 *
-	 * @return array{cards: list<array<string, mixed>>, labels: list<array<string, mixed>>, capped: bool, total: int, limit: int}
+	 * @return array{cards: list<array<string, mixed>>, labels: list<array<string, mixed>>, participants: list<string>, capped: bool, total: int, limit: int}
 	 */
-	public function findMine(string $uid, string $sortMode = 'default', string $sortDir = 'asc'): array {
+	public function findMine(string $uid, string $sortMode = 'default', string $sortDir = 'asc', ?ViewFilter $filter = null): array {
 		$boards = $this->boardService->findAll($uid);
 
 		$out = [];
 		$labels = [];
+		$participants = [];
 		foreach ($boards as $board) {
 			$boardId = (int)$board->getId();
 			// The viewer's resolved side on THIS board scopes every card row
@@ -103,6 +122,18 @@ class ViewService {
 				// The board's human-id prefix, so a card tile can render its real
 				// reference (prefix + '-' + boardSeq), same as the board tiles.
 				$card['boardPrefix'] = $boardPrefix;
+				// Facet VOCABULARY, accumulated before the filter and before the cap
+				// so the assignee/owner facets keep offering everyone even when the
+				// filter narrows the rows to one person - or to none (#9862).
+				foreach ($card['assigneeIds'] ?? [] as $assignee) {
+					if (is_string($assignee) && $assignee !== '') {
+						$participants[$assignee] = true;
+					}
+				}
+				$owner = $card['owner'] ?? null;
+				if (is_string($owner) && $owner !== '') {
+					$participants[$owner] = true;
+				}
 				$out[] = $card;
 			}
 			// Union the readable board's labels so the client can colour the card
@@ -116,7 +147,24 @@ class ViewService {
 			}
 		}
 
-		// Order the WHOLE readable set before the cap slices it, so the cap always
+		// Apply the View's filter (#9862) strictly AFTER the per-board ACL / #3743
+		// masking loop and strictly BEFORE the sort + cap. After, because filtering
+		// must never become a shortcut around the permission masking - it only drops
+		// rows the viewer may already see, it can never add one. Before, because the
+		// whole point is that the cap slices the MATCHING set: otherwise a narrow
+		// filter over a >MAX_CARDS readable set searches only the first window of
+		// the sorted order and silently misses every match past it.
+		if ($filter !== null && !$filter->isEmpty()) {
+			// One `now` for the whole pass, so the relative due / start-date windows
+			// can't shift mid-scan.
+			$now = (int)round(microtime(true) * 1000.0);
+			$out = array_values(array_filter(
+				$out,
+				static fn (array $card): bool => $filter->matches($card, $now),
+			));
+		}
+
+		// Order the WHOLE matching set before the cap slices it, so the cap always
 		// takes the true first N rows of the requested order (never the first N of
 		// an arbitrary window) and repeats the same window across requests. Runs
 		// strictly AFTER the per-board ACL / #3743 masking loop above, so it moves
@@ -129,9 +177,12 @@ class ViewService {
 			$out = array_slice($out, 0, self::MAX_CARDS);
 		}
 
+		ksort($participants, SORT_STRING);
+
 		return [
 			'cards' => $out,
 			'labels' => array_values($labels),
+			'participants' => array_keys($participants),
 			'capped' => $capped,
 			'total' => $total,
 			'limit' => self::MAX_CARDS,

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -182,7 +182,14 @@ class ViewService {
 		return [
 			'cards' => $out,
 			'labels' => array_values($labels),
-			'participants' => array_keys($participants),
+			// strval() because PHP silently coerces a canonical decimal string array
+			// KEY to int - so a numeric uid (routine with LDAP employee-number
+			// provisioning) would come back as int(12345) and ship as a JSON number,
+			// which the client drops as "not a uid". That would resurrect the very
+			// facet self-narrowing this vocabulary exists to prevent: the numeric
+			// account would vanish from the assignee/owner facet with no way to
+			// re-add them.
+			'participants' => array_map('strval', array_keys($participants)),
 			'capped' => $capped,
 			'total' => $total,
 			'limit' => self::MAX_CARDS,

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -6,4 +6,8 @@ __pycache__/
 .pytest_cache/
 dist/
 build/
-uv.lock
+# uv.lock is deliberately COMMITTED, not ignored: the CI `unit-mcp` job runs
+# `uv run --frozen`, so the lock is what pins the resolution. pyproject only
+# declares floors (mcp>=1.2, httpx>=0.27, pydantic>=2) — without the lock every
+# run would resolve fresh from PyPI and an upstream release could redden an
+# unrelated PR.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -194,7 +194,9 @@ template. Mutations need MANAGE on the board.
 ## Development
 
 ```sh
-uv run pytest      # unit tests (respx-mocked, no live server needed)
+# Unit tests (respx-mocked, no live server needed). Same command CI runs in the
+# `unit-mcp` job: --extra dev pulls pytest, --frozen pins uv.lock exactly.
+uv run --frozen --extra dev pytest
 ```
 
 ## License

--- a/mcp/kanso_mcp/models.py
+++ b/mcp/kanso_mcp/models.py
@@ -201,12 +201,28 @@ class RecurRule(_Base):
 
 
 class BoardDetail(_Base):
-    """The full ``GET /boards/{id}`` payload: board + stacks + card summaries + labels."""
+    """The full ``GET /boards/{id}`` payload: board + stacks + card summaries +
+    labels, plus the board-scoped side payloads the endpoint ships alongside
+    them.
+
+    ``reviewTypes``, ``cardFields``, ``blocksEdges``, ``acl`` and
+    ``subscription`` are declared so ``extra='ignore'`` stops dropping them on
+    the floor — the server has always returned them
+    (``BoardController::show``), the model just never named them. They are
+    typed loosely on purpose: they exist to be handed to the LLM as context
+    (review workflow, custom-field definitions, dependency edges, sharing,
+    watch state), not to be validated here.
+    """
 
     board: Board
     stacks: List[Stack] = Field(default_factory=list)
     cards: List[CardSummary] = Field(default_factory=list)
     labels: List[Label] = Field(default_factory=list)
+    reviewTypes: List[Any] = Field(default_factory=list)
+    cardFields: List[Any] = Field(default_factory=list)
+    blocksEdges: List[Any] = Field(default_factory=list)
+    acl: List[Any] = Field(default_factory=list)
+    subscription: Optional[Any] = None
     permissions: Optional[int] = None
     role: Optional[str] = None
     cursor: Optional[int] = None

--- a/mcp/kanso_mcp/tools.py
+++ b/mcp/kanso_mcp/tools.py
@@ -10,7 +10,7 @@ payload is JSON-serializable for the MCP transport.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from mcp.server.fastmcp import FastMCP
 

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -18,7 +18,8 @@ import respx
 
 from kanso_mcp.client import KansoClient
 from kanso_mcp.config import KansoConfig
-from kanso_mcp.tools import register_tools
+from kanso_mcp.models import CardSummary
+from kanso_mcp.tools import _without_archived_cards, register_tools
 
 BASE = "http://nc.test/index.php/apps/kanso/api"
 
@@ -232,6 +233,67 @@ async def test_create_recur_rule_schema_only_requires_the_essentials():
         "kanso_delete_recur_rule",
         "kanso_recur_rule_create_now",
     } <= set(tools)
+
+
+def test_archived_survives_a_card_summary_round_trip_and_the_filter():
+    # `_without_archived_cards` reads `c["archived"]` off a DUMPED CardSummary,
+    # so the whole filter hangs on that one key surviving validate -> dump. The
+    # model defaults it to False, which means a server-side rename would not
+    # raise — every card would silently look active and the filter would become
+    # a no-op. Pin both halves: the round-trip, then the filter on a mixed set.
+    dumped = [
+        CardSummary.model_validate(
+            {"id": 1, "title": "Active", "archived": False}
+        ).model_dump(),
+        CardSummary.model_validate(
+            {"id": 2, "title": "Archived", "archived": True}
+        ).model_dump(),
+    ]
+    assert [c["archived"] for c in dumped] == [False, True]
+
+    filtered = _without_archived_cards({"board": {"id": 7}, "cards": dumped})
+    assert [c["id"] for c in filtered["cards"]] == [1]
+    # Non-card keys are passed through untouched.
+    assert filtered["board"] == {"id": 7}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_board_keeps_the_side_payloads_the_api_ships():
+    # BoardController::show returns reviewTypes / cardFields / blocksEdges /
+    # acl / subscription alongside the core four. BoardDetail is extra="ignore",
+    # so any key it does not declare is dropped before the tool layer ever sees
+    # it — this pins that they reach the LLM.
+    respx.get(f"{BASE}/boards/9").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "board": {"id": 9, "title": "Rich"},
+                "stacks": [],
+                "cards": [],
+                "labels": [],
+                "reviewTypes": [{"id": 1, "title": "QA"}],
+                "cardFields": [{"id": 2, "title": "Story points", "type": "number"}],
+                "blocksEdges": [{"fromCardId": 100, "toCardId": 101}],
+                "acl": [{"id": 3, "participant": "alice", "type": 0}],
+                "subscription": {"subscribed": True, "count": 2},
+                "permissions": 31,
+                "role": "internal",
+                "cursor": 77,
+            },
+        )
+    )
+    tools, client = _tools()
+    async with client:
+        board = await tools["kanso_get_board"](9)
+
+    assert board["reviewTypes"] == [{"id": 1, "title": "QA"}]
+    assert board["cardFields"] == [
+        {"id": 2, "title": "Story points", "type": "number"}
+    ]
+    assert board["blocksEdges"] == [{"fromCardId": 100, "toCardId": 101}]
+    assert board["acl"] == [{"id": 3, "participant": "alice", "type": 0}]
+    assert board["subscription"] == {"subscribed": True, "count": 2}
 
 
 @respx.mock

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -1,0 +1,826 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838, upload-time = "2026-08-03T21:19:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/27/8d207af749c453ee17ea087340b3f2b4adef75aadd1d277b1b129bdda84e/cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94", size = 3974350, upload-time = "2026-08-25T19:45:26.551Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9a/6d3a4d7852e22d657438b7bf51f66102c7d71c0e1fafeec652281d0403e5/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f", size = 4698675, upload-time = "2026-08-25T19:45:28.658Z" },
+    { url = "https://files.pythonhosted.org/packages/73/35/5c3717edf9e68a0550ce04e28eab493fe545eccd81742af03f6a75fe260b/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671", size = 4707410, upload-time = "2026-08-25T19:45:30.816Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e0/e786934472e3ac4ecdecc7b129a0ca1a2a40dffdafcf2c3ea9d4397f8def/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e", size = 4698378, upload-time = "2026-08-25T19:45:33.043Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/5b3f53a0b74d122f023476ede40ba5d3e70d5cf475f73b899740d26a4fb2/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6", size = 4706889, upload-time = "2026-08-25T19:45:35.086Z" },
+    { url = "https://files.pythonhosted.org/packages/71/44/711e61f7d014be825ef79b285b047292d1bf893732ac1bc030a351fb517f/cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b", size = 3824006, upload-time = "2026-08-25T19:45:37.281Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kanso-mcp"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mcp", specifier = ">=1.2,<2" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "python-dotenv", specifier = ">=1" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "mcp"
+version = "1.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/b6/81d2d19ea0be2c03664381b59f65fa72fc7969decedae00bc2c4ad835708/pydantic_core-2.46.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1dee1b804ff4d11c663636cf15d2ea47e9f79cd56c033fb1cbf08924842a48f", size = 2074737, upload-time = "2026-08-28T09:57:57.711Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/18/b70da8300e292df4099684ea11b1958043580d2f50d2dc8bf7e542bdd84a/pydantic_core-2.46.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d625a186a65201c23a9e3b8ed9c47e90a026e03256608cc91851c6709096844f", size = 1921751, upload-time = "2026-08-28T09:57:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1a/0d590341b6ffa4b4aca83508e6b8db4761aaeacfc15a25ca3815876d4797/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8507560a9284e1370bb048ed4282012fbef4e8d109875b95e884d228552061", size = 1948231, upload-time = "2026-08-28T09:58:00.678Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/02eb35761c51f2f7b1b042d6ab4cda6600f0c8c88a2243b3f734376201e5/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f93c5fe914d75fbec9a49209b00da5f08e9e467d69da2b1510c81940cfd10be", size = 2020708, upload-time = "2026-08-28T09:58:02.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ea/f86073830e35d508cc8ddf9c3d9e6e6840fcb88d34bf726b0b4710186f27/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c767f552b21b10f774aeac128e828eafb796adfa1b666a18bf6321453c3a", size = 2194914, upload-time = "2026-08-28T09:58:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/fc36240d7791ce90939e51608568c33bfdae26202016f9770c229a487d86/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:701b2e04b560eeb4bddf7a25ab8ca476176e34fdbd9a0e18196f0d12d4685f0b", size = 2235622, upload-time = "2026-08-28T09:58:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bc/3fa2d76b83162820a17da7f645b28d1cba99fc8e1e5fc6517067ec450fa1/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49776eab08766a08dfff7012f8b422dcd7e25e43b316eedf0477c24fcfa84b7c", size = 2062091, upload-time = "2026-08-28T09:58:07.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9a/095d557bb492c90cd8a70a6dd048bf793d433d03d86c81c11e912e4cd049/pydantic_core-2.46.5-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:a2468d93d181667a7abd66e1b64bb9f76f361b0fef8faddf687456453576f5ee", size = 2089904, upload-time = "2026-08-28T09:58:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/7b76b1ad10a19a617a52aaa1d80e159115af939b095e86f8e756fd52e0df/pydantic_core-2.46.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53feb344243bb9510a9dec7bf3cf1b64d88a98af5dc7872a5160465f8b198c8e", size = 2132244, upload-time = "2026-08-28T09:58:10.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/32/7d6ca365fadba186a0c8f85de1a701663bce81efd309d9479be58687622f/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:cd5214352ae68f3b5e9af7768bdc5253695ee069675db3480518420b3be881f2", size = 2143901, upload-time = "2026-08-28T09:58:12.033Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/09/eb9a6aa57f22fd1541a9c0aa2a1f3aeef3ec65347d33e10a6da2f43e0ee9/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:9432f3598db432cb51c5b37fdbf29a60fcccc79e30d37a05022776a6bc4ab689", size = 2299425, upload-time = "2026-08-28T09:58:13.614Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/548a5bb9d4ba8cd26e26daf48052236f6b38bb61e7b7241fbc3c995719eb/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8feeac04b5794e513e710af2f9c87d49f31a6dc47967bb264a1fed61a8989bec", size = 2318566, upload-time = "2026-08-28T09:58:15.199Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/20/06454d18834c02c406c9133f1a3b485305fd9ee984f9636c2f730bef6a9d/pydantic_core-2.46.5-cp311-cp311-win32.whl", hash = "sha256:892a881d5f68c2b9ea304b7a6c2c60d9343df578a311b0f86b94bc8f1ffe8129", size = 1954258, upload-time = "2026-08-28T09:58:16.813Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/718b9deb4b72453b5d8c7447a3b14cb77bef36917ef5f514e0948a4096a0/pydantic_core-2.46.5-cp311-cp311-win_amd64.whl", hash = "sha256:40375c2d05acec10323e45dfe2077ac44bc74659008614af5069034e2cfc781c", size = 2041030, upload-time = "2026-08-28T09:58:18.288Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ea/c1d1a5b72d6e1ff7f377a4d9199f6591f095beb5b409a8a5d89f7238d939/pydantic_core-2.46.5-cp311-cp311-win_arm64.whl", hash = "sha256:28a6a556cd3b6066bea827857f9d9cce027c96f776e512f544a581f9e42161f8", size = 2009234, upload-time = "2026-08-28T09:58:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475, upload-time = "2026-08-28T09:58:42.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140, upload-time = "2026-08-28T09:58:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729, upload-time = "2026-08-28T09:58:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/37/5abe39a8372a61d3dc3c1338fc504281c01b32fdb3169cd7187153b56d3e/pydantic_core-2.46.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b7ca9034437b6022f941f4857459562ee00a560b97e7cce8a0ec5a74fc6766e0", size = 2075885, upload-time = "2026-08-28T09:58:47.856Z" },
+    { url = "https://files.pythonhosted.org/packages/21/43/6323b1f8b217780454c61304bcd2b38ae4762f50754414124603ccc90bb2/pydantic_core-2.46.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f332f0e72a5a0400141f830744e141bf9f97917878dbe968669e8a7fefea78ff", size = 1922768, upload-time = "2026-08-28T09:58:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a3/c05ca796e1197618a774b01e596aeedfefc2f7d8c01ae3054e910b120e8a/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193375f3548919d3f0b60936ca113ada3e38f264f91b9b8e0508efaad57be931", size = 1951241, upload-time = "2026-08-28T09:58:51.511Z" },
+    { url = "https://files.pythonhosted.org/packages/68/32/33bc39ac705c52cffc908e8389f9754fdb208aea5c69cceddf4eb3ce99af/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79bdfa52f843137045b2d081cc05c120ba6665d29b7559c2c47690906f39279f", size = 2031975, upload-time = "2026-08-28T09:58:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/70/2333e885c0f6a67bc105c5916965dac9b57f2718ee20d81d1a06a4ebdc13/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24922243639cbdac66c75fcb6fd6495a9cb52b213d62f9a0d16f0310b1ff8038", size = 2208542, upload-time = "2026-08-28T09:58:55.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ea/296debfb4264207bbda5936133892e027c0a58875ad53ebd512fba8ec3a2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76fe65e607be28c7fd4d56fc3c42b1583aa058ce3408b7ad0fd540171d31f9f", size = 2264692, upload-time = "2026-08-28T09:58:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/9e4de77a6271e07a76d2d58b11c091a979c191ed2939bf80067568b369d2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7b393a8b3da82f5c1fc0751e6d01ac6c55b93c18226a60bdfba4a724efafd1", size = 2066633, upload-time = "2026-08-28T09:58:58.531Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/f9e9d0c97445987b2084823d5c240de88087338f04fc2cfaa2df186b8049/pydantic_core-2.46.5-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:7ac031912d54f3d83ef3b3eb98dfabc1608802e2202263d25957eeed40b94761", size = 2105235, upload-time = "2026-08-28T09:59:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c5/79169b047b3b2c3e99e04bc76372af9637e0bf6db638274fa927df96369e/pydantic_core-2.46.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:837b396ca3d7b74091ca623f6cbd8351bd42d670a79c2683e79fb089f06a2de5", size = 2157367, upload-time = "2026-08-28T09:59:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b5/ba6057afb7c291bd449f51b867f95aef2072941c4ce4e5c31d6ffd132d3b/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5ee239d575f80b08eca11f6e20f90c4c695de7825c67eefe6091fbf20dda648e", size = 2158420, upload-time = "2026-08-28T09:59:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/2057abecaafdc22912afa819603a51f0a62d40643b7c4871c51721fea9be/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e80675d75ae2cd14372cb65cad5400d9347a3d3f6c13000183f22dfd027283ed", size = 2309588, upload-time = "2026-08-28T09:59:06.048Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9d/881156dc404e27479c4246128d73538464cab4a239bec61995e227644c30/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c4b71f10dd532fb7a5cbc8f58707779e64f03a258c2bf8bfbaecfcd9970b519", size = 2341866, upload-time = "2026-08-28T09:59:08.539Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/38/d66f443a259f84d13babdceae568e572b0ed26da17ca5d0a649ebb110a67/pydantic_core-2.46.5-cp313-cp313-win32.whl", hash = "sha256:97bf8de4d541598c94a59344eeb988a94c08ff76b5723c41f6567ec18c7892ea", size = 1938580, upload-time = "2026-08-28T09:59:10.402Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/1d5371213f4cc9a7ed70c0bfcc7911de22311ee99a662a56077d7292d2ac/pydantic_core-2.46.5-cp313-cp313-win_amd64.whl", hash = "sha256:15f4a94963c95accac15b7b657bb177d3ad82bb90b0d0526d9a9b85079925db5", size = 2041980, upload-time = "2026-08-28T09:59:12.396Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/48/4222d90b1c67568bace4dec6dca6271449c66de3595d72b6d098f5fde597/pydantic_core-2.46.5-cp313-cp313-win_arm64.whl", hash = "sha256:d22a945598fb91236b4dd793a6e42e4f3dd7740bb5aace5ebd7d4c08d13bb575", size = 1997213, upload-time = "2026-08-28T09:59:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827, upload-time = "2026-08-28T09:59:39.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648, upload-time = "2026-08-28T09:59:41.792Z" },
+    { url = "https://files.pythonhosted.org/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652, upload-time = "2026-08-28T09:59:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180, upload-time = "2026-08-28T10:00:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515, upload-time = "2026-08-28T10:00:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276, upload-time = "2026-08-28T10:00:16.984Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1e/ecca01fce348f7e8afa9572441ff6f7d1cc70d21e4859f33944d10877e1e/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:c14ad3bdc85ee7f318742c457ca3968a92126d144b15721c759033bfb06296c2", size = 2075342, upload-time = "2026-08-28T10:00:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4c/af80c7a8032dfc897040ad5cb772bebde529a381186499e6e29987f23f8c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0bddb4020d8f04175865ccd17eff3040874fc11fb593f424edb452653b4b947c", size = 1907219, upload-time = "2026-08-28T10:00:53.438Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3e/54d89e2b092e778716bf6153634ef479e955f48c261090be23aa1e0fb0b5/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2471fd51c61c610e1dcf7de44d7299283661654d11264ab4802b303368d69c47", size = 1953393, upload-time = "2026-08-28T10:00:55.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/828ee90cda28ce17bdefaa3a6eaf74fe430e113295a10e6126beca559d6c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b10ec717381bdbfafef34607824db4c91de69ff085e4fca3b2af91b4fa17e68a", size = 2099024, upload-time = "2026-08-28T10:00:57.794Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+    { url = "https://files.pythonhosted.org/packages/20/21/22102e9950b3049526d20e811b95396508377d87651edd2b80d2b3d28659/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab4b66edffb32d9e951efb3814bd104b8367a7501b81b955cacb5726d897389f", size = 2071333, upload-time = "2026-08-28T10:01:09.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/18/87aefa427d191e6d3ab1447f1efc1cdcac86af1069239b133e8a0fd7f7c9/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:337639ba62a11acde6ef3aeb08c8ea755f8ef1fe5e513356c0f36a2b0d7568b0", size = 1912713, upload-time = "2026-08-28T10:01:12.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/93/fd89e9ad49b1805ca94d24ce1088b7d305f05c35ffafcedb9819d03588a0/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:413a717a410d0c817ef5b786a059415550b3794e1d0c2abffd9efb93a3d9f7b4", size = 2090926, upload-time = "2026-08-28T10:01:15.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/45/8e59dab6acf8d35f02f0a958980074f31038968bdb2c983fcae9d1efee03/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e449def1945a462c464331254e5a44fca7c3b4f9aedf59ec2f50f8066dd8e25", size = 2131303, upload-time = "2026-08-28T10:01:17.937Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/e1d4dc5180dd887a9522efc1f8716b8692b7606b1d3273d7862eaf66be44/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a445486499897b88a7d6c310c88ed64dd37b1b59bfd7ae9107490bbb362f47d6", size = 2145128, upload-time = "2026-08-28T10:01:20.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/ad493864a7fb21c0c4df98f965e2db430cb25a9d7369b5778d5016c09fd9/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2d330aaba8621b1edcec8ae2c4050f63b84ccf6d98723a8f212e9684713abf0e", size = 2294560, upload-time = "2026-08-28T10:01:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/b41c84c913f29973a268e6c2b5bbf13c95adb9956c126d10da11ba3b2bef/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b6acfb46a814762367fb7ba0828b0a17d441b92ce249a0e007474c9072662dda", size = 2317531, upload-time = "2026-08-28T10:01:26.334Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1d/068464f23075f66a8f1b806935e9cd9363ee446636ea70d2c22ee8659dbf/pydantic_core-2.46.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d0a24b40877af2de4950252be9d21eaf7fb07660f3c2cae1f56c6b599ada5266", size = 2140686, upload-time = "2026-08-28T10:01:28.947Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				     drag there never touches the parent). -->
 				<div
 					v-else-if="rows[vRow.index].type === 'card'"
-					v-card-dnd="{ card: rows[vRow.index].card, sortMode: props.sortMode, rowParentId: rows[vRow.index].isChild ? rows[vRow.index].card.parentCardId : null }"
+					v-card-dnd="{ card: rows[vRow.index].card, sortMode: props.sortMode, rowParentId: rows[vRow.index].isChild ? rows[vRow.index].card.parentCardId : null, canEdit: canEditBoard }"
 					class="board-list-row-wrap"
 					:class="{
 						'board-list-row-wrap--dragging': isDraggingCard === rows[vRow.index].card.id,
@@ -143,7 +143,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<button
 						class="board-list-row"
 						:class="{
-							'board-list-row--draggable': props.sortMode === 'manual',
+							'board-list-row--draggable': props.sortMode === 'manual' && canEditBoard,
 							'board-list-row--child': rows[vRow.index].isChild,
 						}"
 						@click="openCard(rows[vRow.index].card)">
@@ -373,6 +373,7 @@ import { draggable, dropTargetForElements, monitorForElements } from '@atlaskit/
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine'
 import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import { buildCardDragData, buildCardDropData, NEST_ENABLED } from '../services/cardNesting.js'
+import { useBoardCanEdit } from '../services/boardPermissions.js'
 import { useCardFeatures } from '../services/cardFeatures.js'
 import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element'
 import { cssColor } from '../services/color.js'
@@ -487,6 +488,12 @@ const nestEnabled = inject(NEST_ENABLED, computed(() => false))
 // rows can mix boards with different settings.
 const cardFeatures = useCardFeatures()
 
+// Whether the viewer may EDIT this board. A row drag ends in a card move, which
+// the server refuses without PERMISSION_EDIT, so a read-only member gets no drag
+// handle and no grab cursor. A cross-board View renders this component without a
+// provider and keeps its drag (default true) — see ../services/boardPermissions.js.
+const canEditBoard = useBoardCanEdit()
+
 // ── Group-level drop targets (column drop zone) ────────────────────────────────
 // One dropTargetForElements per group header element, keyed by stackId. These
 // carry { type:'column', stackId, laneKey:'' } — exactly the shape the BoardView
@@ -582,8 +589,12 @@ function setGroupDropRef(stackId, el) {
 
 function makeCardDndBinding(el, { card, sortMode: mode, rowParentId }) {
 	// Only wire DnD when we are in the classic per-stack path (card has a real
-	// stackId) and the display sort is manual.
-	if (!card?.id || !card?.stackId || mode !== 'manual') return () => {}
+	// stackId), the display sort is manual, and the viewer may actually edit the
+	// board — a viewer's move is refused server-side, so the grab is dead. The
+	// permission is read from the injected computed rather than the binding value
+	// so it cannot be weakened by a caller; the binding still CARRIES it (as
+	// `canEdit`) purely so the `updated` hook below notices a mid-session flip.
+	if (!card?.id || !card?.stackId || mode !== 'manual' || !canEditBoard.value) return () => {}
 
 	const cardId = card.id
 	// The row's rendered level rides BOTH payloads: as a drag source it says what
@@ -689,6 +700,8 @@ const vCardDnd = {
 			// The row's own level decides what a reorder drop does to the parent,
 			// so a row that moved between the indent and the margin must re-register.
 			&& (prev?.rowParentId ?? null) === (next?.rowParentId ?? null)
+			// Losing (or gaining) EDIT mid-session must add or drop the drag handle.
+			&& (prev?.canEdit !== false) === (next?.canEdit !== false)
 		if (sameCard) {
 			pendingRebinds.delete(el)
 			return

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -226,7 +226,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup>
-import { ref, computed, inject, onMounted, onUnmounted } from 'vue'
+import { ref, computed, inject, watch, onMounted, onUnmounted } from 'vue'
 import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
 import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
 import TimerOutlineIcon from 'vue-material-design-icons/TimerOutline.vue'
@@ -262,6 +262,7 @@ import { formatCardDate } from '../utils/dateDisplay.js'
 import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import { buildCardDragData, buildCardDropData, NEST_ENABLED } from '../services/cardNesting.js'
 import { useCardFeatures } from '../services/cardFeatures.js'
+import { useBoardCanEdit } from '../services/boardPermissions.js'
 
 const props = defineProps({
 	card: {
@@ -340,15 +341,38 @@ const nestEnabled = inject(NEST_ENABLED, computed(() => false))
 // a surface with no provider (a cross-board View) gets all-enabled.
 const cardFeatures = useCardFeatures()
 
+// Whether the viewer may EDIT this board. A read-only member's move is refused
+// server-side (CardService::move asserts PERMISSION_EDIT), so picking the tile
+// up can only end in a rollback — don't offer the grab at all. Defaults to true
+// on a surface with no provider (a cross-board View), which keeps its drag.
+const canEditBoard = useBoardCanEdit()
+
+// The drag handle is held apart from `cleanup` because it is the one
+// registration that comes and goes: a board ACL change reaches the client on the
+// periodic board refetch, not through a remount, so a one-shot read at mount
+// would leave a promoted member without a grab and a demoted one with a dead
+// one. The drop target is untouched by the flip and stays registered.
+let dragCleanup = () => {}
+
+/** (Re-)wire the tile's drag handle to the current permission. */
+function syncDragHandle() {
+	dragCleanup()
+	dragCleanup = () => {}
+	if (!el.value || !canEditBoard.value) return
+	dragCleanup = draggable({
+		element: el.value,
+		getInitialData: () => buildCardDragData(props.card, props.laneKey),
+		onDragStart: () => { isDragging.value = true },
+		onDrop: () => { isDragging.value = false },
+	})
+}
+
+watch(canEditBoard, syncDragHandle)
+
 onMounted(() => {
 	if (!el.value) return
+	syncDragHandle()
 	cleanup = combine(
-		draggable({
-			element: el.value,
-			getInitialData: () => buildCardDragData(props.card, props.laneKey),
-			onDragStart: () => { isDragging.value = true },
-			onDrop: () => { isDragging.value = false },
-		}),
 		dropTargetForElements({
 			element: el.value,
 			canDrop: ({ source }) => source.data.type === 'card' && source.data.cardId !== props.card.id,
@@ -372,6 +396,7 @@ onMounted(() => {
 
 onUnmounted(() => {
 	cleanup()
+	dragCleanup()
 })
 
 // Resolve label objects from the labelsById map for the card's assigned labelIds

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -357,6 +357,18 @@ let dragCleanup = () => {}
 /** (Re-)wire the tile's drag handle to the current permission. */
 function syncDragHandle() {
 	dragCleanup()
+	// Destroying the draggable means its onDrop will never run, so a flip that
+	// lands mid-drag would latch `card-tile-wrap--dragging` on forever. Clear it
+	// here — the flag belongs to the registration we just tore down.
+	//
+	// Deliberately NOT the pendingRebinds deferral BoardListView uses: that one
+	// defers rebinding a DROP TARGET, because pragmatic only re-evaluates a drop
+	// target on a native dragover, so re-creating one under a parked pointer
+	// silently kills the drop. This is a DRAGGABLE, and the tile's drop target is
+	// left registered through the flip, so the drop still resolves through the
+	// board-level monitorForElements. The only consequence here is the stale
+	// class.
+	isDragging.value = false
 	dragCleanup = () => {}
 	if (!el.value || !canEditBoard.value) return
 	dragCleanup = draggable({

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -27,12 +27,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<span class="stack-column__rail-title">{{ stack.title }}</span>
 		</button>
 
-		<!-- Column header - drag handle for stack reordering -->
+		<!-- Column header - drag handle for stack reordering (editors only; a
+		     read-only member gets no handle and no grab cursor) -->
 		<div
 			ref="headerRef"
 			v-show="!collapsed"
 			class="stack-column__header"
-			:class="{ 'stack-column__header--colored': !!stack.color }"
+			:class="{
+				'stack-column__header--colored': !!stack.color,
+				'stack-column__header--draggable': !laneKey && canEditBoard,
+			}"
 			:style="stack.color ? { '--stack-color': cssColor(stack.color) } : {}">
 			<div class="stack-column__header-row">
 				<!-- Collapse toggle (#3677). A real button that stops propagation so a
@@ -341,6 +345,7 @@ import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine'
 import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element'
 import { attachClosestEdge, extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useBoardCanEdit } from '../services/boardPermissions.js'
 
 const props = defineProps({
 	stack: {
@@ -528,6 +533,13 @@ const props = defineProps({
 
 const router = useRouter()
 const route = useRoute()
+
+// Whether the viewer may EDIT this board. Reordering a column is a write
+// (StackService::move asserts PERMISSION_EDIT), so a read-only member gets
+// neither the header drag handle nor its grab cursor. The per-entry menu
+// affordances are already gated by their null callbacks. True by default on a
+// surface with no provider — see ../services/boardPermissions.js.
+const canEditBoard = useBoardCanEdit()
 
 // ── Inline column-title editing ─────────────────────────────────────────────
 const editingTitle = ref(false)
@@ -735,8 +747,38 @@ function measureVirtualEl(el, index) {
 	virtualizer.value.measureElement(el)
 }
 
+// ── Stack reorder handle ──────────────────────────────────────────────────────
+// Held apart from `cleanup` because it is the one registration that comes and
+// goes: it exists only for a member who may EDIT, and a board ACL change reaches
+// the client through the periodic board refetch, NOT through a remount. Since
+// the header's grab cursor is a reactive class, a one-shot read at mount would
+// leave the two out of step after a promotion (cursor, no handle) or a
+// demotion (handle, no cursor) — exactly the dead-affordance mismatch this gate
+// exists to remove.
+let stackDragCleanup = () => {}
+
+/** (Re-)wire the header drag handle to the current permission. */
+function syncStackDragHandle() {
+	stackDragCleanup()
+	stackDragCleanup = () => {}
+	// Stack reordering is a board-level operation on a shared stack, so it is
+	// only wired when NOT inside a swimlane (a stack renders once per lane; per-
+	// lane reorder handles would be duplicative and ambiguous). Within a lane
+	// only card drag survives — the swimlane requirement.
+	if (props.laneKey || !canEditBoard.value || !headerRef.value) return
+	stackDragCleanup = draggable({
+		element: headerRef.value,
+		getInitialData: () => ({ type: 'stack', stackId: props.stack.id }),
+		onDragStart: () => { isStackDragging.value = true },
+		onDrop: () => { isStackDragging.value = false },
+	})
+}
+
+watch(canEditBoard, syncStackDragHandle)
+
 // ── Drop targets & auto-scroll ────────────────────────────────────────────────
 onMounted(() => {
+	syncStackDragHandle()
 	if (!cardListRef.value) return
 	const registrations = [
 		// Column-level drop target: catches drops on the empty space below all cards
@@ -754,20 +796,12 @@ onMounted(() => {
 		}),
 	]
 
-	// Stack reordering is a board-level operation on a shared stack, so it is
-	// only wired when NOT inside a swimlane (a stack renders once per lane; per-
-	// lane reorder handles would be duplicative and ambiguous). Within a lane
-	// only card drag survives — the swimlane requirement.
-	if (!props.laneKey && headerRef.value && columnRef.value) {
+	// The drag handle itself lives in syncStackDragHandle() above (it toggles
+	// with the EDIT bit); the column stays a drop target for whatever stack an
+	// editor drags, on the same not-inside-a-swimlane condition.
+	if (!props.laneKey && columnRef.value) {
 		registrations.push(
-			// Stack reordering: only the header is the drag handle …
-			draggable({
-				element: headerRef.value,
-				getInitialData: () => ({ type: 'stack', stackId: props.stack.id }),
-				onDragStart: () => { isStackDragging.value = true },
-				onDrop: () => { isStackDragging.value = false },
-			}),
-			// … but the whole column is the drop target (left/right edges).
+			// The whole column is the drop target (left/right edges).
 			dropTargetForElements({
 				element: columnRef.value,
 				canDrop: ({ source }) => source.data.type === 'stack' && source.data.stackId !== props.stack.id,
@@ -789,6 +823,7 @@ onMounted(() => {
 
 onUnmounted(() => {
 	cleanup()
+	stackDragCleanup()
 })
 
 function openCard(cardId) {
@@ -1112,6 +1147,11 @@ body.theme--dark .stack-column,
 	display: flex;
 	flex-direction: column;
 	gap: 0;
+}
+/* The grab cursor only where the header really is a drag handle: the flat board
+   (a stack inside a swimlane is never reorderable) and only for a member who may
+   edit — a viewer's stack move is refused server-side. */
+.stack-column__header--draggable {
 	cursor: grab;
 }
 .stack-column__header-row {

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -760,6 +760,14 @@ let stackDragCleanup = () => {}
 /** (Re-)wire the header drag handle to the current permission. */
 function syncStackDragHandle() {
 	stackDragCleanup()
+	// Same reason as CardTile's syncDragHandle: tearing the draggable down means
+	// its onDrop never fires, so a permission flip landing mid-drag would latch
+	// `stack-column--dragging` on forever. And likewise NOT BoardListView's
+	// pendingRebinds deferral — that defers a DROP TARGET rebind (pragmatic only
+	// re-evaluates those on a native dragover, so rebinding under a parked
+	// pointer kills the drop). This is a draggable; the column's drop targets
+	// survive the flip untouched.
+	isStackDragging.value = false
 	stackDragCleanup = () => {}
 	// Stack reordering is a board-level operation on a shared stack, so it is
 	// only wired when NOT inside a swimlane (a stack renders once per lane; per-

--- a/src/composables/queryKeys.js
+++ b/src/composables/queryKeys.js
@@ -159,13 +159,19 @@ function invalidateViewFeed(queryClient) {
 	if (viewFeedTrailingTimer !== null) {
 		return
 	}
+	// The delay is CLAMPED to the window. `elapsed` comes from the wall clock,
+	// which can step BACKWARDS (an NTP correction, a suspended VM resuming), and a
+	// negative `elapsed` would otherwise arm this timer for the whole size of the
+	// jump. Every later call would then take the "already scheduled" early-out
+	// above, so the View feed would simply stop invalidating on mutations until
+	// the timer finally fired.
 	viewFeedTrailingTimer = setTimeout(() => {
 		viewFeedTrailingTimer = null
 		viewFeedLastInvalidate = Date.now()
 		const client = viewFeedPendingClient
 		viewFeedPendingClient = null
 		client.invalidateQueries({ queryKey: VIEW_CARDS_QUERY_KEY })
-	}, VIEW_FEED_INVALIDATE_THROTTLE - elapsed)
+	}, Math.min(VIEW_FEED_INVALIDATE_THROTTLE, Math.max(0, VIEW_FEED_INVALIDATE_THROTTLE - elapsed)))
 	// Node's timer object only - a browser setTimeout returns a number.
 	viewFeedTrailingTimer.unref?.()
 }

--- a/src/composables/queryKeys.js
+++ b/src/composables/queryKeys.js
@@ -99,6 +99,78 @@ export function invalidateMyWork(queryClient) {
 }
 
 /**
+ * Burst window for the View feed invalidation (#9981).
+ *
+ * The sibling of main.js's MY_WORK_SIGNAL_THROTTLE, and the same policy read
+ * from the other end: the View feed is the heaviest query in the app, so
+ * neither the realtime cadence nor a mutation burst may drive it once per tick.
+ * main.js throttles the REALTIME funnel (30s, and to the narrow invalidator);
+ * this throttles the MUTATION funnel.
+ *
+ * Much shorter than the realtime one because the trigger is different in kind.
+ * A push event is someone else's change, invisible until it lands, so 30s of
+ * staleness is a fair trade. Here the user is typing in an overlay ON the View,
+ * so the feed must repaint at human speed - hence leading edge + a short
+ * trailing window, not a long throttle.
+ *
+ * @type {number}
+ */
+export const VIEW_FEED_INVALIDATE_THROTTLE = 400
+
+// Burst state for invalidateViewFeed. Module-scoped, like main.js's
+// lastMyWorkSignal: there is exactly one View feed and one QueryClient per app.
+let viewFeedLastInvalidate = 0
+let viewFeedTrailingTimer = null
+let viewFeedPendingClient = null
+
+/**
+ * Invalidate the View feed at most twice per burst: immediately on the first
+ * call, then once more when the burst settles (#9981).
+ *
+ * Why this is needed at all: ticking a checklist item, toggling a label and
+ * setting a priority all settle through invalidateCrossBoardFeeds, and roughly
+ * twenty call sites do. When the card overlay was opened FROM a View, ViewPage
+ * stays mounted behind it, so ['view-cards'] is an ACTIVE query - the only kind
+ * invalidateQueries actually refetches. Five quick edits therefore meant five
+ * full cross-board reads. And TanStack does not absorb them: invalidateQueries
+ * defaults to cancelRefetch:true, but getViewCards is a plain axios GET with no
+ * AbortSignal, so a "cancelled" refetch's request still runs to completion
+ * server-side. N ticks really were N round trips.
+ *
+ * LEADING EDGE FIRES IMMEDIATELY - do not turn this into a plain debounce. The
+ * first edit of a burst is the one the user is watching for, and the View tile
+ * behind the overlay has to repaint on it (tests/e2e/view-checklist-live.spec.js
+ * asserts exactly that). The trailing edge then folds the rest of the burst into
+ * a single catch-up refetch, so the feed still ends up consistent with the last
+ * edit.
+ *
+ * @param {import('@tanstack/vue-query').QueryClient} queryClient
+ */
+function invalidateViewFeed(queryClient) {
+	const elapsed = Date.now() - viewFeedLastInvalidate
+	if (viewFeedTrailingTimer === null && elapsed >= VIEW_FEED_INVALIDATE_THROTTLE) {
+		viewFeedLastInvalidate = Date.now()
+		queryClient.invalidateQueries({ queryKey: VIEW_CARDS_QUERY_KEY })
+		return
+	}
+	// Inside the window: remember the client and make sure exactly one trailing
+	// refetch is scheduled. Later calls in the same burst are absorbed by it.
+	viewFeedPendingClient = queryClient
+	if (viewFeedTrailingTimer !== null) {
+		return
+	}
+	viewFeedTrailingTimer = setTimeout(() => {
+		viewFeedTrailingTimer = null
+		viewFeedLastInvalidate = Date.now()
+		const client = viewFeedPendingClient
+		viewFeedPendingClient = null
+		client.invalidateQueries({ queryKey: VIEW_CARDS_QUERY_KEY })
+	}, VIEW_FEED_INVALIDATE_THROTTLE - elapsed)
+	// Node's timer object only - a browser setTimeout returns a number.
+	viewFeedTrailingTimer.unref?.()
+}
+
+/**
  * Invalidate EVERY cross-board feed: the three My Work feeds plus the View feed.
  *
  * This is the one to call from the settle phase of a card mutation. A View is a
@@ -129,9 +201,13 @@ export function invalidateMyWork(queryClient) {
  * the feed itself - once filtering moves server-side, a client-side field patch
  * cannot know whether the card still belongs in the filtered set.
  *
+ * The View half is burst-collapsed (see invalidateViewFeed); the My Work half is
+ * NOT, and must stay immediate - three cheap per-user GETs, as the note on
+ * invalidateMyWork says. Only the heavy query needs the guard.
+ *
  * @param {import('@tanstack/vue-query').QueryClient} queryClient
  */
 export function invalidateCrossBoardFeeds(queryClient) {
 	invalidateMyWork(queryClient)
-	queryClient.invalidateQueries({ queryKey: VIEW_CARDS_QUERY_KEY })
+	invalidateViewFeed(queryClient)
 }

--- a/src/composables/useCardMove.js
+++ b/src/composables/useCardMove.js
@@ -142,6 +142,11 @@ export function useCardMove(boardId) {
 					afterCardId: afterCardId ?? null,
 				})
 				reconcileFromServer(updated)
+				// A move that lands retires the previous move's banner (#10008).
+				// Identical defect to the keyboard shortcuts: lastError was only
+				// ever cleared by the manual ×, so one failed drag left the board
+				// claiming failure through every later successful drag.
+				lastError.value = null
 			} catch (err) {
 				// 409 = rebalance_required; 403 = review gate; anything else is a generic error
 				const status = err?.response?.status

--- a/src/composables/useCardMove.js
+++ b/src/composables/useCardMove.js
@@ -119,6 +119,22 @@ export function useCardMove(boardId) {
 	}
 
 	function enqueueMove({ cardId, targetStackId, afterCardId, optimisticKey }) {
+		// A NEW GESTURE retires the previous move's banner (#10008) — this is the
+		// only place the clear can safely live. Moves are serialised through the
+		// promise chain below, so clearing on success instead meant: drag A fails,
+		// its revert is painted and its banner raised, then the already-queued
+		// drag B lands a round trip later and wipes the explanation off a revert
+		// the user can still see. Clearing here is ordered by the USER's actions
+		// rather than the server's replies — B's enqueue happened before A failed,
+		// so A's message correctly outlives it — and it needs no extra state.
+		//
+		// Known, deliberately not fixed here: BoardView renders
+		// `moveError || shortcutError`, so clearing moveError can re-expose an
+		// older shortcutError that is still set. Collapsing the two refs into one
+		// action-error ref was considered and ruled out; the banner is
+		// latest-outcome-wins across four writers as it is.
+		lastError.value = null
+
 		// Cancel any in-flight board queries so they don't clobber the optimistic patch
 		queryClient.cancelQueries({ queryKey: getBoardQueryKey() })
 
@@ -142,11 +158,9 @@ export function useCardMove(boardId) {
 					afterCardId: afterCardId ?? null,
 				})
 				reconcileFromServer(updated)
-				// A move that lands retires the previous move's banner (#10008).
-				// Identical defect to the keyboard shortcuts: lastError was only
-				// ever cleared by the manual ×, so one failed drag left the board
-				// claiming failure through every later successful drag.
-				lastError.value = null
+				// No clear here: see enqueueMove()'s head. A success arriving from
+				// the queue is not a user gesture, and clearing on it wipes an
+				// earlier failure's banner off a revert still on screen.
 			} catch (err) {
 				// 409 = rebalance_required; 403 = review gate; anything else is a generic error
 				const status = err?.response?.status

--- a/src/composables/useChecklist.js
+++ b/src/composables/useChecklist.js
@@ -12,7 +12,10 @@
  *   4. ALSO patch the board cache's per-card checklist summary so the tile badge
  *      updates immediately without waiting for the settle invalidation.
  *   5. On settled: invalidate the card detail query AND the board query so server
- *      truth eventually wins.
+ *      truth eventually wins — plus, for the three mutations that move the
+ *      {total,done} summary (add / toggle / delete), the cross-board feeds —
+ *      `checklist` is a View filter facet, so a card can enter or leave a
+ *      filtered View on one of them (#9898).
  *
  * Items are sorted by sortKey using plain codepoint string comparison (< / >),
  * which matches the app's lexorank-style keys. Never use localeCompare here.
@@ -37,7 +40,7 @@ import {
 	unassignChecklistItem as apiUnassignChecklistItem,
 	setChecklistItemDue as apiSetChecklistItemDue,
 } from '../services/api.js'
-import { boardQueryKey } from './queryKeys.js'
+import { boardQueryKey, invalidateCrossBoardFeeds } from './queryKeys.js'
 
 /**
  * Resolve a value that may be a plain primitive, a Vue ref, or a getter fn.
@@ -195,6 +198,9 @@ export function useChecklist(cardId, boardId) {
 			queryClient.invalidateQueries({ queryKey: getChecklistKey() })
 			queryClient.invalidateQueries({ queryKey: getCardKey() })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Moves the {total,done} summary, and that is a View filter facet, so
+			// the card can enter or leave a filtered View on it (#9898).
+			invalidateCrossBoardFeeds(queryClient)
 		},
 	})
 
@@ -241,6 +247,9 @@ export function useChecklist(cardId, boardId) {
 			queryClient.invalidateQueries({ queryKey: getChecklistKey() })
 			queryClient.invalidateQueries({ queryKey: getCardKey() })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Moves the {total,done} summary, and that is a View filter facet, so
+			// the card can enter or leave a filtered View on it (#9898).
+			invalidateCrossBoardFeeds(queryClient)
 		},
 	})
 
@@ -323,6 +332,9 @@ export function useChecklist(cardId, boardId) {
 			queryClient.invalidateQueries({ queryKey: getChecklistKey() })
 			queryClient.invalidateQueries({ queryKey: getCardKey() })
 			queryClient.invalidateQueries({ queryKey: getBoardKey() })
+			// Moves the {total,done} summary, and that is a View filter facet, so
+			// the card can enter or leave a filtered View on it (#9898).
+			invalidateCrossBoardFeeds(queryClient)
 		},
 	})
 

--- a/src/composables/useViewCards.js
+++ b/src/composables/useViewCards.js
@@ -19,25 +19,36 @@ import { MY_WORK_POLL_INTERVAL, VIEW_CARDS_QUERY_KEY } from './queryKeys.js'
  * window, so focus refetch never fires there), card mutations invalidate
  * VIEW_CARDS_QUERY_KEY from their settle phase via invalidateCrossBoardFeeds.
  *
- * `data` is the server envelope `{ cards, capped, total, limit }` - `cards` is
- * hard-capped server-side to bound this single unbounded feed; `capped`/`total`
- * let the surface honestly report when it shows only the first N of M cards.
+ * `data` is the server envelope `{ cards, labels, participants, capped, total,
+ * limit }` - `cards` is hard-capped server-side to bound this single unbounded
+ * feed; `capped`/`total` let the surface honestly report when it shows only the
+ * first N of M matching cards.
  *
- * The View's SORT is the one part of a View the server acts on: it is applied
- * before that cap (so a sorted View starts at the true first row, not the first
- * row of an arbitrary window), which makes the ordering part of the cache
- * identity - hence the sort mode + direction on the query key. Changing the sort
- * therefore refetches; `placeholderData` keeps the previous rows on screen for
- * that beat instead of flashing the loading state.
+ * The View's SORT and FILTER are both applied server-side, before that cap - the
+ * sort so a sorted View starts at the true first row, the filter (#9862) so the
+ * cap slices the MATCHING set instead of the first window of the readable set.
+ * Both therefore belong to the cache identity, hence sort mode + direction + the
+ * flat filter query object on the key. Changing either refetches;
+ * `placeholderData` keeps the previous rows on screen for that beat instead of
+ * flashing the loading state - which is also what keeps chip editing feeling
+ * instant: the client predicate re-filters those cached rows on the same tick,
+ * and the refetch only widens the pool underneath.
  *
  * @param {object|import('vue').Ref<object>} [sort] the active `{ mode, dir }`
+ * @param {object|import('vue').Ref<object>} [filter] the active filter as flat
+ *   short-key params (from `filterToQuery(serializeFilter(state))`)
  */
-export function useViewCards(sort) {
+export function useViewCards(sort, filter) {
 	const sortMode = computed(() => unref(sort)?.mode ?? 'default')
 	const sortDir = computed(() => unref(sort)?.dir ?? 'asc')
+	const filterQuery = computed(() => unref(filter) ?? {})
 	return useQuery({
-		queryKey: [...VIEW_CARDS_QUERY_KEY, sortMode, sortDir],
-		queryFn: () => apiGetViewCards({ sortMode: sortMode.value, sortDir: sortDir.value }),
+		queryKey: [...VIEW_CARDS_QUERY_KEY, sortMode, sortDir, filterQuery],
+		queryFn: () => apiGetViewCards({
+			sortMode: sortMode.value,
+			sortDir: sortDir.value,
+			filter: filterQuery.value,
+		}),
 		placeholderData: (previous) => previous,
 		refetchOnWindowFocus: true,
 		refetchOnMount: 'always',

--- a/src/main.js
+++ b/src/main.js
@@ -109,6 +109,10 @@ function invalidateMyWorkThrottled() {
 	// the user participates in. The View feed (invalidateCrossBoardFeeds) is the
 	// heaviest query in the app and must not ride a 30s push cadence - it keeps
 	// its own 60s interval. See invalidateCrossBoardFeeds in queryKeys.js (#9859).
+	// One policy, two ends: this throttle guards the REALTIME funnel, and
+	// VIEW_FEED_INVALIDATE_THROTTLE in queryKeys.js guards the MUTATION funnel,
+	// where a burst of overlay edits would otherwise refetch the feed per tick
+	// (#9981).
 	invalidateMyWork(queryClient)
 }
 onBoardChangesApplied(invalidateMyWorkThrottled)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -494,20 +494,30 @@ export const deleteView = (id) =>
 	axios.delete(url(`/api/views/${encodeURIComponent(id)}`)).then((r) => r.data.views)
 
 // The cross-board card feed a View renders over: enriched summaries from every
-// readable board. The client applies the View's saved filter + group-by. The
-// server returns an envelope `{cards, capped, total, limit}` - `cards` is hard-
-// capped to bound this single unbounded feed; `capped`/`total`/`limit` let the
-// UI honestly report when it is showing only the first N of M readable cards.
-// The View's saved sort is applied SERVER-side, before the cap, so a sorted View
-// starts at the true first row rather than the first row of an arbitrary window.
-export const getViewCards = ({ sortMode = 'default', sortDir = 'asc' } = {}) =>
-	axios.get(url('/api/views/cards'), { params: { sortMode, sortDir } }).then((r) => {
+// readable board. The server returns an envelope
+// `{cards, labels, participants, capped, total, limit}` - `cards` is hard-capped
+// to bound this single unbounded feed; `capped`/`total`/`limit` let the UI
+// honestly report when it is showing only the first N of M MATCHING cards.
+//
+// Both the View's saved SORT and its active FILTER are applied SERVER-side,
+// before that cap (#9862), so a narrow filter reaches matches anywhere in the
+// readable set instead of only within the first capped window. `filter` is the
+// flat short-key object `filterToQuery()` already produces for shareable board
+// filter links - the same encoding, spread straight into the query string. The
+// client still re-filters the rows it receives, so this is a superset guard.
+export const getViewCards = ({ sortMode = 'default', sortDir = 'asc', filter = {} } = {}) =>
+	axios.get(url('/api/views/cards'), { params: { sortMode, sortDir, ...filter } }).then((r) => {
 		const d = r.data ?? {}
 		return {
 			cards: Array.isArray(d.cards) ? d.cards : [],
 			// Union of label metadata (id/title/color) across the readable boards, so
 			// the client can build a labelsById map and colour card-tile label chips.
 			labels: Array.isArray(d.labels) ? d.labels : [],
+			// Facet VOCABULARY (assignee + owner uids across the readable boards),
+			// shipped separately from the rows on purpose: it is accumulated before
+			// the filter, so narrowing to one person never collapses the facet to the
+			// survivors — you can always add a second person, even at zero matches.
+			participants: Array.isArray(d.participants) ? d.participants.filter((u) => typeof u === 'string') : [],
 			capped: !!d.capped,
 			total: Number.isFinite(d.total) ? d.total : (Array.isArray(d.cards) ? d.cards.length : 0),
 			limit: Number.isFinite(d.limit) ? d.limit : 0,

--- a/src/services/boardPermissions.js
+++ b/src/services/boardPermissions.js
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { computed, inject } from 'vue'
+
+/**
+ * Injection key for "the viewer may EDIT this board" — PERMISSION_EDIT, bit 2 of
+ * the board payload's `permissions` (see `OCA\Kanso\Service\PermissionService`).
+ *
+ * Provided by BoardView so deeply nested write affordances (a card tile's drag
+ * handle, a list row's drag handle, a column's reorder handle) can be gated
+ * without threading a prop through StackColumn / SwimlaneRow. The server already
+ * refuses every one of those writes; this only stops the UI from offering a
+ * gesture that can end in nothing but an error toast.
+ *
+ * Same shape as NEST_ENABLED (./cardNesting.js) and CARD_FEATURES
+ * (./cardFeatures.js): a `ComputedRef<boolean>`.
+ */
+export const BOARD_CAN_EDIT = Symbol('kanso:boardCanEdit')
+
+/**
+ * Reads the provided edit flag inside a descendant of BoardView.
+ *
+ * The default is **true**, unlike NEST_ENABLED's false. Surfaces that render the
+ * same components without a provider — a cross-board View's kanban columns
+ * (ViewKanbanColumn.vue) and its list (ViewPage.vue) — carry rows from several
+ * boards and do their own permission handling; defaulting to false there would
+ * silently disable drag on a board the user can perfectly well edit. Gating is
+ * therefore opt-in per surface: only a board that knows the viewer lacks EDIT
+ * provides `false`.
+ *
+ * @return {import('vue').ComputedRef<boolean>} whether write affordances render
+ */
+export function useBoardCanEdit() {
+	return inject(BOARD_CAN_EDIT, computed(() => true))
+}

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1707,9 +1707,21 @@ function handleKeydown(e) {
 				// resync after a rollback. This branch patches nothing locally, so a
 				// refused write leaves nothing stale — refetching every cross-board
 				// feed after a 403 would be pure waste (#9978).
+				//
+				// The trade: a write that LANDS but fails client-side (a proxy
+				// timeout, a 5xx after commit, a dropped response) now skips the
+				// cross-board resync. Self-limiting and worth it — .finally() below
+				// still invalidates the board query, and the feeds poll on their own
+				// 60s interval — where invalidating from .finally() wasted a full
+				// cross-board read after every refused write.
 				invalidateCrossBoardFeeds(queryClient)
-			})
-			.catch((err) => {
+			},
+			// Second argument, deliberately, rather than a chained .catch(): an
+			// onRejected passed to .then() sees only the request's own failure. A
+			// chained .catch() would ALSO catch a throw out of the success handler
+			// above and paint "Failed to update the card." over a write that
+			// actually succeeded.
+			(err) => {
 				shortcutError.value =
 					err?.response?.data?.error || t('kanso', 'Failed to update the card.')
 			})
@@ -1737,10 +1749,13 @@ function handleKeydown(e) {
 				// resolves its card id lazily inside onError/onSettled, so a j/k
 				// focus move mid-PATCH would roll back the wrong card. The plain
 				// promise chain here closes over the id captured at keypress.
-				// SUCCESS path, not .finally(), for the same reason as 'd' (#9978).
+				// SUCCESS path, not .finally(), for the same reason as 'd' (#9978),
+				// and with the same trade recorded there.
 				invalidateCrossBoardFeeds(queryClient)
-			})
-			.catch((err) => {
+			},
+			// onRejected as .then()'s second argument, not a chained .catch() —
+			// see the 'd' branch above.
+			(err) => {
 				shortcutError.value =
 					err?.response?.data?.error || t('kanso', 'Failed to set priority.')
 			})

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1696,6 +1696,11 @@ function handleKeydown(e) {
 		}
 		apiUpdateCard(id, { done: !isDone })
 			.then(() => {
+				// A shortcut that worked retires the previous shortcut's banner
+				// (#10008) — otherwise the manual × is the only way out, and the
+				// board goes on reporting a failed action while the same key is
+				// visibly working again.
+				shortcutError.value = ''
 				// Done-state changes My Tasks membership (#3766, #9859).
 				// SUCCESS path, not .finally(): the optimistic call sites invalidate
 				// from onSettled because they patched the cache up front and must
@@ -1724,6 +1729,8 @@ function handleKeydown(e) {
 		const id = focusedCardId.value
 		apiUpdateCard(id, { priority })
 			.then(() => {
+				// Clear a previous shortcut's banner on success (#10008), as in 'd'.
+				shortcutError.value = ''
 				// Priority is a My Work sort key and a View filter facet, so the
 				// quick-set has to reach the cross-board feeds too (#9859, #9898).
 				// Deliberately NOT routed through usePriority: that composable
@@ -1983,6 +1990,8 @@ onMounted(() => {
 				apiMoveStack(draggedStackId, afterStackId)
 					.then((updated) => {
 						patchStackKey(updated.sortKey)
+						// Same as the shortcuts (#10008): success retires the banner.
+						shortcutError.value = ''
 					})
 					.catch((err) => {
 						const serverError = err?.response?.data?.error
@@ -2196,6 +2205,12 @@ function handleCardSelect({ id, shiftKey }) {
 async function runBulkAction(action, params) {
 	try {
 		const result = await bulk.apply(action, params)
+		// Same as the shortcuts (#10008): success retires the banner. All four
+		// writers of shortcutError share that one ref, so it is latest-outcome-
+		// wins between them — clearing on only some of them would be harder to
+		// reason about than the bug was. (moveError is a separate ref that wins
+		// the OR at the banner, and clears on its own success.)
+		shortcutError.value = ''
 		const okCount = result?.ok?.length ?? 0
 		const skippedCount = result?.skipped?.length ?? 0
 		if (skippedCount > 0) {

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -346,12 +346,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:on-fetch-templates="canEditBoard ? handleFetchTemplates : null"
 					:on-create-from-template="canEditBoard ? handleCreateFromTemplate : null"
 					:on-manage-templates="canEditBoard ? () => { showManageTemplates = true } : null"
-					:on-delete-stack="handleDeleteStack"
-					:on-restore-stack="handleRestoreStack"
-					:on-rename-stack="handleRenameStack"
-					:on-set-role="handleSetRole"
-					:on-set-wip="handleSetWip"
-					:on-set-color="handleSetColor"
+					:on-delete-stack="canEditBoard ? handleDeleteStack : null"
+					:on-restore-stack="canEditBoard ? handleRestoreStack : null"
+					:on-rename-stack="canEditBoard ? handleRenameStack : null"
+					:on-set-role="canEditBoard ? handleSetRole : null"
+					:on-set-wip="canEditBoard ? handleSetWip : null"
+					:on-set-color="canEditBoard ? handleSetColor : null"
 					:on-card-focus="(cardId) => { focusedCardId = cardId }"
 					:on-card-hover="(cardId) => { hoveredCardId = cardId }"
 					:selection-mode="bulk.selectionMode.value"
@@ -640,6 +640,7 @@ import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-sc
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine'
 import { NEST_ENABLED } from '../services/cardNesting.js'
 import { CARD_FEATURES, normalizeCardFeatures } from '../services/cardFeatures.js'
+import { BOARD_CAN_EDIT } from '../services/boardPermissions.js'
 
 // Stable identity for the "no dependency edges yet" case (#5896): a fresh `[]`
 // in the template would be a new prop value on every render while the board
@@ -1098,6 +1099,15 @@ const showManageTemplates = ref(false)
 
 /** Whether the current user may EDIT this board (bit 2). Gates template mutations. */
 const canEditBoard = computed(() => ((boardData.value?.permissions ?? 0) & 2) !== 0)
+
+// Published to every descendant so the write affordances that are too deep to
+// take a prop — a card tile's drag handle, a list row's, a column's reorder
+// handle — disappear for a read-only member instead of offering a gesture the
+// server can only answer with a 403. Provided here rather than beside the other
+// `provide()` calls above because `canEditBoard` is declared at this point.
+// Surfaces with no provider (a cross-board View) default to true; see
+// ../services/boardPermissions.js.
+provide(BOARD_CAN_EDIT, canEditBoard)
 
 /** First (sorted, non-archived) stack id — hosts a freshly created blank template. */
 const firstStackId = computed(() => sortedStacks.value[0]?.id ?? null)

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -475,11 +475,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<td class="shortcuts-modal__key"><kbd>Space</kbd></td>
 							<td>{{ t('kanso', 'Quick preview of the hovered / focused card') }}</td>
 						</tr>
-						<tr>
+						<!-- The two shortcuts the handler now refuses for a read-only
+						     member (#9978) — don't teach a viewer a key that is gated.
+						     ('n' above stays listed: it is inert rather than refused,
+						     since the composer it focuses isn't rendered for a viewer.) -->
+						<tr v-if="canEditBoard">
 							<td class="shortcuts-modal__key"><kbd>d</kbd></td>
 							<td>{{ t('kanso', 'Toggle done on focused card') }}</td>
 						</tr>
-						<tr>
+						<tr v-if="canEditBoard">
 							<td class="shortcuts-modal__key"><kbd>0</kbd>–<kbd>4</kbd></td>
 							<td>{{ t('kanso', 'Set priority on focused card (0=None, 1=Low … 4=Urgent)') }}</td>
 						</tr>
@@ -1674,6 +1678,10 @@ function handleKeydown(e) {
 
 	if (key === 'd') {
 		e.preventDefault()
+		// Read-only members: same gate as the column actions menu and card drag
+		// (#9897). j/k still move the focus ring, so without this a viewer could
+		// fire a PATCH the server can only answer with 403 "Access denied" (#9978).
+		if (!canEditBoard.value) return
 		if (focusedCardId.value == null) return
 		const id = focusedCardId.value
 		// Look up current done state from cardsByStack cache
@@ -1687,14 +1695,21 @@ function handleKeydown(e) {
 			}
 		}
 		apiUpdateCard(id, { done: !isDone })
+			.then(() => {
+				// Done-state changes My Tasks membership (#3766, #9859).
+				// SUCCESS path, not .finally(): the optimistic call sites invalidate
+				// from onSettled because they patched the cache up front and must
+				// resync after a rollback. This branch patches nothing locally, so a
+				// refused write leaves nothing stale — refetching every cross-board
+				// feed after a 403 would be pure waste (#9978).
+				invalidateCrossBoardFeeds(queryClient)
+			})
 			.catch((err) => {
 				shortcutError.value =
 					err?.response?.data?.error || t('kanso', 'Failed to update the card.')
 			})
 			.finally(() => {
 				queryClient.invalidateQueries({ queryKey: boardQueryKey(props.id) })
-				// Done-state changes My Tasks membership (#3766, #9859).
-				invalidateCrossBoardFeeds(queryClient)
 			})
 		return
 	}
@@ -1703,22 +1718,27 @@ function handleKeydown(e) {
 	// Key 0 clears priority (sets to None). Skip when no card is focused.
 	if ((key === '0' || key === '1' || key === '2' || key === '3' || key === '4') && focusedCardId.value != null) {
 		e.preventDefault()
+		// Read-only members: see the 'd' branch above (#9978).
+		if (!canEditBoard.value) return
 		const priority = Number(key)
 		const id = focusedCardId.value
 		apiUpdateCard(id, { priority })
+			.then(() => {
+				// Priority is a My Work sort key and a View filter facet, so the
+				// quick-set has to reach the cross-board feeds too (#9859, #9898).
+				// Deliberately NOT routed through usePriority: that composable
+				// resolves its card id lazily inside onError/onSettled, so a j/k
+				// focus move mid-PATCH would roll back the wrong card. The plain
+				// promise chain here closes over the id captured at keypress.
+				// SUCCESS path, not .finally(), for the same reason as 'd' (#9978).
+				invalidateCrossBoardFeeds(queryClient)
+			})
 			.catch((err) => {
 				shortcutError.value =
 					err?.response?.data?.error || t('kanso', 'Failed to set priority.')
 			})
 			.finally(() => {
 				queryClient.invalidateQueries({ queryKey: boardQueryKey(props.id) })
-				// Priority is a My Work sort key and a View filter facet, so the
-				// quick-set has to reach the cross-board feeds too (#9859, #9898).
-				// Deliberately NOT routed through usePriority: that composable
-				// resolves its card id lazily inside onError/onSettled, so a j/k
-				// focus move mid-PATCH would roll back the wrong card. The plain
-				// .finally() here closes over the id captured at keypress.
-				invalidateCrossBoardFeeds(queryClient)
 			})
 		return
 	}

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -1712,6 +1712,13 @@ function handleKeydown(e) {
 			})
 			.finally(() => {
 				queryClient.invalidateQueries({ queryKey: boardQueryKey(props.id) })
+				// Priority is a My Work sort key and a View filter facet, so the
+				// quick-set has to reach the cross-board feeds too (#9859, #9898).
+				// Deliberately NOT routed through usePriority: that composable
+				// resolves its card id lazily inside onError/onSettled, so a j/k
+				// focus move mid-PATCH would roll back the wrong card. The plain
+				// .finally() here closes over the id captured at keypress.
+				invalidateCrossBoardFeeds(queryClient)
 			})
 		return
 	}

--- a/src/views/ViewPage.vue
+++ b/src/views/ViewPage.vue
@@ -28,13 +28,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				     (#3815 reuses useBoardFilters + BoardFilterBar). Editing the state
 				     re-filters the loaded rows live AND refetches the feed with the
 				     filter applied server-side (#9862); the save button persists it to
-				     the View. The facets are cross-board: `labels` is the union the feed
-				     envelope carries, `participants` the server-supplied uid vocabulary.
-				     `estimate-scale` is deliberately not passed — an estimate scale is
-				     board-scoped and a cross-board View can span two of them. -->
+				     the View. `participants` is the server-supplied cross-board uid
+				     vocabulary.
+				     `labels` is deliberately NOT passed, so the label facet stays
+				     hidden in a View. Label ids are board-scoped and COLLIDE across
+				     boards (see ViewService.php:139-144): the envelope's union is keyed
+				     by id, so board A's label 5 "Bug" and board B's label 5 "Urgent"
+				     become one chip (last board wins) while the predicate matches the
+				     bare id — picking "Bug" would return the other board's "Urgent"
+				     cards. Wrong results are worse than a missing facet; a
+				     board-qualified label identity is follow-up work.
+				     `estimate-scale` is deliberately not passed either — an estimate
+				     scale is board-scoped and a cross-board View can span two of them. -->
 				<BoardFilterBar
 					:state="filterState"
-					:labels="[...labelsById.values()]"
 					:participants="participants"
 					@save="onSaveFromBar" />
 

--- a/src/views/ViewPage.vue
+++ b/src/views/ViewPage.vue
@@ -26,9 +26,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<div class="view-page__controls">
 				<!-- Filter editor: the SAME progressive filter control the board uses
 				     (#3815 reuses useBoardFilters + BoardFilterBar). Editing the state
-				     re-filters live; the save button persists it to the View. -->
+				     re-filters the loaded rows live AND refetches the feed with the
+				     filter applied server-side (#9862); the save button persists it to
+				     the View. The facets are cross-board: `labels` is the union the feed
+				     envelope carries, `participants` the server-supplied uid vocabulary.
+				     `estimate-scale` is deliberately not passed — an estimate scale is
+				     board-scoped and a cross-board View can span two of them. -->
 				<BoardFilterBar
 					:state="filterState"
+					:labels="[...labelsById.values()]"
 					:participants="participants"
 					@save="onSaveFromBar" />
 
@@ -136,8 +142,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 		<!-- Resolved view: an optional truncation notice, then the chosen display. -->
 		<template v-else>
-			<!-- Honest truncation notice: the readable set exceeded the server cap,
-			     so the feed carries only the first N of M cards (no silent
+			<!-- Honest truncation notice: the MATCHING set exceeded the server cap,
+			     so the feed carries only the first N of M matches (no silent
 			     truncation). -->
 			<div
 				v-if="capped"
@@ -214,6 +220,7 @@ import {
 	serializeFilter,
 	applyFilter,
 	makePredicate,
+	filterToQuery,
 } from '../composables/useBoardFilters.js'
 import { groupCardsByField, VIEW_GROUP_BY } from '../composables/useSwimlanes.js'
 
@@ -267,8 +274,19 @@ const sortMenuName = computed(() => (sortMode.value === 'default'
 	? SORT_LABELS.default
 	: `${SORT_LABELS[sortMode.value]} ${sortDir.value === 'asc' ? '↑' : '↓'}`))
 
+// The live, editable filter state (the reused board filter). Declared up here
+// because - like the sort - it is part of the feed query's key: the SAME filter
+// travels to the server, where it runs before the feed's hard cap so the cap
+// slices the matching set rather than the first window of the readable set
+// (#9862). It is still applied client-side over the rows that come back, so
+// editing a chip re-filters the cached rows on the same tick and the refetch
+// only widens the pool underneath - no debounce, no loading flash.
+// It is seeded from the saved View's blob by the `view` watch further down.
+const filterState = createFilterState()
+const filterQuery = computed(() => filterToQuery(serializeFilter(filterState)))
+
 const { data: viewsData, save, rename } = useViews()
-const { data: cardsData, isLoading, isError } = useViewCards(sort)
+const { data: cardsData, isLoading, isError } = useViewCards(sort, filterQuery)
 
 const view = computed(() => (viewsData.value ?? []).find((v) => String(v.id) === String(props.id)) ?? null)
 
@@ -314,10 +332,9 @@ function setDisplay(mode) {
 	display.value = mode
 }
 
-// The live, editable filter state (reused board filter). Seeded from the saved
-// View's opaque blob and re-seeded whenever the resolved View changes - and the
-// display mode + group-by are seeded from the View at the same time.
-const filterState = createFilterState()
+// Seed the filter state from the saved View's opaque blob, re-seeded whenever
+// the resolved View changes - and the display mode + group-by are seeded from
+// the View at the same time.
 watch(view, (v) => {
 	applyFilter(filterState, v ? v.filter : {})
 	if (v) {
@@ -333,12 +350,14 @@ watch(view, (v) => {
 
 const cards = computed(() => cardsData.value?.cards ?? [])
 
-// Honest truncation hint: when the readable set exceeds the server's hard cap the
-// feed carries only the first `limit` of `total` cards. Surface that rather than
-// silently dropping rows (house rule: no silent truncation).
+// Honest truncation hint: when the MATCHING set exceeds the server's hard cap the
+// feed carries only the first `limit` of `total` matches. `total` counts matching
+// cards, not readable ones (#9862 - the filter runs server-side before the cap),
+// so narrowing the filter genuinely brings the number down. Surface that rather
+// than silently dropping rows (house rule: no silent truncation).
 const capped = computed(() => cardsData.value?.capped === true)
 const cappedHint = computed(() =>
-	t('kanso', 'Showing the first {shown} of {total} cards — refine your filter to see the rest.', {
+	t('kanso', 'Showing the first {shown} of {total} matching cards — refine your filter to see the rest.', {
 		shown: cardsData.value?.limit ?? cards.value.length,
 		total: cardsData.value?.total ?? cards.value.length,
 	}),
@@ -351,10 +370,19 @@ const filteredCards = computed(() => {
 	return cards.value.filter(predicate)
 })
 
-// Assignee display names + board titles for the group headers, derived from the
-// loaded cross-board cards (no extra request).
+// Assignee display names + board titles for the group headers (no extra request).
+//
+// The uid vocabulary comes from the envelope's `participants`, which the server
+// accumulates across the whole readable set BEFORE applying the filter. Deriving
+// it from the returned rows instead would make it self-narrowing now that the
+// server filters: filter to alice and the facet would collapse to alice, so you
+// could never add bob - and at zero matches the facet would vanish outright
+// (BoardFilterBar hides it on an empty participants list), leaving no way back.
+// The row-derived pass is kept as a fallback so an older/cached envelope without
+// `participants` still renders group headers.
 const nameByUid = computed(() => {
 	const m = new Map()
+	for (const uid of cardsData.value?.participants ?? []) if (!m.has(uid)) m.set(uid, uid)
 	for (const c of cards.value) {
 		for (const uid of c.assigneeIds || []) if (!m.has(uid)) m.set(uid, uid)
 		if (c.owner && !m.has(c.owner)) m.set(c.owner, c.owner)
@@ -371,7 +399,8 @@ const groups = computed(() =>
 	groupCardsByField(groupBy.value, filteredCards.value, { nameByUid: nameByUid.value, titleByBoard: titleByBoard.value }),
 )
 
-// Cross-board assignee facet for the filter control: uids seen across the feed.
+// Cross-board assignee/owner facet for the filter control — the server-supplied
+// vocabulary above, so it stays complete however narrow the filter gets.
 const participants = computed(() =>
 	[...nameByUid.value.keys()].map((uid) => ({ uid, displayName: uid })),
 )

--- a/tests/e2e/column-actions-acl.spec.js
+++ b/tests/e2e/column-actions-acl.spec.js
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// The column actions menu (rename / status / WIP limit / colour / "Delete
+// column") and card drag are write affordances: renaming, deleting or reordering
+// a column and moving a card all need the board's EDIT bit server-side, so a
+// read-only member who sees them gets nothing but an error. These specs pin all
+// of them to editors, on the kanban board and in list view.
+
+/** Pick a radio in the board's display menu ("Board"/"List"). */
+async function setDisplay(page, name) {
+	await page.locator('.board-view__display-menu button').first().click()
+	await page.getByRole('menuitemradio', { name, exact: true }).click()
+	await page.keyboard.press('Escape')
+}
+
+test.describe('Column actions and card drag are editors only (#9897)', () => {
+	// A second identity logs in explicitly, so this describe must NOT inherit the
+	// shared admin storageState (it would silently stay admin and false-pass).
+	test.use({ storageState: { cookies: [], origins: [] }, viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, boardUrl: '' }
+
+	test.beforeAll(async ({ peer }) => {
+		const board = await api.post('/boards', { title: 'Column ACL ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		state.stackId = stack.id
+		// A second column so the refused card move has somewhere to aim at.
+		const other = await api.post('/stacks', { boardId: board.id, title: 'Done' })
+		state.otherStackId = other.id
+		const card = await api.post('/cards', { stackId: stack.id, title: 'Read-only card' })
+		state.cardId = card.id
+		// READ only (1) — no EDIT bit, so canEditBoard is false for the peer.
+		await api.post(`/boards/${board.id}/acl`, {
+			participant: peer.user,
+			participantType: 'user',
+			permission: 1,
+		})
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('the server refuses a column delete and a card move from a viewer', async ({ peer }) => {
+		// The UI gates below only hide dead affordances — this pins that the real
+		// gate is server-side, so hiding them never becomes the only check.
+		const deleted = await peer.api.raw('DELETE', `/stacks/${state.stackId}`)
+		expect(deleted.status).toBe(403)
+		const moved = await peer.api.raw('POST', `/cards/${state.cardId}/move`, {
+			targetStackId: state.otherStackId,
+		})
+		expect(moved.status).toBe(403)
+	})
+
+	test('a viewer gets no column actions menu and cannot start a drag', async ({ browser, peer }) => {
+		const ctx = await browser.newContext({ viewport: { width: 1600, height: 900 } })
+		try {
+			const page = await ctx.newPage()
+			await ncLogin(page, { user: peer.user, pass: peer.pass })
+			await page.goto(state.boardUrl)
+			await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+			// Kanban — the columns and the card render for them…
+			await expect(page.locator('.stack-column')).toHaveCount(2, { timeout: 10_000 })
+			await expect(page.locator('.card-tile', { hasText: 'Read-only card' }))
+				.toBeVisible({ timeout: 8_000 })
+			// …but the whole actions menu is gone (all six callbacks are null), so
+			// there is no "Delete column" entry to reach and no rename affordance.
+			await expect(page.locator('.stack-column__actions')).toHaveCount(0)
+			await expect(page.getByRole('button', { name: 'Column actions' })).toHaveCount(0)
+			await expect(page.locator('.stack-column__title--editable')).toHaveCount(0)
+			// Neither the tile nor the column header is a drag source: pragmatic
+			// drag-and-drop marks a registered draggable with draggable="true".
+			await expect(page.locator('.card-tile[draggable="true"]')).toHaveCount(0)
+			await expect(page.locator('.stack-column__header[draggable="true"]')).toHaveCount(0)
+
+			// List view — the row renders, but it is not a drag source either.
+			await setDisplay(page, 'List')
+			await page.waitForSelector('.board-list-group', { timeout: 10_000 })
+			await expect(page.locator('.board-list-row', { hasText: 'Read-only card' }))
+				.toBeVisible({ timeout: 8_000 })
+			await expect(page.locator('.board-list-row-wrap[draggable="true"]')).toHaveCount(0)
+			await expect(page.locator('.board-list-row--draggable')).toHaveCount(0)
+		} finally {
+			await ctx.close()
+		}
+	})
+})
+
+test.describe('Column actions and card drag stay available to editors (#9897)', () => {
+	test.use({ viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Column Editor ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		await api.post('/cards', { stackId: stack.id, title: 'Editable card' })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('an editor keeps the column menu, "Delete column" and both drag handles', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// Kanban — the menu is there and still offers the destructive entry.
+		await expect(page.locator('.stack-column__actions')).toHaveCount(1, { timeout: 10_000 })
+		await page.locator('.stack-column__actions button').first().click()
+		await expect(page.getByRole('button', { name: 'Delete column' })).toBeVisible({ timeout: 8_000 })
+		await page.keyboard.press('Escape')
+
+		// Tile and column header are both real drag sources.
+		await expect(page.locator('.card-tile[draggable="true"]')).toHaveCount(1)
+		await expect(page.locator('.stack-column__header[draggable="true"]')).toHaveCount(1)
+
+		// List view keeps its row drag.
+		await setDisplay(page, 'List')
+		await page.waitForSelector('.board-list-group', { timeout: 10_000 })
+		await expect(page.locator('.board-list-row', { hasText: 'Editable card' }))
+			.toBeVisible({ timeout: 8_000 })
+		await expect(page.locator('.board-list-row-wrap[draggable="true"]')).toHaveCount(1)
+	})
+})

--- a/tests/e2e/keyboard-shortcuts-acl.spec.js
+++ b/tests/e2e/keyboard-shortcuts-acl.spec.js
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// #9897 gated the column actions menu and card drag on the board's EDIT bit, but
+// the two WRITE keyboard shortcuts on the same surface — 'd' (toggle done) and
+// '0'–'4' (set priority) — stayed ungated. A read-only member could focus a card
+// with j/k and fire either one, and the only feedback was the server's 403
+// rendering as an "Access denied" banner. These specs pin the shortcuts to
+// editors on both board render paths (flat and swimlanes), and pin that they
+// still work for an editor.
+
+/** Count PATCHes to /api/cards/<id> that the page issues from here on. */
+function watchCardPatches(page) {
+	const seen = []
+	page.on('request', (req) => {
+		if (req.method() === 'PATCH' && /\/apps\/kanso\/api\/cards\/\d+(\?|$)/.test(req.url())) {
+			seen.push(req.url())
+		}
+	})
+	return seen
+}
+
+/** Pick a radio in the board's display menu ("Board"/"List", "Group by"). */
+async function setDisplay(page, name) {
+	await page.locator('.board-view__display-menu button').first().click()
+	await page.getByRole('menuitemradio', { name, exact: true }).click()
+	await page.keyboard.press('Escape')
+}
+
+test.describe('Done / priority shortcuts are editors only (#9978)', () => {
+	// A second identity logs in explicitly, so this describe must NOT inherit the
+	// shared admin storageState (it would silently stay admin and false-pass).
+	test.use({ storageState: { cookies: [], origins: [] }, viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, stackId: 0, cardId: 0, boardUrl: '' }
+
+	test.beforeAll(async ({ peer }) => {
+		const board = await api.post('/boards', { title: 'Shortcut ACL ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		state.stackId = stack.id
+		const card = await api.post('/cards', { stackId: stack.id, title: 'Read-only card' })
+		state.cardId = card.id
+		// READ only (1) — no EDIT bit, so canEditBoard is false for the peer.
+		await api.post(`/boards/${board.id}/acl`, {
+			participant: peer.user,
+			participantType: 'user',
+			permission: 1,
+		})
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('the server refuses a done / priority PATCH from a viewer', async ({ peer }) => {
+		// The UI gates below only hide dead affordances — this pins that the real
+		// gate is server-side, so hiding them never becomes the only check.
+		const done = await peer.api.raw('PATCH', `/cards/${state.cardId}`, { done: true })
+		expect(done.status).toBe(403)
+		const priority = await peer.api.raw('PATCH', `/cards/${state.cardId}`, { priority: 3 })
+		expect(priority.status).toBe(403)
+	})
+
+	test("a viewer's 'd' and '0'–'4' fire no PATCH and are not advertised", async ({ browser, peer }) => {
+		const ctx = await browser.newContext({ viewport: { width: 1600, height: 900 } })
+		try {
+			const page = await ctx.newPage()
+			await ncLogin(page, { user: peer.user, pass: peer.pass })
+			await page.goto(state.boardUrl)
+			await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+			await expect(page.locator('.card-tile', { hasText: 'Read-only card' }))
+				.toBeVisible({ timeout: 10_000 })
+
+			const patches = watchCardPatches(page)
+
+			// j focuses the card — navigation itself stays available to a viewer.
+			await page.keyboard.press('j')
+			await expect(page.locator('.card-tile').first()).toBeFocused({ timeout: 5000 })
+
+			// Neither write shortcut may reach the API…
+			await page.keyboard.press('d')
+			await page.keyboard.press('3')
+			await page.keyboard.press('0')
+			await page.waitForTimeout(1500)
+			expect(patches).toEqual([])
+
+			// …and nothing may render the refusal banner ("Access denied" — the
+			// server supplies `error`, so that string, not the generic fallback).
+			await expect(page.locator('.board-view__move-error')).toHaveCount(0)
+			await expect(page.locator('.card-tile--done')).toHaveCount(0)
+
+			// The overlay must not teach a viewer keys the handler now refuses.
+			await page.keyboard.press('?')
+			const modal = page.locator('.modal-container, [role="dialog"]')
+				.filter({ hasText: 'Keyboard shortcuts' })
+			await expect(modal).toBeVisible({ timeout: 5000 })
+			await expect(modal.getByText('Toggle done on focused card')).toHaveCount(0)
+			await expect(modal.getByText('Set priority on focused card', { exact: false })).toHaveCount(0)
+			// The read-only navigation rows are still listed — the overlay is
+			// trimmed, not emptied.
+			await expect(modal.getByText('Navigate cards up / down')).toHaveCount(1)
+			await page.keyboard.press('Escape')
+			await expect(modal).not.toBeVisible({ timeout: 5000 })
+
+			// Swimlane render path (#9978): its :on-card-focus is unconditional too,
+			// so the gate has to live in the handler, not on the prop sites.
+			await setDisplay(page, 'Assignee')
+			await expect(page.locator('.swimlane')).toHaveCount(1, { timeout: 10_000 })
+			await expect(page.locator('.swimlane .card-tile', { hasText: 'Read-only card' }))
+				.toBeVisible({ timeout: 8_000 })
+
+			patches.length = 0
+			await page.keyboard.press('j')
+			await expect(page.locator('.swimlane .card-tile').first()).toBeFocused({ timeout: 5000 })
+			await page.keyboard.press('d')
+			await page.keyboard.press('4')
+			await page.waitForTimeout(1500)
+			expect(patches).toEqual([])
+			await expect(page.locator('.board-view__move-error')).toHaveCount(0)
+		} finally {
+			await ctx.close()
+		}
+	})
+})
+
+test.describe('Done / priority shortcuts still work for an editor (#9978)', () => {
+	test.use({ viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Shortcut Editor ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		await api.post('/cards', { stackId: stack.id, title: 'Editable card' })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test("an editor fires exactly one PATCH per 'd' / priority key", async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		const tile = page.locator('.card-tile', { hasText: 'Editable card' })
+		await expect(tile).toBeVisible({ timeout: 10_000 })
+
+		const patches = watchCardPatches(page)
+
+		await page.keyboard.press('j')
+		await expect(tile).toBeFocused({ timeout: 5000 })
+
+		await page.keyboard.press('3')
+		await expect(tile.locator('.card-tile__priority')).toHaveClass(/card-tile__priority--3/, { timeout: 10_000 })
+		expect(patches).toHaveLength(1)
+
+		await page.keyboard.press('d')
+		await expect(tile).toHaveClass(/card-tile--done/, { timeout: 10_000 })
+		expect(patches).toHaveLength(2)
+
+		// Both keys are advertised to an editor.
+		await page.keyboard.press('?')
+		const modal = page.locator('.modal-container, [role="dialog"]')
+			.filter({ hasText: 'Keyboard shortcuts' })
+		await expect(modal).toBeVisible({ timeout: 5000 })
+		await expect(modal.getByText('Toggle done on focused card')).toHaveCount(1)
+		await expect(modal.getByText('Set priority on focused card', { exact: false })).toHaveCount(1)
+	})
+})

--- a/tests/e2e/shortcut-error-banner.spec.js
+++ b/tests/e2e/shortcut-error-banner.spec.js
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// #10008: `shortcutError` was only ever cleared by the banner's manual ×, so a
+// single failed shortcut (a network blip, a refused write, a card that vanished)
+// left the board reporting that failure through every later shortcut that
+// actually worked. These specs pin that a successful shortcut retires the
+// banner on its own, and that a genuine failure still raises it and the × still
+// dismisses it.
+//
+// A viewer never reaches this surface at all — #9978 made 'd' and '0'–'4' no-op
+// for read-only members, and that (no banner for a viewer) is pinned in
+// keyboard-shortcuts-acl.spec.js.
+
+const CARD_PATCH = /\/apps\/kanso\/api\/cards\/\d+(\?|$)/
+
+/**
+ * Reject card PATCHes with a server-shaped error body.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} message - goes in the `error` field, so it is what the banner shows
+ * @param {object} [options]
+ * @param {boolean} [options.onlyFirst] - fail just the first PATCH, then let later ones
+ *   through (the exact shape of the bug: a transient failure, then a shortcut that works)
+ */
+async function failCardPatch(page, message, { onlyFirst = false } = {}) {
+	let failures = 0
+	await page.route(CARD_PATCH, async (route) => {
+		if (route.request().method() === 'PATCH' && !(onlyFirst && failures > 0)) {
+			failures++
+			await route.fulfill({
+				status: 500,
+				contentType: 'application/json',
+				body: JSON.stringify({ error: message }),
+			})
+			return
+		}
+		await route.continue()
+	})
+}
+
+test.describe('Shortcut error banner auto-clears on success (#10008)', () => {
+	test.use({ viewport: { width: 1600, height: 900 } })
+
+	const state = { boardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Shortcut Banner ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		await api.post('/cards', { stackId: stack.id, title: 'Banner card' })
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	/**
+	 * Open the board and focus its only card with j.
+	 *
+	 * @param {import('@playwright/test').Page} page
+	 * @return {Promise<import('@playwright/test').Locator>} the focused tile
+	 */
+	async function openBoardWithFocusedCard(page) {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+		const tile = page.locator('.card-tile', { hasText: 'Banner card' })
+		await expect(tile).toBeVisible({ timeout: 10_000 })
+		await page.keyboard.press('j')
+		await expect(tile).toBeFocused({ timeout: 5000 })
+		return tile
+	}
+
+	test('a priority key that succeeds clears the previous failure banner', async ({ page }) => {
+		const tile = await openBoardWithFocusedCard(page)
+		await failCardPatch(page, 'Simulated shortcut failure', { onlyFirst: true })
+
+		// First priority key is refused — the banner reports it.
+		await page.keyboard.press('3')
+		await expect(page.locator('.board-view__move-error'))
+			.toContainText('Simulated shortcut failure', { timeout: 10_000 })
+
+		// Second one reaches the server and lands…
+		await page.keyboard.press('2')
+		await expect(tile.locator('.card-tile__priority'))
+			.toHaveClass(/card-tile__priority--2/, { timeout: 10_000 })
+		// …so the stale failure must retire itself, with no click on the ×.
+		await expect(page.locator('.board-view__move-error')).toHaveCount(0, { timeout: 10_000 })
+	})
+
+	// 'd' and the priority keys clear the banner from their own separate success
+	// callbacks, so neither one covers the other.
+	test('a done key that succeeds clears the previous failure banner', async ({ page }) => {
+		const tile = await openBoardWithFocusedCard(page)
+		await failCardPatch(page, 'Simulated toggle failure', { onlyFirst: true })
+
+		await page.keyboard.press('d')
+		await expect(page.locator('.board-view__move-error'))
+			.toContainText('Simulated toggle failure', { timeout: 10_000 })
+
+		await page.keyboard.press('d')
+		await expect(tile).toHaveClass(/card-tile--done/, { timeout: 10_000 })
+		await expect(page.locator('.board-view__move-error')).toHaveCount(0, { timeout: 10_000 })
+	})
+
+	test('a genuine failure still raises the banner, and the × still dismisses it', async ({ page }) => {
+		await openBoardWithFocusedCard(page)
+		await failCardPatch(page, 'Simulated done failure')
+
+		await page.keyboard.press('d')
+		const banner = page.locator('.board-view__move-error')
+		await expect(banner).toContainText('Simulated done failure', { timeout: 10_000 })
+
+		await banner.locator('.board-view__move-error-dismiss').click()
+		await expect(banner).toHaveCount(0, { timeout: 5000 })
+	})
+})

--- a/tests/e2e/view-checklist-live.spec.js
+++ b/tests/e2e/view-checklist-live.spec.js
@@ -80,8 +80,13 @@ test.describe('Cross-board feed invalidation, the missed paths (#9898)', () => {
 		await api.patch(`/checklist/${bDone.id}`, { done: true })
 		await api.post(`/cards/${state.incompleteCardId}/checklist`, { title: SEED_OPEN })
 
-		// A third card for the board-route priority shortcut. Assigned to the
-		// current user so it is genuinely a My Tasks row.
+		// A third card, created LAST, for the board-route priority shortcut test.
+		// It is not the card that test acts on - it presses the shortcut on the
+		// FIRST tile, which is COMPLETE_CARD. This one is the paint gate: because
+		// it is the last row inserted it is the last to appear, so waiting for it
+		// means the whole stack has rendered before the keyboard sequence starts.
+		// No assignee is needed - every card here is owned by the API user, which
+		// is what puts it in the My Work feeds.
 		await api.post('/cards', { stackId: stack.id, title: PRIORITY_CARD })
 
 		await api.put(`/cards/${state.completeCardId}/labels/${state.scopeLabelId}`)
@@ -250,7 +255,10 @@ test.describe('Cross-board feed invalidation, the missed paths (#9898)', () => {
 		// resolves its card id lazily and would roll back the wrong card if focus
 		// moved mid-PATCH), so its .finally() is the only thing that can reach the
 		// cross-board feeds.
-		// ArrowDown with nothing focused seeds to the first card of the first stack.
+		// ArrowDown with nothing focused seeds to the first card of the first stack
+		// - COMPLETE_CARD, the first row inserted. Which card it lands on does not
+		// matter here; what is under test is that the shortcut's settle phase
+		// invalidates the cross-board feeds at all.
 		const firstTile = page.locator('.stack-column').nth(0).locator('.card-tile').first()
 		await page.keyboard.press('ArrowDown')
 		await expect(firstTile).toBeFocused({ timeout: 8000 })

--- a/tests/e2e/view-checklist-live.spec.js
+++ b/tests/e2e/view-checklist-live.spec.js
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #9898 — the two mutation paths #9859 left behind.
+//
+// #9859 swapped card mutations onto invalidateCrossBoardFeeds so an edit made
+// in the card overlay reaches the View feed and the My Work feeds. Two paths
+// reached NEITHER and were out of scope:
+//
+//   1. useChecklist's addItem / toggleItem / deleteItem — they settled on the
+//      checklist + card + board keys only.
+//   2. BoardView's 0–4 priority quick-set shortcut — its .finally() invalidated
+//      only the board key (the adjacent `d` shortcut already did the right
+//      thing).
+//
+// The checklist half is the one with real teeth, and it is what the first two
+// tests drive. `checklist` is a View FILTER facet (useBoardFilters: has /
+// incomplete / complete / none, off the derived {total,done} summary), so an
+// item add/toggle/delete can push a card INTO or OUT OF a filtered View. And
+// the card detail opens as an in-place overlay ON the View (ViewPage), so
+// ['view-cards'] is an ACTIVE query at mutation time — invalidateQueries
+// refetches it immediately. Without the fix the tile behind the overlay keeps
+// the stale membership until the 60s interval ticks, so these two tests FAIL on
+// unfixed code. Every assertion runs with the overlay still open and a
+// no-reload marker in place, so nothing but the settle-phase invalidation can
+// be doing the work.
+//
+// The priority shortcut is asserted on its observable half only (third test):
+// useMyWorkBadges keeps ['my-cards'] mounted app-wide, so the fix makes the
+// keypress fire a real GET /api/my-cards. It is deliberately NOT asserted via
+// "press 0–4 then navigate to a View": the shortcut only exists on the board
+// route, where view-cards is INACTIVE, and useViewCards sets
+// refetchOnMount:'always' — so that navigation refetches with or without the
+// fix and the assertion could not fail.
+//
+// The complementary guard — that a notify_push event still does NOT drag the
+// View feed onto the 30s realtime cadence — lives in
+// tests/unit/queryKeys.test.mjs. Push is disabled in CI
+// (KANSO_SKIP_NOTIFY_PUSH=1) and absent from the dev stack, so asserting it in
+// a browser would pass vacuously.
+
+import { test, expect, api, ncLogin, BASE, boardUrl } from './helpers.js'
+
+test.describe('Cross-board feed invalidation, the missed paths (#9898)', () => {
+	const ts = Math.floor(Date.now() / 1000)
+	const COMPLETE_CARD = `CLLive Complete ${ts}`
+	const INCOMPLETE_CARD = `CLLive Incomplete ${ts}`
+	const PRIORITY_CARD = `CLLive Priority ${ts}`
+	const SEED_DONE = 'seeded done step'
+	const SEED_OPEN = 'seeded open step'
+
+	const state = {
+		boardId: 0,
+		scopeLabelId: 0,
+		completeCardId: 0,
+		incompleteCardId: 0,
+	}
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: `CLLive E2E ${ts}` })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
+
+		// A per-run scope label the saved Views filter on, so each View resolves
+		// to EXACTLY this run's cards no matter what else lives in the dev DB.
+		state.scopeLabelId = (await api.post('/labels', {
+			boardId: board.id,
+			title: `cllive-scope ${ts}`,
+			color: 'ff0000',
+		})).id
+
+		// Card A: one item, done → checklist summary {1,1} → facet 'complete'.
+		state.completeCardId = (await api.post('/cards', { stackId: stack.id, title: COMPLETE_CARD })).id
+		const doneItem = await api.post(`/cards/${state.completeCardId}/checklist`, { title: SEED_DONE })
+		await api.patch(`/checklist/${doneItem.id}`, { done: true })
+
+		// Card B: two items, one done → {2,1} → facet 'incomplete'.
+		state.incompleteCardId = (await api.post('/cards', { stackId: stack.id, title: INCOMPLETE_CARD })).id
+		const bDone = await api.post(`/cards/${state.incompleteCardId}/checklist`, { title: SEED_DONE })
+		await api.patch(`/checklist/${bDone.id}`, { done: true })
+		await api.post(`/cards/${state.incompleteCardId}/checklist`, { title: SEED_OPEN })
+
+		// A third card for the board-route priority shortcut. Assigned to the
+		// current user so it is genuinely a My Tasks row.
+		await api.post('/cards', { stackId: stack.id, title: PRIORITY_CARD })
+
+		await api.put(`/cards/${state.completeCardId}/labels/${state.scopeLabelId}`)
+		await api.put(`/cards/${state.incompleteCardId}/labels/${state.scopeLabelId}`)
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	/** Create a saved View scoped to this run's cards on one checklist facet. */
+	async function createChecklistView(name, checklist) {
+		const created = await api.put('/views', {
+			name: `${name} ${ts}`,
+			filter: { labels: [state.scopeLabelId], checklist },
+			groupBy: 'board',
+			display: 'list',
+		})
+		const view = created.views[created.views.length - 1]
+		expect(view.id).toBeTruthy()
+		return view.id
+	}
+
+	/** A refetch of the cross-board View feed. */
+	function feedRefetch(page) {
+		return page.waitForResponse(
+			(r) => r.url().includes('/api/views/cards') && r.ok(),
+			{ timeout: 15_000 },
+		)
+	}
+
+	test('adding then completing a checklist item moves the card in and out of a filtered View', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+		// 'complete' = every item done. Card A ({1,1}) matches; Card B ({2,1}) does not.
+		const viewId = await createChecklistView('CLLive complete', 'complete')
+		const NEW_ITEM = `cllive extra ${ts}`
+
+		try {
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${viewId}`)
+
+			const completeRow = page.locator('.board-list-row__title', { hasText: COMPLETE_CARD })
+			const incompleteRow = page.locator('.board-list-row__title', { hasText: INCOMPLETE_CARD })
+			await expect(completeRow).toBeVisible({ timeout: 15_000 })
+			// The facet really is filtering, not showing everything.
+			await expect(incompleteRow).toHaveCount(0)
+
+			// Marker that only survives if NO full page reload happens from here on.
+			await page.evaluate(() => { window.__kansoNoReload = true })
+
+			// Open the card as an in-place overlay ON the View (never navigates).
+			await completeRow.click()
+			await expect(page.locator('.card-modal-modal')).toBeVisible({ timeout: 15_000 })
+			await expect(page).toHaveURL(new RegExp(`/views/${viewId}`))
+			await expect(page.locator('.card-modal__checklist-count')).toHaveText('1 / 1', { timeout: 15_000 })
+
+			// ── addItem ──────────────────────────────────────────────────────────
+			// A new, undone item makes the summary {2,1}: no longer 'complete', so
+			// the row behind the overlay must LEAVE the View on its own.
+			let refetch = feedRefetch(page)
+			await page.locator('.card-modal__checklist-add-input').fill(NEW_ITEM)
+			await page.locator('.card-modal__checklist-add-input').press('Enter')
+			await expect(page.locator('.card-modal__checklist-item').filter({ hasText: NEW_ITEM }))
+				.toBeVisible({ timeout: 15_000 })
+			await expect(page.locator('.card-modal__checklist-count')).toHaveText('1 / 2', { timeout: 15_000 })
+			await refetch
+
+			await expect(completeRow).toHaveCount(0, { timeout: 10_000 })
+
+			// ── toggleItem ───────────────────────────────────────────────────────
+			// Tick it: {2,2} is 'complete' again, so the row must come BACK.
+			refetch = feedRefetch(page)
+			const newItem = page.locator('.card-modal__checklist-item').filter({ hasText: NEW_ITEM })
+			const checkbox = newItem.locator('.card-modal__checklist-checkbox')
+			await expect(checkbox).toBeEnabled({ timeout: 15_000 })
+			await checkbox.click()
+			await expect(checkbox).toBeChecked({ timeout: 15_000 })
+			await expect(page.locator('.card-modal__checklist-count')).toHaveText('2 / 2', { timeout: 15_000 })
+			await refetch
+
+			await expect(completeRow).toHaveCount(1, { timeout: 10_000 })
+
+			// …and every bit of that happened in place, with the overlay still open.
+			await expect(page.locator('.card-modal-modal')).toBeVisible()
+			expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+		} finally {
+			await api.delete(`/views/${viewId}`).catch(() => {})
+			// Put card A back to {1,1} so the tests stay order-independent.
+			const items = await api.get(`/cards/${state.completeCardId}/checklist`).catch(() => [])
+			for (const it of items) {
+				if (it.title === NEW_ITEM) await api.delete(`/checklist/${it.id}`).catch(() => {})
+			}
+		}
+	})
+
+	test('deleting a checklist item moves the card out of a filtered View', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+		// 'incomplete' = has items, not all done. Card B ({2,1}) matches; A ({1,1}) does not.
+		const viewId = await createChecklistView('CLLive incomplete', 'incomplete')
+
+		try {
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${viewId}`)
+
+			const incompleteRow = page.locator('.board-list-row__title', { hasText: INCOMPLETE_CARD })
+			const completeRow = page.locator('.board-list-row__title', { hasText: COMPLETE_CARD })
+			await expect(incompleteRow).toBeVisible({ timeout: 15_000 })
+			await expect(completeRow).toHaveCount(0)
+
+			await page.evaluate(() => { window.__kansoNoReload = true })
+
+			await incompleteRow.click()
+			await expect(page.locator('.card-modal-modal')).toBeVisible({ timeout: 15_000 })
+			await expect(page.locator('.card-modal__checklist-count')).toHaveText('1 / 2', { timeout: 15_000 })
+
+			// ── deleteItem ───────────────────────────────────────────────────────
+			// Dropping the only OPEN item leaves {1,1}: 'complete', not
+			// 'incomplete', so the row behind the overlay must leave the View.
+			const refetch = feedRefetch(page)
+			const openItem = page.locator('.card-modal__checklist-item').filter({ hasText: SEED_OPEN })
+			await expect(openItem).toBeVisible({ timeout: 15_000 })
+			await openItem.locator('.card-modal__checklist-item-delete').click()
+			await expect(page.locator('.card-modal__checklist-count')).toHaveText('1 / 1', { timeout: 15_000 })
+			await refetch
+
+			await expect(incompleteRow).toHaveCount(0, { timeout: 10_000 })
+			await expect(page.locator('.card-modal-modal')).toBeVisible()
+			expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+		} finally {
+			await api.delete(`/views/${viewId}`).catch(() => {})
+			// Restore card B to {2,1} for order-independence.
+			const items = await api.get(`/cards/${state.incompleteCardId}/checklist`).catch(() => [])
+			if (!items.some((i) => i.title === SEED_OPEN)) {
+				await api.post(`/cards/${state.incompleteCardId}/checklist`, { title: SEED_OPEN }).catch(() => {})
+			}
+		}
+	})
+
+	test('the 0–4 priority shortcut refreshes the My Work feeds', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+		await ncLogin(page)
+
+		// Record every my-cards hit, registered BEFORE the board loads so the
+		// app-boot fetch (App.vue mounts useMyWorkBadges for the app's lifetime)
+		// is counted too. The assertion below is then against the count at
+		// keypress time, not against "some request eventually happened".
+		let myCardsHits = 0
+		page.on('response', (r) => {
+			if (r.url().includes('/api/my-cards')) myCardsHits++
+		})
+
+		await page.goto(boardUrl(state.boardId))
+
+		await expect(page.locator('.card-tile__title', { hasText: PRIORITY_CARD }))
+			.toBeVisible({ timeout: 20_000 })
+
+		// useMyCards fetches once on app mount and then polls every 60s, so the
+		// mount hit has already landed by the time the board paints and the next
+		// scheduled one is ~a minute out: nothing but the shortcut can satisfy the
+		// short window below.
+		await expect.poll(() => myCardsHits, { timeout: 20_000 }).toBeGreaterThan(0)
+		const hitsBeforeKeypress = myCardsHits
+
+		// Focus the first card, then quick-set priority. The shortcut calls the
+		// card API directly (deliberately not routed through usePriority, which
+		// resolves its card id lazily and would roll back the wrong card if focus
+		// moved mid-PATCH), so its .finally() is the only thing that can reach the
+		// cross-board feeds.
+		// ArrowDown with nothing focused seeds to the first card of the first stack.
+		const firstTile = page.locator('.stack-column').nth(0).locator('.card-tile').first()
+		await page.keyboard.press('ArrowDown')
+		await expect(firstTile).toBeFocused({ timeout: 8000 })
+
+		const patched = page.waitForResponse(
+			(r) => /\/api\/cards\/\d+(?:\?|$)/.test(r.url())
+				&& r.request().method() === 'PATCH'
+				&& r.status() < 400,
+			{ timeout: 15_000 },
+		)
+		await page.keyboard.press('3')
+		await patched
+
+		// The settle-phase invalidateCrossBoardFeeds is the only thing that can
+		// have fired this. Without it the shortcut invalidates the board key alone
+		// and the count stays put.
+		await expect.poll(() => myCardsHits, { timeout: 15_000 })
+			.toBeGreaterThan(hitsBeforeKeypress)
+	})
+})

--- a/tests/e2e/view-feed-burst.spec.js
+++ b/tests/e2e/view-feed-burst.spec.js
@@ -138,12 +138,17 @@ test.describe('View feed burst collapsing (#9981)', () => {
 		await page.waitForTimeout(3000)
 		const observed = feedRequests
 
-		// Leading edge + one trailing catch-up is the contract. The third slot is
-		// slack for a settle that straddles the window on a slow runner; on
-		// unguarded code this is ITEMS, so the assertion has real teeth either way.
+		// Leading edge + one trailing catch-up is the contract. The slots above
+		// that are deliberate slack, not sloppiness: on a 2-worker, 4-CPU runner
+		// the 8 stubbed settles need not all land inside one 400ms window, and the
+		// counter matches on URL alone — the View feed's own 60s refetchInterval
+		// ticking mid-burst would add a spurious read this route handler cannot
+		// tell apart. Slack is the right answer here rather than `retries`, which
+		// would mask a real regression in the suite's longest pole. The teeth are
+		// unaffected: unguarded code issues ITEMS (8) of these.
 		expect(observed,
 			`${ITEMS} ticks issued ${observed} /api/views/cards reads — the burst was not collapsed`)
-			.toBeLessThanOrEqual(3)
+			.toBeLessThanOrEqual(4)
 		expect(observed).toBeLessThan(ITEMS)
 
 		// …and the leading edge still fired, so the View behind the overlay is not

--- a/tests/e2e/view-feed-burst.spec.js
+++ b/tests/e2e/view-feed-burst.spec.js
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #9981 — a burst of edits in a card overlay opened FROM a View must not fire
+// one cross-board feed read per edit.
+//
+// ~20 mutation settle sites call invalidateCrossBoardFeeds. Opening the card
+// detail from a View leaves ViewPage mounted behind the overlay, so
+// ['view-cards'] is an ACTIVE query — the only kind invalidateQueries actually
+// refetches. Every settle therefore used to trigger a full read of the heaviest
+// query in the app (enriched summaries across every readable board, up to the
+// server cap), and TanStack did not absorb the duplicates: invalidateQueries
+// defaults to cancelRefetch:true, but getViewCards is a plain axios GET with no
+// AbortSignal, so a "cancelled" refetch's request still completes server-side.
+//
+// ── Why the checklist PATCH is stubbed ───────────────────────────────────────
+// The quantity under test is purely client-side: how many /api/views/cards
+// requests the settle path ISSUES for one burst. Left on the real endpoint, the
+// burst is paced by the PATCH round trip — measured here at ~160ms/tick, which
+// collapses 8 ticks into 4 reads locally but into ~8 on the ~5x slower CI
+// runner, where nothing is a burst any more. That would make the assertion
+// track the runner's disk speed rather than the guard. Fulfilling the PATCH in
+// the browser removes that one variable and nothing else: the real checkbox,
+// the real Vue handler, the real mutation, the real settle phase and the real
+// /api/views/cards requests all still run. (The trade is that server state
+// doesn't move, so this spec asserts request counts only — the state half is
+// tests/e2e/view-checklist-live.spec.js's job.)
+//
+// The counting is done with page.route, not with timing: the route handler sees
+// every request the page issues. The cadence unit tests are in
+// tests/unit/queryKeys.test.mjs; this spec is what proves the guard survives the
+// real bundle, the real overlay and the real settle path.
+//
+// tests/e2e/view-checklist-live.spec.js is the other half of the contract and
+// must keep passing unchanged: the leading edge still repaints the View tile on
+// the first edit.
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+test.describe('View feed burst collapsing (#9981)', () => {
+	const ts = Math.floor(Date.now() / 1000)
+	const CARD = `Burst card ${ts}`
+	const ITEMS = 8
+
+	const state = { boardId: 0, scopeLabelId: 0, cardId: 0, viewId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: `Burst E2E ${ts}` })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
+
+		// A per-run scope label the View filters on, so the View resolves to
+		// exactly this run's card whatever else lives in the dev DB.
+		state.scopeLabelId = (await api.post('/labels', {
+			boardId: board.id,
+			title: `burst-scope ${ts}`,
+			color: '00aa00',
+		})).id
+
+		state.cardId = (await api.post('/cards', { stackId: stack.id, title: CARD })).id
+		await api.put(`/cards/${state.cardId}/labels/${state.scopeLabelId}`)
+		for (let i = 1; i <= ITEMS; i++) {
+			await api.post(`/cards/${state.cardId}/checklist`, { title: `burst step ${i}` })
+		}
+
+		// Filtered on the LABEL, not on the checklist facet, so a tick never moves
+		// the row in or out of the View — the only thing that varies across the
+		// burst is how often the feed is re-read.
+		const created = await api.put('/views', {
+			name: `Burst view ${ts}`,
+			filter: { labels: [state.scopeLabelId] },
+			groupBy: 'board',
+			display: 'list',
+		})
+		state.viewId = created.views[created.views.length - 1].id
+		expect(state.viewId).toBeTruthy()
+	})
+
+	test.afterAll(async () => {
+		if (state.viewId) await api.delete(`/views/${state.viewId}`).catch(() => {})
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('a burst of checklist ticks in a View overlay collapses into a couple of cross-board reads', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+		await ncLogin(page)
+
+		// page.route sees the request as the page ISSUES it — a response listener
+		// would miss any the browser never completes, and "issued" is the quantity
+		// that regressed (a cancelled refetch still runs server-side).
+		let feedRequests = 0
+		let counting = false
+		await page.route('**/api/views/cards*', async (route) => {
+			if (counting) feedRequests++
+			await route.continue()
+		})
+
+		// See the header: latency removal, not behaviour replacement. Nothing in
+		// the toggle mutation reads this body.
+		await page.route('**/api/checklist/*', async (route) => {
+			if (route.request().method() !== 'PATCH') return route.continue()
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: '{}',
+			})
+		})
+
+		await page.goto(`${BASE}/index.php/apps/kanso#/views/${state.viewId}`)
+
+		const row = page.locator('.board-list-row__title', { hasText: CARD })
+		await expect(row).toBeVisible({ timeout: 20_000 })
+
+		// Open the card as an in-place overlay ON the View (never navigates), so
+		// ViewPage stays mounted and ['view-cards'] stays ACTIVE.
+		await page.evaluate(() => { window.__kansoNoReload = true })
+		await row.click()
+		await expect(page.locator('.card-modal-modal')).toBeVisible({ timeout: 15_000 })
+		await expect(page.locator('.card-modal__checklist-count'))
+			.toHaveText(`0 / ${ITEMS}`, { timeout: 15_000 })
+		await expect(page.locator('.card-modal__checklist-checkbox')).toHaveCount(ITEMS)
+
+		// Everything before this point (view load, overlay open) is setup traffic.
+		counting = true
+
+		// One synchronous task, so all ITEMS toggles start before Vue can re-render
+		// the checkboxes into their in-flight disabled state — i.e. a genuine
+		// burst, the shape ungated call sites (bulk apply, quick-set shortcuts)
+		// produce on their own.
+		const fired = await page.evaluate((expected) => {
+			const boxes = [...document.querySelectorAll('.card-modal__checklist-checkbox')]
+			boxes.forEach((box) => box.click())
+			return boxes.length === expected ? boxes.length : -boxes.length
+		}, ITEMS)
+		expect(fired).toBe(ITEMS)
+
+		// Long enough for every settle plus the trailing edge (400ms) to land.
+		await page.waitForTimeout(3000)
+		const observed = feedRequests
+
+		// Leading edge + one trailing catch-up is the contract. The third slot is
+		// slack for a settle that straddles the window on a slow runner; on
+		// unguarded code this is ITEMS, so the assertion has real teeth either way.
+		expect(observed,
+			`${ITEMS} ticks issued ${observed} /api/views/cards reads — the burst was not collapsed`)
+			.toBeLessThanOrEqual(3)
+		expect(observed).toBeLessThan(ITEMS)
+
+		// …and the leading edge still fired, so the View behind the overlay is not
+		// simply going unrefreshed.
+		expect(observed,
+			'the burst produced no feed read at all — the leading edge is gone')
+			.toBeGreaterThan(0)
+
+		// All of it happened in place, with the overlay still open.
+		await expect(page.locator('.card-modal-modal')).toBeVisible()
+		expect(await page.evaluate(() => window.__kansoNoReload)).toBe(true)
+	})
+})

--- a/tests/e2e/view-filter-facets.spec.js
+++ b/tests/e2e/view-filter-facets.spec.js
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, me, ncLogin, BASE } from './helpers.js'
+
+// #9862 — a View's filter now travels to the server, which applies it BEFORE the
+// cross-board feed's 5000-card cap so the cap slices the MATCHING set. That fixes
+// the miss-past-the-cap bug, but it creates a second one if the facets are built
+// naively: if the assignee/owner options were derived from the RETURNED rows,
+// filtering to one person would collapse the facet to that person — and at zero
+// matches the facet would disappear entirely (BoardFilterBar hides it on an empty
+// participants list), leaving no way to add a second person back.
+//
+// So the envelope ships the participant VOCABULARY separately from the rows,
+// accumulated across the whole readable set before the filter. This spec pins
+// that with TWO identities, because a single-user board can never lose anyone
+// from the facet and would false-pass.
+
+test.describe('View filter facets survive a narrow server-side filter (#9862)', () => {
+	// Two identities take part (the peer owns/holds cards this user filters to), and
+	// the browser logs in explicitly — so this describe must NOT inherit the shared
+	// admin storageState, which would silently keep us as admin and false-pass.
+	test.use({ storageState: { cookies: [], origins: [] }, viewport: { width: 1280, height: 900 } })
+
+	const state = { boardId: 0, labelId: 0, viewId: '', mineTitle: '', theirsTitle: '', viewUrl: '' }
+
+	test.beforeAll(async ({ peer }) => {
+		const stamp = Math.floor(Date.now() / 1000)
+		const board = await api.post('/boards', { title: 'ViewFacets ' + stamp })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
+
+		// READ | EDIT so the peer is a real board participant and can be assigned.
+		await api.post(`/boards/${board.id}/acl`, {
+			participant: peer.user,
+			participantType: 'user',
+			permission: 3,
+			role: 'internal',
+		})
+
+		state.mineTitle = 'ViewFacets mine ' + stamp
+		state.theirsTitle = 'ViewFacets theirs ' + stamp
+		const label = await api.post('/labels', { boardId: board.id, title: 'vfacets ' + stamp, color: '00ccff' })
+		state.labelId = label.id
+		const mine = await api.post('/cards', { stackId: stack.id, title: state.mineTitle })
+		const theirs = await api.post('/cards', { stackId: stack.id, title: state.theirsTitle })
+		await api.put(`/cards/${mine.id}/assignees/${me}`)
+		await api.put(`/cards/${theirs.id}/assignees/${peer.user}`)
+		await api.put(`/cards/${mine.id}/labels/${label.id}`)
+		await api.put(`/cards/${theirs.id}/labels/${label.id}`)
+
+		// The View is pre-narrowed to this spec's own label so it resolves to exactly
+		// these two cards — the list is virtualised, so an unfiltered cross-board feed
+		// would leave them off-screen. The ASSIGNEE filter under test is then layered
+		// on top from the UI.
+		const created = await api.put('/views', {
+			name: 'ViewFacets ' + stamp,
+			filter: { labels: [label.id] },
+			groupBy: 'status',
+			display: 'list',
+		})
+		state.viewId = created.views[created.views.length - 1].id
+		state.viewUrl = `${BASE}/index.php/apps/kanso#/views/${state.viewId}`
+	})
+
+	test.afterAll(async () => {
+		if (state.viewId) await api.delete(`/views/${state.viewId}`).catch(() => {})
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('the feed endpoint applies the filter server-side and still ships the facet vocabulary', async ({ peer }) => {
+		// The UI test below drives the same path through the browser; this pins the
+		// wire contract directly against the real endpoint (the unit tests mock the
+		// mappers, so only this proves the controller actually binds the short keys).
+		const label = state.labelId
+		const all = await api.get(`/views/cards?fl=${label}`)
+		expect(all.cards.map((c) => c.title).sort()).toEqual([state.mineTitle, state.theirsTitle].sort())
+		expect(all.total).toBe(2)
+
+		// Narrowing by assignee is applied by the SERVER: the row count drops…
+		const narrowed = await api.get(`/views/cards?fl=${label}&fa=${encodeURIComponent(peer.user)}`)
+		expect(narrowed.cards.map((c) => c.title)).toEqual([state.theirsTitle])
+		expect(narrowed.total).toBe(1)
+		// …and `total` is the MATCHING count, so the capped banner stays honest.
+		expect(narrowed.total).toBeLessThan(all.total)
+
+		// The facet vocabulary is NOT narrowed with the rows — it still carries both
+		// identities even when the filter matches nothing at all.
+		const none = await api.get(`/views/cards?fl=${label}&fa=${encodeURIComponent(peer.user)}&fp=4`)
+		expect(none.cards).toEqual([])
+		expect(none.total).toBe(0)
+		expect(none.participants).toEqual(expect.arrayContaining([me, peer.user]))
+
+		// An unknown key and an unrecognised value are ignored, never rejected and
+		// never a reason to drop a row (an older or newer client must still work).
+		const tolerant = await api.get(`/views/cards?fl=${label}&fzz=whatever&fd=someday`)
+		expect(tolerant.cards.map((c) => c.title).sort()).toEqual([state.mineTitle, state.theirsTitle].sort())
+	})
+
+	test('filtering to one assignee still offers everyone — even at zero matches', async ({ page, user, peer }) => {
+		await ncLogin(page, { user: user.user, pass: user.pass })
+
+		const rowMine = page.locator('.board-list-row__title', { hasText: state.mineTitle })
+		const rowTheirs = page.locator('.board-list-row__title', { hasText: state.theirsTitle })
+		const trigger = page.locator('.board-filter-bar__trigger')
+		const assigneesDim = page.locator('.board-filter-bar__dim-row[data-dim="assignees"]')
+		const optFor = (uid) => page.locator('.board-filter-bar__opt-text', { hasText: new RegExp(`^${uid}$`) })
+
+		await page.goto(state.viewUrl)
+		await expect(rowMine).toBeVisible({ timeout: 20_000 })
+		await expect(rowTheirs).toBeVisible({ timeout: 15_000 })
+
+		// Baseline: the facet offers both identities.
+		await trigger.click()
+		await assigneesDim.click()
+		await expect(optFor(me)).toBeVisible({ timeout: 10_000 })
+		await expect(optFor(peer.user)).toBeVisible()
+
+		// ── The filter really does travel to the server ─────────────────────────
+		// Pin the wire contract, not just the rendered result: selecting the peer
+		// must issue a feed request carrying the `fa` short key. Without this the
+		// spec would still pass on a purely client-side filter — the bug being fixed.
+		const filteredFeed = page.waitForRequest(
+			(r) => r.url().includes('/api/views/cards') && r.url().includes(`fa=${encodeURIComponent(peer.user)}`),
+			{ timeout: 20_000 },
+		)
+		await optFor(peer.user).click()
+		await filteredFeed
+
+		// Only the peer's card survives…
+		await expect(rowTheirs).toBeVisible({ timeout: 15_000 })
+		await expect(rowMine).toHaveCount(0, { timeout: 15_000 })
+
+		// …and the facet has NOT collapsed to the survivor: this user is still
+		// offered, so a second person can be added on top of the first.
+		await expect(optFor(me)).toBeVisible()
+		await expect(optFor(peer.user)).toBeVisible()
+		await optFor(me).click()
+		await expect(rowMine).toBeVisible({ timeout: 15_000 })
+		await expect(rowTheirs).toBeVisible()
+
+		// ── Zero matches: the hard case ─────────────────────────────────────────
+		// Narrow to the peer plus a priority neither card carries, so the server
+		// returns NO rows at all. A row-derived facet would vanish here.
+		await optFor(me).click()
+		await expect(rowMine).toHaveCount(0, { timeout: 15_000 })
+		await page.locator('.board-filter-bar__back').click()
+		await page.locator('.board-filter-bar__dim-row[data-dim="priorities"]').click()
+		await page.locator('.board-filter-bar__opt', { hasText: /Urgent/ }).click()
+		await expect(rowTheirs).toHaveCount(0, { timeout: 15_000 })
+
+		// The Assignees dimension row is still listed (it hides on an empty
+		// participants list), and still offers BOTH identities.
+		await page.locator('.board-filter-bar__back').click()
+		await expect(assigneesDim).toBeVisible()
+		await assigneesDim.click()
+		await expect(optFor(me)).toBeVisible()
+		await expect(optFor(peer.user)).toBeVisible()
+
+		// The Owner facet reads the same vocabulary, so it survives too.
+		await page.locator('.board-filter-bar__back').click()
+		const ownersDim = page.locator('.board-filter-bar__dim-row[data-dim="owners"]')
+		await expect(ownersDim).toBeVisible()
+		await ownersDim.click()
+		await expect(optFor(me)).toBeVisible()
+	})
+})

--- a/tests/fixtures/board-filter-parity.json
+++ b/tests/fixtures/board-filter-parity.json
@@ -1,0 +1,183 @@
+{
+  "_comment": [
+    "Golden PHP<->JS parity fixture for the View filter (#9862).",
+    "The filter now runs on BOTH sides: the client's makePredicate",
+    "(src/composables/useBoardFilters.js) over the rows it receives, and the",
+    "server's OCA\\Kanso\\Service\\ViewFilter before the cross-board feed's cap.",
+    "Two predicates that must agree are two predicates that WILL drift, so both",
+    "runners assert this same file: tests/unit/Service/ViewFilterTest.php",
+    "(PHPUnit) and tests/unit/boardFilters.test.mjs (node --test).",
+    "",
+    "Both sides consume the filter through the SAME wire encoding the board's",
+    "shareable filter links use: serialized filter -> filterToQuery() short keys",
+    "-> decode -> predicate. So this pins the decode as well as the matching.",
+    "",
+    "`now` is 2026-01-01T00:00:00Z in milliseconds, injected into both",
+    "predicates so the relative due / start-date windows are deterministic.",
+    "`expected` lists the surviving card ids in fixture order."
+  ],
+  "now": 1767225600000,
+  "cards": [
+    {
+      "id": 1,
+      "title": "Overdue blocked bug",
+      "labelIds": [10, 11],
+      "assigneeIds": ["alice"],
+      "priority": 3,
+      "type": "bug",
+      "estimate": "3",
+      "owner": "alice",
+      "reviewState": "pending",
+      "duedate": "2025-12-01T00:00:00+00:00",
+      "startDate": "2025-12-01T00:00:00+00:00",
+      "doneAt": 0,
+      "waitingOnExternal": true,
+      "blocked": true,
+      "checklist": { "total": 3, "done": 1 },
+      "parentCardId": null,
+      "childProgress": { "total": 2, "done": 0 },
+      "commentCount": 2
+    },
+    {
+      "id": 2,
+      "title": "Done sub-card, nothing set",
+      "labelIds": [],
+      "assigneeIds": [],
+      "priority": 0,
+      "type": "feature",
+      "estimate": null,
+      "owner": "bob",
+      "reviewState": null,
+      "duedate": null,
+      "startDate": null,
+      "doneAt": 1700000000,
+      "waitingOnExternal": false,
+      "blocked": false,
+      "checklist": { "total": 0, "done": 0 },
+      "parentCardId": 1,
+      "childProgress": { "total": 0, "done": 0 },
+      "commentCount": 0
+    },
+    {
+      "id": 3,
+      "title": "Due this week, approved",
+      "labelIds": [11],
+      "assigneeIds": ["bob", "carol"],
+      "priority": 4,
+      "type": "task",
+      "estimate": "8",
+      "owner": "carol",
+      "reviewState": "approved",
+      "duedate": "2026-01-03T00:00:00+00:00",
+      "startDate": "2026-03-01T00:00:00+00:00",
+      "doneAt": 0,
+      "waitingOnExternal": false,
+      "blocked": false,
+      "checklist": { "total": 2, "done": 2 },
+      "parentCardId": null,
+      "childProgress": { "total": 0, "done": 0 },
+      "commentCount": 5
+    },
+    {
+      "id": 4,
+      "title": "Far-future chore, parent AND child",
+      "labelIds": [12],
+      "assigneeIds": ["alice", "bob"],
+      "priority": 1,
+      "type": "chore",
+      "estimate": "",
+      "owner": "alice",
+      "reviewState": "changes_requested",
+      "duedate": "2026-06-01T00:00:00+00:00",
+      "startDate": null,
+      "doneAt": 0,
+      "waitingOnExternal": true,
+      "blocked": false,
+      "checklist": { "total": 4, "done": 0 },
+      "parentCardId": 3,
+      "childProgress": { "total": 1, "done": 1 },
+      "commentCount": 0
+    },
+    {
+      "id": 5,
+      "title": "Typeless, started long ago",
+      "labelIds": [],
+      "assigneeIds": ["dave"],
+      "priority": 2,
+      "type": "",
+      "estimate": "13",
+      "owner": "dave",
+      "reviewState": null,
+      "duedate": null,
+      "startDate": "2025-06-01T00:00:00+00:00",
+      "doneAt": 0,
+      "waitingOnExternal": false,
+      "blocked": true,
+      "checklist": { "total": 0, "done": 0 },
+      "parentCardId": null,
+      "childProgress": { "total": 0, "done": 0 },
+      "commentCount": 1
+    }
+  ],
+  "cases": [
+    { "name": "empty filter keeps everything", "filter": {}, "expected": [1, 2, 3, 4, 5] },
+
+    { "name": "labels: OR within", "filter": { "labels": [11] }, "expected": [1, 3] },
+    { "name": "labels: two selected", "filter": { "labels": [10, 12] }, "expected": [1, 4] },
+    { "name": "labels: unknown id matches nothing", "filter": { "labels": [99] }, "expected": [] },
+
+    { "name": "assignees: one uid", "filter": { "assignees": ["alice"] }, "expected": [1, 4] },
+    { "name": "assignees: __none__ sentinel", "filter": { "assignees": ["__none__"] }, "expected": [2] },
+    { "name": "assignees: sentinel OR uid", "filter": { "assignees": ["__none__", "dave"] }, "expected": [2, 5] },
+
+    { "name": "priorities: 0 is a real value", "filter": { "priorities": [0, 2] }, "expected": [2, 5] },
+    { "name": "priorities: high only", "filter": { "priorities": [3, 4] }, "expected": [1, 3] },
+
+    { "name": "types: OR within, typeless never matches", "filter": { "types": ["bug", "chore"] }, "expected": [1, 4] },
+
+    { "name": "estimates: raw tokens", "filter": { "estimates": ["13", "3"] }, "expected": [1, 5] },
+    { "name": "estimates: __none__ covers null AND empty string", "filter": { "estimates": ["__none__"] }, "expected": [2, 4] },
+    { "name": "estimates: token OR sentinel", "filter": { "estimates": ["8", "__none__"] }, "expected": [2, 3, 4] },
+
+    { "name": "owners: OR within", "filter": { "owners": ["alice", "dave"] }, "expected": [1, 4, 5] },
+
+    { "name": "reviews: none sentinel", "filter": { "reviews": ["none"] }, "expected": [2, 5] },
+    { "name": "reviews: real states", "filter": { "reviews": ["approved", "pending"] }, "expected": [1, 3] },
+    { "name": "reviews: changes requested", "filter": { "reviews": ["changes_requested"] }, "expected": [4] },
+
+    { "name": "due: overdue", "filter": { "due": "overdue" }, "expected": [1] },
+    { "name": "due: this week", "filter": { "due": "week" }, "expected": [3] },
+    { "name": "due: none", "filter": { "due": "none" }, "expected": [2, 5] },
+
+    { "name": "done: done", "filter": { "done": "done" }, "expected": [2] },
+    { "name": "done: open", "filter": { "done": "open" }, "expected": [1, 3, 4, 5] },
+
+    { "name": "waiting: waiting", "filter": { "waiting": "waiting" }, "expected": [1, 4] },
+    { "name": "waiting: not waiting", "filter": { "waiting": "not_waiting" }, "expected": [2, 3, 5] },
+
+    { "name": "blocked: blocked", "filter": { "blocked": "blocked" }, "expected": [1, 5] },
+    { "name": "blocked: not blocked", "filter": { "blocked": "not_blocked" }, "expected": [2, 3, 4] },
+
+    { "name": "checklist: has", "filter": { "checklist": "has" }, "expected": [1, 3, 4] },
+    { "name": "checklist: incomplete", "filter": { "checklist": "incomplete" }, "expected": [1, 4] },
+    { "name": "checklist: complete", "filter": { "checklist": "complete" }, "expected": [3] },
+    { "name": "checklist: none", "filter": { "checklist": "none" }, "expected": [2, 5] },
+
+    { "name": "startDate: started", "filter": { "startDate": "started" }, "expected": [1, 5] },
+    { "name": "startDate: upcoming", "filter": { "startDate": "upcoming" }, "expected": [3] },
+    { "name": "startDate: none", "filter": { "startDate": "none" }, "expected": [2, 4] },
+
+    { "name": "subcard: top-level", "filter": { "subcard": "top_level" }, "expected": [1, 3, 5] },
+    { "name": "subcard: parent (a card can be both)", "filter": { "subcard": "parent" }, "expected": [1, 4] },
+    { "name": "subcard: child", "filter": { "subcard": "child" }, "expected": [2, 4] },
+
+    { "name": "comments: has", "filter": { "comments": "has" }, "expected": [1, 3, 5] },
+    { "name": "comments: none", "filter": { "comments": "none" }, "expected": [2, 4] },
+
+    { "name": "AND across two dimensions", "filter": { "labels": [11], "done": "open" }, "expected": [1, 3] },
+    { "name": "AND narrows to one", "filter": { "labels": [11], "owners": ["alice"] }, "expected": [1] },
+    { "name": "AND across three dimensions", "filter": { "assignees": ["alice"], "due": "overdue", "blocked": "blocked" }, "expected": [1] },
+    { "name": "AND with no survivors", "filter": { "types": ["bug"], "done": "done" }, "expected": [] },
+    { "name": "every dimension at once", "filter": { "labels": [10, 11], "assignees": ["alice"], "priorities": [3], "types": ["bug"], "estimates": ["3"], "owners": ["alice"], "reviews": ["pending"], "due": "overdue", "done": "open", "waiting": "waiting", "blocked": "blocked", "checklist": "incomplete", "startDate": "started", "subcard": "parent", "comments": "has" }, "expected": [1] }
+  ]
+}

--- a/tests/fixtures/board-filter-parity.json
+++ b/tests/fixtures/board-filter-parity.json
@@ -23,6 +23,16 @@
     "green. Do not give either card a due/start date that is merely NEAR the",
     "boundary: the point is the equality case.",
     "",
+    "Card 9 is due `now + 8d`, one day PAST the window, and pins its WIDTH.",
+    "The boundary cards only pin the comparison OPERATORS: with card 7 as the",
+    "last due date before card 4's far-future one, widening the window from 7d",
+    "to 14d or 30d changed no expectation at all, and the duplicated constant",
+    "(lib/Service/ViewFilter.php's WEEK_MS and the inline `7 * 24 * 60 * 60 *",
+    "1000` in src/composables/useBoardFilters.js) is exactly the kind that",
+    "drifts. Card 9 must stay OUT of the `due: week` case, so any widening on",
+    "either side turns that runner red. Card 9 is otherwise a copy of card 7,",
+    "so it changes no other dimension's meaning - only its membership.",
+    "",
     "Card 8 is the sparse row - an older cached summary, or a payload from a",
     "version that did not carry an enrichment field yet. Its keys are OMITTED,",
     "not set to null: both predicates read `card.x ?? default`, which treats",
@@ -180,10 +190,30 @@
     {
       "id": 8,
       "title": "Sparse row: every enrichment field ABSENT (not null)"
+    },
+    {
+      "id": 9,
+      "title": "Due eight days out: one day OUTSIDE the week window",
+      "labelIds": [13],
+      "assigneeIds": ["erin"],
+      "priority": 2,
+      "type": "task",
+      "estimate": "5",
+      "owner": "erin",
+      "reviewState": "pending",
+      "duedate": "2026-01-09T00:00:00+00:00",
+      "startDate": null,
+      "doneAt": 0,
+      "waitingOnExternal": false,
+      "blocked": false,
+      "checklist": { "total": 0, "done": 0 },
+      "parentCardId": null,
+      "childProgress": { "total": 0, "done": 0 },
+      "commentCount": 0
     }
   ],
   "cases": [
-    { "name": "empty filter keeps everything", "filter": {}, "expected": [1, 2, 3, 4, 5, 6, 7, 8] },
+    { "name": "empty filter keeps everything", "filter": {}, "expected": [1, 2, 3, 4, 5, 6, 7, 8, 9] },
 
     { "name": "labels: OR within", "filter": { "labels": [11] }, "expected": [1, 3] },
     { "name": "labels: two selected", "filter": { "labels": [10, 12] }, "expected": [1, 4] },
@@ -193,7 +223,7 @@
     { "name": "assignees: __none__ sentinel", "filter": { "assignees": ["__none__"] }, "expected": [2, 8] },
     { "name": "assignees: sentinel OR uid", "filter": { "assignees": ["__none__", "dave"] }, "expected": [2, 5, 8] },
 
-    { "name": "priorities: 0 is a real value", "filter": { "priorities": [0, 2] }, "expected": [2, 5, 6, 7, 8] },
+    { "name": "priorities: 0 is a real value", "filter": { "priorities": [0, 2] }, "expected": [2, 5, 6, 7, 8, 9] },
     { "name": "priorities: high only", "filter": { "priorities": [3, 4] }, "expected": [1, 3] },
 
     { "name": "types: OR within, typeless never matches", "filter": { "types": ["bug", "chore"] }, "expected": [1, 4] },
@@ -205,37 +235,37 @@
     { "name": "owners: OR within", "filter": { "owners": ["alice", "dave"] }, "expected": [1, 4, 5] },
 
     { "name": "reviews: none sentinel", "filter": { "reviews": ["none"] }, "expected": [2, 5, 8] },
-    { "name": "reviews: real states", "filter": { "reviews": ["approved", "pending"] }, "expected": [1, 3, 6, 7] },
+    { "name": "reviews: real states", "filter": { "reviews": ["approved", "pending"] }, "expected": [1, 3, 6, 7, 9] },
     { "name": "reviews: changes requested", "filter": { "reviews": ["changes_requested"] }, "expected": [4] },
 
     { "name": "due: overdue", "filter": { "due": "overdue" }, "expected": [1] },
-    { "name": "due: this week", "filter": { "due": "week" }, "expected": [3, 6, 7] },
+    { "name": "due: this week (card 9, at now + 8d, must stay out - pins the window WIDTH)", "filter": { "due": "week" }, "expected": [3, 6, 7] },
     { "name": "due: none", "filter": { "due": "none" }, "expected": [2, 5, 8] },
 
     { "name": "done: done", "filter": { "done": "done" }, "expected": [2] },
-    { "name": "done: open", "filter": { "done": "open" }, "expected": [1, 3, 4, 5, 6, 7, 8] },
+    { "name": "done: open", "filter": { "done": "open" }, "expected": [1, 3, 4, 5, 6, 7, 8, 9] },
 
     { "name": "waiting: waiting", "filter": { "waiting": "waiting" }, "expected": [1, 4] },
-    { "name": "waiting: not waiting", "filter": { "waiting": "not_waiting" }, "expected": [2, 3, 5, 6, 7, 8] },
+    { "name": "waiting: not waiting", "filter": { "waiting": "not_waiting" }, "expected": [2, 3, 5, 6, 7, 8, 9] },
 
     { "name": "blocked: blocked", "filter": { "blocked": "blocked" }, "expected": [1, 5] },
-    { "name": "blocked: not blocked", "filter": { "blocked": "not_blocked" }, "expected": [2, 3, 4, 6, 7, 8] },
+    { "name": "blocked: not blocked", "filter": { "blocked": "not_blocked" }, "expected": [2, 3, 4, 6, 7, 8, 9] },
 
     { "name": "checklist: has", "filter": { "checklist": "has" }, "expected": [1, 3, 4] },
     { "name": "checklist: incomplete", "filter": { "checklist": "incomplete" }, "expected": [1, 4] },
     { "name": "checklist: complete", "filter": { "checklist": "complete" }, "expected": [3] },
-    { "name": "checklist: none", "filter": { "checklist": "none" }, "expected": [2, 5, 6, 7, 8] },
+    { "name": "checklist: none", "filter": { "checklist": "none" }, "expected": [2, 5, 6, 7, 8, 9] },
 
     { "name": "startDate: started", "filter": { "startDate": "started" }, "expected": [1, 5, 6] },
     { "name": "startDate: upcoming", "filter": { "startDate": "upcoming" }, "expected": [3] },
-    { "name": "startDate: none", "filter": { "startDate": "none" }, "expected": [2, 4, 7, 8] },
+    { "name": "startDate: none", "filter": { "startDate": "none" }, "expected": [2, 4, 7, 8, 9] },
 
-    { "name": "subcard: top-level", "filter": { "subcard": "top_level" }, "expected": [1, 3, 5, 6, 7, 8] },
+    { "name": "subcard: top-level", "filter": { "subcard": "top_level" }, "expected": [1, 3, 5, 6, 7, 8, 9] },
     { "name": "subcard: parent (a card can be both)", "filter": { "subcard": "parent" }, "expected": [1, 4] },
     { "name": "subcard: child", "filter": { "subcard": "child" }, "expected": [2, 4] },
 
     { "name": "comments: has", "filter": { "comments": "has" }, "expected": [1, 3, 5] },
-    { "name": "comments: none", "filter": { "comments": "none" }, "expected": [2, 4, 6, 7, 8] },
+    { "name": "comments: none", "filter": { "comments": "none" }, "expected": [2, 4, 6, 7, 8, 9] },
 
     { "name": "AND across two dimensions", "filter": { "labels": [11], "done": "open" }, "expected": [1, 3] },
     { "name": "AND narrows to one", "filter": { "labels": [11], "owners": ["alice"] }, "expected": [1] },

--- a/tests/fixtures/board-filter-parity.json
+++ b/tests/fixtures/board-filter-parity.json
@@ -14,7 +14,26 @@
     "",
     "`now` is 2026-01-01T00:00:00Z in milliseconds, injected into both",
     "predicates so the relative due / start-date windows are deterministic.",
-    "`expected` lists the surviving card ids in fixture order."
+    "`expected` lists the surviving card ids in fixture order.",
+    "",
+    "Cards 6 and 7 sit exactly ON the two relative boundaries (`now` and",
+    "`now + 7d`). Without them every one of the four now-relative comparisons",
+    "- overdue `<`, week `>=` and `<=`, started `<=`, upcoming `>` - could be",
+    "flipped in EITHER direction on one side only and both runners would stay",
+    "green. Do not give either card a due/start date that is merely NEAR the",
+    "boundary: the point is the equality case.",
+    "",
+    "Card 8 is the sparse row - an older cached summary, or a payload from a",
+    "version that did not carry an enrichment field yet. Its keys are OMITTED,",
+    "not set to null: both predicates read `card.x ?? default`, which treats",
+    "JSON null exactly like an absent key, so the nulls already on cards 2-5",
+    "do not exercise the absent-key path. json_decode(..., true) yields a",
+    "genuinely absent PHP key and JSON.parse a genuinely absent JS property,",
+    "so omission is symmetric where null is not. Card 8 must therefore keep",
+    "matching every `??`-default case (assignees __none__, estimates __none__,",
+    "reviews none, priority 0, due none, done open, checklist none, startDate",
+    "none, subcard top_level, comments none) and must never appear under a",
+    "positive constraint."
   ],
   "now": 1767225600000,
   "cards": [
@@ -117,62 +136,106 @@
       "parentCardId": null,
       "childProgress": { "total": 0, "done": 0 },
       "commentCount": 1
+    },
+    {
+      "id": 6,
+      "title": "Due exactly at now, started exactly at now",
+      "labelIds": [13],
+      "assigneeIds": ["erin"],
+      "priority": 2,
+      "type": "task",
+      "estimate": "5",
+      "owner": "erin",
+      "reviewState": "pending",
+      "duedate": "2026-01-01T00:00:00+00:00",
+      "startDate": "2026-01-01T00:00:00+00:00",
+      "doneAt": 0,
+      "waitingOnExternal": false,
+      "blocked": false,
+      "checklist": { "total": 0, "done": 0 },
+      "parentCardId": null,
+      "childProgress": { "total": 0, "done": 0 },
+      "commentCount": 0
+    },
+    {
+      "id": 7,
+      "title": "Due exactly one week ahead",
+      "labelIds": [13],
+      "assigneeIds": ["erin"],
+      "priority": 2,
+      "type": "task",
+      "estimate": "5",
+      "owner": "erin",
+      "reviewState": "pending",
+      "duedate": "2026-01-08T00:00:00+00:00",
+      "startDate": null,
+      "doneAt": 0,
+      "waitingOnExternal": false,
+      "blocked": false,
+      "checklist": { "total": 0, "done": 0 },
+      "parentCardId": null,
+      "childProgress": { "total": 0, "done": 0 },
+      "commentCount": 0
+    },
+    {
+      "id": 8,
+      "title": "Sparse row: every enrichment field ABSENT (not null)"
     }
   ],
   "cases": [
-    { "name": "empty filter keeps everything", "filter": {}, "expected": [1, 2, 3, 4, 5] },
+    { "name": "empty filter keeps everything", "filter": {}, "expected": [1, 2, 3, 4, 5, 6, 7, 8] },
 
     { "name": "labels: OR within", "filter": { "labels": [11] }, "expected": [1, 3] },
     { "name": "labels: two selected", "filter": { "labels": [10, 12] }, "expected": [1, 4] },
     { "name": "labels: unknown id matches nothing", "filter": { "labels": [99] }, "expected": [] },
 
     { "name": "assignees: one uid", "filter": { "assignees": ["alice"] }, "expected": [1, 4] },
-    { "name": "assignees: __none__ sentinel", "filter": { "assignees": ["__none__"] }, "expected": [2] },
-    { "name": "assignees: sentinel OR uid", "filter": { "assignees": ["__none__", "dave"] }, "expected": [2, 5] },
+    { "name": "assignees: __none__ sentinel", "filter": { "assignees": ["__none__"] }, "expected": [2, 8] },
+    { "name": "assignees: sentinel OR uid", "filter": { "assignees": ["__none__", "dave"] }, "expected": [2, 5, 8] },
 
-    { "name": "priorities: 0 is a real value", "filter": { "priorities": [0, 2] }, "expected": [2, 5] },
+    { "name": "priorities: 0 is a real value", "filter": { "priorities": [0, 2] }, "expected": [2, 5, 6, 7, 8] },
     { "name": "priorities: high only", "filter": { "priorities": [3, 4] }, "expected": [1, 3] },
 
     { "name": "types: OR within, typeless never matches", "filter": { "types": ["bug", "chore"] }, "expected": [1, 4] },
 
     { "name": "estimates: raw tokens", "filter": { "estimates": ["13", "3"] }, "expected": [1, 5] },
-    { "name": "estimates: __none__ covers null AND empty string", "filter": { "estimates": ["__none__"] }, "expected": [2, 4] },
-    { "name": "estimates: token OR sentinel", "filter": { "estimates": ["8", "__none__"] }, "expected": [2, 3, 4] },
+    { "name": "estimates: __none__ covers null AND empty string", "filter": { "estimates": ["__none__"] }, "expected": [2, 4, 8] },
+    { "name": "estimates: token OR sentinel", "filter": { "estimates": ["8", "__none__"] }, "expected": [2, 3, 4, 8] },
 
     { "name": "owners: OR within", "filter": { "owners": ["alice", "dave"] }, "expected": [1, 4, 5] },
 
-    { "name": "reviews: none sentinel", "filter": { "reviews": ["none"] }, "expected": [2, 5] },
-    { "name": "reviews: real states", "filter": { "reviews": ["approved", "pending"] }, "expected": [1, 3] },
+    { "name": "reviews: none sentinel", "filter": { "reviews": ["none"] }, "expected": [2, 5, 8] },
+    { "name": "reviews: real states", "filter": { "reviews": ["approved", "pending"] }, "expected": [1, 3, 6, 7] },
     { "name": "reviews: changes requested", "filter": { "reviews": ["changes_requested"] }, "expected": [4] },
 
     { "name": "due: overdue", "filter": { "due": "overdue" }, "expected": [1] },
-    { "name": "due: this week", "filter": { "due": "week" }, "expected": [3] },
-    { "name": "due: none", "filter": { "due": "none" }, "expected": [2, 5] },
+    { "name": "due: this week", "filter": { "due": "week" }, "expected": [3, 6, 7] },
+    { "name": "due: none", "filter": { "due": "none" }, "expected": [2, 5, 8] },
 
     { "name": "done: done", "filter": { "done": "done" }, "expected": [2] },
-    { "name": "done: open", "filter": { "done": "open" }, "expected": [1, 3, 4, 5] },
+    { "name": "done: open", "filter": { "done": "open" }, "expected": [1, 3, 4, 5, 6, 7, 8] },
 
     { "name": "waiting: waiting", "filter": { "waiting": "waiting" }, "expected": [1, 4] },
-    { "name": "waiting: not waiting", "filter": { "waiting": "not_waiting" }, "expected": [2, 3, 5] },
+    { "name": "waiting: not waiting", "filter": { "waiting": "not_waiting" }, "expected": [2, 3, 5, 6, 7, 8] },
 
     { "name": "blocked: blocked", "filter": { "blocked": "blocked" }, "expected": [1, 5] },
-    { "name": "blocked: not blocked", "filter": { "blocked": "not_blocked" }, "expected": [2, 3, 4] },
+    { "name": "blocked: not blocked", "filter": { "blocked": "not_blocked" }, "expected": [2, 3, 4, 6, 7, 8] },
 
     { "name": "checklist: has", "filter": { "checklist": "has" }, "expected": [1, 3, 4] },
     { "name": "checklist: incomplete", "filter": { "checklist": "incomplete" }, "expected": [1, 4] },
     { "name": "checklist: complete", "filter": { "checklist": "complete" }, "expected": [3] },
-    { "name": "checklist: none", "filter": { "checklist": "none" }, "expected": [2, 5] },
+    { "name": "checklist: none", "filter": { "checklist": "none" }, "expected": [2, 5, 6, 7, 8] },
 
-    { "name": "startDate: started", "filter": { "startDate": "started" }, "expected": [1, 5] },
+    { "name": "startDate: started", "filter": { "startDate": "started" }, "expected": [1, 5, 6] },
     { "name": "startDate: upcoming", "filter": { "startDate": "upcoming" }, "expected": [3] },
-    { "name": "startDate: none", "filter": { "startDate": "none" }, "expected": [2, 4] },
+    { "name": "startDate: none", "filter": { "startDate": "none" }, "expected": [2, 4, 7, 8] },
 
-    { "name": "subcard: top-level", "filter": { "subcard": "top_level" }, "expected": [1, 3, 5] },
+    { "name": "subcard: top-level", "filter": { "subcard": "top_level" }, "expected": [1, 3, 5, 6, 7, 8] },
     { "name": "subcard: parent (a card can be both)", "filter": { "subcard": "parent" }, "expected": [1, 4] },
     { "name": "subcard: child", "filter": { "subcard": "child" }, "expected": [2, 4] },
 
     { "name": "comments: has", "filter": { "comments": "has" }, "expected": [1, 3, 5] },
-    { "name": "comments: none", "filter": { "comments": "none" }, "expected": [2, 4] },
+    { "name": "comments: none", "filter": { "comments": "none" }, "expected": [2, 4, 6, 7, 8] },
 
     { "name": "AND across two dimensions", "filter": { "labels": [11], "done": "open" }, "expected": [1, 3] },
     { "name": "AND narrows to one", "filter": { "labels": [11], "owners": ["alice"] }, "expected": [1] },

--- a/tests/unit/Service/CsvImportServiceTest.php
+++ b/tests/unit/Service/CsvImportServiceTest.php
@@ -384,6 +384,15 @@ class CsvImportServiceTest extends TestCase {
 		$log = [];
 		$this->traceTransactions($log);
 
+		// The retry must not double-count. The first attempt writes its CREATE
+		// change rows and then rolls back, so if those rows survived the rollback -
+		// or were recorded outside the transaction - the count here is 4, not 2,
+		// and every importer would ship duplicate deltas to every connected client
+		// on any stack that hit the sort-key wall. Same for the board-changed push:
+		// exactly one, at the end of the successful attempt.
+		$this->changeNotifier->expects(self::exactly(2))->method('recordChange');
+		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(self::BOARD_ID);
+
 		// The real rebalanceStack() opens its OWN transaction and locks the stack's
 		// rows FOR UPDATE, so it must never run nested inside the import's. Mirror
 		// that here: assert nothing is open, then open/close one of its own.

--- a/tests/unit/Service/CsvImportServiceTest.php
+++ b/tests/unit/Service/CsvImportServiceTest.php
@@ -19,6 +19,7 @@ use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCA\Kanso\Service\BoardService;
+use OCA\Kanso\Service\CardService;
 use OCA\Kanso\Service\ChangeNotifier;
 use OCA\Kanso\Service\CsvImportService;
 use OCA\Kanso\Service\InvalidInputException;
@@ -39,6 +40,7 @@ class CsvImportServiceTest extends TestCase {
 	private CardAssigneeMapper&MockObject $cardAssigneeMapper;
 	private ChangeNotifier&MockObject $changeNotifier;
 	private PermissionService&MockObject $permissionService;
+	private CardService&MockObject $cardService;
 	private IUserManager&MockObject $userManager;
 	private IDBConnection&MockObject $db;
 	private CsvImportService $service;
@@ -56,6 +58,7 @@ class CsvImportServiceTest extends TestCase {
 		$this->cardAssigneeMapper = $this->createMock(CardAssigneeMapper::class);
 		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->cardService = $this->createMock(CardService::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->db = $this->createMock(IDBConnection::class);
 
@@ -69,6 +72,7 @@ class CsvImportServiceTest extends TestCase {
 			new SortKeyService(),
 			$this->changeNotifier,
 			$this->permissionService,
+			$this->cardService,
 			$this->userManager,
 			$this->db,
 		);
@@ -315,6 +319,162 @@ class CsvImportServiceTest extends TestCase {
 
 		$this->labelMapper->method('findByBoard')->willReturn([]);
 		$this->cardMapper->method('insert')->willThrowException(new \RuntimeException('boom'));
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->import("title\nX\n", self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');
+	}
+
+	// ── sort-key wall: auto-rebalance + retry ───────────────────────────────────
+
+	/**
+	 * Wires the board/stack lookups with a tail card whose sort key is read
+	 * through $tailKey by reference, so a simulated rebalance can shorten it
+	 * mid-test the way the real one would.
+	 */
+	private function primeStackWithTail(string &$tailKey): void {
+		$this->boardService->method('find')->willReturn($this->board());
+		$this->stackMapper->method('find')->willReturn($this->stack());
+		$this->permissionService->method('assertPermission');
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardMapper->method('nextBoardSeq')->willReturnCallback(function (): int {
+			static $n = 0;
+			return ++$n;
+		});
+		$this->cardMapper->method('findLastInStack')->willReturnCallback(
+			function () use (&$tailKey): Card {
+				$tail = new Card();
+				$tail->setId(1);
+				$tail->setStackId(self::STACK_ID);
+				$tail->setSortKey($tailKey);
+				return $tail;
+			},
+		);
+	}
+
+	/**
+	 * Records the transaction lifecycle into $log and refuses a nested
+	 * beginTransaction(), so a rebalance issued from INSIDE the import
+	 * transaction fails the test instead of silently deadlocking in production.
+	 */
+	private function traceTransactions(array &$log): void {
+		$depth = 0;
+		$this->db->method('beginTransaction')->willReturnCallback(function () use (&$log, &$depth): void {
+			self::assertSame(0, $depth, 'a transaction was opened while another was still open');
+			$depth++;
+			$log[] = 'begin';
+		});
+		$this->db->method('commit')->willReturnCallback(function () use (&$log, &$depth): void {
+			$depth--;
+			$log[] = 'commit';
+		});
+		$this->db->method('rollBack')->willReturnCallback(function () use (&$log, &$depth): void {
+			$depth--;
+			$log[] = 'rollback';
+		});
+		$this->db->method('inTransaction')->willReturnCallback(static fn (): bool => $depth > 0);
+	}
+
+	public function testRebalancesAndRetriesWhenTheTargetStackIsAtTheSortKeyWall(): void {
+		// A long-lived stack whose tail key already fills the varchar(64) column:
+		// appending a block past it overflows, which used to fail the whole import
+		// with a 409 only `occ kanso:rebalance` could clear.
+		$tailKey = str_repeat('Z', SortKeyService::MAX_KEY_LENGTH);
+		$this->primeStackWithTail($tailKey);
+
+		$log = [];
+		$this->traceTransactions($log);
+
+		// The real rebalanceStack() opens its OWN transaction and locks the stack's
+		// rows FOR UPDATE, so it must never run nested inside the import's. Mirror
+		// that here: assert nothing is open, then open/close one of its own.
+		$this->cardService->expects(self::once())->method('rebalanceStack')
+			->with(self::STACK_ID)
+			->willReturnCallback(function () use (&$log, &$tailKey): int {
+				self::assertFalse(
+					$this->db->inTransaction(),
+					'rebalanceStack() ran inside the import transaction',
+				);
+				$log[] = 'rebalance';
+				$this->db->beginTransaction();
+				$this->db->commit();
+				$tailKey = 'MM'; // the stack now carries short, rebalanced keys
+				return 3;
+			});
+
+		$cards = [];
+		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c) use (&$cards): Card {
+			$c->setId(200 + count($cards));
+			$cards[] = $c;
+			return $c;
+		});
+
+		$result = $this->service->import(
+			"title\nAlpha\nBeta\n",
+			self::BOARD_ID,
+			self::STACK_ID,
+			['title' => 0],
+			true,
+			'alice',
+		);
+
+		// The import succeeds instead of returning `rebalance_required`.
+		self::assertSame(2, $result['cards']);
+		self::assertCount(2, $cards);
+		self::assertSame(['Alpha', 'Beta'], array_map(static fn (Card $c): string => $c->getTitle(), $cards));
+		foreach ($cards as $card) {
+			self::assertGreaterThan('MM', $card->getSortKey());
+			self::assertLessThanOrEqual(SortKeyService::MAX_KEY_LENGTH, strlen($card->getSortKey()));
+		}
+		self::assertTrue($cards[0]->getSortKey() < $cards[1]->getSortKey());
+
+		// The rebalance sits BETWEEN the two attempts - after the first attempt
+		// rolled back, before the second began - never inside either.
+		self::assertSame(
+			['begin', 'rollback', 'rebalance', 'begin', 'commit', 'begin', 'commit'],
+			$log,
+		);
+	}
+
+	public function testStillSurfacesOverflowWhenTheRebalanceDoesNotHelp(): void {
+		// Retry ONCE, not a loop: if the keys still overflow after the rebalance
+		// the caller gets the same 409 `rebalance_required` as before, and not a
+		// single row was written.
+		$tailKey = str_repeat('Z', SortKeyService::MAX_KEY_LENGTH);
+		$this->primeStackWithTail($tailKey);
+
+		$this->cardService->expects(self::once())->method('rebalanceStack')
+			->with(self::STACK_ID)
+			->willReturn(0);
+
+		$this->db->expects(self::exactly(2))->method('beginTransaction');
+		$this->db->expects(self::exactly(2))->method('rollBack');
+		$this->db->expects(self::never())->method('commit');
+		$this->cardMapper->expects(self::never())->method('insert');
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+
+		$this->expectException(\OverflowException::class);
+		$this->service->import(
+			"title\nAlpha\n",
+			self::BOARD_ID,
+			self::STACK_ID,
+			['title' => 0],
+			true,
+			'alice',
+		);
+	}
+
+	public function testDoesNotRebalanceWhenTheImportFailsForAnotherReason(): void {
+		// A genuine failure still rolls back completely - no rebalance, no retry,
+		// no partial rows.
+		$tailKey = 'MM';
+		$this->primeStackWithTail($tailKey);
+		$this->cardService->expects(self::never())->method('rebalanceStack');
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('rollBack');
+		$this->db->expects(self::never())->method('commit');
+		$this->changeNotifier->expects(self::never())->method('pushBoardChanged');
+		$this->cardMapper->expects(self::once())->method('insert')
+			->willThrowException(new \RuntimeException('boom'));
 
 		$this->expectException(\RuntimeException::class);
 		$this->service->import("title\nX\n", self::BOARD_ID, self::STACK_ID, ['title' => 0], true, 'alice');

--- a/tests/unit/Service/CsvImportServiceTest.php
+++ b/tests/unit/Service/CsvImportServiceTest.php
@@ -384,12 +384,25 @@ class CsvImportServiceTest extends TestCase {
 		$log = [];
 		$this->traceTransactions($log);
 
-		// The retry must not double-count. The first attempt writes its CREATE
-		// change rows and then rolls back, so if those rows survived the rollback -
-		// or were recorded outside the transaction - the count here is 4, not 2,
-		// and every importer would ship duplicate deltas to every connected client
-		// on any stack that hit the sort-key wall. Same for the board-changed push:
-		// exactly one, at the end of the successful attempt.
+		// The retry must not double-count: two rows imported, exactly two CREATE
+		// change rows, no matter how many attempts it took.
+		//
+		// Two is what the CURRENT code produces for a structural reason, not an
+		// accidental one: appendSequence() throws at CsvImportService::import()
+		// BEFORE the insert loop is reached, so the first attempt records nothing
+		// at all and only the successful second attempt writes. That is precisely
+		// why this number is worth pinning - the regression it catches is the
+		// overflow check MOVING INTO the loop (per-row key allocation, a
+		// partially-written first attempt), which would make the count 4 while
+		// every other assertion in this test stayed green, and every importer
+		// would ship duplicate deltas to every connected client on any stack that
+		// hit the sort-key wall.
+		//
+		// Note this cannot lean on the rollback: IDBConnection is a mock here, so
+		// rollBack() only appends to $log - it could never un-count a recordChange
+		// the service had already made. The count has to be right by construction.
+		// Same for the board-changed push: exactly one, at the end of the
+		// successful attempt.
 		$this->changeNotifier->expects(self::exactly(2))->method('recordChange');
 		$this->changeNotifier->expects(self::once())->method('pushBoardChanged')->with(self::BOARD_ID);
 

--- a/tests/unit/Service/ViewFilterTest.php
+++ b/tests/unit/Service/ViewFilterTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace OCA\Kanso\Tests\Unit\Service;
 
+use OCA\Kanso\Controller\ViewController;
 use OCA\Kanso\Service\ViewFilter;
 use PHPUnit\Framework\TestCase;
 
@@ -30,6 +31,9 @@ class ViewFilterTest extends TestCase {
 	/** @var array{now: int, cards: list<array<string, mixed>>, cases: list<array{name: string, filter: array<string, mixed>, expected: list<int>}>} */
 	private static array $fixture;
 
+	/** @var array<string, string>|null memoized {@see self::wireKeys()} */
+	private static ?array $wireKeys = null;
+
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		$raw = file_get_contents(__DIR__ . '/../../fixtures/board-filter-parity.json');
@@ -41,6 +45,48 @@ class ViewFilterTest extends TestCase {
 	}
 
 	/**
+	 * The dimension -> short-key map, PARSED FROM THE ONE REAL SOURCE: the body of
+	 * `filterToQuery()` in src/composables/useBoardFilters.js.
+	 *
+	 * It used to be a hand-copied literal here, and that copy was the hole. Rename a
+	 * short key symmetrically in `filterToQuery()` + `queryToFilter()` and the JS
+	 * runner stays green (its round trip is self-consistent) - while this file kept
+	 * encoding the OLD key, so it stayed green too, and the server silently stopped
+	 * reading that dimension. Deriving the map means the encoder here now emits
+	 * whatever the client emits: rename `fl` to `fll` and PHP sends `fll`,
+	 * {@see ViewFilter::fromQuery()} still reads `fl`, and the first labels case in
+	 * testGoldenFixtureParity() goes red. No extra assertion needed - deleting the
+	 * duplicate copy of the truth is the guard.
+	 *
+	 * @return array<string, string> dimension name => short query key, in emit order
+	 */
+	private static function wireKeys(): array {
+		if (self::$wireKeys !== null) {
+			return self::$wireKeys;
+		}
+		$src = file_get_contents(__DIR__ . '/../../../src/composables/useBoardFilters.js');
+		self::assertIsString($src, 'the client filter composable must be readable');
+
+		$start = strpos($src, 'export function filterToQuery(');
+		$end = strpos($src, 'export function queryToFilter(');
+		self::assertIsInt($start, 'filterToQuery() must still exist in useBoardFilters.js');
+		self::assertIsInt($end, 'queryToFilter() must still exist in useBoardFilters.js');
+		self::assertGreaterThan($start, $end, 'filterToQuery() must precede queryToFilter()');
+		$body = substr($src, $start, $end - $start);
+
+		// Each emit line reads `if (ser.<dimension>…) q.<key> = …`.
+		$count = preg_match_all('/ser\.(\w+)[^\n]*?q\.(\w+) =/', $body, $m, PREG_SET_ORDER);
+		self::assertNotFalse($count, 'the filterToQuery() emit-line pattern must compile');
+		self::assertGreaterThan(0, $count, 'no emit lines parsed out of filterToQuery()');
+
+		$map = [];
+		foreach ($m as $match) {
+			$map[$match[1]] = $match[2];
+		}
+		return self::$wireKeys = $map;
+	}
+
+	/**
 	 * Encode a serialized filter into the flat short-key query the client's
 	 * `filterToQuery()` produces - the exact wire format the feed endpoint reads.
 	 *
@@ -48,29 +94,46 @@ class ViewFilterTest extends TestCase {
 	 * @return array<string, string>
 	 */
 	private static function toQuery(array $serialized): array {
-		$multi = [
-			'labels' => 'fl', 'assignees' => 'fa', 'priorities' => 'fp',
-			'types' => 'ft', 'estimates' => 'fe', 'owners' => 'fo', 'reviews' => 'fr',
-		];
-		$single = [
-			'due' => 'fd', 'done' => 'fs', 'waiting' => 'fw', 'blocked' => 'fb',
-			'checklist' => 'fk', 'startDate' => 'fsd', 'subcard' => 'fsc', 'comments' => 'fcm',
-		];
-
 		$query = [];
-		foreach ($multi as $dimension => $key) {
-			$values = $serialized[$dimension] ?? [];
-			if (is_array($values) && $values !== []) {
-				$query[$key] = implode(',', array_map(static fn ($v): string => (string)$v, $values));
-			}
-		}
-		foreach ($single as $dimension => $key) {
+		foreach (self::wireKeys() as $dimension => $key) {
 			$value = $serialized[$dimension] ?? null;
-			if (is_string($value) && $value !== '') {
+			if (is_array($value)) {
+				if ($value !== []) {
+					$query[$key] = implode(',', array_map(static fn ($v): string => (string)$v, $value));
+				}
+			} elseif (is_string($value) && $value !== '') {
 				$query[$key] = $value;
 			}
 		}
 		return $query;
+	}
+
+	/**
+	 * Every card id in the fixture, in fixture order - what a filter that constrains
+	 * nothing must return. Derived so adding a card to the fixture does not silently
+	 * weaken the tolerance assertions below into a stale subset.
+	 *
+	 * @return list<int>
+	 */
+	private static function allCardIds(): array {
+		return array_map(static fn (array $card): int => (int)$card['id'], self::$fixture['cards']);
+	}
+
+	/**
+	 * The filter's dimensions, taken from {@see ViewFilter}'s own constructor
+	 * signature rather than a literal - so a 16th dimension added to the class
+	 * without a golden case, a wire key, or a controller param turns this red.
+	 * The JS half already derives its list from `createFilterState()`.
+	 *
+	 * @return list<string>
+	 */
+	private static function filterDimensions(): array {
+		$ctor = (new \ReflectionClass(ViewFilter::class))->getConstructor();
+		self::assertNotNull($ctor, 'ViewFilter must declare a constructor');
+		return array_map(
+			static fn (\ReflectionParameter $p): string => $p->getName(),
+			$ctor->getParameters(),
+		);
 	}
 
 	/**
@@ -108,11 +171,7 @@ class ViewFilterTest extends TestCase {
 	 * asserts the mirror image of this.
 	 */
 	public function testTheGoldenFixtureExercisesAllFifteenDimensions(): void {
-		$dimensions = [
-			'labels', 'assignees', 'priorities', 'types', 'estimates', 'owners',
-			'reviews', 'due', 'done', 'waiting', 'blocked', 'checklist',
-			'startDate', 'subcard', 'comments',
-		];
+		$dimensions = self::filterDimensions();
 		self::assertCount(15, $dimensions);
 
 		$covered = [];
@@ -122,6 +181,42 @@ class ViewFilterTest extends TestCase {
 			}
 		}
 		self::assertSame([], array_values(array_diff($dimensions, array_keys($covered))));
+	}
+
+	/**
+	 * The golden fixture pins the two PREDICATES against each other, but it cannot
+	 * see the wire: it feeds `ViewFilter::fromQuery()` an array built in this file.
+	 * The feed endpoint gets its array from the dispatcher, which fills it from
+	 * `cards()`'s DECLARED PARAMETERS ({@see ViewController::cards()}) - so a short
+	 * key with no matching `mixed $fXX = null` param never reaches the filter at
+	 * all. The server then silently stops constraining that dimension, and because
+	 * the client re-filters whatever it receives, nothing looks wrong until an
+	 * account has more readable cards than the feed's cap - the exact regression
+	 * #9862 fixed.
+	 *
+	 * Reflection over the controller signature is the cheap honest guard for that:
+	 * it proves the BINDING, which is the failure mode, without spending a round
+	 * trip per key on the shared e2e backend.
+	 */
+	public function testEveryWireKeyIsBoundOnTheFeedController(): void {
+		$map = self::wireKeys();
+
+		$params = array_map(
+			static fn (\ReflectionParameter $p): string => $p->getName(),
+			(new \ReflectionMethod(ViewController::class, 'cards'))->getParameters(),
+		);
+		foreach ($map as $dimension => $key) {
+			self::assertContains(
+				$key,
+				$params,
+				"the client emits '{$key}' for the '{$dimension}' filter, but ViewController::cards() "
+				. "declares no \${$key} param - the dispatcher will never pass it through",
+			);
+		}
+
+		// …and the map covers exactly the dimensions ViewFilter itself carries, in
+		// the same order. A 16th dimension added on one side only turns this red.
+		self::assertSame(self::filterDimensions(), array_keys($map));
 	}
 
 	/**
@@ -146,7 +241,7 @@ class ViewFilterTest extends TestCase {
 	public function testAnUnknownQueryKeyIsIgnoredAndNeverDropsARow(): void {
 		$filter = ViewFilter::fromQuery(['fzz' => 'from-a-newer-client', 'sortMode' => 'due']);
 		self::assertTrue($filter->isEmpty(), 'an unknown key must impose no constraint');
-		self::assertSame([1, 2, 3, 4, 5], self::survivors($filter), 'an unknown key must never drop a row');
+		self::assertSame(self::allCardIds(), self::survivors($filter), 'an unknown key must never drop a row');
 
 		// And an unknown key alongside a known one leaves the known one intact.
 		$mixed = ViewFilter::fromQuery(['fzz' => 'nonsense', 'fl' => '11']);
@@ -169,7 +264,7 @@ class ViewFilterTest extends TestCase {
 			'fsc' => 'sibling',       // not a sub-card relation
 		]);
 		self::assertTrue($filter->isEmpty());
-		self::assertSame([1, 2, 3, 4, 5], self::survivors($filter));
+		self::assertSame(self::allCardIds(), self::survivors($filter));
 	}
 
 	/**

--- a/tests/unit/Service/ViewFilterTest.php
+++ b/tests/unit/Service/ViewFilterTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Service\ViewFilter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The PHP half of the View filter's PHP<->JS parity contract (#9862).
+ *
+ * {@see ViewFilter} exists so the cross-board feed's hard cap slices the MATCHING
+ * set rather than the first window of the readable set. Because the CLIENT still
+ * re-filters the rows it receives, the two predicates must agree - and two
+ * predicates that must agree are two predicates that WILL drift. So the same
+ * golden fixture (tests/fixtures/board-filter-parity.json) is asserted from both
+ * CI runners: here under PHPUnit, and from tests/unit/boardFilters.test.mjs under
+ * `npm run test:unit`. Edit one predicate without the other and exactly one of the
+ * two jobs goes red.
+ *
+ * Both sides read the fixture's SERIALIZED filter, encode it with the same short
+ * keys `filterToQuery()` emits, and decode it back - so this pins the wire format
+ * and the decode, not just the matching.
+ */
+class ViewFilterTest extends TestCase {
+	/** @var array{now: int, cards: list<array<string, mixed>>, cases: list<array{name: string, filter: array<string, mixed>, expected: list<int>}>} */
+	private static array $fixture;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		$raw = file_get_contents(__DIR__ . '/../../fixtures/board-filter-parity.json');
+		self::assertIsString($raw, 'the golden parity fixture must be readable');
+		$decoded = json_decode($raw, true);
+		self::assertIsArray($decoded, 'the golden parity fixture must be valid JSON');
+		/** @var array{now: int, cards: list<array<string, mixed>>, cases: list<array{name: string, filter: array<string, mixed>, expected: list<int>}>} $decoded */
+		self::$fixture = $decoded;
+	}
+
+	/**
+	 * Encode a serialized filter into the flat short-key query the client's
+	 * `filterToQuery()` produces - the exact wire format the feed endpoint reads.
+	 *
+	 * @param array<string, mixed> $serialized
+	 * @return array<string, string>
+	 */
+	private static function toQuery(array $serialized): array {
+		$multi = [
+			'labels' => 'fl', 'assignees' => 'fa', 'priorities' => 'fp',
+			'types' => 'ft', 'estimates' => 'fe', 'owners' => 'fo', 'reviews' => 'fr',
+		];
+		$single = [
+			'due' => 'fd', 'done' => 'fs', 'waiting' => 'fw', 'blocked' => 'fb',
+			'checklist' => 'fk', 'startDate' => 'fsd', 'subcard' => 'fsc', 'comments' => 'fcm',
+		];
+
+		$query = [];
+		foreach ($multi as $dimension => $key) {
+			$values = $serialized[$dimension] ?? [];
+			if (is_array($values) && $values !== []) {
+				$query[$key] = implode(',', array_map(static fn ($v): string => (string)$v, $values));
+			}
+		}
+		foreach ($single as $dimension => $key) {
+			$value = $serialized[$dimension] ?? null;
+			if (is_string($value) && $value !== '') {
+				$query[$key] = $value;
+			}
+		}
+		return $query;
+	}
+
+	/**
+	 * Run one filter over the fixture's cards and collect the surviving ids.
+	 *
+	 * @return list<int>
+	 */
+	private static function survivors(ViewFilter $filter): array {
+		$out = [];
+		foreach (self::$fixture['cards'] as $card) {
+			if ($filter->matches($card, (int)self::$fixture['now'])) {
+				$out[] = (int)$card['id'];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Every golden case, run through the real wire path: serialized filter ->
+	 * short-key query -> ViewFilter::fromQuery() -> matches(). The JS runner
+	 * asserts the identical expectations over the identical cards, so a drift in
+	 * either predicate turns exactly one of the two CI jobs red.
+	 */
+	public function testGoldenFixtureParity(): void {
+		self::assertNotEmpty(self::$fixture['cases'], 'the fixture must carry cases');
+		foreach (self::$fixture['cases'] as $case) {
+			$filter = ViewFilter::fromQuery(self::toQuery($case['filter']));
+			self::assertSame($case['expected'], self::survivors($filter), 'golden case: ' . $case['name']);
+		}
+	}
+
+	/**
+	 * The fixture is only worth what it covers: a dimension that loses its last
+	 * case could drift silently while both runners stay green. The JS runner
+	 * asserts the mirror image of this.
+	 */
+	public function testTheGoldenFixtureExercisesAllFifteenDimensions(): void {
+		$dimensions = [
+			'labels', 'assignees', 'priorities', 'types', 'estimates', 'owners',
+			'reviews', 'due', 'done', 'waiting', 'blocked', 'checklist',
+			'startDate', 'subcard', 'comments',
+		];
+		self::assertCount(15, $dimensions);
+
+		$covered = [];
+		foreach (self::$fixture['cases'] as $case) {
+			foreach (array_keys($case['filter']) as $key) {
+				$covered[$key] = true;
+			}
+		}
+		self::assertSame([], array_values(array_diff($dimensions, array_keys($covered))));
+	}
+
+	/**
+	 * An empty filter constrains nothing, so ViewService::findMine() can skip the
+	 * pass entirely rather than walking a set that can reach the cap.
+	 */
+	public function testAnEmptyQueryIsRecognisedAsNoConstraint(): void {
+		self::assertTrue(ViewFilter::fromQuery([])->isEmpty());
+		// Present-but-blank params (a cleared filter still spelling out its keys)
+		// are the same thing.
+		self::assertTrue(ViewFilter::fromQuery(['fl' => '', 'fa' => ' , ', 'fd' => null])->isEmpty());
+		self::assertFalse(ViewFilter::fromQuery(['fl' => '7'])->isEmpty());
+	}
+
+	/**
+	 * The tolerance contract (#9862): an unknown key - an older or newer client, a
+	 * hand-edited URL - is IGNORED. Never a rejection, and never a reason to drop a
+	 * row. The client re-filters what it receives, so the server predicate is a
+	 * superset guard: erring towards keeping a row is harmless, dropping one is a
+	 * silent correctness bug.
+	 */
+	public function testAnUnknownQueryKeyIsIgnoredAndNeverDropsARow(): void {
+		$filter = ViewFilter::fromQuery(['fzz' => 'from-a-newer-client', 'sortMode' => 'due']);
+		self::assertTrue($filter->isEmpty(), 'an unknown key must impose no constraint');
+		self::assertSame([1, 2, 3, 4, 5], self::survivors($filter), 'an unknown key must never drop a row');
+
+		// And an unknown key alongside a known one leaves the known one intact.
+		$mixed = ViewFilter::fromQuery(['fzz' => 'nonsense', 'fl' => '11']);
+		self::assertFalse($mixed->isEmpty());
+		self::assertSame([1, 3], self::survivors($mixed));
+	}
+
+	/**
+	 * An unrecognised VALUE inside a known dimension is dropped, leaving that
+	 * dimension unconstrained - exactly what the client's `applyFilter()` does with
+	 * a hand-edited URL. Rejecting instead would drop every row, which is the one
+	 * failure mode the superset rule forbids.
+	 */
+	public function testAnUnknownValueInAKnownDimensionLeavesItUnconstrained(): void {
+		$filter = ViewFilter::fromQuery([
+			'fd' => 'someday',        // not a due option
+			'fs' => 'maybe',          // not a done option
+			'ft' => 'epic',           // not a filterable type
+			'fr' => 'rubber_stamped', // not a review state
+			'fsc' => 'sibling',       // not a sub-card relation
+		]);
+		self::assertTrue($filter->isEmpty());
+		self::assertSame([1, 2, 3, 4, 5], self::survivors($filter));
+	}
+
+	/**
+	 * The params are typed `mixed` all the way down because a malformed query string
+	 * hands the dispatcher arrays and other junk (`?fl[]=1`). Decoding must absorb
+	 * that rather than throw - this is a read path an older or newer client must not
+	 * be able to hard-fail.
+	 */
+	public function testMalformedParamTypesDecodeInsteadOfThrowing(): void {
+		// An array param: the client's csv() takes the FIRST value; so do we.
+		$array = ViewFilter::fromQuery(['fl' => ['11', '12']]);
+		self::assertFalse($array->isEmpty());
+		self::assertTrue($array->matches(self::$fixture['cards'][2], (int)self::$fixture['now']), 'card 3 carries label 11');
+
+		// Nested arrays, booleans, objects and an empty array all read as absent.
+		$junk = ViewFilter::fromQuery([
+			'fl' => [[]],
+			'fa' => true,
+			'fp' => new \stdClass(),
+			'fd' => [],
+		]);
+		self::assertTrue($junk->isEmpty());
+	}
+
+	/**
+	 * The relative windows read the INJECTED `now`, not the wall clock - which is
+	 * what makes them testable and stable across a whole feed pass.
+	 */
+	public function testRelativeWindowsFollowTheInjectedNow(): void {
+		$card = ['id' => 1, 'duedate' => '2026-01-03T00:00:00+00:00'];
+		$overdue = ViewFilter::fromQuery(['fd' => 'overdue']);
+		$week = ViewFilter::fromQuery(['fd' => 'week']);
+
+		// now = 2026-01-01 → the card is due in two days: in the week window.
+		$before = 1767225600000;
+		self::assertFalse($overdue->matches($card, $before));
+		self::assertTrue($week->matches($card, $before));
+
+		// now = 2026-02-01 → the same card is now overdue, and out of the window.
+		$after = 1769904000000;
+		self::assertTrue($overdue->matches($card, $after));
+		self::assertFalse($week->matches($card, $after));
+	}
+
+	/**
+	 * Priority parity detail: the client accepts any integer-VALUED token in 0..4
+	 * (`Number()` + `Number.isInteger()`), so '03' and '3.0' are the same selection
+	 * as '3'. A fractional or out-of-range token is dropped, leaving the dimension
+	 * unconstrained rather than matching nothing.
+	 */
+	public function testPriorityTokensAreParsedLikeTheClientDoes(): void {
+		$card = ['id' => 1, 'priority' => 3];
+		foreach (['3', '03', '3.0'] as $token) {
+			self::assertTrue(ViewFilter::fromQuery(['fp' => $token])->matches($card, 0), "token {$token}");
+		}
+		// Out of range / fractional / non-numeric are all dropped.
+		self::assertTrue(ViewFilter::fromQuery(['fp' => '9,3.5,high'])->isEmpty());
+	}
+
+	/**
+	 * A card missing an enrichment field entirely (an older cached row, a partial
+	 * summary) must not blow up the predicate - the absent field reads as its empty
+	 * value, exactly as `card.x ?? default` does on the client.
+	 */
+	public function testASparseCardRowIsTreatedAsAllDefaultsNotAnError(): void {
+		$sparse = ['id' => 99];
+		self::assertTrue(ViewFilter::fromQuery(['fa' => ViewFilter::UNASSIGNED])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fe' => ViewFilter::UNESTIMATED])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fr' => ViewFilter::REVIEW_NONE])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fp' => '0'])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fd' => 'none'])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fs' => 'open'])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fk' => 'none'])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fsd' => 'none'])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fsc' => 'top_level'])->matches($sparse, 0));
+		self::assertTrue(ViewFilter::fromQuery(['fcm' => 'none'])->matches($sparse, 0));
+		// …and it does NOT masquerade as a match for a positive constraint.
+		self::assertFalse(ViewFilter::fromQuery(['fl' => '1'])->matches($sparse, 0));
+		self::assertFalse(ViewFilter::fromQuery(['fo' => 'alice'])->matches($sparse, 0));
+	}
+}

--- a/tests/unit/Service/ViewFilterTest.php
+++ b/tests/unit/Service/ViewFilterTest.php
@@ -109,6 +109,53 @@ class ViewFilterTest extends TestCase {
 	}
 
 	/**
+	 * The short keys `ViewController::cards()` actually FORWARDS, parsed out of the
+	 * hand-written `$query` literal in its body, in literal order.
+	 *
+	 * The controller binds the wire in two independent places - the param list and
+	 * this literal that copies each param into the array handed to
+	 * {@see ViewFilter::fromQuery()} - and only the second one decides what the
+	 * filter sees. Reflection over the signature cannot see it: drop
+	 * `'fsc' => $fsc,` from the literal while keeping `mixed $fsc = null` and the
+	 * dispatcher still binds the param, the filter still never receives it, and the
+	 * server silently stops constraining `subcard`. That is the #9862 symptom with
+	 * the param half left intact, so the guard has to read this half too.
+	 *
+	 * Each entry must also forward its OWN param: `'fsd' => $fsc` would compile,
+	 * type-check and quietly cross two dimensions.
+	 *
+	 * @return list<string> the literal's keys, in the order they appear
+	 */
+	private static function feedQueryLiteralKeys(): array {
+		$src = file_get_contents(__DIR__ . '/../../../lib/Controller/ViewController.php');
+		self::assertIsString($src, 'the feed controller must be readable');
+
+		$method = strpos($src, 'public function cards(');
+		self::assertIsInt($method, 'ViewController::cards() must still exist');
+		$start = strpos($src, '$query = [', $method);
+		self::assertIsInt($start, 'cards() must still build a $query array literal');
+		$end = strpos($src, '];', $start);
+		self::assertIsInt($end, 'the $query literal must be terminated');
+		$literal = substr($src, $start, $end - $start);
+
+		$count = preg_match_all('/\'(\w+)\'\s*=>\s*\$(\w+)/', $literal, $m, PREG_SET_ORDER);
+		self::assertNotFalse($count, 'the $query literal pattern must compile');
+		self::assertGreaterThan(0, $count, 'no entries parsed out of the $query literal');
+
+		$keys = [];
+		foreach ($m as $match) {
+			self::assertSame(
+				$match[1],
+				$match[2],
+				"the '{$match[1]}' entry of cards()'s \$query forwards \${$match[2]} - "
+				. 'each key must carry its own param, or two dimensions are crossed',
+			);
+			$keys[] = $match[1];
+		}
+		return $keys;
+	}
+
+	/**
 	 * Every card id in the fixture, in fixture order - what a filter that constrains
 	 * nothing must return. Derived so adding a card to the fixture does not silently
 	 * weaken the tolerance assertions below into a stale subset.
@@ -186,17 +233,19 @@ class ViewFilterTest extends TestCase {
 	/**
 	 * The golden fixture pins the two PREDICATES against each other, but it cannot
 	 * see the wire: it feeds `ViewFilter::fromQuery()` an array built in this file.
-	 * The feed endpoint gets its array from the dispatcher, which fills it from
-	 * `cards()`'s DECLARED PARAMETERS ({@see ViewController::cards()}) - so a short
-	 * key with no matching `mixed $fXX = null` param never reaches the filter at
-	 * all. The server then silently stops constraining that dimension, and because
-	 * the client re-filters whatever it receives, nothing looks wrong until an
-	 * account has more readable cards than the feed's cap - the exact regression
-	 * #9862 fixed.
+	 * The feed endpoint builds its array in TWO steps, and a key has to survive
+	 * both: the dispatcher fills `cards()`'s DECLARED PARAMETERS, and the body then
+	 * copies each of them into the `$query` literal it hands the filter. Lose the
+	 * key on either side - no `mixed $fXX = null` param, or no `'fXX' => $fXX,`
+	 * entry - and the filter never receives that dimension. The server silently
+	 * stops constraining it, and because the client re-filters whatever it
+	 * receives, nothing looks wrong until an account has more readable cards than
+	 * the feed's cap: the exact regression #9862 fixed.
 	 *
-	 * Reflection over the controller signature is the cheap honest guard for that:
-	 * it proves the BINDING, which is the failure mode, without spending a round
-	 * trip per key on the shared e2e backend.
+	 * So this asserts BOTH halves - the signature by reflection, the literal by
+	 * parsing the method body ({@see self::feedQueryLiteralKeys()}) - which is the
+	 * cheap honest guard for the whole binding, without spending a round trip per
+	 * key on the shared e2e backend.
 	 */
 	public function testEveryWireKeyIsBoundOnTheFeedController(): void {
 		$map = self::wireKeys();
@@ -213,6 +262,17 @@ class ViewFilterTest extends TestCase {
 				. "declares no \${$key} param - the dispatcher will never pass it through",
 			);
 		}
+
+		// A bound param that the body never copies into $query is just as invisible
+		// to the filter as a missing param, so the forwarding literal is pinned too
+		// - exactly, and in the same order the client emits.
+		self::assertSame(
+			array_values($map),
+			self::feedQueryLiteralKeys(),
+			'the $query literal in ViewController::cards() must forward every short key the client '
+			. 'emits, and nothing else - a param bound but not forwarded leaves that dimension '
+			. 'unconstrained on the server',
+		);
 
 		// …and the map covers exactly the dimensions ViewFilter itself carries, in
 		// the same order. A 16th dimension added on one side only turns this red.

--- a/tests/unit/Service/ViewServiceTest.php
+++ b/tests/unit/Service/ViewServiceTest.php
@@ -570,17 +570,22 @@ class ViewServiceTest extends TestCase {
 	/**
 	 * The filter runs BEFORE the sort, so the sort orders the matching set. Both
 	 * still run after the ACL loop.
+	 *
+	 * The rows are deliberately seeded so the sorted answer REVERSES fixture order:
+	 * alice owns 1:'cherry' and 3:'apple', so an unsorted (or mis-sorted) pass
+	 * returns [1, 3] and only a real `title asc` returns [3, 1]. Sorting by title
+	 * rather than id also keeps this honest if the seed order ever changes.
 	 */
 	public function testFindMineSortsTheFilteredSet(): void {
 		$this->seedFeed([1 => ['rows' => [
-			['id' => 1, 'title' => 'banana', 'owner' => 'alice'],
-			['id' => 2, 'title' => 'apple', 'owner' => 'bob'],
-			['id' => 3, 'title' => 'cherry', 'owner' => 'alice'],
+			['id' => 1, 'title' => 'cherry', 'owner' => 'alice'],
+			['id' => 2, 'title' => 'banana', 'owner' => 'bob'],
+			['id' => 3, 'title' => 'apple', 'owner' => 'alice'],
 		]]]);
 
 		$result = $this->service->findMine('alice', 'title', 'asc', ViewFilter::fromQuery(['fo' => 'alice']));
 
-		self::assertSame([1, 3], $this->idsOf($result));
+		self::assertSame([3, 1], $this->idsOf($result));
 		self::assertSame(2, $result['total']);
 	}
 

--- a/tests/unit/Service/ViewServiceTest.php
+++ b/tests/unit/Service/ViewServiceTest.php
@@ -489,6 +489,32 @@ class ViewServiceTest extends TestCase {
 	}
 
 	/**
+	 * A NUMERIC uid must survive as a STRING. `participants` is accumulated as an
+	 * array KEY set, and PHP silently coerces a canonical decimal string key to int -
+	 * so a uid like '12345' (routine wherever accounts are provisioned from LDAP
+	 * employee numbers) would be stored as int(12345), come back from array_keys() as
+	 * a number, and ship in the envelope as a JSON number. The client drops non-string
+	 * entries, so that account would disappear from the assignee/owner facet with no
+	 * way to add them back - and at zero matches the facet hides entirely. That is
+	 * precisely the facet self-narrowing this vocabulary exists to prevent, which is
+	 * why the type is pinned here and not just the membership.
+	 */
+	public function testFindMineShipsNumericUidsAsStringsNotNumbers(): void {
+		$this->seedFeed([1 => ['rows' => [
+			['id' => 1, 'owner' => '12345', 'assigneeIds' => ['67890']],
+			['id' => 2, 'owner' => 'alice', 'assigneeIds' => ['alice']],
+		]]]);
+
+		$participants = $this->service->findMine('alice')['participants'];
+
+		// assertSame is strict: int(12345) would NOT satisfy '12345'.
+		self::assertSame(['12345', '67890', 'alice'], $participants);
+		foreach ($participants as $uid) {
+			self::assertIsString($uid, 'every participant uid must ship as a string');
+		}
+	}
+
+	/**
 	 * The ACL boundary again, this time with a filter active (REQUIRED leak-denial).
 	 * Filtering must never become a shortcut around the per-board permission
 	 * masking: it runs strictly AFTER that loop, over rows the viewer may already

--- a/tests/unit/Service/ViewServiceTest.php
+++ b/tests/unit/Service/ViewServiceTest.php
@@ -16,6 +16,7 @@ use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Service\BoardService;
 use OCA\Kanso\Service\CardSummaryService;
+use OCA\Kanso\Service\ViewFilter;
 use OCA\Kanso\Service\ViewService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -163,9 +164,14 @@ class ViewServiceTest extends TestCase {
 
 	/**
 	 * The scale guard (#3892): the feed is a SINGLE unbounded payload, so it is
-	 * hard-capped. Whatever the readable-set size, `cards` never exceeds
-	 * MAX_CARDS, `total` reports the true pre-cap count, and `capped` is honest -
-	 * the cap is applied AFTER the per-board ACL loop, so it moves no leak boundary.
+	 * hard-capped. Whatever the set size, `cards` never exceeds MAX_CARDS, `total`
+	 * reports the true pre-cap count, and `capped` is honest - the cap is applied
+	 * AFTER the per-board ACL loop, so it moves no leak boundary.
+	 *
+	 * Post-filter semantics (#9862): `total` counts MATCHING rows, so with no
+	 * filter - as here - it is still the whole readable-set count. The filtered
+	 * counterparts live in testFindMineAppliesTheFilterBeforeTheCap() and
+	 * testFindMineReportsTheMatchingTotalNotTheReadableTotal() below.
 	 */
 	public function testFindMineCapsThePayloadAndReportsTotalWhenReadableSetIsHuge(): void {
 		$overCap = ViewService::MAX_CARDS + 250;
@@ -386,6 +392,170 @@ class ViewServiceTest extends TestCase {
 		$boardIds = array_map(static fn (array $c): int => (int)$c['boardId'], $rows);
 		self::assertSame([3], array_values(array_unique($boardIds)));
 		self::assertNotContains(7, $boardIds);
+	}
+
+	// ── The View filter (#9862) ──────────────────────────────────────────────────
+
+	/**
+	 * THE bug this filter exists to fix. The feed is hard-capped, and the filter
+	 * used to run only in the browser - so on an account with more readable cards
+	 * than the cap, a narrow filter searched ONLY the first MAX_CARDS rows of the
+	 * sorted order and silently missed every match past them.
+	 *
+	 * Asserting that at >5000 rows through the UI is impractical, so it is pinned
+	 * here instead, at the exact seam that was wrong: the readable set is larger
+	 * than the cap and the ONLY matching cards sit at the very END of it, well
+	 * outside the capped window. They come back, which is only possible if the
+	 * filter ran before the slice.
+	 */
+	public function testFindMineAppliesTheFilterBeforeTheCap(): void {
+		$overCap = ViewService::MAX_CARDS + 250;
+		// Every row is owned by 'alice' EXCEPT the last three, which are the only
+		// ones the filter wants - i.e. they are outside the first MAX_CARDS rows of
+		// the default (boardId, id) order the cap slices on.
+		$needles = [$overCap - 2, $overCap - 1, $overCap];
+		$rows = array_map(
+			static fn (int $i): array => [
+				'id' => $i,
+				'owner' => $i > $overCap - 3 ? 'zoe' : 'alice',
+			],
+			range(1, $overCap),
+		);
+		$this->seedFeed([1 => ['rows' => $rows]]);
+
+		$result = $this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery(['fo' => 'zoe']));
+
+		// Pre-fix this returned an empty list: the cap had already thrown these rows
+		// away before any filter could see them.
+		self::assertSame($needles, $this->idsOf($result));
+		self::assertFalse($result['capped'], 'the matching set fits well inside the cap');
+		self::assertSame(3, $result['total'], 'total counts MATCHING cards, not readable ones');
+	}
+
+	/**
+	 * `total` / `capped` describe the MATCHING set, so the "showing the first N of
+	 * M" banner is honest about what refining the filter would actually do. Here
+	 * the matching set is itself larger than the cap.
+	 */
+	public function testFindMineReportsTheMatchingTotalNotTheReadableTotal(): void {
+		$overCap = ViewService::MAX_CARDS + 250;
+		// Half the readable set is done; the filter keeps only the open ones, which
+		// still overflow the cap.
+		$rows = array_map(
+			static fn (int $i): array => ['id' => $i, 'doneAt' => $i % 2 === 0 ? 1700000000 : 0],
+			range(1, 2 * $overCap),
+		);
+		$this->seedFeed([1 => ['rows' => $rows]]);
+
+		$result = $this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery(['fs' => 'open']));
+
+		self::assertTrue($result['capped']);
+		self::assertSame($overCap, $result['total'], 'the matching count, not the 2x readable count');
+		self::assertCount(ViewService::MAX_CARDS, $result['cards']);
+		// …and the window it kept is the head of the MATCHING set (odd ids only).
+		self::assertSame([1, 3, 5], array_slice($this->idsOf($result), 0, 3));
+	}
+
+	/**
+	 * The facet-collapse guard. `participants` is accumulated in the per-board loop
+	 * BEFORE the filter, so the client's assignee/owner facets keep offering
+	 * everyone however narrow the filter gets - including at ZERO matches, where a
+	 * row-derived facet would vanish outright and leave no way to add a second
+	 * person back.
+	 */
+	public function testFindMineShipsTheWholeParticipantVocabularyEvenAtZeroMatches(): void {
+		$this->seedFeed([1 => ['rows' => [
+			['id' => 1, 'owner' => 'alice', 'assigneeIds' => ['alice']],
+			['id' => 2, 'owner' => 'bob', 'assigneeIds' => ['bob', 'carol']],
+		]]]);
+
+		// A filter nobody matches.
+		$result = $this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery(['fo' => 'nobody']));
+
+		self::assertSame([], $result['cards']);
+		self::assertSame(0, $result['total']);
+		// The facet vocabulary survives the wipe-out, sorted and de-duplicated.
+		self::assertSame(['alice', 'bob', 'carol'], $result['participants']);
+	}
+
+	/** Unfiltered, the same vocabulary is the union across every readable board. */
+	public function testFindMineUnionsParticipantsAcrossReadableBoards(): void {
+		$this->seedFeed([
+			3 => ['rows' => [['id' => 11, 'owner' => 'alice', 'assigneeIds' => ['dave']]]],
+			9 => ['rows' => [['id' => 22, 'owner' => 'bob', 'assigneeIds' => ['alice']]]],
+		]);
+
+		self::assertSame(['alice', 'bob', 'dave'], $this->service->findMine('alice')['participants']);
+	}
+
+	/**
+	 * The ACL boundary again, this time with a filter active (REQUIRED leak-denial).
+	 * Filtering must never become a shortcut around the per-board permission
+	 * masking: it runs strictly AFTER that loop, over rows the viewer may already
+	 * see, so it can only ever REMOVE rows - never surface one from a board outside
+	 * the readable set, however the filter is spelled.
+	 */
+	public function testFindMineWithAFilterStillNeverQueriesABoardOutsideTheReadableSet(): void {
+		// alice can read board 3 only. Board 7 exists but is absent from findAll().
+		$b3 = $this->board(3, 'Readable');
+		$this->boardService->method('findAll')->with('alice')->willReturn([$b3]);
+		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
+		$this->boardAccess->method('contextFor')->with($b3, 'alice')->willReturn($ctx3);
+
+		// Asked ONLY for board 3, under board 3's viewer context - the filter does
+		// not widen, re-run or bypass the query.
+		$this->cardMapper->expects(self::once())
+			->method('findSummariesByBoard')
+			->with(3, $ctx3)
+			->willReturn([$this->summaryCard(11, 3)]);
+		$this->cardSummaryService->method('serialize')
+			->willReturn([['id' => 11, 'owner' => 'mallory', 'assigneeIds' => ['mallory']]]);
+
+		// A filter deliberately shaped to describe the unreadable board's card.
+		$result = $this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery([
+			'fo' => 'mallory',
+			'fa' => 'mallory',
+		]));
+
+		$boardIds = array_map(static fn (array $c): int => (int)$c['boardId'], $result['cards']);
+		self::assertSame([3], array_values(array_unique($boardIds)));
+		self::assertNotContains(7, $boardIds, 'a filter must never surface a card from an unreadable board');
+		// The vocabulary is scoped to the readable set too - it cannot become a
+		// side channel for uids seen only on boards alice cannot read.
+		self::assertSame(['mallory'], $result['participants']);
+	}
+
+	/**
+	 * An empty filter (or one whose every value this version doesn't recognise) is a
+	 * no-op: the feed is exactly what it was before the filter shipped. This is the
+	 * tolerance half of the contract - a filter must never be able to blank a View.
+	 */
+	public function testFindMineTreatsAnEmptyOrUnrecognisedFilterAsNoConstraint(): void {
+		$this->seedFeed([1 => ['rows' => [['id' => 1], ['id' => 2], ['id' => 3]]]]);
+
+		self::assertSame([1, 2, 3], $this->idsOf($this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery([]))));
+		// An unknown key and an unrecognised value in a known dimension are both
+		// ignored rather than dropping every row.
+		self::assertSame([1, 2, 3], $this->idsOf($this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery(['fzz' => 'x', 'fd' => 'someday']))));
+		// …and passing no filter at all is the same thing.
+		self::assertSame([1, 2, 3], $this->idsOf($this->service->findMine('alice')));
+	}
+
+	/**
+	 * The filter runs BEFORE the sort, so the sort orders the matching set. Both
+	 * still run after the ACL loop.
+	 */
+	public function testFindMineSortsTheFilteredSet(): void {
+		$this->seedFeed([1 => ['rows' => [
+			['id' => 1, 'title' => 'banana', 'owner' => 'alice'],
+			['id' => 2, 'title' => 'apple', 'owner' => 'bob'],
+			['id' => 3, 'title' => 'cherry', 'owner' => 'alice'],
+		]]]);
+
+		$result = $this->service->findMine('alice', 'title', 'asc', ViewFilter::fromQuery(['fo' => 'alice']));
+
+		self::assertSame([1, 3], $this->idsOf($result));
+		self::assertSame(2, $result['total']);
 	}
 
 	public function testFindMineEmptyWhenNoReadableBoards(): void {

--- a/tests/unit/boardFilters.test.mjs
+++ b/tests/unit/boardFilters.test.mjs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #9862 — the JS half of the View filter's PHP↔JS parity contract.
+//
+// The View filter now runs on BOTH sides: the client keeps applying
+// `makePredicate` over the rows it receives (that is what keeps chip editing
+// instant), and the server applies the mirrored OCA\Kanso\Service\ViewFilter
+// BEFORE the cross-board feed's 5000-row cap, so the cap slices the MATCHING set
+// instead of the first window of the readable set.
+//
+// Two predicates that must agree are two predicates that WILL drift. So the same
+// golden fixture — cards × filter states × expected surviving ids — is asserted
+// from both CI runners: this file under `npm run test:unit` (node --test), and
+// tests/unit/Service/ViewFilterTest.php under PHPUnit. If someone edits one
+// predicate and not the other, exactly one of the two jobs goes red.
+//
+// Both sides consume the filter through the SAME wire encoding the board's
+// shareable filter links already use, so this pins the decode too:
+//   serialized filter → filterToQuery() short keys → decode → predicate.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+	createFilterState,
+	applyFilter,
+	filterToQuery,
+	queryToFilter,
+	makePredicate,
+	serializeFilter,
+} from '../../src/composables/useBoardFilters.js'
+
+const fixture = JSON.parse(
+	readFileSync(new URL('../fixtures/board-filter-parity.json', import.meta.url), 'utf8'),
+)
+
+/** The full round trip a real request makes: serialized → query → state. */
+function stateFor(serialized) {
+	const state = createFilterState()
+	applyFilter(state, queryToFilter(filterToQuery(serialized)))
+	return state
+}
+
+for (const testCase of fixture.cases) {
+	test(`golden filter parity — ${testCase.name}`, () => {
+		const predicate = makePredicate(stateFor(testCase.filter), fixture.now)
+		const survivors = fixture.cards.filter(predicate).map((card) => card.id)
+		assert.deepEqual(survivors, testCase.expected)
+	})
+}
+
+// The fixture is only worth what it covers: if a dimension loses its last case,
+// PHP and JS could silently diverge on it and both runners would still be green.
+test('the golden fixture exercises all 15 filter dimensions', () => {
+	const allKeys = Object.keys(createFilterState())
+	assert.equal(allKeys.length, 15, 'the filter state should carry exactly 15 dimensions')
+
+	const covered = new Set()
+	for (const testCase of fixture.cases) {
+		for (const key of Object.keys(testCase.filter)) covered.add(key)
+	}
+	const missing = allKeys.filter((key) => !covered.has(key))
+	assert.deepEqual(missing, [], `dimensions with no golden case: ${missing.join(', ')}`)
+})
+
+// The round trip must be lossless for every dimension, otherwise a "parity"
+// pass could just be both sides receiving the same EMPTY filter.
+test('the short-key wire encoding round-trips every dimension', () => {
+	for (const testCase of fixture.cases) {
+		const back = serializeFilter(stateFor(testCase.filter))
+		assert.deepEqual(back, testCase.filter, `lost data round-tripping "${testCase.name}"`)
+	}
+})

--- a/tests/unit/cardMoveQueue.test.mjs
+++ b/tests/unit/cardMoveQueue.test.mjs
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10008 — WHEN the move queue's error banner is allowed to clear itself.
+//
+// Moves are serialised: each enqueueMove() chains onto the previous server call.
+// So "clear the banner when a move succeeds" is the wrong hook — drag A fails,
+// its card is visibly reverted and the banner explains why, and then drag B,
+// which the user started BEFORE A came back, lands one round trip later and
+// wipes the explanation off a revert that is still on screen. The right hook is
+// the user's next gesture: clearing at the TOP of enqueueMove() retires the old
+// banner when the user acts, and lets A's message outlive an already-queued B.
+//
+// Exercised for real rather than at the source level: useCardMove is a plain
+// composable, so it runs under a Vue app context with no DOM and no bundler
+// (app.runWithContext supplies the injected QueryClient without mounting). Only
+// the transport is stubbed, and at the axios ADAPTER — the real composable, the
+// real FIFO queue, the real services/api.js call and the real optimistic
+// patch/rollback all run.
+//
+// `window` has to exist before @nextcloud/router is imported; the stub is
+// deliberately not a DOM (defining `document` would pull Vue's browser runtime
+// in and need a real one).
+
+import test, { after } from 'node:test'
+import assert from 'node:assert/strict'
+
+globalThis.window = {
+	_oc_webroot: '',
+	location: { href: 'http://localhost/' },
+	addEventListener() {},
+	removeEventListener() {},
+}
+
+// Dynamic, and in this order, on purpose: static `import` declarations are
+// hoisted and evaluated BEFORE any statement in the module, so a static import
+// of the composable would reach @nextcloud/router before the stub above exists.
+const { createApp } = await import('vue')
+const { QueryClient, VueQueryPlugin } = await import('@tanstack/vue-query')
+const axios = (await import('@nextcloud/axios')).default
+const { useCardMove } = await import('../../src/composables/useCardMove.js')
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Every cached query arms a garbage-collection timer, which would keep the test
+// process alive for the full gcTime after the last assertion. Tear them down.
+const clients = []
+after(() => {
+	for (const client of clients) {
+		client.unmount()
+		client.clear()
+	}
+})
+
+/** A 403 with a server-shaped body, i.e. the review gate refusing a move. */
+function refusal(message) {
+	return { response: { status: 403, data: { error: message } } }
+}
+
+/**
+ * A composable wired to its own QueryClient, seeded with one card, plus an
+ * axios adapter that answers each move request from `outcomes` in order.
+ *
+ * @param {number} boardId - distinct per test; the pending-move registry is module-scoped
+ * @param {Array<Error|object|null>} outcomes - per call: a rejection value, or null to succeed
+ */
+function harness(boardId, outcomes) {
+	const app = createApp({})
+	const queryClient = new QueryClient()
+	app.use(VueQueryPlugin, { queryClient })
+	clients.push(queryClient)
+
+	queryClient.setQueryData(['board', String(boardId)], {
+		cards: [
+			{ id: 1, stackId: 10, sortKey: 'a' },
+			{ id: 2, stackId: 10, sortKey: 'b' },
+		],
+	})
+
+	let call = 0
+	axios.defaults.adapter = async (config) => {
+		const outcome = outcomes[call++]
+		if (outcome) throw outcome
+		return {
+			status: 200,
+			statusText: 'OK',
+			data: { id: 1, stackId: 20, sortKey: 'm', lastModified: 1 },
+			headers: {},
+			config,
+		}
+	}
+
+	return { queryClient, ...app.runWithContext(() => useCardMove(boardId)) }
+}
+
+/** One drag: card `cardId` dropped into stack 20. */
+function drag(enqueueMove, cardId) {
+	enqueueMove({ cardId, targetStackId: 20, afterCardId: null, optimisticKey: 'z' })
+}
+
+test('a queued move that lands does NOT retire the failed move\'s banner', async () => {
+	// Drag A fails; drag B was already queued behind it and succeeds. B's enqueue
+	// happened before A came back, so it is not the user reacting to A's failure —
+	// A's revert is still on screen and must keep its explanation.
+	const { enqueueMove, lastError } = harness(1, [refusal('Card is under review.'), null])
+
+	drag(enqueueMove, 1) // A — will be refused
+	drag(enqueueMove, 2) // B — queued behind A, will land
+
+	await sleep(200)
+
+	assert.equal(lastError.value, 'Card is under review.',
+		'a later queued success wiped the failed move\'s banner while its revert '
+		+ 'was still on screen')
+})
+
+test('starting a new move retires the previous failure\'s banner immediately', async () => {
+	const { enqueueMove, lastError } = harness(2, [refusal('Card is under review.'), null])
+
+	drag(enqueueMove, 1)
+	await sleep(200)
+	assert.equal(lastError.value, 'Card is under review.', 'the failure must raise the banner')
+
+	// The next gesture clears it on the spot — synchronously, at enqueue, not a
+	// round trip later when the server answers.
+	drag(enqueueMove, 2)
+	assert.equal(lastError.value, null,
+		'a new drag is the user moving on; the stale banner must go with the gesture, '
+		+ 'not with the response')
+
+	await sleep(200)
+	assert.equal(lastError.value, null)
+})
+
+test('a refused move still raises the banner and reverts that card only', async () => {
+	// The clear moving to the top of enqueueMove() must not cost the banner its
+	// reason to exist, nor the per-card rollback.
+	const { enqueueMove, lastError, queryClient } = harness(3, [refusal('Card is under review.')])
+
+	drag(enqueueMove, 1)
+	assert.equal(
+		queryClient.getQueryData(['board', '3']).cards.find((c) => c.id === 1).stackId,
+		20,
+		'the optimistic patch must move the card straight away',
+	)
+
+	await sleep(200)
+
+	assert.equal(lastError.value, 'Card is under review.')
+	const cards = queryClient.getQueryData(['board', '3']).cards
+	assert.equal(cards.find((c) => c.id === 1).stackId, 10, 'the refused card must be reverted')
+	assert.equal(cards.find((c) => c.id === 2).stackId, 10, 'the untouched card must not move')
+})
+
+test('the manual dismiss still clears the banner', async () => {
+	const { enqueueMove, lastError, dismissError } = harness(4, [refusal('Card is under review.')])
+
+	drag(enqueueMove, 1)
+	await sleep(200)
+	assert.equal(lastError.value, 'Card is under review.')
+
+	dismissError()
+	assert.equal(lastError.value, null)
+})

--- a/tests/unit/dragHandleSync.test.mjs
+++ b/tests/unit/dragHandleSync.test.mjs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #9981 — the drag-handle re-registration must not leave a latched drag class.
+//
+// CardTile and StackColumn hold their pragmatic draggable apart from the rest
+// of their cleanup because it is the one registration that comes and goes: a
+// board ACL change reaches the client on the periodic board refetch, not
+// through a remount, so both re-run a sync function when `canEditBoard` flips.
+//
+// Tearing the draggable down destroys it, which means its `onDrop` will never
+// run. If the flip lands DURING a drag (an admin demoting the viewer to a
+// read-only member while they hold a tile), the component's dragging flag —
+// which only `onDrop` clears — stays true and the visual drag state
+// (`card-tile-wrap--dragging` / `stack-column--dragging`) latches on for the
+// rest of the session. The fix is one line per component: clear the flag as
+// part of the teardown, since it describes the registration being destroyed.
+//
+// Asserted at the source level, in the same spirit as the main.js guard in
+// queryKeys.test.mjs. The alternative would be mounting two SFCs with a stubbed
+// pragmatic adapter, which needs a bundler + DOM this suite deliberately does
+// not carry; and manufacturing the race in Playwright needs an admin demotion
+// to land inside a live HTML5 drag, which is not worth the e2e budget. What can
+// regress here is the line going missing, and that is exactly what this catches.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+/** The body of `function <name>() { … }`, brace-matched. */
+function functionBody(source, name) {
+	const start = source.indexOf(`function ${name}() {`)
+	assert.notEqual(start, -1, `${name}() not found — was it renamed?`)
+	let depth = 0
+	for (let i = source.indexOf('{', start); i < source.length; i++) {
+		if (source[i] === '{') depth++
+		else if (source[i] === '}' && --depth === 0) return source.slice(start, i + 1)
+	}
+	assert.fail(`unbalanced braces in ${name}()`)
+}
+
+const cases = [
+	{
+		file: 'CardTile.vue',
+		fn: 'syncDragHandle',
+		cleanup: 'dragCleanup()',
+		flag: 'isDragging.value = false',
+	},
+	{
+		file: 'StackColumn.vue',
+		fn: 'syncStackDragHandle',
+		cleanup: 'stackDragCleanup()',
+		flag: 'isStackDragging.value = false',
+	},
+]
+
+for (const { file, fn, cleanup, flag } of cases) {
+	test(`${file}: ${fn} clears the dragging flag when it tears the draggable down`, async () => {
+		const source = await readFile(
+			new URL(`../../src/components/${file}`, import.meta.url), 'utf8',
+		)
+		const body = functionBody(source, fn)
+
+		const teardownAt = body.indexOf(cleanup)
+		const flagAt = body.indexOf(flag)
+		const reregisterAt = body.indexOf('draggable({')
+
+		assert.notEqual(teardownAt, -1, `${fn}() no longer tears the draggable down`)
+		assert.notEqual(reregisterAt, -1, `${fn}() no longer re-registers a draggable`)
+		assert.notEqual(flagAt, -1,
+			`${fn}() must reset the dragging flag — a flip mid-drag destroys the `
+			+ 'draggable before its onDrop can run, latching the drag class on')
+
+		assert.ok(flagAt > teardownAt && flagAt < reregisterAt,
+			`the reset must sit between the teardown and the re-registration in ${fn}()`)
+	})
+}

--- a/tests/unit/queryKeys.test.mjs
+++ b/tests/unit/queryKeys.test.mjs
@@ -176,6 +176,36 @@ test('an isolated edit after the window still refetches the View feed at once', 
 		'a lone edit outside the burst window must not be deferred')
 })
 
+test('a backwards clock step cannot park the trailing refetch past the window', async () => {
+	// The burst window is measured with Date.now(), which is NOT monotonic: an
+	// NTP correction or a resumed VM can step it backwards. That makes `elapsed`
+	// negative, and an unclamped `THROTTLE - elapsed` would arm the trailing timer
+	// for the whole size of the jump. Every later call then takes the "a trailing
+	// refetch is already scheduled" early-out, so the View feed stops invalidating
+	// on mutations entirely until that timer finally fires — a minute here, but as
+	// long as the clock jumped in the field.
+	const { invalidateCrossBoardFeeds: invalidate, VIEW_FEED_INVALIDATE_THROTTLE: window }
+		= await freshQueryKeys()
+	const client = recordingClient()
+	const realNow = Date.now
+
+	try {
+		invalidate(client) // leading edge — stamps the wall clock
+		assert.equal(viewFeedHits(client), 1)
+
+		Date.now = () => realNow() - 60_000 // the clock jumps a minute backwards
+		invalidate(client) // …so this call computes a negative `elapsed`
+	} finally {
+		Date.now = realNow
+	}
+
+	await sleep(window * 3)
+
+	assert.equal(viewFeedHits(client), 2,
+		'the trailing refetch must still land within the window after a backwards '
+		+ 'clock step — an unclamped delay silently disables View feed invalidation')
+})
+
 test('the burst window is short enough to read as instant', async () => {
 	const { VIEW_FEED_INVALIDATE_THROTTLE: window } = await freshQueryKeys()
 

--- a/tests/unit/queryKeys.test.mjs
+++ b/tests/unit/queryKeys.test.mjs
@@ -99,3 +99,90 @@ test('main.js wires the realtime path to the narrow invalidator only', async () 
 		'main.js must not put the View feed on the realtime path — that is the #9859 regression',
 	)
 })
+
+// ── #9981 — the mutation-side burst guard ────────────────────────────────────
+//
+// invalidateCrossBoardFeeds is called from ~20 mutation settle sites. With the
+// card overlay open ON a View, ViewPage stays mounted, so ['view-cards'] is an
+// ACTIVE query and every one of those calls used to trigger a full cross-board
+// refetch. Ticking five checklist items = five of the heaviest reads in the app.
+//
+// The guard is leading-edge + trailing-debounce, and BOTH halves matter: the
+// leading edge is what keeps the View tile repainting on the first edit (the
+// property tests/e2e/view-checklist-live.spec.js asserts in a browser), the
+// trailing edge is what collapses the rest of the burst.
+//
+// The throttle keeps burst state in module scope, so each test below imports its
+// own fresh copy of the module (a unique ?burst= makes Node treat it as a
+// distinct module) rather than leaking a hot window into its neighbours.
+
+let burstCounter = 0
+/** A fresh, un-warmed copy of queryKeys.js with its own burst state. */
+function freshQueryKeys() {
+	return import(`../../src/composables/queryKeys.js?burst=${++burstCounter}`)
+}
+
+/** Count of view-cards invalidations recorded by a recordingClient. */
+function viewFeedHits(client) {
+	return client.invalidated.filter((k) => k === 'view-cards').length
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('a burst of mutations refetches the View feed once, immediately', async () => {
+	const { invalidateCrossBoardFeeds: invalidate } = await freshQueryKeys()
+	const client = recordingClient()
+
+	for (let i = 0; i < 5; i++) invalidate(client)
+
+	// Leading edge only, and it already fired — synchronously, before any await.
+	assert.equal(viewFeedHits(client), 1,
+		'five settle calls in one tick must not be five cross-board reads')
+	// The cheap per-user feeds are deliberately NOT throttled: 5 calls × 3 keys.
+	assert.equal(client.invalidated.filter((k) => k === 'my-cards').length, 5,
+		'the My Work feeds must stay immediate — only the heavy query is guarded')
+})
+
+test('the burst settles with exactly one catch-up refetch', async () => {
+	const { invalidateCrossBoardFeeds: invalidate, VIEW_FEED_INVALIDATE_THROTTLE: window }
+		= await freshQueryKeys()
+	const client = recordingClient()
+
+	for (let i = 0; i < 5; i++) invalidate(client)
+	assert.equal(viewFeedHits(client), 1)
+
+	await sleep(window * 2)
+
+	// Leading + one trailing. The trailing edge is what makes the feed agree with
+	// the LAST edit of the burst, not just the first.
+	assert.equal(viewFeedHits(client), 2,
+		'the burst must settle on exactly one catch-up refetch, not one per tick')
+})
+
+test('an isolated edit after the window still refetches the View feed at once', async () => {
+	const { invalidateCrossBoardFeeds: invalidate, VIEW_FEED_INVALIDATE_THROTTLE: window }
+		= await freshQueryKeys()
+	const client = recordingClient()
+
+	invalidate(client)
+	assert.equal(viewFeedHits(client), 1)
+
+	await sleep(window * 2)
+
+	// A single edit is not a burst: the leading edge must fire on the spot, or
+	// the View tile behind the overlay stops repainting promptly.
+	invalidate(client)
+	assert.equal(viewFeedHits(client), 2,
+		'a lone edit outside the burst window must not be deferred')
+})
+
+test('the burst window is short enough to read as instant', async () => {
+	const { VIEW_FEED_INVALIDATE_THROTTLE: window } = await freshQueryKeys()
+
+	// Bounded on both sides on purpose. Too long and the trailing refetch stops
+	// feeling live (view-checklist-live.spec.js would need a longer wait — the
+	// signal that this number, not the spec, is wrong). Too short and it stops
+	// collapsing anything.
+	assert.ok(window >= 200 && window <= 600,
+		`View feed burst window out of range: ${window}ms`)
+})

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -4433,7 +4433,7 @@ msgid "Show watchers"
 msgstr ""
 
 #: src/views/ViewPage.vue
-msgid "Showing the first {shown} of {total} cards — refine your filter to see the rest."
+msgid "Showing the first {shown} of {total} matching cards — refine your filter to see the rest."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue


### PR DESCRIPTION
Every card was re-validated against `origin/main` before execution; three of the four had drifted line refs and two had substantively wrong claims, corrected on the cards.

## What's in it

**`fix:` Hide column actions, Delete column and card drag from read-only members** (KANSO-23)
A read-only board member could see the column actions menu — including **Delete column** — an editable-looking column title, and could pick up and drag cards. Every one of those writes was already rejected server-side; they were dead affordances that read as a broken app. `BoardView` now gates all six stack callbacks on `canEditBoard` and provides a `BOARD_CAN_EDIT` inject consumed by `CardTile`, `BoardListView` and `StackColumn`. **No server-side check was loosened.**
The inject defaults to `true` on purpose: `ViewKanbanColumn` renders `CardTile` with no provider, so a `false` default would silently kill drag on cross-board Views.
Review also caught a reactivity bug: the permission was read only at mount while the grab-cursor class was reactive, so a mid-session ACL flip via the 60s refetch would desync into a dead grab handle. Both drag registrations now re-register under `watch`.

**`fix:` Refresh Views and My Work when a checklist item or the priority shortcut changes a card** (KANSO-24)
Completes #9859. The `0`–`4` priority shortcut and the three checklist mutations that change `{total,done}` reached neither the Views feed nor the My Work feeds, so a View filtered on those facets went stale for up to 60s.
Deliberately **not** routed through `usePriority`: it resolves `cardId` lazily inside `onError`/`onSettled`, so moving focus (j/k) mid-flight would roll back the wrong card. Uses the one-line `.finally()` precedent from the `d` shortcut in the same file.

**`ci:` Run the MCP server's Python test suite in CI** (KANSO-25)
`mcp/` had 46 passing tests and nothing in the repo ran them. Adds a `unit-mcp` job, plus the five keys `BoardDetail` was silently dropping (`reviewTypes`, `cardFields`, `blocksEdges`, `acl`, `subscription`) — a real MCP capability gap, not just hygiene. `extra="ignore"` deliberately left alone; the feared regression is pinned by a targeted `archived` round-trip test instead.

**`fix:` Search every readable card when filtering a View, not just the first 5000** (KANSO-21)
`ViewService::findMine()` capped at `MAX_CARDS = 5000` *before* any filter existed server-side, while the browser filtered afterwards — so on a large account a narrow filter searched an arbitrary window and `total` counted readable, not matching, cards.
New `lib/Service/ViewFilter.php` mirrors the client's 15-dimension predicate and runs **strictly after the per-board ACL masking loop and before the sort and cap**. The client predicate is kept as the render path, so the server filter is a superset guard: chip editing stays instant, and a looser PHP predicate can only ship harmless extra rows the client drops — never drop a match.
The facet-collapse blocker is solved by shipping the facet vocabulary separately: `participants` is accumulated in the existing board loop (zero extra queries), so filtering to one person no longer makes the assignee facet vanish. Also passes `:labels`, which makes the Labels facet reachable in Views at all for the first time.
**This is not a speedup** — `serialize()` still runs its enrichment queries per board. It fixes correctness and shrinks the payload.

## Verification

Every new test was executed green **and proven non-vacuous** by breaking the source and re-running:

- `column-actions-acl.spec.js` (3) — stashed the fix, rebuilt, watched it fail on each of the three assertions in turn.
- `view-checklist-live.spec.js` (3) — stashed both source files: all three failed (View row never left/re-entered the filtered set; `my-cards` hits 1, expected >1).
- `unit-mcp` — deleting a `BoardDetail` field fails the job (exit 1); renaming `uv.lock` away makes `--frozen` exit 2, proving the lock is load-bearing.
- Views filter — four independent breakages: moving the filter after the cap (4 PHPUnit failures), loosening `checklist:incomplete` in the PHP predicate, the same loosening in the JS predicate (caught by the parity fixture in the mjs runner), and removing the `participants` seed (caught by the facet e2e).

Totals: **PHPUnit 1513 tests / 912507 assertions green**; `npm run test:unit` **50/50**; new e2e specs green alongside the existing `views`, `board-filters`, `checklist`, `keyboard`, `priority`, `dnd*`, `list-view` and `swimlanes` suites; `cs-check` clean; psalm "No errors found".

The >5000-card criterion is asserted at the PHPUnit level (rows built past the cap where the only matches sit outside the capped window), not as a fake 5000-row browser test. A new ACL test proves a filter cannot surface a card from a non-readable board and that `participants` stays scoped to the readable set, so the facet vocabulary can't become a uid side channel.

## Maintainer actions

1. **`unit-mcp` is not required yet** — making it required is a branch-protection setting, not a repo file. Flip it in Settings → Branches after the first green run. The lockfile is committed so that's now safe to do.
2. `CLAUDE.md`'s "Required checks" list was deliberately left unchanged until that flip actually happens.

## Also on the board (no code here)

- **KANSO-27** — investigated whether the `E2E_ISOLATE` block in `helpers.js` defeats the `storageState` opt-out, which would have meant the anonymous public-share assertions were passing vacuously inside a required check. **Disproven** with a standalone minimal repro: `test.use` wins in Playwright 1.62.1, all 15 opt-out sites are fine. Closed with no code change.
- **KANSO-20 / KANSO-26** — the two red Dependabot PRs (#85 lockfile drift, #95 an upstream `@nextcloud/vite-config` peer pin that no in-repo change can fix) are in Dev Priority awaiting a decision; both need GitHub-side writes.

---

## Addendum — adversarial review pass (3 blocking findings fixed)

After the four cards above shipped, an adversarial review ran over the whole delta. It confirmed the highest-risk parts are sound — the filter provably sits after the per-board ACL masking loop and can never surface a non-readable card, `participants` is accumulated only from already-masked rows, field-type parity between the PHP and JS predicates is exact, `cards()` resisted every attempt to make it 500, nothing above PHP 8.0 syntax, the CSV retry is bounded to exactly once, and none of the four performance bets regress (`findMine()` adds one in-memory O(n) pass and zero queries).

It also found three blocking defects, now fixed:

**`da47cbc` `fix:` keep numeric usernames in a View's assignee and owner filters**
`participants` was built as a PHP array *key* set, and PHP coerces canonical decimal string keys to `int`. A numeric uid like `12345` (routine with LDAP employee-number provisioning) shipped as a JSON number and was then dropped by the client's `typeof u === 'string'` guard — **reintroducing the exact facet self-narrowing bug `participants` was added to prevent**. Filter to one person and the numeric-uid user vanished from the facet with no way to add them. Fixed with `array_map('strval', …)`; proven by reverting the line and watching the new test go red on `- '12345' / + 12345`.

**`147179f` `ci:` make unit-mcp assert the lockfile is in sync**
`uv run --frozen` means "don't update the lock" — it does *not* check the lock matches `pyproject.toml`. Reproduced: adding an unlocked `rich>=13` still gave `48 passed, exit 0`. So a contributor bumping a dep and forgetting `uv lock` would get green CI that tested the **old** resolution, defeating the point of committing the lock. Now `--locked`, which correctly exits 2 with "the lockfile needs to be updated".
The same commit corrects `CONTRIBUTING.md`, which had listed `unit-mcp` among the checks required to merge — live branch protection returns only the six, so it is advisory until the flip.

**`a1b21c5` `chore:` don't offer the label facet in cross-board Views**
The Views commit opportunistically passed `:labels` to turn on the label facet. But label ids collide across boards — `ViewService.php:139-144` documents this as "acceptable for chip colouring" — so with board A's label 5 = "Bug" and board B's label 5 = "Urgent", the facet showed one name while both predicates matched the bare id: **pick "Bug", get board B's "Urgent" cards**. Newly user-reachable, and wrong results rather than wrong colours, so the one line is reverted and the facet is hidden in Views again. Doing it properly needs board-qualified label identity, tracked as KANSO-29.

Full suite after the fixes: **PHPUnit 1517 / 912537 green**, `test:unit` 50/50, psalm clean, php-cs-fixer clean, 12/12 on the affected e2e specs.

### Non-blocking findings, filed as cards rather than fixed here

- **KANSO-28** — the `d` and `0`–`4` keyboard shortcuts are still ungated for read-only members, on the very surface the first commit set out to gate. Same dead-affordance class; the server correctly refuses.
- **KANSO-29** — board-qualified label identity for the Views label facet (the follow-up to the revert above).
- **KANSO-30** — parity-fixture gaps: no `now`-relative boundary cases, no sparse-row case on the JS side, and the fixture pins the two predicates but not the *wire*, so a renamed short key or a 16th dimension missing its controller param would pass green.
- **KANSO-31** — throttle the cross-board refetch on checklist edits (8 ticks in a card overlay on a View = 8 refetches of the heaviest query), and guard drag-handle teardown mid-drag.
- **KANSO-32** — the MCP container still installs unpinned; `uv.lock` pins CI only.

One review finding was **rejected**: it flagged the `E2E_ISOLATE` `storageState` override as inert, which would mean the anonymous public-share specs assert nothing in CI. That exact hypothesis was tested empirically earlier in this session and **disproven** with a live probe and a standalone repro — `test.use` wins in Playwright 1.62.1. The reviewer reached its conclusion by reading the code and noted it could not execute the suite. Executed evidence wins; details on KANSO-27.



---

## Addendum 2 — second `/pm` session (2026-08-29, later)

Eight more commits. **Every card was re-validated against the branch before execution, and grooming
caught material errors in three of the four it inherited** — two cards prescribed the wrong fix, and
two acceptance criteria would have false-passed. Details on each card.

### Shipped

**`ci:` `af25e0f` — pin setup-uv to an existing tag** (KANSO-36)
`unit-mcp` was the only red check here: `astral-sh/setup-uv@v10` does not resolve — upstream stops
publishing bare major tags after `v7`, so the v10 line exists only as `v10.0.1`. The maintainer and a
worker reached the identical fix 95 seconds apart; the duplicate was dropped and this commit kept.
Every other action pin in `ci.yml` was audited and resolves.

**`fix:` `e73af17` — the done and priority keyboard shortcuts no longer fire for read-only members** (KANSO-28)
Completes the read-only affordance work. `d` and `0`–`4` wrote with no permission check and were
advertised in the shortcuts overlay; the server correctly refused with 403 `{"error":"Access denied"}`,
so it read as a broken app. Gated on the same `canEditBoard` computed, read directly — `BoardView`
*owns* that ref and provides it, so the inject used by descendants would have been indirection for
its own sake. **Grooming caught a second live entry point the card missed:** `:on-card-focus` is also
unconditional on the swimlane path (`:411`), and the proof shows it — reverting the fix records
2 PATCHes there. Non-vacuity proven three ways.

**`fix:` `4d863df` — rapid edits in a card opened from a View refresh the feed once, not once per edit** (KANSO-31)
A card overlay on `ViewPage` keeps `view-cards` *active*, so 8 checklist ticks fired 8 refetches of
the heaviest query in the app. **The card's hedge that TanStack probably collapses these was
disproved:** `invalidateQueries` defaults to `cancelRefetch: true`, but `getViewCards` carries no
AbortSignal, so a cancelled refetch still completes server-side. Fixed at the `queryKeys.js` choke
point rather than the three checklist call sites — those are 3 of ~20 callers with the same shape.
Leading edge fires immediately so the View still repaints; `view-checklist-live.spec.js` passes
unchanged, which is the proof the leading edge is intact.

**`chore:` `e2174af` — clear the dragging flag when a permission flip tears the drag handle down** (KANSO-31)
Two lines. **The card prescribed porting `BoardListView`'s `pendingRebinds` deferral; that was wrong**
— it guards *drop targets*, and this path touches only the draggable. One of the card's two stated
triggers is also unreachable (a falsy `boardData` unmounts the tile outright). The comment records
why the deferral is deliberately not copied.

**`test:` `bc2b76a` + `8903644` — close the parity-fixture gaps** (KANSO-30)
The golden fixture pinned the predicates but not the boundaries, not sparse rows, and **not the wire**.
The last is the one that mattered: a symmetric short-key rename left both unit runners green while the
client sent a key the server never read — reverting the whole point of server-side View filtering,
invisibly, because the client still re-filters what it receives. Fixed by deleting the hand-copied key
map (parsing the real one instead) and adding reflection guards. Red output was produced for every
guard, and the new sparse row was **proven to be the sole discriminator** — delete it and the same
defect passes 45/45.

**`fix:` `41a9637` — the error banner clears itself once the next action succeeds** (KANSO-37)
The banner was only ever cleared by its ×, so a stale failure survived a later *successful* action.
`moveError` had the same defect and is materially worse — it wins the `moveError || shortcutError` OR
and masks every later shortcut error. Validation grew the scope by two lines: the ref has **four**
writers, and clearing on two of four would have been less coherent than the bug.

### Adversarial review of the above, and the fixes it forced

A review pass over `af25e0f..41a9637` **verified the delta is safe on the source side** — no
production defect — and confirmed by mutation testing that the new tests genuinely fail against
broken source. It also found one real gap and several small ones, all now fixed:

**`test:` `a1710fb` — close the wire guard's blind half and pin the week window's width**
The headline new guard was **half-blind and its docblock overclaimed.** `ViewController::cards()`
binds filter params in *two* places — the parameter list and a hand-written `$query` literal — and the
guard only checked the first. Deleting `'fsc' => $fsc,` from the literal left all ten tests green
while the server silently stopped constraining `subcard`: exactly the failure mode the docblock
claimed to catch, and the half more likely to drift. Also: the fixture pinned the boundary
*operators* but not the window *width* (`WEEK_MS` 7d→14d survived undetected, and it is duplicated
across PHP and JS), fixed with one card at `now + 8d`. Two factually wrong comments corrected — the
CSV retry rationale described an unreachable scenario, though its assertion count was right.

**`fix:` `5f1e776` — a failed card move keeps its explanation until you act again**
Three real behaviours. (1) The move-queue race flagged when `41a9637` shipped is **confirmed, not
refuted**: moves are serialised, so a queued drag B that succeeds wiped failed drag A's banner while
A's rollback was still on screen. The review found a simpler fix than the containment considered and
rejected — clear on *enqueue*, not on success, so a new gesture retires the banner but a queued
success cannot. (2) A backwards clock step (NTP correction, VM resume) made the new debounce's
`elapsed` negative and could **wedge View-feed invalidation off entirely**; now clamped. (3) The
`.catch` had come to chain after the `.then`, so a throw from the invalidation would paint a failure
over a write that actually succeeded.

### Verification

PHPUnit on **8.2 and 8.3**: 1518 tests / **912,584 assertions** green. `npm run test:unit`: **61/61**
(50 at session start). psalm "No errors found!"; php-cs-fixer "0 of 372 files"; `npm run build` OK;
l10n extract/compile/lint clean. e2e specs run at `--retries=0` throughout.

**Every new guard has pasted red output against the defect it targets** — the deleted `$query` entry,
`WEEK_MS` on both sides, the unclamped clock delay, and the restored clear-on-success each turn a
runner red. The dev container's bind mount was re-verified with `docker inspect` before any e2e was
trusted; it had been pointing at a pruned sibling worktree, which would have silently tested other code.

### Deliberately left open

- **`getViewCards` still has no AbortSignal** (KANSO-39, parked) — the debounce bounds how often a
  cancelled-but-completed refetch happens; it does not remove it. The remaining win depends on whether
  PHP-FPM actually stops work on client abort, which has not been measured.
- **`BoardView` still renders `moveError || shortcutError`**, so clearing one can re-expose the other.
  Collapsing them into a single ref is the clean fix and stays deliberately out of scope.
- **Six hand-maintained parallel dimension lists in `useBoardFilters.js`** (KANSO-41, parked) — this
  work pinned one of them.
- **KANSO-29** (board-qualified label identity for the Views label facet) is in Dev Priority awaiting
  a decision. Validation settled the design and found the card's own suggested cheaper alternative
  does not actually fix anything; what remains is a priority call.

### Maintainer actions

Unchanged from Addendum 1, plus: `unit-mcp` should now actually run — it could not before, so its
first green result on this PR is the first real signal from that job.
