### PR TITLE
fix: stop silent data loss across filters, cards, recurrence and archived boards

### DIFF
--- a/lib/Db/ChecklistItemMapper.php
+++ b/lib/Db/ChecklistItemMapper.php
@@ -46,6 +46,13 @@ class ChecklistItemMapper extends QBMapper {
 	/**
 	 * All items of a card, in display order.
 	 *
+	 * Checklist items carry no unique index on their sort key and
+	 * {@see \OCA\Kanso\Service\SortKeyService::between()} is deterministic, so two
+	 * concurrent moves into the same gap can derive the SAME key. `sort_key` alone
+	 * would then leave the tied rows in whatever order the DB returns, which can
+	 * flip between reloads; the `id` tiebreaker (same idiom as
+	 * {@see self::findOpenAssignedInBoards()}) keeps that order stable.
+	 *
 	 * @return ChecklistItem[]
 	 * @throws Exception
 	 */
@@ -54,7 +61,8 @@ class ChecklistItemMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
-			->orderBy('sort_key', 'ASC');
+			->orderBy('sort_key', 'ASC')
+			->addOrderBy('id', 'ASC');
 
 		return $this->findEntities($qb);
 	}

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -41,6 +41,13 @@ class StackMapper extends QBMapper {
 	/**
 	 * All non-deleted stacks of a board in display order.
 	 *
+	 * Unlike cards, stacks carry no unique index on their sort key, and
+	 * {@see \OCA\Kanso\Service\SortKeyService::between()} is deterministic, so two
+	 * concurrent moves into the same gap can derive the SAME key (documented as
+	 * accepted in StackService). `sort_key` alone therefore leaves tied rows in
+	 * whatever order the DB happens to return, which can flip between reloads.
+	 * The `id` tiebreaker makes a duplicate key harmless and stable instead.
+	 *
 	 * @return Stack[]
 	 * @throws Exception
 	 */
@@ -50,7 +57,8 @@ class StackMapper extends QBMapper {
 			->from($this->getTableName())
 			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
-			->orderBy('sort_key', 'ASC');
+			->orderBy('sort_key', 'ASC')
+			->addOrderBy('id', 'ASC');
 
 		return $this->findEntities($qb);
 	}
@@ -85,7 +93,9 @@ class StackMapper extends QBMapper {
 	/**
 	 * The first non-deleted stack of a board carrying the given workflow role
 	 * (in display order), or null. Used to resolve auto-move targets (e.g. the
-	 * "In review" or "Done" column) without a separate config surface.
+	 * "In review" or "Done" column) without a separate config surface. Ordered
+	 * with the same `id` tiebreaker as {@see self::findByBoard()} so two stacks
+	 * tied on `sort_key` always resolve to the same one.
 	 *
 	 * @throws Exception
 	 */
@@ -97,6 +107,7 @@ class StackMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('role', $qb->createNamedParameter($role, IQueryBuilder::PARAM_INT)))
 			->orderBy('sort_key', 'ASC')
+			->addOrderBy('id', 'ASC')
 			->setMaxResults(1);
 
 		$stacks = $this->findEntities($qb);

--- a/lib/Service/BoardGroupService.php
+++ b/lib/Service/BoardGroupService.php
@@ -251,9 +251,12 @@ class BoardGroupService {
 	}
 
 	/**
-	 * The caller's readable board-id set - the exact ACL-authorized set the
-	 * boards-list uses. Reused to filter folder membership so a folder never
-	 * surfaces a board the user has since lost access to.
+	 * The caller's readable, ACTIVE board-id set. Reused to filter folder
+	 * membership so a folder never surfaces a board the user has since lost
+	 * access to - or one they have archived (#10126): a shelved board drops out
+	 * of the folder listing (its membership row is kept, so unarchiving restores
+	 * it). The boards page keeps its own Archived tab, built from the boards-list
+	 * payload, not from here.
 	 *
 	 * @return int[]
 	 * @throws \OCP\DB\Exception
@@ -261,7 +264,7 @@ class BoardGroupService {
 	private function readableBoardIds(string $uid): array {
 		return array_map(
 			static fn ($b): int => $b->getId(),
-			$this->boardService->findAll($uid)
+			$this->boardService->findAllActive($uid)
 		);
 	}
 

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -56,6 +56,32 @@ class BoardService {
 	}
 
 	/**
+	 * The user's ACTIVE visible boards: {@see self::findAll()} minus the ones
+	 * they have archived (#10126).
+	 *
+	 * This is the board set every CROSS-BOARD FEED reads from - Views, My tasks,
+	 * the Inbox, My reviews, search, My steps, Projects and board folders.
+	 * Archiving a board shelves it, so its cards must not keep surfacing in
+	 * those feeds, and the exclusion is UNCONDITIONAL: it is not wired to the
+	 * archived-CARDS facet ({@see ViewFilter::includesArchived()}), which is
+	 * about archived cards on boards that are still active. An archived board's
+	 * cards stay out even under "include archived" / "only archived".
+	 *
+	 * It is deliberately a SIBLING of findAll() and not a filter inside it: the
+	 * boards-LIST payload ({@see self::findAllWithStats()}) is what the boards
+	 * page splits into its Active / Archived tabs, so filtering at the source
+	 * would empty the Archived tab. Board-level surfaces keep using findAll().
+	 *
+	 * @return Board[]
+	 */
+	public function findAllActive(string $uid): array {
+		return array_values(array_filter(
+			$this->findAll($uid),
+			static fn (Board $board): bool => !$board->getArchived(),
+		));
+	}
+
+	/**
 	 * The boards-LIST payload: every visible board serialized to a summary, each
 	 * with a `stats` block of per-board signal for the boards page - card count,
 	 * done progress %, needs-review count and overdue count.

--- a/lib/Service/InboxService.php
+++ b/lib/Service/InboxService.php
@@ -48,7 +48,9 @@ class InboxService {
 	 * @return list<array<string, mixed>>
 	 */
 	public function findMine(string $uid): array {
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so nothing
+		// on it belongs in this feed.
+		$boards = $this->boardService->findAllActive($uid);
 		$boardIds = array_map(
 			static fn ($board): int => $board->getId(),
 			$boards

--- a/lib/Service/MyCardsService.php
+++ b/lib/Service/MyCardsService.php
@@ -55,7 +55,9 @@ class MyCardsService {
 	 * @return array{cards: list<array<string, mixed>>, truncated: bool, limit: int}
 	 */
 	public function findMine(string $uid): array {
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so nothing
+		// on it belongs in this feed.
+		$boards = $this->boardService->findAllActive($uid);
 		$boardIds = array_map(
 			static fn ($board): int => $board->getId(),
 			$boards
@@ -101,7 +103,9 @@ class MyCardsService {
 	 * @return array{cards: list<array<string, mixed>>, truncated: bool, limit: int, windowDays: int}
 	 */
 	public function findMineRecentlyDone(string $uid): array {
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so nothing
+		// on it belongs in this feed.
+		$boards = $this->boardService->findAllActive($uid);
 		$boardIds = array_map(
 			static fn ($board): int => $board->getId(),
 			$boards

--- a/lib/Service/MyStepsService.php
+++ b/lib/Service/MyStepsService.php
@@ -31,7 +31,9 @@ class MyStepsService {
 	 * @return list<array<string, mixed>>
 	 */
 	public function findMine(string $uid): array {
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so nothing
+		// on it belongs in this feed.
+		$boards = $this->boardService->findAllActive($uid);
 		$boardIds = array_map(
 			static fn ($board): int => $board->getId(),
 			$boards

--- a/lib/Service/ProjectService.php
+++ b/lib/Service/ProjectService.php
@@ -172,7 +172,9 @@ class ProjectService {
 	 */
 	public function listCards(int $projectId, string $uid): array {
 		$project = $this->loadOwnedProject($projectId, $uid);
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so its
+		// cards leave the project's card set (and its metrics with them).
+		$boards = $this->boardService->findAllActive($uid);
 
 		return $this->projectCardMapper->findCardsInProjectAndBoards(
 			$project->getId(),
@@ -201,7 +203,9 @@ class ProjectService {
 	public function stats(int $projectId, string $uid): array {
 		$project = $this->loadOwnedProject($projectId, $uid);
 
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so its
+		// cards leave the project's card set (and its metrics with them).
+		$boards = $this->boardService->findAllActive($uid);
 		$cards = $this->projectCardMapper->findCardsInProjectAndBoards(
 			$project->getId(),
 			array_map(static fn (Board $board): int => $board->getId(), $boards),

--- a/lib/Service/ReviewService.php
+++ b/lib/Service/ReviewService.php
@@ -60,7 +60,9 @@ class ReviewService {
 	 * @return list<array<string, mixed>>
 	 */
 	public function findMine(string $uid): array {
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so nothing
+		// on it belongs in this feed.
+		$boards = $this->boardService->findAllActive($uid);
 		$boardIds = array_map(
 			static fn ($board): int => $board->getId(),
 			$boards

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -54,7 +54,9 @@ class SearchService {
 			return ['query' => $term, 'total' => 0, 'results' => []];
 		}
 
-		$boards = $this->boardService->findAll($uid);
+		// Active boards only (#10126): an archived board is shelved, so its
+		// cards and comments are out of search entirely.
+		$boards = $this->boardService->findAllActive($uid);
 		$boardIds = $this->readableBoardIds($boards, $boardId);
 		if ($boardIds === []) {
 			return ['query' => $term, 'total' => 0, 'results' => []];

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -30,8 +30,9 @@ use OCA\Kanso\Db\LabelMapper;
  * match past them. The filter still consumes only already-serialized summary
  * fields - no new query, no SQL shortcut.
  *
- * ACL is enforced by restricting to the boards {@see BoardService::findAll()}
- * returns (the readable set) and running each board's summary query under the
+ * ACL is enforced by restricting to the boards
+ * {@see BoardService::findAllActive()} returns (the readable, non-archived set)
+ * and running each board's summary query under the
  * viewer's own per-board {@see \OCA\Kanso\Access\ViewerContext} - so a card on a
  * board the user cannot read, or a card hidden from the viewer's board side
  * (#3743), is never returned. A View run by user A can never surface a card from
@@ -98,7 +99,12 @@ class ViewService {
 	 * @return array{cards: list<array<string, mixed>>, labels: list<array<string, mixed>>, participants: list<string>, capped: bool, total: int, limit: int}
 	 */
 	public function findMine(string $uid, string $sortMode = 'default', string $sortDir = 'asc', ?ViewFilter $filter = null): array {
-		$boards = $this->boardService->findAll($uid);
+		// ARCHIVED BOARDS are out of the feed entirely (#10126) - an archived
+		// board is shelved, so even its live cards must not surface here. This
+		// is unconditional and deliberately NOT wired to the `archived` facet
+		// below: that facet is about archived CARDS on boards that are still
+		// active, so "include"/"only" can never bring an archived board back.
+		$boards = $this->boardService->findAllActive($uid);
 
 		// Archived cards are excluded from the feed by DEFAULT, and only the
 		// `archived` facet ('include' / 'only') opts them back in. The exclusion
@@ -121,7 +127,7 @@ class ViewService {
 		foreach ($boards as $board) {
 			$boardId = (int)$board->getId();
 			// The viewer's resolved side on THIS board scopes every card row
-			// (#3743). findAll() already returned only member boards, so
+			// (#3743). findAllActive() already returned only member boards, so
 			// contextFor() resolves without throwing.
 			$viewer = $this->boardAccess->contextFor($board, $uid);
 			$cards = $this->cardSummaryService->serialize(

--- a/src/components/BoardFilterBar.vue
+++ b/src/components/BoardFilterBar.vue
@@ -56,8 +56,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						</li>
 					</ul>
 
-					<!-- Clear all (only when something is active) -->
-					<template v-if="count > 0">
+					<!-- Clear all — gated on the dimensions this control actually
+					     RENDERS, not on `count`. `count` deliberately includes hidden
+					     dimensions (under-reporting an active constraint is the worse
+					     failure), but a Clear button that clears nothing visible is a
+					     dead affordance, so it only appears when there is something on
+					     screen to clear. -->
+					<template v-if="visibleCount > 0">
 						<div class="board-filter-bar__sep" role="separator" />
 						<button
 							type="button"
@@ -68,20 +73,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						</button>
 					</template>
 
-					<!-- ── Saved views (folded in from the old Saved dropdown) ──── -->
-					<div class="board-filter-bar__sep" role="separator" />
-					<p class="board-filter-bar__caption">{{ t('kanso', 'Views') }}</p>
-					<button
-						type="button"
-						class="board-filter-bar__action board-filter-bar__saved-item"
-						:class="{ 'board-filter-bar__saved-item--active': !activeSavedName && count === 0 }"
-						@click="clearAll">
-						<CheckIcon v-if="!activeSavedName && count === 0" :size="20" />
-						<FilterVariantRemoveIcon v-else :size="20" />
-						<span>{{ t('kanso', 'Default (no filter)') }}</span>
-					</button>
-
+					<!-- ── Saved views (folded in from the old Saved dropdown) ────
+					     Only when this surface actually has saved views to offer. A
+					     surface that passes none (the View page) would otherwise render
+					     an empty "Views" section whose one entry is a second, unlabelled
+					     clear-all button. -->
 					<template v-if="savedFilters.length">
+						<div class="board-filter-bar__sep" role="separator" />
+						<p class="board-filter-bar__caption">{{ t('kanso', 'Views') }}</p>
+						<button
+							type="button"
+							class="board-filter-bar__action board-filter-bar__saved-item"
+							:class="{ 'board-filter-bar__saved-item--active': !activeSavedName && count === 0 }"
+							@click="clearAll">
+							<CheckIcon v-if="!activeSavedName && count === 0" :size="20" />
+							<FilterVariantRemoveIcon v-else :size="20" />
+							<span>{{ t('kanso', 'Default (no filter)') }}</span>
+						</button>
+
 						<button
 							v-for="view in savedFilters"
 							:key="'v-' + view.name"
@@ -570,6 +579,12 @@ const dimensions = computed(() => {
 
 const visibleDimensions = computed(() => dimensions.value.filter((d) => d.show))
 
+// Active constraints among the dimensions this control RENDERS. Distinct from
+// `count` (which spans every dimension, hidden ones included) and used only to
+// gate the Clear button — see the template.
+const visibleCount = computed(() =>
+	visibleDimensions.value.reduce((n, d) => n + d.count, 0))
+
 const activeDimMeta = computed(() =>
 	dimensions.value.find((d) => d.key === activeDim.value) ?? {})
 
@@ -591,23 +606,21 @@ function setSingleRadio(dim, value) {
 	props.state[dim] = value || null
 }
 
+// Clear every dimension this control RENDERS — and only those. The invariant is
+// that a control may only clear what it shows (#10091): a surface can hide a
+// dimension while still holding a constraint on it, and wiping that invisibly is
+// destructive with no way back. The View page is the case that bites — it hides
+// the Labels facet on purpose (board-scoped label ids collide across boards) yet
+// seeds the View's own saved label filter into this same state, so a blanket
+// clear silently destroyed the View's identity and widened the page to the whole
+// unfiltered cross-board feed, recoverable only by reloading. Driving off
+// `visibleDimensions` also keeps this in step with the dimension list instead of
+// being a hand-maintained parallel copy of it.
 function clearAll() {
-	props.state.labels.clear()
-	props.state.assignees.clear()
-	props.state.priorities.clear()
-	props.state.types.clear()
-	props.state.estimates.clear()
-	props.state.owners.clear()
-	props.state.reviews.clear()
-	props.state.due = null
-	props.state.done = null
-	props.state.waiting = null
-	props.state.blocked = null
-	props.state.checklist = null
-	props.state.startDate = null
-	props.state.subcard = null
-	props.state.comments = null
-	props.state.archived = null
+	for (const dim of visibleDimensions.value) {
+		if (SINGLE_SELECT_DIMS.includes(dim.key)) props.state[dim.key] = null
+		else props.state[dim.key].clear()
+	}
 }
 
 function submitSave() {

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -1803,6 +1803,23 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</div>
 						</div>
 
+						<!-- A schedule these controls can't round-trip (BYMONTHDAY, a
+						     positional BYDAY, …) is shown read-only and saved untouched;
+						     everything else on the rule stays editable. -->
+						<div v-if="isEditingCustomSchedule" class="automation__form-row automation__form-row--top">
+							<label class="automation__form-label">{{ t('kanso', 'Repeats') }}</label>
+							<div class="automation__custom-schedule">
+								<!-- The raw rule, not humanRrule(): the readable summary only
+								     knows the parts this editor models, so it would describe
+								     "FREQ=MONTHLY;BYMONTHDAY=1,15" as plain "Every month". -->
+								<code class="automation__custom-rrule">{{ editingRecurRrule }}</code>
+								<span class="automation__custom-note">
+									{{ t('kanso', 'Custom schedule — it is kept exactly as it is. The settings below can still be changed.') }}
+								</span>
+							</div>
+						</div>
+
+						<template v-else>
 						<!-- Frequency + interval -->
 						<div class="automation__form-row">
 							<label class="automation__form-label" :for="`recur-freq-${boardId}`">
@@ -1886,6 +1903,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								type="date"
 								class="workflow__select automation__form-select" />
 						</div>
+						</template>
 
 						<!-- Due-date policy -->
 						<div class="automation__form-row">
@@ -2178,6 +2196,7 @@ import { useBoardActions } from '../composables/useBoardActions.js'
 import { useArchiveRules } from '../composables/useArchiveRules.js'
 import { useRecurRules } from '../composables/useRecurRules.js'
 import { useAutomationRules } from '../composables/useAutomationRules.js'
+import { parseRecurRrule, buildRecurRrule, isCustomRrule } from '../utils/rrule.js'
 import { cssColor, LABEL_COLOR_PRESETS } from '../services/color.js'
 import { BACKGROUND_PRESETS } from '../services/backgrounds.js'
 import { normalizeCardFeatures } from '../services/cardFeatures.js'
@@ -3894,6 +3913,9 @@ async function doDeleteRecurRule(rule) {
 	try {
 		await deleteRecurRule.mutateAsync(rule.id)
 		confirmDeleteRecurRuleId.value = null
+		// Deleting the rule that is open in the editor would otherwise leave the
+		// form bound to a dead id, with "Save rule" PATCHing it.
+		if (editingRecurRuleId.value === rule.id) cancelEditRecurRule()
 	} catch (err) {
 		deleteRecurRuleError.value = err?.response?.data?.error || t('kanso', 'Failed to delete rule.')
 	} finally {
@@ -3922,6 +3944,7 @@ const newRecurWeekdays = ref([])         // e.g. ['MO', 'WE']
 const newRecurEndType = ref('forever')   // 'forever' | 'count' | 'until'
 const newRecurCount = ref(10)
 const newRecurUntil = ref('')            // YYYY-MM-DD input
+const newRecurUntilSuffix = ref('T000000Z') // time-of-day carried by UNTIL, preserved verbatim
 const newRecurDuedatePolicy = ref(0)     // 0=at occurrence, 1=offset after, 2=none
 const newRecurDuedateOffsetDays = ref(1)
 const newRecurSkipWhileOpen = ref(false)
@@ -3935,6 +3958,12 @@ const createRecurRuleError = ref('')
 const newRecurUnitCount = computed(() => Math.max(1, Number(newRecurInterval.value) || 1))
 const editingRecurRuleId = ref(null)  // null = create mode, number = edit mode
 const isEditingRecurRule = computed(() => editingRecurRuleId.value !== null)
+
+// The rule being edited carries a schedule these controls cannot round-trip
+// (BYMONTHDAY, a positional BYDAY, BYSETPOS …). We keep the original string to
+// show it, render the schedule read-only, and leave `rrule` out of the save.
+const editingRecurRrule = ref('')
+const isEditingCustomSchedule = ref(false)
 
 /** Close the settings modal and open the rule's template card (to edit it). */
 function openRecurTemplateCard(rule) {
@@ -3951,29 +3980,19 @@ function startEditRecurRule(rule) {
 	newRecurSkipWhileOpen.value = rule.skipWhileOpen ?? false
 	newRecurDuedatePolicy.value = rule.duedatePolicy ?? 0
 	newRecurDuedateOffsetDays.value = rule.duedateOffsetSeconds ? Math.round(rule.duedateOffsetSeconds / 86400) : 1
-	// Parse rrule back into form fields
-	const parts = {}
-	for (const seg of (rule.rrule || '').split(';')) {
-		const eq = seg.indexOf('=')
-		if (eq !== -1) parts[seg.slice(0, eq).toUpperCase()] = seg.slice(eq + 1)
-	}
-	newRecurFreq.value = parts['FREQ'] || 'WEEKLY'
-	newRecurInterval.value = parseInt(parts['INTERVAL'] || '1', 10)
-	if (parts['BYDAY']) {
-		newRecurWeekdays.value = parts['BYDAY'].split(',')
-	} else {
-		newRecurWeekdays.value = []
-	}
-	if (parts['COUNT']) {
-		newRecurEndType.value = 'count'
-		newRecurCount.value = parseInt(parts['COUNT'], 10)
-	} else if (parts['UNTIL']) {
-		newRecurEndType.value = 'until'
-		const u = parts['UNTIL'].replace(/T.*/, '')
-		newRecurUntil.value = u.length === 8 ? `${u.slice(0, 4)}-${u.slice(4, 6)}-${u.slice(6, 8)}` : ''
-	} else {
-		newRecurEndType.value = 'forever'
-	}
+	// Parse rrule back into form fields. A schedule these controls cannot
+	// represent is shown read-only instead — re-serializing it from the five
+	// fields below would silently drop the parts we never parsed.
+	editingRecurRrule.value = rule.rrule || ''
+	isEditingCustomSchedule.value = isCustomRrule(rule.rrule)
+	const parsed = parseRecurRrule(rule.rrule)
+	newRecurFreq.value = parsed.freq
+	newRecurInterval.value = parsed.interval
+	newRecurWeekdays.value = parsed.weekdays
+	newRecurEndType.value = parsed.endType
+	newRecurCount.value = parsed.count
+	newRecurUntil.value = parsed.until
+	newRecurUntilSuffix.value = parsed.untilSuffix
 }
 
 function cancelEditRecurRule() {
@@ -3987,27 +4006,26 @@ function cancelEditRecurRule() {
 	newRecurEndType.value = 'forever'
 	newRecurCount.value = 10
 	newRecurUntil.value = ''
+	newRecurUntilSuffix.value = 'T000000Z'
 	newRecurDuedatePolicy.value = 0
 	newRecurDuedateOffsetDays.value = 1
 	newRecurSkipWhileOpen.value = false
+	editingRecurRrule.value = ''
+	isEditingCustomSchedule.value = false
 	createRecurRuleError.value = ''
 }
 
 /** Build the RFC5545 RRULE string from the builder controls. */
 function buildRrule() {
-	const parts = [`FREQ=${newRecurFreq.value}`]
-	if (newRecurInterval.value > 1) parts.push(`INTERVAL=${newRecurInterval.value}`)
-	if (newRecurFreq.value === 'WEEKLY' && newRecurWeekdays.value.length > 0) {
-		parts.push(`BYDAY=${newRecurWeekdays.value.join(',')}`)
-	}
-	if (newRecurEndType.value === 'count') {
-		parts.push(`COUNT=${newRecurCount.value}`)
-	} else if (newRecurEndType.value === 'until' && newRecurUntil.value) {
-		// Convert YYYY-MM-DD → YYYYMMDDТ000000Z
-		const d = newRecurUntil.value.replace(/-/g, '')
-		parts.push(`UNTIL=${d}T000000Z`)
-	}
-	return parts.join(';')
+	return buildRecurRrule({
+		freq: newRecurFreq.value,
+		interval: newRecurInterval.value,
+		weekdays: newRecurWeekdays.value,
+		endType: newRecurEndType.value,
+		count: newRecurCount.value,
+		until: newRecurUntil.value,
+		untilSuffix: newRecurUntilSuffix.value,
+	})
 }
 
 /** Non-archived cards for the template selector. */
@@ -4023,8 +4041,21 @@ async function submitCreateRecurRule() {
 		const data = {
 			targetStackId: newRecurTargetStackId.value,
 			mode: newRecurMode.value,
-			rrule: buildRrule(),
 			duedatePolicy: newRecurDuedatePolicy.value,
+		}
+		// Only send a schedule the user actually changed. Omitting `rrule` tells
+		// the API to keep the stored string, which also spares the occurrences
+		// tally and the next-fire cursor — both of which reset on any change to
+		// the rule TEXT, even a semantically identical one (`INTERVAL=1`,
+		// reordered or lower-case parts). A custom schedule is never rebuilt at
+		// all; an untouched simple one rebuilds to the same string it parsed from.
+		if (!isEditingCustomSchedule.value) {
+			const rrule = buildRrule()
+			const unchanged = isEditingRecurRule.value
+				&& rrule === buildRecurRrule(parseRecurRrule(editingRecurRrule.value))
+			if (!unchanged) {
+				data.rrule = rrule
+			}
 		}
 		if (newRecurDuedatePolicy.value === 1) {
 			data.duedateOffsetSeconds = newRecurDuedateOffsetDays.value * 86400
@@ -4041,18 +4072,7 @@ async function submitCreateRecurRule() {
 			await createRecurRule.mutateAsync(data)
 		}
 		// Reset form
-		newRecurTemplateCardId.value = null
-		newRecurTargetStackId.value = null
-		newRecurMode.value = 0
-		newRecurFreq.value = 'WEEKLY'
-		newRecurInterval.value = 1
-		newRecurWeekdays.value = []
-		newRecurEndType.value = 'forever'
-		newRecurCount.value = 10
-		newRecurUntil.value = ''
-		newRecurDuedatePolicy.value = 0
-		newRecurDuedateOffsetDays.value = 1
-		newRecurSkipWhileOpen.value = false
+		cancelEditRecurRule()
 	} catch (err) {
 		createRecurRuleError.value = err?.response?.data?.error || t('kanso', isEditingRecurRule.value ? 'Failed to update rule.' : 'Failed to create rule.')
 	} finally {
@@ -5303,6 +5323,26 @@ async function doDeleteAutoRule(rule) {
 
 .automation__form-row--top {
 	align-items: flex-start;
+}
+
+/* Read-only schedule for a rule the builder can't round-trip. */
+.automation__custom-schedule {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.automation__custom-rrule {
+	font-family: var(--font-face-monospace, monospace);
+	font-size: 0.85em;
+	color: var(--color-text-maxcontrast);
+	overflow-wrap: anywhere;
+}
+
+.automation__custom-note {
+	font-size: 0.85em;
+	color: var(--color-text-maxcontrast);
 }
 
 /* ── GitHub webhook config ─────────────────────────────────────────────────── */

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -3478,18 +3478,19 @@ const descriptionBaseText = ref('')
 const descriptionConflict = ref(null)
 
 // The board shell renders this component through an UNKEYED router-view, so
-// navigating card→card REUSES it. Every piece of description-editing state is
-// per-card and must be dropped on the switch - carrying the optimistic base
-// version across would compare the new card's version against the old card's
-// and silently skip the conflict guard, and a stale conflict panel would show
-// the wrong card's text. Not `immediate`: there is nothing to clear on mount.
+// navigating card→card REUSES it. Every piece of editing state is per-card and
+// must be dropped on the switch - carrying the optimistic base version across
+// would compare the new card's version against the old card's and silently skip
+// the conflict guard, and a stale conflict panel would show the wrong card's
+// text. The same reuse also leaked the COMMENT drafts (#10069): a half-typed
+// reply or new thread stayed in the composer and turned up on the next card you
+// opened, one Post away from landing on the wrong discussion. `discardDrafts()`
+// clears all of them. Not `immediate`: there is nothing to clear on mount.
 watch(() => props.cardId, () => {
-	editingDescription.value = false
-	draftDescription.value = ''
+	discardDrafts()
 	descriptionBaseVersion.value = null
-	descriptionBaseText.value = ''
-	descriptionConflict.value = null
 	saveError.value = ''
+	commentError.value = ''
 })
 
 function startDescriptionEdit() {
@@ -4449,6 +4450,10 @@ async function submitNewComment() {
 // Reply state
 const replyingToId = ref(null)
 const replyBody = ref('')
+// What the composer was PRE-FILLED with (a blockquote of the quoted comment, or
+// ''). The unsaved-work guard compares against this rather than against '', so
+// merely clicking Reply on an older comment isn't mistaken for typed work.
+const replyBaseBody = ref('')
 const replyRefs = {}
 
 function setReplyRef(id, el) {
@@ -4492,6 +4497,7 @@ async function openReplyBox(target, root) {
 	const last = thread && thread.replies.length ? thread.replies[thread.replies.length - 1] : thread?.comment
 	const quote = last && target.id !== last.id ? buildQuote(target) : ''
 	replyBody.value = quote
+	replyBaseBody.value = quote
 	await nextTick()
 	// The reply ref is now a MarkdownEditor component (exposes focus/setContent).
 	// setContent pre-fills the editor with the blockquote and moves caret to end.
@@ -4508,6 +4514,7 @@ async function openReplyBox(target, root) {
 function closeReplyBox() {
 	replyingToId.value = null
 	replyBody.value = ''
+	replyBaseBody.value = ''
 }
 
 async function submitReply(parentCommentId) {
@@ -4518,6 +4525,7 @@ async function submitReply(parentCommentId) {
 		await addComment.mutateAsync({ body, parentCommentId })
 		// Clear + close the reply box only after success (keep text on failure).
 		replyBody.value = ''
+		replyBaseBody.value = ''
 		replyingToId.value = null
 	} catch (err) {
 		commentError.value = err?.response?.data?.error || t('kanso', 'Failed to post reply.')
@@ -4527,6 +4535,9 @@ async function submitReply(parentCommentId) {
 // Inline comment edit state
 const editingCommentId = ref(null)
 const editingCommentBody = ref('')
+// The comment's text as the editor opened it — an untouched inline edit must not
+// count as unsaved work (see hasUnsavedChanges).
+const editingCommentBase = ref('')
 const commentEditRefs = {}
 
 function setCommentEditRef(id, el) {
@@ -4537,6 +4548,7 @@ function setCommentEditRef(id, el) {
 async function startCommentEdit(comment) {
 	editingCommentId.value = comment.id
 	editingCommentBody.value = comment.body
+	editingCommentBase.value = comment.body
 	await nextTick()
 	commentEditRefs[comment.id]?.focus()
 }
@@ -4544,6 +4556,7 @@ async function startCommentEdit(comment) {
 function cancelCommentEdit() {
 	editingCommentId.value = null
 	editingCommentBody.value = ''
+	editingCommentBase.value = ''
 }
 
 async function saveCommentEdit(comment) {
@@ -4810,8 +4823,107 @@ function findOnBoard() {
 // have no `from` and still close to the board (do not regress that flow).
 const MY_WORK_RETURN_ROUTES = ['my-work', 'my-cards', 'my-reviews', 'inbox']
 
+// ── Unsaved-work guard (#10069) ───────────────────────────────────────────────
+// Nothing on this card autosaves: the title, the description, a new thread, a
+// reply and an inline comment edit are all explicit-save. Dismissing the card
+// used to drop every one of them silently. This is the single source of truth
+// for "there is typed work here that the server has never seen".
+//
+// Each draft is compared against the text it STARTED from, not against '' —
+// opening the description editor, or clicking Reply on an older comment (which
+// pre-fills a quote), must not read as unsaved work. Getting that wrong would
+// confirm on every single close, which is worse than the bug being fixed.
+const hasUnsavedChanges = computed(() => {
+	if (editingTitle.value && draftTitle.value.trim() !== (cardData.value?.title ?? '')) {
+		return true
+	}
+	if (editingDescription.value && draftDescription.value !== descriptionBaseText.value) {
+		return true
+	}
+	if (newCommentBody.value.trim() !== '') {
+		return true
+	}
+	if (replyingToId.value !== null && replyBody.value !== replyBaseBody.value) {
+		return true
+	}
+	if (editingCommentId.value !== null && editingCommentBody.value !== editingCommentBase.value) {
+		return true
+	}
+	return false
+})
+
+/**
+ * Drop every unsaved draft — once the user has confirmed the loss, and on a
+ * card→card switch, where the shared component would otherwise carry one card's
+ * half-typed reply into the next one.
+ */
+function discardDrafts() {
+	editingTitle.value = false
+	draftTitle.value = ''
+	editingDescription.value = false
+	draftDescription.value = ''
+	descriptionBaseText.value = ''
+	descriptionConflict.value = null
+	newCommentBody.value = ''
+	replyingToId.value = null
+	replyBody.value = ''
+	replyBaseBody.value = ''
+	editingCommentId.value = null
+	editingCommentBody.value = ''
+	editingCommentBase.value = ''
+}
+
+/**
+ * Ask before throwing typed work away. `window.confirm` is what this component
+ * already uses for the same class of question (the description-conflict discard
+ * above), and it answers synchronously — the close paths act on the result
+ * immediately.
+ *
+ * @return {boolean} true when it is safe to leave
+ */
+function confirmDiscardUnsaved() {
+	if (!hasUnsavedChanges.value) {
+		return true
+	}
+	if (!window.confirm(t('kanso', 'You have unsaved changes on this card. If you leave now, they will be lost.'))) {
+		return false
+	}
+	discardDrafts()
+	return true
+}
+
+// Tab close / reload: the browser's own generic prompt is the only thing
+// available here, and it only shows when preventDefault() is called.
+function onBeforeUnload(event) {
+	if (!hasUnsavedChanges.value) {
+		return
+	}
+	event.preventDefault()
+	// Legacy browsers still require a truthy returnValue to show the prompt.
+	event.returnValue = ''
+}
+onMounted(() => {
+	window.addEventListener('beforeunload', onBeforeUnload)
+})
+onBeforeUnmount(() => {
+	window.removeEventListener('beforeunload', onBeforeUnload)
+})
+
+// Browser Back is deliberately NOT guarded. An `onBeforeRouteLeave` hook here
+// does raise the question, but cancelling it does not put the user back on the
+// card: under hash history vue-router restores the aborted popstate in the wrong
+// direction and the browser ends up OUTSIDE the app entirely, card and draft
+// gone — strictly worse than no prompt. Measured, not assumed. The X, the
+// backdrop, Escape and a tab close/reload are all covered above; Back is left
+// alone until the router can cancel it cleanly.
+
 function closeModal() {
 	isOpen.value = false
+	// Every caller has either just asked the user (requestClose / Escape) or has
+	// removed the card outright (archive, delete, move to another board, save as
+	// template), so nothing here is still wanted. Clearing it keeps a draft from
+	// surviving on the (reused) component into whatever is opened next.
+	discardDrafts()
 	// Controlled overlay (#3950): the parent owns open/close and the surrounding
 	// URL (e.g. a View at /views/:id). Do NOT navigate — just tell the parent to
 	// tear the overlay down, leaving the user exactly where they were.
@@ -4870,6 +4982,9 @@ function onRootEscape() {
 		return
 	}
 	if (props.mode === 'modal') {
+		if (!confirmDiscardUnsaved()) {
+			return
+		}
 		closeModal()
 	}
 }
@@ -4934,9 +5049,17 @@ onBeforeUnmount(() => {
 // it first rather than closing the whole card (which would drop the picker context).
 // Exposed to the shell as requestClose() so the modal's close button obeys the same
 // popover-first precedence as Escape / the backdrop.
+// Deliberate dismissal of the whole card, so it is also where the unsaved-work
+// question belongs (#10069). closeModal() itself stays unguarded: archive,
+// delete, move-to-board and template flows call it after the card has already
+// left this surface, and asking to keep drafts for a card you just deleted would
+// be nonsense.
 function requestClose() {
 	if (openPicker.value !== null) {
 		openPicker.value = null
+		return
+	}
+	if (!confirmDiscardUnsaved()) {
 		return
 	}
 	closeModal()

--- a/src/composables/queryKeys.js
+++ b/src/composables/queryKeys.js
@@ -132,10 +132,12 @@ let viewFeedPendingClient = null
  * twenty call sites do. When the card overlay was opened FROM a View, ViewPage
  * stays mounted behind it, so ['view-cards'] is an ACTIVE query - the only kind
  * invalidateQueries actually refetches. Five quick edits therefore meant five
- * full cross-board reads. And TanStack does not absorb them: invalidateQueries
- * defaults to cancelRefetch:true, but getViewCards is a plain axios GET with no
- * AbortSignal, so a "cancelled" refetch's request still runs to completion
- * server-side. N ticks really were N round trips.
+ * full cross-board reads, and TanStack cannot absorb them for us: cancelling a
+ * refetch (invalidateQueries defaults to cancelRefetch:true) aborts the browser
+ * request - useViewCards forwards the query's AbortSignal to axios, see
+ * tests/e2e/view-feed-abort.spec.js - but the server response is written in one
+ * go, so PHP finishes the request anyway. N ticks really are N round trips on
+ * the server; this throttle is what makes them fewer.
  *
  * LEADING EDGE FIRES IMMEDIATELY - do not turn this into a plain debounce. The
  * first edit of a burst is the one the user is watching for, and the View tile

--- a/src/composables/useViewCards.js
+++ b/src/composables/useViewCards.js
@@ -44,10 +44,15 @@ export function useViewCards(sort, filter) {
 	const filterQuery = computed(() => unref(filter) ?? {})
 	return useQuery({
 		queryKey: [...VIEW_CARDS_QUERY_KEY, sortMode, sortDir, filterQuery],
-		queryFn: () => apiGetViewCards({
+		// The query's AbortSignal is forwarded to axios: when TanStack cancels a
+		// refetch (this feed is invalidated from many mutation settle phases), the
+		// in-flight request is aborted client-side instead of being read to the end
+		// and normalised into an envelope the cache immediately discards.
+		queryFn: ({ signal }) => apiGetViewCards({
 			sortMode: sortMode.value,
 			sortDir: sortDir.value,
 			filter: filterQuery.value,
+			signal,
 		}),
 		placeholderData: (previous) => previous,
 		refetchOnWindowFocus: true,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -524,8 +524,14 @@ export const deleteView = (id) =>
 // flat short-key object `filterToQuery()` already produces for shareable board
 // filter links - the same encoding, spread straight into the query string. The
 // client still re-filters the rows it receives, so this is a superset guard.
-export const getViewCards = ({ sortMode = 'default', sortDir = 'asc', filter = {} } = {}) =>
-	axios.get(url('/api/views/cards'), { params: { sortMode, sortDir, ...filter } }).then((r) => {
+//
+// `signal` is the caller's AbortSignal (TanStack hands one to every queryFn).
+// Aborting does NOT stop the server - the response is written in one go, so PHP
+// finishes the request either way - but it frees the browser connection slot at
+// once and skips normalising an envelope of up to `limit` enriched cards that
+// the cache is about to discard. Optional: callers may omit it.
+export const getViewCards = ({ sortMode = 'default', sortDir = 'asc', filter = {}, signal } = {}) =>
+	axios.get(url('/api/views/cards'), { params: { sortMode, sortDir, ...filter }, signal }).then((r) => {
 		const d = r.data ?? {}
 		return {
 			cards: Array.isArray(d.cards) ? d.cards : [],

--- a/src/utils/rrule.js
+++ b/src/utils/rrule.js
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * rrule - parse / serialize / custom-detect for the recurrence editor.
+ *
+ * The Board settings → Automation recurrence editor models a deliberately small
+ * slice of RFC 5545: FREQ, INTERVAL, a weekly BYDAY, and one end condition
+ * (COUNT or UNTIL). A rule authored elsewhere (the API, the MCP server, an
+ * import) can carry parts outside that slice - BYMONTHDAY, BYSETPOS, a
+ * positional BYDAY like `1MO`, WKST … - and re-serializing such a rule from the
+ * five fields the editor knows silently rewrites the user's schedule.
+ *
+ * So the editor asks `isCustomRrule()` first and, when the answer is yes, shows
+ * the schedule read-only and omits `rrule` from the PATCH entirely (the API
+ * treats a missing rrule as "leave it alone", which also keeps the
+ * occurrences-spawned tally intact).
+ *
+ * Pure and side-effect free, so it unit-tests without a DOM or a Vue runtime.
+ */
+
+/** The four frequencies the editor's unit `<select>` can represent. */
+const RRULE_FREQS = ['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY']
+
+/** RRULE parts the editor round-trips. Anything else makes a rule "custom". */
+const KNOWN_PARTS = ['FREQ', 'INTERVAL', 'BYDAY', 'COUNT', 'UNTIL']
+
+/** A BYDAY entry carrying an ordinal ("1MO", "-1FR") - not representable here. */
+const POSITIONAL_BYDAY = /^[+-]?\d/
+
+/**
+ * Split an RRULE string into an uppercase-keyed parts map. Empty segments and
+ * segments without an `=` are ignored, matching what the display helper does.
+ *
+ * @param {string} rrule RFC 5545 RRULE body, e.g. `FREQ=WEEKLY;BYDAY=MO,WE`
+ * @return {Record<string, string>} uppercase key → raw value
+ */
+export function rruleParts(rrule) {
+	const parts = {}
+	for (const seg of String(rrule || '').split(';')) {
+		const eq = seg.indexOf('=')
+		if (eq === -1) continue
+		parts[seg.slice(0, eq).trim().toUpperCase()] = seg.slice(eq + 1).trim()
+	}
+	return parts
+}
+
+/**
+ * Does this RRULE carry anything the editor cannot round-trip?
+ *
+ * True for any part outside FREQ/INTERVAL/COUNT/UNTIL/weekly-BYDAY, for a BYDAY
+ * on a non-weekly FREQ, for a positional BYDAY, and for a FREQ the unit select
+ * has no option for (including a missing one).
+ *
+ * @param {string} rrule the stored rule
+ * @return {boolean} true when the schedule must be left untouched
+ */
+export function isCustomRrule(rrule) {
+	const parts = rruleParts(rrule)
+	const freq = (parts.FREQ || '').toUpperCase()
+	if (!RRULE_FREQS.includes(freq)) return true
+	for (const key of Object.keys(parts)) {
+		if (!KNOWN_PARTS.includes(key)) return true
+	}
+	if (parts.BYDAY !== undefined) {
+		if (freq !== 'WEEKLY') return true
+		// An empty BYDAY would serialize back to nothing at all.
+		if (parts.BYDAY.trim() === '') return true
+		if (parts.BYDAY.split(',').some((d) => POSITIONAL_BYDAY.test(d.trim()))) return true
+	}
+	// COUNT and UNTIL together is not a schedule this editor's single "Ends"
+	// select can express either.
+	if (parts.COUNT !== undefined && parts.UNTIL !== undefined) return true
+	// An end condition we cannot read back is an end condition we would drop,
+	// turning a bounded rule into an endless one. Only the basic UNTIL format
+	// (YYYYMMDD…) and a plain integer COUNT survive the round trip.
+	if (parts.COUNT !== undefined && !/^\d+$/.test(parts.COUNT.trim())) return true
+	if (parts.UNTIL !== undefined && !/^\d{8}/.test(parts.UNTIL.trim())) return true
+	return false
+}
+
+/**
+ * Parse an RRULE into the fields the editor binds to.
+ *
+ * `untilSuffix` carries the time-of-day part of UNTIL verbatim (`T235959Z`, or
+ * `''` for a DATE-valued UNTIL) so re-serializing a rule whose end time is not
+ * midnight does not quietly move it to midnight.
+ *
+ * @param {string} rrule the stored rule
+ * @return {{freq: string, interval: number, weekdays: string[], endType: string, count: number, until: string, untilSuffix: string}} editor fields
+ */
+export function parseRecurRrule(rrule) {
+	const parts = rruleParts(rrule)
+	const freq = (parts.FREQ || '').toUpperCase()
+
+	const out = {
+		freq: RRULE_FREQS.includes(freq) ? freq : 'WEEKLY',
+		interval: Math.max(1, parseInt(parts.INTERVAL || '1', 10) || 1),
+		weekdays: [],
+		endType: 'forever',
+		count: 10,
+		until: '',
+		untilSuffix: 'T000000Z',
+	}
+
+	if (parts.BYDAY) {
+		out.weekdays = parts.BYDAY.split(',').map((d) => d.trim().toUpperCase()).filter(Boolean)
+	}
+
+	if (parts.COUNT) {
+		out.endType = 'count'
+		out.count = Math.max(1, parseInt(parts.COUNT, 10) || 1)
+	} else if (parts.UNTIL) {
+		const raw = parts.UNTIL.trim()
+		const day = raw.slice(0, 8)
+		if (/^\d{8}$/.test(day)) {
+			out.endType = 'until'
+			out.until = `${day.slice(0, 4)}-${day.slice(4, 6)}-${day.slice(6, 8)}`
+			out.untilSuffix = raw.slice(8)
+		}
+	}
+
+	return out
+}
+
+/**
+ * Serialize the editor fields back into an RFC 5545 RRULE.
+ *
+ * Only ever called for a rule `isCustomRrule()` said no to, so the five parts
+ * below are the whole rule by construction.
+ *
+ * @param {object} fields the editor state
+ * @param {string} fields.freq DAILY/WEEKLY/MONTHLY/YEARLY
+ * @param {number} fields.interval repeat interval, 1 is omitted
+ * @param {string[]} [fields.weekdays] weekly BYDAY entries
+ * @param {string} [fields.endType] 'forever' | 'count' | 'until'
+ * @param {number} [fields.count] occurrences for endType 'count'
+ * @param {string} [fields.until] YYYY-MM-DD for endType 'until'
+ * @param {string} [fields.untilSuffix] time-of-day part to preserve on UNTIL
+ * @return {string} the RRULE body
+ */
+export function buildRecurRrule({ freq, interval, weekdays, endType, count, until, untilSuffix }) {
+	const parts = [`FREQ=${freq}`]
+	const every = Number(interval)
+	if (every > 1) parts.push(`INTERVAL=${every}`)
+	if (freq === 'WEEKLY' && Array.isArray(weekdays) && weekdays.length > 0) {
+		parts.push(`BYDAY=${weekdays.join(',')}`)
+	}
+	if (endType === 'count') {
+		parts.push(`COUNT=${count}`)
+	} else if (endType === 'until' && until) {
+		// YYYY-MM-DD → YYYYMMDD + whatever time-of-day the rule already carried
+		// (T000000Z for anything the editor itself created).
+		parts.push(`UNTIL=${String(until).replace(/-/g, '')}${untilSuffix ?? 'T000000Z'}`)
+	}
+	return parts.join(';')
+}

--- a/src/views/BoardView.vue
+++ b/src/views/BoardView.vue
@@ -190,6 +190,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</template>
 
 
+				<!-- Command palette - the only OTHER way in is Ctrl/Cmd+K, which a
+				     phone or tablet cannot press, so the feature was unreachable on
+				     touch entirely (#10066). It lives here rather than in the header
+				     because the overflow menu is already touch-reachable and costs the
+				     header no width (it collapses at NARROW_HEADER_PX). The shortcut
+				     keeps working unchanged. -->
+				<NcActionButton
+					class="board-view__palette-btn"
+					:close-after-click="true"
+					@click="showCommandPalette = true">
+					<template #icon>
+						<MagnifyIcon :size="20" />
+					</template>
+					{{ t('kanso', 'Open command palette') }}
+				</NcActionButton>
+
 				<!-- Archived cards page - only offered when ≥1 archived card. The
 				     visible label already carries the count, so no separate aria-label
 				     is set (that would override the accessible name). -->
@@ -521,7 +537,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				@open="openPreviewCard" />
 		</template>
 
-		<!-- Command palette (Ctrl/Cmd+K) -->
+		<!-- Command palette (Ctrl/Cmd+K, or "Open command palette" in the More
+		     menu - the touch-reachable trigger, #10066) -->
 		<CommandPalette
 			:open="showCommandPalette"
 			@close="showCommandPalette = false" />
@@ -584,6 +601,7 @@ import NcActionCaption from '@nextcloud/vue/components/NcActionCaption'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import MagnifyIcon from 'vue-material-design-icons/Magnify.vue'
 import TuneVariantIcon from 'vue-material-design-icons/TuneVariant.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'

--- a/src/views/ViewPage.vue
+++ b/src/views/ViewPage.vue
@@ -37,9 +37,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				     become one chip (last board wins) while the predicate matches the
 				     bare id — picking "Bug" would return the other board's "Urgent"
 				     cards. Wrong results are worse than a missing facet; a
-				     board-qualified label identity is follow-up work.
+				     board-qualified label identity is follow-up work. Hiding the facet
+				     is also what keeps this View's saved label filter safe from the
+				     bar's "Clear filters", which only clears what it renders (#10091).
 				     `estimate-scale` is deliberately not passed either — an estimate
-				     scale is board-scoped and a cross-board View can span two of them. -->
+				     scale is board-scoped and a cross-board View can span two of them.
+				     Nor `saved-filters`: saved views are a board-surface concept, and
+				     the bar drops that whole section when it is given none. -->
 				<BoardFilterBar
 					:state="filterState"
 					:participants="participants"

--- a/tests/e2e/card-unsaved-guard.spec.js
+++ b/tests/e2e/card-unsaved-guard.spec.js
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// #10069 — leaving a card without saving used to throw the work away silently:
+// the description, the title, a new thread and a reply are ALL explicit-save, and
+// dismissing the card just navigated away. These specs pin the confirm-before-you-
+// lose-it behaviour, the "don't nag me when nothing changed" half of it (which is
+// what would make the feature hated), and the draft LEAK the same defect caused —
+// the board renders CardDetail through an unkeyed <router-view>, so a half-typed
+// reply used to survive a card→card switch and turn up in the next card.
+
+/** The ProseMirror inside the new-thread composer. */
+function composerProse(page) {
+	return page.locator('.card-modal__composer .kanso-md-editor .ProseMirror').first()
+}
+
+/** The ProseMirror inside the open reply box. */
+function replyProse(page) {
+	return page.locator('.card-modal__reply-compose .kanso-md-editor .ProseMirror').first()
+}
+
+/** The ProseMirror inside the description editor. */
+function descProse(page) {
+	return page.locator('.card-modal__section .kanso-md-editor .ProseMirror').first()
+}
+
+// A point on the dark backdrop: midway between the modal wrapper's left edge and
+// the centred container's left edge, at the container's vertical centre. Same
+// geometry card-modal-layout.spec.js uses — that point resolves to .modal-wrapper,
+// which is what the close-on-backdrop handler keys off.
+async function backdropPoint(page) {
+	return page.evaluate(() => {
+		const wrapper = document.querySelector('.card-modal-modal .modal-wrapper')
+		const container = document.querySelector('.card-modal-modal .modal-container')
+		const wb = wrapper.getBoundingClientRect()
+		const cb = container.getBoundingClientRect()
+		return { x: (wb.x + cb.x) / 2, y: cb.y + cb.height / 2 }
+	})
+}
+
+/**
+ * Record every native dialog the page raises and answer it. `control.accept`
+ * decides the answer, so one test can first Cancel ("keep me here") and then OK
+ * ("yes, discard") without re-wiring the listener.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @return {{messages: string[], accept: boolean}} live record + the answer switch
+ */
+function trackDialogs(page) {
+	const control = { messages: [], accept: false }
+	page.on('dialog', async (dialog) => {
+		control.messages.push(dialog.message())
+		if (control.accept) {
+			await dialog.accept()
+		} else {
+			await dialog.dismiss()
+		}
+	})
+	return control
+}
+
+test.describe('Unsaved changes are confirmed before leaving a card (#10069)', () => {
+	const state = { boardId: 0, stackId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Unsaved-Guard E2E' })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Do' })
+		state.stackId = stack.id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	async function makeCard(title) {
+		const card = await api.post('/cards', { stackId: state.stackId, title })
+		return {
+			id: card.id,
+			url: `${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${card.id}`,
+		}
+	}
+
+	async function openCard(page, card) {
+		await page.setViewportSize({ width: 1280, height: 900 })
+		await ncLogin(page)
+		await page.goto(card.url)
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+	}
+
+	test('a description draft: Cancel keeps the card open with the text, OK discards and closes', async ({ page }) => {
+		const card = await makeCard('Description draft card')
+		const dialogs = trackDialogs(page)
+		await openCard(page, card)
+
+		await page.locator('.card-modal__desc-placeholder').click()
+		const prose = descProse(page)
+		await expect(prose).toBeVisible({ timeout: 8_000 })
+		await prose.click()
+		await page.keyboard.type('half-written description')
+		await expect(prose).toContainText('half-written description')
+
+		// Click the backdrop → the guard must ask before losing the draft.
+		dialogs.accept = false
+		let pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+
+		await expect.poll(() => dialogs.messages.length, { timeout: 8_000 }).toBe(1)
+		expect(dialogs.messages[0]).toContain('unsaved changes')
+
+		// Cancelled → still on the card, editor still open, draft untouched.
+		await expect(page).toHaveURL(new RegExp(`/card/${card.id}`))
+		await expect(page.locator('.card-modal')).toBeVisible()
+		await expect(descProse(page)).toContainText('half-written description')
+
+		// Confirmed → the card closes and the draft is gone.
+		dialogs.accept = true
+		pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+
+		await expect(page).not.toHaveURL(new RegExp(`/card/${card.id}`), { timeout: 8_000 })
+		expect(dialogs.messages.length).toBe(2)
+		// Nothing was written to the server.
+		const fresh = await api.get(`/cards/${card.id}`)
+		expect(fresh.description || '').toBe('')
+	})
+
+	test('a reply draft is confirmed too (the owner named replies explicitly)', async ({ page }) => {
+		const card = await makeCard('Reply draft card')
+		await api.post(`/cards/${card.id}/comments`, { body: 'Thread to answer' })
+		const dialogs = trackDialogs(page)
+		await openCard(page, card)
+
+		const replyBtn = page.locator('.card-modal__comment-group > .card-modal__comment .card-modal__comment-link-btn').first()
+		await expect(replyBtn).toBeVisible({ timeout: 10_000 })
+		await replyBtn.click()
+
+		const prose = replyProse(page)
+		await expect(prose).toBeVisible({ timeout: 8_000 })
+		await prose.click()
+		await page.keyboard.type('half-written reply')
+		await expect(prose).toContainText('half-written reply')
+
+		dialogs.accept = false
+		let pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+
+		await expect.poll(() => dialogs.messages.length, { timeout: 8_000 }).toBe(1)
+		expect(dialogs.messages[0]).toContain('unsaved changes')
+		await expect(page).toHaveURL(new RegExp(`/card/${card.id}`))
+		await expect(replyProse(page)).toContainText('half-written reply')
+
+		dialogs.accept = true
+		pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+		await expect(page).not.toHaveURL(new RegExp(`/card/${card.id}`), { timeout: 8_000 })
+
+		// The reply was never posted.
+		const comments = await api.get(`/cards/${card.id}/comments`)
+		expect(comments.length).toBe(1)
+	})
+
+	// The regression that would make the guard hated: prompting on a card nobody
+	// typed into. Opening the description editor and the reply box WITHOUT typing
+	// must still count as clean.
+	test('closing a card with nothing typed never prompts', async ({ page }) => {
+		const card = await makeCard('Untouched card')
+		await api.post(`/cards/${card.id}/comments`, { body: 'Just reading' })
+		const dialogs = trackDialogs(page)
+		await openCard(page, card)
+
+		// Merely opening the editors is not "unsaved work".
+		await page.locator('.card-modal__desc-placeholder').click()
+		await expect(descProse(page)).toBeVisible({ timeout: 8_000 })
+		const replyBtn = page.locator('.card-modal__comment-group > .card-modal__comment .card-modal__comment-link-btn').first()
+		await expect(replyBtn).toBeVisible({ timeout: 10_000 })
+		await replyBtn.click()
+		await expect(replyProse(page)).toBeVisible({ timeout: 8_000 })
+
+		// Escape at the card root closes it, silently.
+		dialogs.accept = true
+		const pt = await backdropPoint(page)
+		await page.mouse.click(pt.x, pt.y)
+
+		await expect(page).not.toHaveURL(new RegExp(`/card/${card.id}`), { timeout: 8_000 })
+		expect(dialogs.messages).toEqual([])
+	})
+
+	// Tab close / reload leaves the app entirely, where only the browser's own
+	// beforeunload prompt is available. It must fire with a draft…
+	test('reloading with a draft raises the browser leave prompt', async ({ page }) => {
+		const card = await makeCard('Reload card')
+		const dialogs = trackDialogs(page)
+		dialogs.accept = true
+		await openCard(page, card)
+
+		await page.locator('.card-modal__desc-placeholder').click()
+		await expect(descProse(page)).toBeVisible({ timeout: 8_000 })
+		await descProse(page).click()
+		await page.keyboard.type('typed then reloaded')
+
+		await page.reload()
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+		expect(dialogs.messages.length).toBe(1)
+	})
+
+	// …and must stay silent on a clean card.
+	test('reloading a card with no draft does not raise the browser leave prompt', async ({ page }) => {
+		const card = await makeCard('Clean reload card')
+		const dialogs = trackDialogs(page)
+		dialogs.accept = true
+		await openCard(page, card)
+
+		await page.reload()
+		await page.waitForSelector('.card-modal__attrbar', { timeout: 15_000 })
+		expect(dialogs.messages).toEqual([])
+	})
+
+	// The same unkeyed-<router-view> reuse the description state already guarded
+	// against: comment drafts survived a card→card switch and showed up in the
+	// next card's composer / reply box, one Post away from the wrong discussion.
+	test('a draft never leaks into the next card opened', async ({ page }) => {
+		const cardA = await makeCard('Leak source A')
+		const cardB = await makeCard('Leak target B')
+		await api.post(`/cards/${cardA.id}/comments`, { body: 'Thread on A' })
+		await api.post(`/cards/${cardB.id}/comments`, { body: 'Thread on B' })
+		const dialogs = trackDialogs(page)
+		await openCard(page, cardA)
+
+		// A new-thread draft AND a reply draft on card A.
+		const replyBtnA = page.locator('.card-modal__comment-group > .card-modal__comment .card-modal__comment-link-btn').first()
+		await expect(replyBtnA).toBeVisible({ timeout: 10_000 })
+		await replyBtnA.click()
+		await expect(replyProse(page)).toBeVisible({ timeout: 8_000 })
+		await replyProse(page).click()
+		await page.keyboard.type('reply meant for A')
+
+		await composerProse(page).click()
+		await page.keyboard.type('thread meant for A')
+		await expect(composerProse(page)).toContainText('thread meant for A')
+
+		// Card→card navigation (same route record, so the component is REUSED).
+		await page.goto(cardB.url)
+		await expect(page.locator('.card-modal__title')).toHaveText('Leak target B', { timeout: 15_000 })
+		await page.waitForSelector('.card-modal__comment', { timeout: 10_000 })
+
+		// The new-thread composer on B is empty…
+		await expect(composerProse(page)).toHaveText('')
+		// …no reply box is left open…
+		await expect(page.locator('.card-modal__reply-compose')).toHaveCount(0)
+		// …and opening B's own reply box starts blank.
+		const replyBtnB = page.locator('.card-modal__comment-group > .card-modal__comment .card-modal__comment-link-btn').first()
+		await replyBtnB.click()
+		await expect(replyProse(page)).toBeVisible({ timeout: 8_000 })
+		await expect(replyProse(page)).toHaveText('')
+
+		// Card→card is not a dismissal, so it must not have prompted either.
+		expect(dialogs.messages).toEqual([])
+	})
+})

--- a/tests/e2e/filter-clear-scope.spec.js
+++ b/tests/e2e/filter-clear-scope.spec.js
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// #10091 — "Clear filters" may only clear the facets the control actually
+// RENDERS.
+//
+// The filter bar is shared by two surfaces that render DIFFERENT facet sets, over
+// one and the same filter state. A View hides the Labels facet on purpose (label
+// ids are board-scoped and collide across boards) while seeding the View's own
+// saved label filter into that state — so a blanket clear wiped a constraint the
+// user could not see, silently widening the page from "this View" to the entire
+// unfiltered cross-board feed, with a page reload as the only way back.
+//
+// Two halves, one invariant:
+//   1. On a View, clearing keeps the hidden saved label filter — and the feed
+//      request that follows still carries the `fl` short key.
+//   2. On a board, where Labels IS rendered, clearing still clears labels.
+// Without the second half the fix could be "never clear labels", which would
+// break the surface the button was written for.
+
+test.describe('Clear filters is scoped to the rendered facets (#10091)', () => {
+	test('on a View it keeps the hidden saved label filter (and the feed keeps `fl`)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+
+		const stamp = Math.floor(Date.now() / 1000)
+		// One board; two cards share the View's label (one bug, one feature) and a
+		// third carries no label at all. The View is defined by that label alone, so
+		// "the label filter survived" is directly readable off the rendered rows: two
+		// rows, never the whole cross-board feed.
+		const board = await api.post('/boards', { title: 'ClearScope ' + stamp })
+		const label = await api.post('/labels', { boardId: board.id, title: 'vclear ' + stamp, color: 'cc0066' })
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
+		const bugTitle = 'ClearScope bug ' + stamp
+		const featureTitle = 'ClearScope feature ' + stamp
+		const bug = await api.post('/cards', { stackId: stack.id, title: bugTitle })
+		const feature = await api.post('/cards', { stackId: stack.id, title: featureTitle })
+		await api.post('/cards', { stackId: stack.id, title: 'ClearScope unlabelled ' + stamp })
+		await api.put(`/cards/${bug.id}/labels/${label.id}`)
+		await api.put(`/cards/${feature.id}/labels/${label.id}`)
+		await api.patch(`/cards/${bug.id}`, { type: 'bug' })
+		await api.patch(`/cards/${feature.id}`, { type: 'feature' })
+
+		const created = await api.put('/views', {
+			name: 'ClearScope ' + stamp,
+			filter: { labels: [label.id] },
+			groupBy: 'status',
+			display: 'list',
+		})
+		const view = created.views[created.views.length - 1]
+
+		try {
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${view.id}`)
+
+			const rowBug = page.locator('.board-list-row__title', { hasText: bugTitle })
+			const rowFeature = page.locator('.board-list-row__title', { hasText: featureTitle })
+			const trigger = page.locator('.board-filter-bar__trigger')
+			await expect(rowBug).toBeVisible({ timeout: 20_000 })
+			await expect(rowFeature).toBeVisible({ timeout: 15_000 })
+			// The saved label filter counts as one active constraint even though its
+			// facet is hidden — the trigger deliberately over-reports rather than hide
+			// an active constraint.
+			await expect(trigger).toContainText('Filter · 1')
+
+			// There is no Views section to click through: this surface passes no saved
+			// views, so the empty "Views / Default (no filter)" block is not rendered.
+			await trigger.click()
+			await expect(page.locator('.board-filter-bar__saved-item')).toHaveCount(0)
+
+			// Layer a VISIBLE facet on top: Type = Bug.
+			await page.locator('.board-filter-bar__dim-row[data-dim="types"]').click()
+			await page.locator('.board-filter-bar__opt', { hasText: /^Bug$/ }).click()
+			await expect(rowFeature).toHaveCount(0, { timeout: 15_000 })
+			await expect(rowBug).toBeVisible()
+			await expect(trigger).toContainText('Filter · 2')
+
+			// ── Clear ────────────────────────────────────────────────────────────────
+			await page.locator('.board-filter-bar__back').click()
+			await page.locator('.board-filter-bar__clear').click()
+
+			// The visible facet is gone…
+			await expect(rowFeature).toBeVisible({ timeout: 15_000 })
+			await expect(rowBug).toBeVisible()
+			// …and the hidden one is NOT: the View is still exactly its two labelled
+			// cards, not the unfiltered cross-board feed (which would render the whole
+			// dev database into this list).
+			await expect(page.locator('.board-list-row__title')).toHaveCount(2)
+			await expect(trigger).toContainText('Filter · 1')
+
+			// With nothing left that this control renders, Clear is no longer offered —
+			// it would be a button that clears nothing visible.
+			await expect(page.locator('.board-filter-bar__clear')).toHaveCount(0)
+			await page.keyboard.press('Escape')
+
+			// ── The wire, not just the DOM ───────────────────────────────────────────
+			// Clearing leaves the query key untouched (that is the point), so force the
+			// next feed request by changing the sort: it must still carry `fl`. Without
+			// this the spec would pass on a client-side-only survival while the server
+			// was being asked for the unfiltered feed — the heaviest query in the app.
+			const filteredFeed = page.waitForRequest(
+				(r) => r.url().includes('/api/views/cards')
+					&& r.url().includes('sortMode=title')
+					&& r.url().includes(`fl=${label.id}`),
+				{ timeout: 20_000 },
+			)
+			await page.locator('.view-page__sort button').first().click()
+			await page.waitForTimeout(400)
+			await page.locator('.action-radio__text', { hasText: /^Title$/ }).click()
+			await filteredFeed
+			await page.keyboard.press('Escape')
+			await expect(page.locator('.board-list-row__title')).toHaveCount(2)
+		} finally {
+			await api.delete(`/views/${view.id}`).catch(() => {})
+			await api.delete(`/boards/${board.id}`).catch(() => {})
+		}
+	})
+
+	test('on a board, where the Labels facet IS rendered, clearing still clears labels', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+
+		const stamp = Math.floor(Date.now() / 1000)
+		const board = await api.post('/boards', { title: 'ClearScopeBoard ' + stamp })
+		const label = await api.post('/labels', { boardId: board.id, title: 'bclear ' + stamp, color: '0066cc' })
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
+		const taggedTitle = 'ClearScopeBoard tagged ' + stamp
+		const plainTitle = 'ClearScopeBoard plain ' + stamp
+		const tagged = await api.post('/cards', { stackId: stack.id, title: taggedTitle })
+		await api.post('/cards', { stackId: stack.id, title: plainTitle })
+		await api.put(`/cards/${tagged.id}/labels/${label.id}`)
+
+		try {
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/board/${board.id}`)
+			await page.waitForSelector('.board-view__header', { timeout: 20_000 })
+
+			const tileTagged = page.locator('.card-tile__title', { hasText: taggedTitle })
+			const tilePlain = page.locator('.card-tile__title', { hasText: plainTitle })
+			await expect(tileTagged).toHaveCount(1)
+			await expect(tilePlain).toHaveCount(1)
+
+			// Filter by the label through the rendered Labels facet.
+			const trigger = page.locator('.board-filter-bar__trigger')
+			await trigger.click()
+			await page.locator('.board-filter-bar__dim-row[data-dim="labels"]').click()
+			await page.locator('.board-filter-bar__opt-text', { hasText: 'bclear ' + stamp }).click()
+			await expect(tilePlain).toHaveCount(0, { timeout: 15_000 })
+			await expect(tileTagged).toHaveCount(1)
+			await expect.poll(() => page.url()).toContain(`fl=${label.id}`)
+
+			// Clear: on THIS surface the Labels facet is rendered, so it must still be
+			// cleared — every card returns, the count badge drops, and the shareable
+			// URL loses its `fl` param.
+			await page.locator('.board-filter-bar__back').click()
+			await page.locator('.board-filter-bar__clear').click()
+			await page.keyboard.press('Escape')
+
+			await expect(tilePlain).toHaveCount(1, { timeout: 15_000 })
+			await expect(tileTagged).toHaveCount(1)
+			await expect(trigger).not.toContainText('·')
+			await expect.poll(() => page.url()).not.toContain('fl=')
+		} finally {
+			await api.delete(`/boards/${board.id}`).catch(() => {})
+		}
+	})
+})

--- a/tests/e2e/mobile-pwa.spec.js
+++ b/tests/e2e/mobile-pwa.spec.js
@@ -55,6 +55,32 @@ test('board is usable on a phone viewport', async ({ page }) => {
 	await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15_000 })
 })
 
+// #10066 — the command palette used to have exactly one trigger, Ctrl/Cmd+K,
+// and the overlay documenting it opens on '?'. Neither key exists on a phone, so
+// the whole feature was unreachable on touch. This test lives HERE because only
+// tests/e2e/mobile-pwa.spec.js runs at a phone viewport (both mobile projects
+// match on this file); tests/e2e/command-palette.spec.js is keyboard-driven and
+// runs desktop-only, so it cannot cover reachability.
+//
+// Driven with tap(), not click(): a real touch sequence is the thing under test.
+test('the command palette is reachable by touch alone', async ({ page }) => {
+	await gotoBoard(page, state.boardId)
+	await expect(page.locator('.stack-column').first()).toBeVisible({ timeout: 30_000 })
+
+	// The trigger lives in the "More" overflow, which is already touch-reachable
+	// and costs the (narrow) header no width.
+	await page.getByRole('button', { name: 'More board actions' }).tap()
+	const paletteItem = page.getByRole('menuitem', { name: 'Open command palette' })
+	await expect(paletteItem).toBeVisible({ timeout: 10_000 })
+	await paletteItem.tap()
+
+	// The palette itself was already touch-usable (its results carry @click and
+	// mobile.css enforces 44px targets) — only the way in was missing.
+	const palette = page.locator('.command-palette')
+	await expect(palette).toBeVisible({ timeout: 10_000 })
+	await expect(palette.locator('.command-palette__input')).toBeVisible()
+})
+
 test('has an installable web app manifest', async ({ page }) => {
 	await gotoBoard(page, state.boardId)
 

--- a/tests/e2e/recur-rule-custom-schedule.spec.js
+++ b/tests/e2e/recur-rule-custom-schedule.spec.js
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10045 — the Automation recurrence editor parses five RRULE parts (FREQ,
+// INTERVAL, BYDAY, COUNT, UNTIL) and used to re-serialize the rule from exactly
+// those on every save. A rule authored through the API — `FREQ=MONTHLY;
+// BYMONTHDAY=1,15`, "the 1st and the 15th" — therefore came back as a bare
+// `FREQ=MONTHLY` the moment someone opened it to change its target column.
+//
+// The assertion that matters is the API read-back: the panel never rendered the
+// dropped part in the first place, so "the form still looks right" passes
+// against the broken build. Only the stored string can tell the two apart.
+
+import { test, expect, BASE, api, ncLogin } from './helpers.js'
+
+const CUSTOM_RRULE = 'FREQ=MONTHLY;BYMONTHDAY=1,15'
+
+test.describe('Editing an API-authored recurrence rule (#10045)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Custom RRULE ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Invoices' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Paid' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'Send the invoice' })).id
+
+		// The kind of rule only the API / MCP can author today: twice a month.
+		const rule = await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: CUSTOM_RRULE,
+		})
+		state.ruleId = rule.id
+
+		// Spawn one occurrence so the "ends after N times" tally is non-zero —
+		// otherwise "the counter was not reset" is a vacuous 0 === 0.
+		await api.post(`/recur-rules/${state.ruleId}/create-now`)
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	const storedRule = async () => {
+		const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+		return rules.find((r) => Number(r.id) === Number(state.ruleId)) ?? null
+	}
+
+	test('changing only the target column leaves the custom schedule byte-identical', async ({ page }) => {
+		const before = await storedRule()
+		expect(before.rrule).toBe(CUSTOM_RRULE)
+		expect(before.occurrencesSpawned).toBe(1)
+
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+
+		// Board settings → Automation → expand "Recurring cards".
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /automation/i }).click()
+		await page.getByRole('button', { name: /Recurring cards/ }).click()
+
+		const recurring = page.locator('#bs-automation-recurring')
+		const item = recurring.locator('.automation__rule-item').filter({ hasText: 'Send the invoice' })
+		await expect(item).toBeVisible({ timeout: 8_000 })
+		await item.getByRole('button', { name: /^Edit$/ }).click()
+
+		// The schedule half of the editor is read-only: the raw rule is shown with
+		// a note, and the frequency/interval controls are not rendered at all.
+		await expect(recurring.locator('.automation__custom-rrule')).toHaveText(CUSTOM_RRULE)
+		await expect(recurring.locator('.automation__custom-note')).toBeVisible()
+		await expect(page.locator(`#recur-freq-${state.boardId}`)).toHaveCount(0)
+
+		// Everything the editor genuinely owns stays editable — only the schedule
+		// is frozen. Change the target column AND the due-date policy, then save.
+		await page.locator(`#recur-stack-${state.boardId}`).selectOption(String(state.otherStackId))
+		await page.locator(`#recur-due-${state.boardId}`).selectOption('2') // None
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		// Read the rule back from the server. Both edited fields moved; the
+		// schedule string is untouched byte for byte, and the tally did not restart.
+		await expect.poll(
+			async () => Number((await storedRule())?.targetStackId),
+			{ timeout: 8_000 },
+		).toBe(Number(state.otherStackId))
+
+		const after = await storedRule()
+		expect(Number(after.duedatePolicy)).toBe(2)
+		expect(after.rrule).toBe(CUSTOM_RRULE)
+		expect(after.occurrencesSpawned).toBe(1)
+	})
+})
+
+// The second half of the same harm: RecurrenceService::update() compares rule
+// STRINGS, so re-sending a semantically identical but differently spelled rule
+// (INTERVAL=1, which any generic RRULE library emits) restarts the
+// occurrences-spawned tally — an "ends after 5" rule quietly becomes 5 MORE.
+// The editor only sends a schedule the user actually changed.
+test.describe('Saving a rule whose schedule was not touched (#10045)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+	const VERBOSE_RRULE = 'FREQ=WEEKLY;INTERVAL=1;COUNT=5'
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Verbose RRULE ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Standup' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Archive' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'Write the update' })).id
+		state.ruleId = (await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: VERBOSE_RRULE,
+		})).id
+		await api.post(`/recur-rules/${state.ruleId}/create-now`)
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('an untouched schedule is not re-sent, so the occurrence tally survives', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /automation/i }).click()
+		await page.getByRole('button', { name: /Recurring cards/ }).click()
+
+		const recurring = page.locator('#bs-automation-recurring')
+		const item = recurring.locator('.automation__rule-item').filter({ hasText: 'Write the update' })
+		await expect(item).toBeVisible({ timeout: 8_000 })
+		await item.getByRole('button', { name: /^Edit$/ }).click()
+
+		// This rule IS editable — it is only spelled more verbosely than the
+		// builder would spell it.
+		await expect(page.locator(`#recur-freq-${state.boardId}`)).toHaveValue('WEEKLY')
+		await page.locator(`#recur-stack-${state.boardId}`).selectOption(String(state.otherStackId))
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		const stored = async () => {
+			const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+			return rules.find((r) => Number(r.id) === Number(state.ruleId)) ?? null
+		}
+		await expect.poll(
+			async () => Number((await stored())?.targetStackId),
+			{ timeout: 8_000 },
+		).toBe(Number(state.otherStackId))
+
+		const after = await stored()
+		expect(after.rrule).toBe(VERBOSE_RRULE)
+		expect(after.occurrencesSpawned).toBe(1)
+	})
+})
+
+test.describe('Editing a rule the recurrence editor fully models (#10045)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Simple RRULE ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Chores' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Done-ish' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'Take the bins out' })).id
+		state.ruleId = (await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE',
+		})).id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	// The custom-schedule guard must not swallow the ordinary case: a rule built
+	// from these very controls still round-trips and still saves edits.
+	test('the builder stays editable and keeps round-tripping a weekly rule', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /automation/i }).click()
+		await page.getByRole('button', { name: /Recurring cards/ }).click()
+
+		const recurring = page.locator('#bs-automation-recurring')
+		const item = recurring.locator('.automation__rule-item').filter({ hasText: 'Take the bins out' })
+		await expect(item).toBeVisible({ timeout: 8_000 })
+		await item.getByRole('button', { name: /^Edit$/ }).click()
+
+		// The real controls, populated from the stored rule — no read-only note.
+		await expect(recurring.locator('.automation__custom-note')).toHaveCount(0)
+		await expect(page.locator(`#recur-freq-${state.boardId}`)).toHaveValue('WEEKLY')
+		await expect(page.locator(`#recur-interval-${state.boardId}`)).toHaveValue('2')
+
+		// Bump the interval and save: the rule is re-serialized, weekdays included.
+		await page.locator(`#recur-interval-${state.boardId}`).fill('3')
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		await expect.poll(async () => {
+			const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+			return rules.find((r) => Number(r.id) === Number(state.ruleId))?.rrule ?? ''
+		}, { timeout: 8_000 }).toBe('FREQ=WEEKLY;INTERVAL=3;BYDAY=MO,WE')
+	})
+})

--- a/tests/e2e/view-feed-abort.spec.js
+++ b/tests/e2e/view-feed-abort.spec.js
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10010 — a cancelled View-feed refetch must be aborted in the browser, not
+// read to the end.
+//
+// ['view-cards'] is the heaviest query in the app and stays ACTIVE while the
+// card detail sits as an overlay on the View, so the ~44 invalidateCrossBoardFeeds
+// call sites refetch it. invalidateQueries defaults to cancelRefetch:true, but
+// TanStack can only act on that if the queryFn CONSUMES the AbortSignal it is
+// handed — useViewCards used to drop it, so a "cancelled" refetch kept its
+// connection open and normalised an envelope of up to `limit` enriched cards
+// that the cache threw away on arrival.
+//
+// What this spec pins is exactly that, and only that: the superseded request
+// ends client-ABORTED rather than completed. It is NOT a claim about the
+// server — the response body is written in one go, so PHP finishes the request
+// either way; the 400ms VIEW_FEED_INVALIDATE_THROTTLE (tests/e2e/view-feed-burst.spec.js)
+// is what keeps the server load down and stays load-bearing.
+//
+// ── How the abort is observed ────────────────────────────────────────────────
+// In-page transport instrumentation, not Playwright network events: the point
+// is what the CLIENT did with its own request (XMLHttpRequest#abort / an aborted
+// fetch signal), which is precisely the thing a request/response listener cannot
+// distinguish from a slow response. The /api/views/cards route is stalled so the
+// first refetch is guaranteed to still be in flight when the second one
+// supersedes it — without that the race is decided by the dev box's disk.
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+test.describe('View feed refetch cancellation (#10010)', () => {
+	const ts = Math.floor(Date.now() / 1000)
+	const CARD = `Abort card ${ts}`
+
+	const state = { boardId: 0, cardId: 0, viewId: 0, scopeLabelId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: `Abort E2E ${ts}` })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
+
+		// A per-run scope label the View filters on, so the View resolves to this
+		// run's card whatever else lives in the dev DB.
+		state.scopeLabelId = (await api.post('/labels', {
+			boardId: board.id,
+			title: `abort-scope ${ts}`,
+			color: '0066aa',
+		})).id
+
+		state.cardId = (await api.post('/cards', { stackId: stack.id, title: CARD })).id
+		await api.put(`/cards/${state.cardId}/labels/${state.scopeLabelId}`)
+		for (let i = 1; i <= 2; i++) {
+			await api.post(`/cards/${state.cardId}/checklist`, { title: `abort step ${i}` })
+		}
+
+		// Filtered on the LABEL, so a tick never moves the row in or out of the
+		// View — the only thing the ticks vary is how often the feed is re-read.
+		const created = await api.put('/views', {
+			name: `Abort view ${ts}`,
+			filter: { labels: [state.scopeLabelId] },
+			groupBy: 'board',
+			display: 'list',
+		})
+		state.viewId = created.views[created.views.length - 1].id
+		expect(state.viewId).toBeTruthy()
+	})
+
+	test.afterAll(async () => {
+		if (state.viewId) await api.delete(`/views/${state.viewId}`).catch(() => {})
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('a superseded view-cards refetch is aborted client-side instead of completing', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+
+		// Records every /api/views/cards request the page issues and how it ended.
+		// Both transports are patched: axios picks XHR in browsers today, but the
+		// assertion must not silently go vacuous if it ever picks fetch.
+		await page.addInitScript(() => {
+			const FEED = '/api/views/cards'
+			window.__kansoFeedXhr = []
+
+			const origOpen = XMLHttpRequest.prototype.open
+			const origSend = XMLHttpRequest.prototype.send
+			const origAbort = XMLHttpRequest.prototype.abort
+			XMLHttpRequest.prototype.open = function (method, requestUrl, ...rest) {
+				this.__kansoUrl = String(requestUrl)
+				return origOpen.call(this, method, requestUrl, ...rest)
+			}
+			XMLHttpRequest.prototype.send = function (...args) {
+				if (typeof this.__kansoUrl === 'string' && this.__kansoUrl.includes(FEED)) {
+					const entry = { transport: 'xhr', aborted: false, completed: false }
+					this.__kansoEntry = entry
+					window.__kansoFeedXhr.push(entry)
+					this.addEventListener('load', () => { entry.completed = true })
+				}
+				return origSend.apply(this, args)
+			}
+			XMLHttpRequest.prototype.abort = function (...args) {
+				if (this.__kansoEntry) this.__kansoEntry.aborted = true
+				return origAbort.apply(this, args)
+			}
+
+			const origFetch = window.fetch
+			window.fetch = function (input, init) {
+				const requestUrl = typeof input === 'string' ? input : (input && input.url) || ''
+				if (!requestUrl.includes(FEED)) return origFetch.call(this, input, init)
+				const entry = { transport: 'fetch', aborted: false, completed: false }
+				window.__kansoFeedXhr.push(entry)
+				const signal = init && init.signal
+				if (signal) signal.addEventListener('abort', () => { entry.aborted = true })
+				return origFetch.call(this, input, init).then((response) => {
+					entry.completed = true
+					return response
+				})
+			}
+		})
+
+		await ncLogin(page)
+
+		// Stalling the feed endpoint is what makes the overlap deterministic: the
+		// first refetch is still open when the second supersedes it.
+		let stallMs = 0
+		await page.route('**/api/views/cards*', async (route) => {
+			if (stallMs > 0) await new Promise((resolve) => setTimeout(resolve, stallMs))
+			// A request the page aborted mid-flight can no longer be continued.
+			await route.continue().catch(() => {})
+		})
+
+		await page.goto(`${BASE}/index.php/apps/kanso#/views/${state.viewId}`)
+
+		const row = page.locator('.board-list-row__title', { hasText: CARD })
+		await expect(row).toBeVisible({ timeout: 20_000 })
+
+		// Open the card as an in-place overlay ON the View (never navigates), so
+		// ViewPage stays mounted and ['view-cards'] stays ACTIVE.
+		await page.evaluate(() => { window.__kansoNoReload = true })
+		await row.click()
+		await expect(page.locator('.card-modal-modal')).toBeVisible({ timeout: 15_000 })
+		await expect(page.locator('.card-modal__checklist-checkbox')).toHaveCount(2)
+
+		await page.evaluate(() => { window.__kansoFeedXhr.length = 0 })
+		stallMs = 4000
+
+		const boxes = page.locator('.card-modal__checklist-checkbox')
+		// Tick one: leading-edge invalidate → a refetch that the route now stalls.
+		await boxes.nth(0).click()
+		await expect.poll(
+			() => page.evaluate(() => window.__kansoFeedXhr.length),
+			{ timeout: 15_000, message: 'the first tick issued no view-cards refetch at all' },
+		).toBeGreaterThan(0)
+
+		// Tick two, past the 400ms throttle window so it invalidates immediately:
+		// TanStack supersedes the still-open refetch (cancelRefetch defaults true).
+		await page.waitForTimeout(700)
+		await boxes.nth(1).click()
+
+		await expect.poll(
+			async () => (await page.evaluate(() => window.__kansoFeedXhr)).filter((e) => e.aborted).length,
+			{
+				timeout: 20_000,
+				message: 'the superseded view-cards refetch was never aborted — the query signal is not reaching axios',
+			},
+		).toBeGreaterThan(0)
+
+		// …and the abort really replaced a completion rather than following one.
+		const entries = await page.evaluate(() => window.__kansoFeedXhr)
+		expect(entries.some((e) => e.aborted && !e.completed),
+			`no aborted-and-unfinished view-cards request: ${JSON.stringify(entries)}`).toBe(true)
+	})
+})

--- a/tests/e2e/view-feed-burst.spec.js
+++ b/tests/e2e/view-feed-burst.spec.js
@@ -9,9 +9,11 @@
 // ['view-cards'] is an ACTIVE query — the only kind invalidateQueries actually
 // refetches. Every settle therefore used to trigger a full read of the heaviest
 // query in the app (enriched summaries across every readable board, up to the
-// server cap), and TanStack did not absorb the duplicates: invalidateQueries
-// defaults to cancelRefetch:true, but getViewCards is a plain axios GET with no
-// AbortSignal, so a "cancelled" refetch's request still completes server-side.
+// server cap), and TanStack cannot absorb the duplicates for us: invalidateQueries
+// defaults to cancelRefetch:true, and getViewCards now honours the query's
+// AbortSignal (#10010, proven in tests/e2e/view-feed-abort.spec.js), but the
+// response is written in one go, so a "cancelled" refetch still completes
+// SERVER-side. Only this throttle removes the round trip.
 //
 // ── Why the checklist PATCH is stubbed ───────────────────────────────────────
 // The quantity under test is purely client-side: how many /api/views/cards

--- a/tests/e2e/views.spec.js
+++ b/tests/e2e/views.spec.js
@@ -257,10 +257,14 @@ test.describe('Cross-board Views (#3815)', () => {
 			await expect(rowA).toBeVisible({ timeout: 10_000 })
 			await expect(rowB).toHaveCount(0, { timeout: 10_000 })
 
-			// Clear filters back to both cards before exercising the next dimension.
-			await page.locator('.board-filter-bar__back').click()
-			await page.locator('.board-filter-bar__clear').click()
+			// Reset the TYPE facet itself (toggle "Bug" back off) before exercising the
+			// next dimension — NOT the panel's global "Clear filters". Clearing is
+			// scoped to the facets this control renders (#10091), so on a View it no
+			// longer touches the View's own saved label filter; but resetting the one
+			// facet under test keeps this step's undo exact and independent of that.
+			await page.locator('.board-filter-bar__opt', { hasText: /^Bug$/ }).click()
 			await expect(rowB).toBeVisible({ timeout: 10_000 })
+			await page.locator('.board-filter-bar__back').click()
 
 			// ── New filter dimension #2: COMMENTS (single-select radio) ──────────────
 			await page.locator('.board-filter-bar__dim-row[data-dim="comments"]').click()
@@ -269,9 +273,9 @@ test.describe('Cross-board Views (#3815)', () => {
 			await expect(rowA).toBeVisible({ timeout: 10_000 })
 			await expect(rowB).toHaveCount(0, { timeout: 10_000 })
 
-			// Clear again, close the popover.
+			// Reset the COMMENTS facet with its own "Any" radio, close the popover.
+			await page.locator('.board-filter-bar__opt', { hasText: /^Any$/ }).click()
 			await page.locator('.board-filter-bar__back').click()
-			await page.locator('.board-filter-bar__clear').click()
 			await page.keyboard.press('Escape')
 			await expect(rowB).toBeVisible({ timeout: 10_000 })
 
@@ -436,12 +440,10 @@ test.describe('Cross-board Views (#3815)', () => {
 			await expect(rowLive).toHaveCount(0, { timeout: 15_000 })
 
 			// Clearing the facet restores the default: the archived card is gone again.
-			// Reset the Archived facet itself ("Any"), NOT the panel's global "Clear
-			// filters": on a View that button also drops the View's own saved label
-			// filter — its facet is deliberately hidden here (board-scoped label ids
-			// collide across boards), so the wipe is invisible and would widen the
-			// page to the entire cross-board feed, where the virtualised list keeps
-			// both of these rows off-screen and the assertions stop meaning anything.
+			// Reset the Archived facet itself ("Any") rather than the panel's global
+			// "Clear filters" — this step is about THIS facet, and the global button is
+			// covered by its own spec (#10091: it clears only rendered facets, so the
+			// View's hidden saved label filter survives it).
 			await page.locator('.board-filter-bar__opt', { hasText: /^Any$/ }).click()
 			await page.keyboard.press('Escape')
 			await expect(rowLive).toBeVisible({ timeout: 15_000 })

--- a/tests/e2e/views.spec.js
+++ b/tests/e2e/views.spec.js
@@ -460,6 +460,97 @@ test.describe('Cross-board Views (#3815)', () => {
 		}
 	})
 
+	test('an archived BOARD is out of a View entirely, even with the Archived facet on (#10126)', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 })
+
+		const stamp = Math.floor(Date.now() / 1000)
+		// Two boards, one card each, each tagged with its own label. The View
+		// filters to both labels, so it resolves to exactly these two rows and the
+		// virtualized list stays deterministic.
+		const live = await api.post('/boards', { title: 'ViewsLiveBoard ' + stamp })
+		const liveLabel = await api.post('/labels', { boardId: live.id, title: 'vlb ' + stamp, color: '3366ff' })
+		const liveStack = await api.post('/stacks', { boardId: live.id, title: 'To do' })
+		const liveTitle = 'ViewsLiveBoard card ' + stamp
+		const liveCard = await api.post('/cards', { stackId: liveStack.id, title: liveTitle })
+		await api.put(`/cards/${liveCard.id}/labels/${liveLabel.id}`)
+
+		const shelved = await api.post('/boards', { title: 'ViewsShelvedBoard ' + stamp })
+		const shelvedLabel = await api.post('/labels', { boardId: shelved.id, title: 'vsb ' + stamp, color: 'ff9900' })
+		const shelvedStack = await api.post('/stacks', { boardId: shelved.id, title: 'To do' })
+		const shelvedTitle = 'ViewsShelvedBoard card ' + stamp
+		const shelvedCard = await api.post('/cards', { stackId: shelvedStack.id, title: shelvedTitle })
+		await api.put(`/cards/${shelvedCard.id}/labels/${shelvedLabel.id}`)
+		// The CARD stays unarchived — only its BOARD is archived. That is the
+		// reported case: a shelved board whose cards were never archived one by one.
+		await api.patch(`/boards/${shelved.id}`, { archived: true })
+
+		const created = await api.put('/views', {
+			name: 'Views archived board ' + stamp,
+			filter: { labels: [liveLabel.id, shelvedLabel.id] },
+			groupBy: 'board',
+			display: 'list',
+		})
+		const view = created.views[created.views.length - 1]
+
+		try {
+			const fl = `${liveLabel.id},${shelvedLabel.id}`
+
+			// ── Server side: the archived board is not in the feed's board set ──
+			const feed = await api.get(`/views/cards?fl=${fl}`)
+			expect(feed.cards.map((c) => c.title)).toEqual([liveTitle])
+			expect(feed.total).toBe(1)
+
+			// … and the archived-CARDS facet cannot reach around it. That facet is
+			// about archived cards on boards that are still active, so neither
+			// 'include' nor 'only' may surface a row from an archived board.
+			const included = await api.get(`/views/cards?fl=${fl}&far=include`)
+			expect(included.cards.map((c) => c.title)).toEqual([liveTitle])
+			expect(included.cards.map((c) => c.boardId)).not.toContain(shelved.id)
+			const onlyArchived = await api.get(`/views/cards?fl=${fl}&far=only`)
+			expect(onlyArchived.cards.map((c) => c.title)).toEqual([])
+			expect(onlyArchived.total).toBe(0)
+
+			// REGRESSION GUARD: the boards LIST still ships the archived board — the
+			// boards page's Archived tab is built on it, so a filter applied to
+			// BoardService::findAll() would have silently emptied that page.
+			const boards = await api.get('/boards')
+			const shelvedRow = boards.find((b) => b.id === shelved.id)
+			expect(shelvedRow).toBeTruthy()
+			expect(shelvedRow.archived).toBe(true)
+
+			// ── Client side: the same, in the rendered View ─────────────────────
+			await ncLogin(page)
+			await page.goto(`${BASE}/index.php/apps/kanso#/views/${view.id}`)
+
+			const rowLive = page.locator('.board-list-row__title', { hasText: liveTitle })
+			const rowShelved = page.locator('.board-list-row__title', { hasText: shelvedTitle })
+			await expect(rowLive).toBeVisible({ timeout: 20_000 })
+			await expect(rowShelved).toHaveCount(0)
+
+			// Turning the Archived facet on still leaves the archived board out.
+			const includeFeed = page.waitForRequest(
+				(r) => r.url().includes('/api/views/cards') && r.url().includes('far=include'),
+				{ timeout: 20_000 },
+			)
+			await page.locator('.board-filter-bar__trigger').click()
+			await page.locator('.board-filter-bar__dim-row[data-dim="archived"]').click()
+			await page.locator('.board-filter-bar__opt', { hasText: /Include archived/ }).click()
+			await includeFeed
+			await expect(rowLive).toBeVisible({ timeout: 15_000 })
+			await expect(rowShelved).toHaveCount(0)
+
+			// Unarchiving the board brings its card straight back — proving the row
+			// was withheld by the board's archived flag and nothing else.
+			await api.patch(`/boards/${shelved.id}`, { archived: false })
+			const restored = await api.get(`/views/cards?fl=${fl}`)
+			expect(restored.cards.map((c) => c.title).sort()).toEqual([liveTitle, shelvedTitle].sort())
+		} finally {
+			await api.delete(`/views/${view.id}`).catch(() => {})
+			await api.delete(`/boards/${live.id}`).catch(() => {})
+			await api.delete(`/boards/${shelved.id}`).catch(() => {})
+		}
+	})
+
 	test('a View drops archived rows that still arrive in the feed (the client half of #10052)', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 900 })
 

--- a/tests/unit/Architecture/ArchitectureTest.php
+++ b/tests/unit/Architecture/ArchitectureTest.php
@@ -170,6 +170,37 @@ class ArchitectureTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Archived-board ratchet (#10126). Every CROSS-BOARD feed resolves its board
+	 * set through {@see \OCA\Kanso\Service\BoardService::findAllActive()}, which
+	 * drops boards the user has archived. `findAll()` keeps them and exists for
+	 * exactly one consumer - the boards-LIST payload, which the boards page
+	 * splits into its Active / Archived tabs - so it is called only from inside
+	 * BoardService itself ({@see \OCA\Kanso\Service\BoardService::findAllWithStats()}).
+	 *
+	 * This is the cross-surface guarantee the per-service tests cannot give: a
+	 * NEW feed wired to `$this->boardService->findAll(...)` re-opens the leak on
+	 * a surface nobody wrote an archived-board test for, and fails here instead.
+	 */
+	private const BOARD_SERVICE_FIND_ALL_ALLOWLIST = [];
+
+	public function testCrossBoardFeedsResolveBoardsThroughFindAllActive(): void {
+		$actual = self::scanLib(
+			static fn (string $content): bool => str_contains($content, 'boardService->findAll('),
+		);
+
+		self::assertSame(
+			self::BOARD_SERVICE_FIND_ALL_ALLOWLIST,
+			$actual,
+			'A lib/ class resolves its board set with BoardService::findAll(), which still '
+			. 'carries boards the user has ARCHIVED (#10126). Cross-board feeds must call '
+			. 'findAllActive() instead, so a shelved board stops surfacing its cards - '
+			. 'unconditionally, independent of the archived-CARDS facet. findAll() is for '
+			. 'the boards-LIST payload only (it feeds the boards page Archived tab), and '
+			. 'BoardService reaches it internally as $this->findAll().',
+		);
+	}
+
 	public function testViewerContextIsMintedOnlyByBoardAccess(): void {
 		$expected = [
 			'Access/BoardAccess.php',

--- a/tests/unit/Db/ChecklistItemMapperTest.php
+++ b/tests/unit/Db/ChecklistItemMapperTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Db;
+
+use OCA\Kanso\Db\ChecklistItemMapper;
+use OCA\Kanso\Service\CardVisibilityScope;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mapper-level tests for the checklist read order. The DB is mocked, so the
+ * query builder records every ORDER BY column and the fed rows are then sorted
+ * by exactly those columns, with rows the query left tied returned in the worst
+ * case a DB is free to pick (reverse insertion order). Checklist items have no
+ * unique sort-key index and SortKeyService::between() is deterministic, so two
+ * items CAN end up sharing a sort key - a tie must not decide their order.
+ */
+class ChecklistItemMapperTest extends TestCase {
+	private IDBConnection&MockObject $db;
+	private ChecklistItemMapper $mapper;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->mapper = new ChecklistItemMapper($this->db, new CardVisibilityScope());
+	}
+
+	/**
+	 * A stand-in for the expression builder: its OCP interface references
+	 * Doctrine symbols that are not autoloadable in the unit env, so a __call
+	 * sink returns a harmless value for every builder call.
+	 */
+	private static function exprSink(): object {
+		return new class {
+			public function __call(string $name, array $args): string {
+				return '';
+			}
+		};
+	}
+
+	/**
+	 * Sorts $rows the way a DB would: by the columns the query actually ordered
+	 * by, in order. Rows the ORDER BY leaves tied get the worst case a DB may
+	 * legally return - reverse insertion order - so an ordering that does not
+	 * fully disambiguate its rows is visibly unstable here.
+	 *
+	 * @param list<array<string, mixed>> $rows
+	 * @param list<string> $ordering ORDER BY columns, in order
+	 * @return list<array<string, mixed>>
+	 */
+	private static function sortLikeAdversarialDb(array $rows, array $ordering): array {
+		$indexed = [];
+		foreach ($rows as $i => $row) {
+			$indexed[] = ['row' => $row, 'i' => $i];
+		}
+
+		usort($indexed, static function (array $a, array $b) use ($ordering): int {
+			foreach ($ordering as $column) {
+				$left = $a['row'][$column] ?? null;
+				$right = $b['row'][$column] ?? null;
+				$cmp = \is_int($left) && \is_int($right)
+					? $left <=> $right
+					: strcmp((string)$left, (string)$right);
+				if ($cmp !== 0) {
+					return $cmp;
+				}
+			}
+			return $b['i'] <=> $a['i'];
+		});
+
+		return array_column($indexed, 'row');
+	}
+
+	/**
+	 * A query builder that records its ORDER BY columns and, on execution,
+	 * returns the fed rows sorted by exactly those columns.
+	 *
+	 * @param list<array<string, mixed>> $rows
+	 */
+	private function orderingQb(array $rows): IQueryBuilder&MockObject {
+		$qb = $this->createMock(IQueryBuilder::class);
+		foreach (['select', 'from', 'where', 'andWhere', 'setMaxResults'] as $method) {
+			$qb->method($method)->willReturnSelf();
+		}
+
+		$ordering = [];
+		$record = function (string $column, ?string $direction = null) use (&$ordering, &$qb): IQueryBuilder {
+			$ordering[] = $column;
+			return $qb;
+		};
+		$qb->method('orderBy')->willReturnCallback($record);
+		$qb->method('addOrderBy')->willReturnCallback($record);
+		$qb->method('expr')->willReturn(self::exprSink());
+		$qb->method('createNamedParameter')->willReturn('?');
+
+		$result = $this->createMock(IResult::class);
+		$queue = null;
+		$result->method('fetch')->willReturnCallback(static function () use (&$queue, $rows, &$ordering) {
+			if ($queue === null) {
+				$queue = self::sortLikeAdversarialDb($rows, $ordering);
+			}
+			$row = array_shift($queue);
+			return $row ?? false;
+		});
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}
+
+	public function testFindByCardBreaksSortKeyTiesByIdAscending(): void {
+		// Two items tied on sort_key, fed in an order that is neither id order
+		// nor the expected order, so only a real id tiebreaker in the query can
+		// produce the assertion below.
+		$this->db->method('getQueryBuilder')->willReturn($this->orderingQb([
+			['id' => 5, 'card_id' => 3, 'title' => 'Second', 'sort_key' => 'mm', 'done' => false, 'created_at' => 0],
+			['id' => 100, 'card_id' => 3, 'title' => 'First', 'sort_key' => 'aa', 'done' => false, 'created_at' => 0],
+			['id' => 9, 'card_id' => 3, 'title' => 'Third', 'sort_key' => 'mm', 'done' => false, 'created_at' => 0],
+		]));
+
+		$ids = array_map(
+			static fn ($item): int => $item->getId(),
+			$this->mapper->findByCard(3)
+		);
+
+		self::assertSame(
+			[100, 5, 9],
+			$ids,
+			'checklist items tied on sort_key must come back in a stable, id-ascending order'
+		);
+	}
+}

--- a/tests/unit/Db/StackMapperTest.php
+++ b/tests/unit/Db/StackMapperTest.php
@@ -19,6 +19,14 @@ use PHPUnit\Framework\TestCase;
  * these verify the pure-PHP contract of findByIds: an explicit id set hydrates
  * the matching stacks, and an empty set short-circuits without touching the DB
  * (never emit `IN ()`, which is invalid SQL).
+ *
+ * The ordering tests additionally pin the column order the stack reads ASK the
+ * DB for: the query builder records every ORDER BY and the fed rows are then
+ * sorted by exactly those columns, with rows the query left tied returned in the
+ * worst-case order a DB is free to pick (see {@see self::sortLikeAdversarialDb()}).
+ * Duplicate stack sort keys are reachable - stacks have no unique sort-key index
+ * and SortKeyService::between() is deterministic - so a tie must not decide the
+ * column order.
  */
 class StackMapperTest extends TestCase {
 	private IDBConnection&MockObject $db;
@@ -74,5 +82,120 @@ class StackMapperTest extends TestCase {
 	public function testFindByIdsEmptySetShortCircuitsWithoutQuery(): void {
 		$this->db->expects(self::never())->method('getQueryBuilder');
 		self::assertSame([], $this->mapper->findByIds(7, []));
+	}
+
+	/**
+	 * Sorts $rows the way a DB would: by the columns the query actually ordered
+	 * by, in order. Rows the ORDER BY leaves tied get the worst case a DB may
+	 * legally return - reverse insertion order - so an ordering that does not
+	 * fully disambiguate its rows is visibly unstable here.
+	 *
+	 * @param list<array<string, mixed>> $rows
+	 * @param list<string> $ordering ORDER BY columns, in order
+	 * @return list<array<string, mixed>>
+	 */
+	private static function sortLikeAdversarialDb(array $rows, array $ordering): array {
+		$indexed = [];
+		foreach ($rows as $i => $row) {
+			$indexed[] = ['row' => $row, 'i' => $i];
+		}
+
+		usort($indexed, static function (array $a, array $b) use ($ordering): int {
+			foreach ($ordering as $column) {
+				$left = $a['row'][$column] ?? null;
+				$right = $b['row'][$column] ?? null;
+				$cmp = \is_int($left) && \is_int($right)
+					? $left <=> $right
+					: strcmp((string)$left, (string)$right);
+				if ($cmp !== 0) {
+					return $cmp;
+				}
+			}
+			return $b['i'] <=> $a['i'];
+		});
+
+		return array_column($indexed, 'row');
+	}
+
+	/**
+	 * A query builder that records its ORDER BY columns and, on execution,
+	 * returns the fed rows sorted by exactly those columns.
+	 *
+	 * @param list<array<string, mixed>> $rows
+	 */
+	private function orderingQb(array $rows): IQueryBuilder&MockObject {
+		$qb = $this->createMock(IQueryBuilder::class);
+		foreach (['select', 'from', 'where', 'andWhere', 'setMaxResults'] as $method) {
+			$qb->method($method)->willReturnSelf();
+		}
+
+		$ordering = [];
+		$record = function (string $column, ?string $direction = null) use (&$ordering, &$qb): IQueryBuilder {
+			$ordering[] = $column;
+			return $qb;
+		};
+		$qb->method('orderBy')->willReturnCallback($record);
+		$qb->method('addOrderBy')->willReturnCallback($record);
+		$qb->method('expr')->willReturn(self::exprSink());
+		$qb->method('createNamedParameter')->willReturn('?');
+
+		$result = $this->createMock(IResult::class);
+		$queue = null;
+		$result->method('fetch')->willReturnCallback(static function () use (&$queue, $rows, &$ordering) {
+			if ($queue === null) {
+				$queue = self::sortLikeAdversarialDb($rows, $ordering);
+			}
+			$row = array_shift($queue);
+			return $row ?? false;
+		});
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}
+
+	/**
+	 * Two stacks tied on sort_key, fed in an order that is neither id order nor
+	 * the expected order, so only a real id tiebreaker in the query can produce
+	 * the assertion below.
+	 *
+	 * @return list<array<string, mixed>>
+	 */
+	private static function tiedStackRows(int $role = 0): array {
+		return [
+			['id' => 5, 'board_id' => 7, 'title' => 'Doing', 'sort_key' => 'mm', 'deleted_at' => 0, 'role' => $role],
+			['id' => 100, 'board_id' => 7, 'title' => 'Todo', 'sort_key' => 'aa', 'deleted_at' => 0, 'role' => $role],
+			['id' => 9, 'board_id' => 7, 'title' => 'Review', 'sort_key' => 'mm', 'deleted_at' => 0, 'role' => $role],
+		];
+	}
+
+	public function testFindByBoardBreaksSortKeyTiesByIdAscending(): void {
+		$this->db->method('getQueryBuilder')->willReturn($this->orderingQb(self::tiedStackRows()));
+
+		$ids = array_map(
+			static fn ($stack): int => $stack->getId(),
+			$this->mapper->findByBoard(7)
+		);
+
+		self::assertSame(
+			[100, 5, 9],
+			$ids,
+			'stacks tied on sort_key must come back in a stable, id-ascending order'
+		);
+	}
+
+	public function testFindByBoardAndRoleResolvesTiesToTheLowestId(): void {
+		$this->db->method('getQueryBuilder')->willReturn($this->orderingQb([
+			['id' => 11, 'board_id' => 7, 'title' => 'Done', 'sort_key' => 'mm', 'deleted_at' => 0, 'role' => 2],
+			['id' => 42, 'board_id' => 7, 'title' => 'Done (dup)', 'sort_key' => 'mm', 'deleted_at' => 0, 'role' => 2],
+		]));
+
+		$stack = $this->mapper->findByBoardAndRole(7, 2);
+
+		self::assertNotNull($stack);
+		self::assertSame(
+			11,
+			$stack->getId(),
+			'a role lookup tied on sort_key must always resolve to the same stack'
+		);
 	}
 }

--- a/tests/unit/Service/BoardGroupServiceTest.php
+++ b/tests/unit/Service/BoardGroupServiceTest.php
@@ -220,7 +220,7 @@ class BoardGroupServiceTest extends TestCase {
 		$this->groupMapper->method('findByUser')->with('alice')
 			->willReturn([$this->group(1, 'alice', 'Work', 0), $this->group(2, 'alice', 'Personal', 1)]);
 		// Readable board set is derived from findAll (ACL-authorized).
-		$this->boardService->method('findAll')->with('alice')
+		$this->boardService->method('findAllActive')->with('alice')
 			->willReturn([$this->board(10), $this->board(11), $this->board(12)]);
 		// ONE batched lookup over the readable ids.
 		$this->memberMapper->expects(self::once())
@@ -237,9 +237,33 @@ class BoardGroupServiceTest extends TestCase {
 		self::assertSame([12], $out[1]['boardIds']);
 	}
 
+	public function testListGroupsSkipsBoardsTheUserHasArchived(): void {
+		// #10126: an archived board leaves its folder's listing. The mock mirrors
+		// the real BoardService - findAll() STILL carries the archived board (the
+		// boards page's Archived tab is built on it), only findAllActive() drops
+		// it - so reverting the service to findAll() puts board 11 back in the
+		// batched lookup and this goes red. The membership row itself is kept, so
+		// unarchiving restores the board to its folder.
+		$active = $this->board(10);
+		$archived = $this->board(11);
+		$archived->setArchived(true);
+		$this->groupMapper->method('findByUser')->with('alice')
+			->willReturn([$this->group(1, 'alice', 'Work', 0)]);
+		$this->boardService->method('findAll')->with('alice')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$active]);
+		$this->memberMapper->expects(self::once())
+			->method('findGroupIdsByBoards')->with('alice', [10])
+			->willReturn([10 => 1]);
+
+		// The active board is still filed under the folder - both halves matter,
+		// or a filter that dropped everything would pass too.
+		$out = $this->service->listGroups('alice');
+		self::assertSame([10], $out[0]['boardIds']);
+	}
+
 	public function testListGroupsEmptyWhenNoFolders(): void {
 		$this->groupMapper->method('findByUser')->with('alice')->willReturn([]);
-		$this->boardService->expects(self::never())->method('findAll');
+		$this->boardService->expects(self::never())->method('findAllActive');
 		self::assertSame([], $this->service->listGroups('alice'));
 	}
 
@@ -251,7 +275,7 @@ class BoardGroupServiceTest extends TestCase {
 		$g3 = $this->group(3, 'alice', 'C', 2);
 		// findByUser is called by reorder AND by the trailing listGroups.
 		$this->groupMapper->method('findByUser')->with('alice')->willReturn([$g1, $g2, $g3]);
-		$this->boardService->method('findAll')->with('alice')->willReturn([]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([]);
 		$this->memberMapper->method('findGroupIdsByBoards')->willReturn([]);
 
 		$updated = [];

--- a/tests/unit/Service/BoardServiceTest.php
+++ b/tests/unit/Service/BoardServiceTest.php
@@ -526,6 +526,23 @@ class BoardServiceTest extends TestCase {
 		self::assertSame($boards, $this->service->findAll('alice'));
 	}
 
+	public function testFindAllActiveDropsArchivedBoardsWhileFindAllKeepsThem(): void {
+		// #10126: the cross-board FEEDS (Views, My tasks, Inbox, My reviews,
+		// search, My steps, projects, folders) read findAllActive(), so a board
+		// the user shelved stops surfacing its cards there. findAll() must keep
+		// carrying it: the boards-list payload is what the boards page splits
+		// into Active / Archived tabs, and filtering here would empty that tab.
+		$active = $this->board(1);
+		$archived = $this->board(2);
+		$archived->setArchived(true);
+		$this->permissionService->method('getUserGroupIds')->with('alice')->willReturn([]);
+		$this->boardMapper->method('findAllForUser')->with('alice', [])->willReturn([$active, $archived]);
+
+		$ids = static fn (array $boards): array => array_map(static fn (Board $b): int => $b->getId(), $boards);
+		self::assertSame([1, 2], $ids($this->service->findAll('alice')), 'the boards LIST still sees archived boards');
+		self::assertSame([1], $ids($this->service->findAllActive('alice')), 'the feeds do not');
+	}
+
 	public function testFindAllWithStatsStitchesBatchedAggregatesOntoEachBoard(): void {
 		$b1 = $this->board(1, 'alice');
 		$b2 = $this->board(2, 'alice');

--- a/tests/unit/Service/InboxServiceTest.php
+++ b/tests/unit/Service/InboxServiceTest.php
@@ -56,7 +56,7 @@ class InboxServiceTest extends TestCase {
 	}
 
 	public function testFindMineReturnsCommentsOnFollowedCardsInReadableBoards(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([$this->board(1), $this->board(2)]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([$this->board(1), $this->board(2)]);
 		$this->subscriptionMapper->method('findSubscribedCardIds')->with('bob')->willReturn([9, 10]);
 		$roles = [1 => ViewerContext::ROLE_INTERNAL, 2 => ViewerContext::ROLE_EXTERNAL];
 		$this->boardAccess->expects(self::once())->method('rolesFor')->willReturn($roles);
@@ -79,7 +79,7 @@ class InboxServiceTest extends TestCase {
 	}
 
 	public function testFindMineMergesCommentsAndStatusChangesNewestFirst(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([$this->board(1)]);
 		$this->subscriptionMapper->method('findSubscribedCardIds')->with('bob')->willReturn([9]);
 		$roles = [1 => ViewerContext::ROLE_INTERNAL];
 		$this->boardAccess->method('rolesFor')->willReturn($roles);
@@ -107,8 +107,42 @@ class InboxServiceTest extends TestCase {
 		self::assertSame('comment', $result[1]['type']);
 	}
 
+	public function testFindMineSkipsBoardsTheUserHasArchived(): void {
+		// #10126: a followed card on an archived board stops feeding the Inbox.
+		// The mock mirrors the real BoardService - findAll() STILL carries the
+		// archived board (the boards page's Archived tab is built on it), only
+		// findAllActive() drops it - so reverting the service to findAll() puts
+		// board 2 back in the queried set and this goes red.
+		$active = $this->board(1);
+		$archived = $this->board(2);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->with('bob')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([$active]);
+		$this->subscriptionMapper->method('findSubscribedCardIds')->with('bob')->willReturn([9, 10]);
+		$roles = [1 => ViewerContext::ROLE_INTERNAL];
+		$this->boardAccess->method('rolesFor')->willReturn($roles);
+
+		// Only the active board is queried - the archived one is not in the set.
+		$row = [
+			'id' => 5, 'cardId' => 9, 'boardId' => 1, 'cardTitle' => 'Card', 'boardTitle' => 'Board',
+			'author' => 'alice', 'body' => 'hi', 'createdAt' => 100,
+		];
+		$this->commentMapper->expects(self::once())
+			->method('findInboxForCards')
+			->with([9, 10], [1], 'bob', 50, $roles)
+			->willReturn([$row]);
+		$this->changeMapper->method('findInboxForCards')->willReturn([]);
+		$this->userManager->method('get')->willReturn(null);
+
+		// The active board's item still arrives - both halves matter, or a filter
+		// that dropped everything would pass too.
+		$result = $this->service->findMine('bob');
+		self::assertCount(1, $result);
+		self::assertSame(1, $result[0]['boardId']);
+	}
+
 	public function testFindMineEmptyWhenNoReadableBoards(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([]);
 		$this->subscriptionMapper->expects(self::never())->method('findSubscribedCardIds');
 		$this->commentMapper->expects(self::never())->method('findInboxForCards');
 
@@ -116,7 +150,7 @@ class InboxServiceTest extends TestCase {
 	}
 
 	public function testFindMineEmptyWhenNoSubscribedCards(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([$this->board(1)]);
 		$this->subscriptionMapper->method('findSubscribedCardIds')->with('bob')->willReturn([]);
 		$this->commentMapper->expects(self::never())->method('findInboxForCards');
 

--- a/tests/unit/Service/MyCardsServiceTest.php
+++ b/tests/unit/Service/MyCardsServiceTest.php
@@ -45,7 +45,7 @@ class MyCardsServiceTest extends TestCase {
 		// The ACL boundary: only the boards findAll() returns (the readable set)
 		// are ever passed to the query, and only the current user's identity.
 		$this->boardService->expects($this->once())
-			->method('findAll')
+			->method('findAllActive')
 			->with('alice')
 			->willReturn([$this->board(3), $this->board(9)]);
 
@@ -65,8 +65,50 @@ class MyCardsServiceTest extends TestCase {
 		$this->assertFalse($feed['truncated']);
 	}
 
+	public function testFindMineSkipsBoardsTheUserHasArchived(): void {
+		// #10126: a card assigned to me on an archived board leaves My tasks.
+		// The mock mirrors the real BoardService - findAll() STILL carries the
+		// archived board (the boards page's Archived tab is built on it), only
+		// findAllActive() drops it - so reverting the service to findAll() puts
+		// board 9 back in the queried set and this goes red.
+		$active = $this->board(3);
+		$archived = $this->board(9);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->willReturn([$active]);
+		$roles = [3 => ViewerContext::ROLE_INTERNAL];
+		$this->boardAccess->method('rolesFor')->willReturn($roles);
+
+		$expected = [['id' => 1, 'boardId' => 3, 'title' => 'A task']];
+		$this->cardMapper->expects($this->once())
+			->method('findAssignedInBoards')
+			->with(['alice'], [3], 'alice', $roles, MyCardsService::LIMIT + 1)
+			->willReturn($expected);
+
+		// The identical card on the ACTIVE board still arrives - both halves
+		// matter, or a filter that dropped everything would pass too.
+		$this->assertSame($expected, $this->service->findMine('alice')['cards']);
+	}
+
+	public function testFindMineRecentlyDoneSkipsBoardsTheUserHasArchived(): void {
+		// The opt-in recently-done feed shares the boundary: an archived board's
+		// completed cards are gone from it too (#10126).
+		$active = $this->board(3);
+		$archived = $this->board(9);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->willReturn([$active]);
+		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
+
+		$done = [['id' => 2, 'boardId' => 3, 'title' => 'A finished task']];
+		[$args, $feed] = $this->captureRecentlyDone('alice', $done);
+
+		$this->assertSame([3], $args[1], 'only the ACTIVE readable board set is queried');
+		$this->assertSame($done, $feed['cards']);
+	}
+
 	public function testFindMineWithNoReadableBoardsQueriesEmptySet(): void {
-		$this->boardService->method('findAll')->willReturn([]);
+		$this->boardService->method('findAllActive')->willReturn([]);
 		$this->boardAccess->method('rolesFor')->willReturn([]);
 		$this->cardMapper->expects($this->once())
 			->method('findAssignedInBoards')
@@ -93,7 +135,7 @@ class MyCardsServiceTest extends TestCase {
 		// 201 assigned cards: the user is over the cap. The feed must SAY it is
 		// truncated - a silent 200-row slice makes the page (and the nav badge
 		// counting the same array) claim a wrong, frozen total.
-		$this->boardService->method('findAll')->willReturn([$this->board(3)]);
+		$this->boardService->method('findAllActive')->willReturn([$this->board(3)]);
 		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
 		$this->cardMapper->expects($this->once())
 			->method('findAssignedInBoards')
@@ -114,7 +156,7 @@ class MyCardsServiceTest extends TestCase {
 	public function testFindMineAtExactlyTheLimitIsNotTruncated(): void {
 		// Exactly LIMIT rows means the query found no row beyond the cap - the
 		// feed is complete and must not cry "more".
-		$this->boardService->method('findAll')->willReturn([$this->board(3)]);
+		$this->boardService->method('findAllActive')->willReturn([$this->board(3)]);
 		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
 		$this->cardMapper->method('findAssignedInBoards')->willReturn($this->rows(MyCardsService::LIMIT));
 
@@ -157,7 +199,7 @@ class MyCardsServiceTest extends TestCase {
 		// can never be returned, because that board id never reaches the query.
 		// Same boundary as the open feed - assignment grants no visibility.
 		$this->boardService->expects($this->once())
-			->method('findAll')
+			->method('findAllActive')
 			->with('alice')
 			->willReturn([$this->board(3), $this->board(9)]);
 
@@ -176,7 +218,7 @@ class MyCardsServiceTest extends TestCase {
 	public function testFindMineRecentlyDoneWithNoReadableBoardsQueriesTheEmptySet(): void {
 		// No readable boards → an empty board set, which the mapper
 		// short-circuits. Nothing assigned can leak through the back door.
-		$this->boardService->method('findAll')->willReturn([]);
+		$this->boardService->method('findAllActive')->willReturn([]);
 		$this->boardAccess->method('rolesFor')->willReturn([]);
 
 		[$args, $feed] = $this->captureRecentlyDone('bob', []);
@@ -191,7 +233,7 @@ class MyCardsServiceTest extends TestCase {
 		// not - so a user with years of completed work still gets a query that
 		// touches a fortnight. Widen or narrow RECENT_DONE_WINDOW_DAYS and one
 		// of these two assertions fails.
-		$this->boardService->method('findAll')->willReturn([$this->board(3)]);
+		$this->boardService->method('findAllActive')->willReturn([$this->board(3)]);
 		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
 
 		$now = time();
@@ -217,7 +259,7 @@ class MyCardsServiceTest extends TestCase {
 		// The second bound. The window alone has no ceiling for someone who
 		// closes hundreds of cards a fortnight, so the row cap applies too -
 		// and, like the open feed's, it is reported rather than silent.
-		$this->boardService->method('findAll')->willReturn([$this->board(3)]);
+		$this->boardService->method('findAllActive')->willReturn([$this->board(3)]);
 		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
 
 		[$args, $feed] = $this->captureRecentlyDone('alice', $this->rows(MyCardsService::RECENT_DONE_LIMIT + 1));
@@ -234,7 +276,7 @@ class MyCardsServiceTest extends TestCase {
 	}
 
 	public function testFindMineRecentlyDoneAtExactlyTheLimitIsNotTruncated(): void {
-		$this->boardService->method('findAll')->willReturn([$this->board(3)]);
+		$this->boardService->method('findAllActive')->willReturn([$this->board(3)]);
 		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
 
 		[, $feed] = $this->captureRecentlyDone('alice', $this->rows(MyCardsService::RECENT_DONE_LIMIT));
@@ -246,7 +288,7 @@ class MyCardsServiceTest extends TestCase {
 	public function testFindMineRecentlyDoneDoesNotTouchTheOpenFeed(): void {
 		// The two feeds are independent queries: asking for completed work must
 		// not re-run (or replace) the open one.
-		$this->boardService->method('findAll')->willReturn([$this->board(3)]);
+		$this->boardService->method('findAllActive')->willReturn([$this->board(3)]);
 		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
 		$this->cardMapper->expects($this->never())->method('findAssignedInBoards');
 

--- a/tests/unit/Service/MyStepsServiceTest.php
+++ b/tests/unit/Service/MyStepsServiceTest.php
@@ -41,7 +41,7 @@ class MyStepsServiceTest extends TestCase {
 		// returns are ever queried, and the viewer's per-board role map rides
 		// along so the card-visibility scope can hide steps of hidden cards.
 		$this->boardService->expects($this->once())
-			->method('findAll')
+			->method('findAllActive')
 			->with('alice')
 			->willReturn([$this->board(3), $this->board(9)]);
 
@@ -59,8 +59,33 @@ class MyStepsServiceTest extends TestCase {
 		$this->assertSame($expected, $this->service->findMine('alice'));
 	}
 
+	public function testFindMineSkipsBoardsTheUserHasArchived(): void {
+		// #10126: an archived board is shelved - its steps leave this feed even
+		// though the checklist items themselves are still open. The mock mirrors
+		// the real BoardService: findAll() STILL carries the archived board (the
+		// boards page's Archived tab is built on it), only findAllActive() drops
+		// it - so reverting the service to findAll() puts board 9 back in the
+		// queried set and this goes red.
+		$active = $this->board(3);
+		$archived = $this->board(9);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->with('alice')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$active]);
+		$this->boardAccess->method('rolesFor')->willReturn([3 => ViewerContext::ROLE_INTERNAL]);
+
+		$step = ['id' => 7, 'cardId' => 1, 'boardId' => 3, 'title' => 'Send the contract'];
+		$this->checklistItemMapper->expects($this->once())
+			->method('findOpenAssignedInBoards')
+			->with('alice', [3], [3 => ViewerContext::ROLE_INTERNAL])
+			->willReturn([$step]);
+
+		// The active board's identical step DOES come back - both halves matter,
+		// or a filter that dropped everything would pass too.
+		$this->assertSame([$step], $this->service->findMine('alice'));
+	}
+
 	public function testFindMineWithNoReadableBoardsQueriesEmptySet(): void {
-		$this->boardService->method('findAll')->willReturn([]);
+		$this->boardService->method('findAllActive')->willReturn([]);
 		$this->boardAccess->method('rolesFor')->willReturn([]);
 		$this->checklistItemMapper->expects($this->once())
 			->method('findOpenAssignedInBoards')

--- a/tests/unit/Service/ProjectServiceTest.php
+++ b/tests/unit/Service/ProjectServiceTest.php
@@ -165,13 +165,40 @@ class ProjectServiceTest extends TestCase {
 
 	public function testListCardsFiltersToReadableBoardSet(): void {
 		$this->projectMapper->method('find')->with(5)->willReturn($this->project('alice'));
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1), $this->board(7)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1), $this->board(7)]);
 		$this->projectCardMapper->expects(self::once())
 			->method('findCardsInProjectAndBoards')
 			->with(5, [1, 7])
 			->willReturn([['id' => 9, 'boardId' => 1]]);
 		$result = $this->service->listCards(5, 'alice');
 		self::assertSame(9, $result[0]['id']);
+	}
+
+	public function testListCardsAndStatsSkipBoardsTheOwnerHasArchived(): void {
+		// #10126: an archived board's cards drop out of the project - both from
+		// its card list and from the metrics computed over the same set. The mock
+		// mirrors the real BoardService: findAll() STILL carries the archived
+		// board (the boards page's Archived tab is built on it), only
+		// findAllActive() drops it - so reverting the service to findAll() puts
+		// board 7 back in the frame and this goes red.
+		$active = $this->board(1);
+		$archived = $this->board(7);
+		$archived->setArchived(true);
+		$this->projectMapper->method('find')->with(5)->willReturn($this->project('alice'));
+		$this->boardService->method('findAll')->with('alice')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$active]);
+
+		$this->projectCardMapper->expects(self::exactly(2))
+			->method('findCardsInProjectAndBoards')
+			->with(5, [1])
+			->willReturn([['id' => 9, 'boardId' => 1]]);
+		$this->statsService->method('projectStats')->with([9])->willReturn(['cardCount' => 1]);
+
+		// The card on the ACTIVE board is still listed and still counted - both
+		// halves matter, or a filter that dropped everything would pass too.
+		$result = $this->service->listCards(5, 'alice');
+		self::assertSame([9], array_column($result, 'id'));
+		self::assertSame(1, $this->service->stats(5, 'alice')['cardCount']);
 	}
 
 	public function testListCardsRejectsNonOwner(): void {
@@ -183,7 +210,7 @@ class ProjectServiceTest extends TestCase {
 
 	public function testStatsResolvesReadableCardIdsAndDelegatesToStatsService(): void {
 		$this->projectMapper->method('find')->with(5)->willReturn($this->project('alice'));
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1), $this->board(7)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1), $this->board(7)]);
 		// The ACL-filtered card set (already restricted to boards 1 & 7).
 		$this->projectCardMapper->expects(self::once())
 			->method('findCardsInProjectAndBoards')
@@ -218,7 +245,7 @@ class ProjectServiceTest extends TestCase {
 		// drops it - so the id set fed to projectStats holds only the readable
 		// card. This is the cross-board-leak guard for project analytics.
 		$this->projectMapper->method('find')->with(5)->willReturn($this->project('alice'));
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
 
 		$this->projectCardMapper->expects(self::once())
 			->method('findCardsInProjectAndBoards')

--- a/tests/unit/Service/ReviewServiceTest.php
+++ b/tests/unit/Service/ReviewServiceTest.php
@@ -683,7 +683,7 @@ class ReviewServiceTest extends TestCase {
 	// ---- findMine ---------------------------------------------------------
 
 	public function testFindMineQueriesTheReadableBoardSet(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([
 			$this->board(1),
 			$this->board(2),
 		]);
@@ -703,8 +703,37 @@ class ReviewServiceTest extends TestCase {
 		self::assertSame($rows, $this->service->findMine('bob'));
 	}
 
+	public function testFindMineSkipsBoardsTheUserHasArchived(): void {
+		// #10126: a review requested on an archived board leaves My reviews. The
+		// mock mirrors the real BoardService - findAll() STILL carries the
+		// archived board (the boards page's Archived tab is built on it), only
+		// findAllActive() drops it - so reverting the service to findAll() puts
+		// board 2 back in the queried set and this goes red.
+		$active = $this->board(1);
+		$archived = $this->board(2);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->with('bob')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([$active]);
+		$roles = [1 => ViewerContext::ROLE_INTERNAL];
+		$this->boardAccess->method('rolesFor')->willReturn($roles);
+
+		$rows = [[
+			'id' => 1, 'cardId' => 9, 'cardTitle' => 'Card', 'boardId' => 1,
+			'boardTitle' => 'Board', 'state' => 'pending', 'reviewTypeId' => null,
+			'requestedBy' => 'alice', 'createdAt' => 100,
+		]];
+		$this->cardReviewMapper->expects(self::once())
+			->method('findByReviewerInBoards')
+			->with('bob', [1], $roles)
+			->willReturn($rows);
+
+		// The identical review on the ACTIVE board still arrives - both halves
+		// matter, or a filter that dropped everything would pass too.
+		self::assertSame($rows, $this->service->findMine('bob'));
+	}
+
 	public function testFindMineWithNoReadableBoardsReturnsEmpty(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([]);
 		$this->boardAccess->method('rolesFor')->willReturn([]);
 		$this->cardReviewMapper->expects(self::once())
 			->method('findByReviewerInBoards')

--- a/tests/unit/Service/SearchServiceTest.php
+++ b/tests/unit/Service/SearchServiceTest.php
@@ -63,7 +63,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testShortQueryReturnsEmptyWithoutTouchingBoards(): void {
-		$this->boardService->expects(self::never())->method('findAll');
+		$this->boardService->expects(self::never())->method('findAllActive');
 		$this->cardMapper->expects(self::never())->method('searchInBoards');
 
 		$result = $this->service->search('a', 'alice', null, 25, 0);
@@ -71,14 +71,14 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testBlankQueryReturnsEmpty(): void {
-		$this->boardService->expects(self::never())->method('findAll');
+		$this->boardService->expects(self::never())->method('findAllActive');
 		$result = $this->service->search('   ', 'alice', null, 25, 0);
 		self::assertSame(0, $result['total']);
 		self::assertSame([], $result['results']);
 	}
 
 	public function testNoReadableBoardsReturnsEmpty(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([]);
 		$this->cardMapper->expects(self::never())->method('searchInBoards');
 		$this->commentMapper->expects(self::never())->method('searchInBoards');
 
@@ -87,7 +87,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testRanksCardTitleThenDescriptionThenComment(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
 		// Source order is most-recent-first; ranking must reorder to title>desc.
 		$this->cardMapper->method('searchInBoards')->willReturn([
 			$this->card(20, 1, 'Unrelated', 'contains widget in body'), // desc-only → rank 2
@@ -108,8 +108,53 @@ class SearchServiceTest extends TestCase {
 		self::assertSame(5, $result['results'][2]['commentId']);
 	}
 
+	public function testSearchSkipsBoardsTheUserHasArchived(): void {
+		// #10126: an archived board is shelved - its cards and comments leave
+		// search entirely. The mock mirrors the real BoardService: findAll()
+		// STILL carries the archived board (the boards page's Archived tab is
+		// built on it), only findAllActive() drops it - so reverting the service
+		// to findAll() puts board 7 back in the searched set and this goes red.
+		$active = $this->board(1);
+		$archived = $this->board(7);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->with('alice')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$active]);
+		$roles = [1 => ViewerContext::ROLE_INTERNAL];
+		$this->boardAccess->method('rolesFor')->willReturn($roles);
+
+		$this->cardMapper->expects(self::once())
+			->method('searchInBoards')
+			->with([1], self::anything(), self::anything(), 'alice', $roles)
+			->willReturn([$this->card(20, 1, 'Widget master', 'nope')]);
+		$this->commentMapper->expects(self::once())
+			->method('searchInBoards')
+			->with([1], self::anything(), self::anything(), 'alice', $roles)
+			->willReturn([]);
+
+		// The identical card on the ACTIVE board still matches - both halves
+		// matter, or a filter that dropped everything would pass too.
+		$result = $this->service->search('widget', 'alice', null, 25, 0);
+		self::assertSame(1, $result['total']);
+		self::assertSame(20, $result['results'][0]['cardId']);
+	}
+
+	public function testArchivedBoardCannotBeSearchedByExplicitBoardScope(): void {
+		// The board-scope parameter is checked against the SAME active set, so
+		// naming an archived board explicitly does not reach around the filter.
+		$active = $this->board(1);
+		$archived = $this->board(7);
+		$archived->setArchived(true);
+		$this->boardService->method('findAll')->with('alice')->willReturn([$active, $archived]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$active]);
+		$this->cardMapper->expects(self::never())->method('searchInBoards');
+		$this->commentMapper->expects(self::never())->method('searchInBoards');
+
+		$result = $this->service->search('widget', 'alice', 7, 25, 0);
+		self::assertSame(0, $result['total']);
+	}
+
 	public function testBoardScopeRejectsUnreadableBoard(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
 		// Requesting board 99 (not readable) must yield no results and never query.
 		$this->cardMapper->expects(self::never())->method('searchInBoards');
 		$this->commentMapper->expects(self::never())->method('searchInBoards');
@@ -119,7 +164,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testBoardScopeNarrowsToRequestedReadableBoard(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1), $this->board(2)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1), $this->board(2)]);
 		$this->cardMapper->expects(self::once())
 			->method('searchInBoards')
 			->with([2], self::anything(), self::anything())
@@ -130,7 +175,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testSearchesAllReadableBoardsWhenNoBoardScope(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1), $this->board(7)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1), $this->board(7)]);
 		// Both sources are scoped by the viewer's uid + per-board roles (#3743).
 		$roles = [1 => ViewerContext::ROLE_INTERNAL, 7 => ViewerContext::ROLE_EXTERNAL];
 		$this->boardAccess->expects(self::once())->method('rolesFor')->willReturn($roles);
@@ -147,7 +192,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testEscapesLikeWildcardsInTerm(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
 		$this->cardMapper->expects(self::once())
 			->method('searchInBoards')
 			->willReturnCallback(function (array $ids, string $pattern): array {
@@ -163,7 +208,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testPaginationSlicesResults(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
 		$cards = [];
 		for ($i = 1; $i <= 5; $i++) {
 			$cards[] = $this->card($i, 1, 'Widget ' . $i);
@@ -177,7 +222,7 @@ class SearchServiceTest extends TestCase {
 	}
 
 	public function testSnippetIsTruncated(): void {
-		$this->boardService->method('findAll')->with('alice')->willReturn([$this->board(1)]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
 		$long = str_repeat('lorem ipsum ', 40); // > 160 chars
 		$this->cardMapper->method('searchInBoards')->willReturn([$this->card(1, 1, 'Widget', $long)]);
 		$this->commentMapper->method('searchInBoards')->willReturn([]);

--- a/tests/unit/Service/ViewServiceTest.php
+++ b/tests/unit/Service/ViewServiceTest.php
@@ -75,7 +75,7 @@ class ViewServiceTest extends TestCase {
 		$b3 = $this->board(3, 'Alpha');
 		$b9 = $this->board(9, 'Beta');
 		$this->boardService->expects(self::once())
-			->method('findAll')->with('alice')->willReturn([$b3, $b9]);
+			->method('findAllActive')->with('alice')->willReturn([$b3, $b9]);
 
 		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
 		$ctx9 = ViewerContext::forMember('alice', 9, ViewerContext::ROLE_EXTERNAL, false);
@@ -121,7 +121,7 @@ class ViewServiceTest extends TestCase {
 		$b3 = $this->board(3, 'Alpha', 'ALP');
 		// A board with no explicit prefix falls back to the shared default.
 		$b9 = $this->board(9, 'Beta', null);
-		$this->boardService->method('findAll')->with('alice')->willReturn([$b3, $b9]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$b3, $b9]);
 
 		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
 		$ctx9 = ViewerContext::forMember('alice', 9, ViewerContext::ROLE_INTERNAL, true);
@@ -178,7 +178,7 @@ class ViewServiceTest extends TestCase {
 
 		// One readable board whose (viewer-gated) summary set exceeds the cap.
 		$b1 = $this->board(1, 'Huge');
-		$this->boardService->method('findAll')->with('alice')->willReturn([$b1]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$b1]);
 		$ctx1 = ViewerContext::forMember('alice', 1, ViewerContext::ROLE_INTERNAL, true);
 		$this->boardAccess->method('contextFor')->with($b1, 'alice')->willReturn($ctx1);
 
@@ -209,7 +209,7 @@ class ViewServiceTest extends TestCase {
 		// alice can read board 3 only; board 7 (which she cannot read) exists in
 		// the system but is absent from findAll()'s readable set.
 		$b3 = $this->board(3, 'Readable');
-		$this->boardService->method('findAll')->with('alice')->willReturn([$b3]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$b3]);
 
 		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
 		$this->boardAccess->method('contextFor')->with($b3, 'alice')->willReturn($ctx3);
@@ -245,7 +245,7 @@ class ViewServiceTest extends TestCase {
 			$boards[] = $board;
 			$contexts[] = [$board, 'alice', ViewerContext::forMember('alice', $boardId, ViewerContext::ROLE_INTERNAL, true)];
 		}
-		$this->boardService->method('findAll')->with('alice')->willReturn($boards);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn($boards);
 		$this->boardAccess->method('contextFor')->willReturnMap($contexts);
 		$this->cardMapper->method('findSummariesByBoard')
 			->willReturnCallback(fn (int $boardId): array => array_map(
@@ -376,7 +376,7 @@ class ViewServiceTest extends TestCase {
 	 */
 	public function testFindMineWithASortStillNeverQueriesABoardOutsideTheReadableSet(): void {
 		$b3 = $this->board(3, 'Readable');
-		$this->boardService->method('findAll')->with('alice')->willReturn([$b3]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$b3]);
 		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
 		$this->boardAccess->method('contextFor')->with($b3, 'alice')->willReturn($ctx3);
 
@@ -524,7 +524,7 @@ class ViewServiceTest extends TestCase {
 	public function testFindMineWithAFilterStillNeverQueriesABoardOutsideTheReadableSet(): void {
 		// alice can read board 3 only. Board 7 exists but is absent from findAll().
 		$b3 = $this->board(3, 'Readable');
-		$this->boardService->method('findAll')->with('alice')->willReturn([$b3]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$b3]);
 		$ctx3 = ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true);
 		$this->boardAccess->method('contextFor')->with($b3, 'alice')->willReturn($ctx3);
 
@@ -680,8 +680,52 @@ class ViewServiceTest extends TestCase {
 		);
 	}
 
+	/**
+	 * #10126: an ARCHIVED BOARD is out of the View entirely - including its live,
+	 * never-archived cards - and UNCONDITIONALLY: the archived-CARDS facet
+	 * ('include' / 'only') is about archived cards on boards that are still
+	 * ACTIVE, so it can never opt an archived board's rows back in.
+	 *
+	 * The wiring mirrors the real BoardService: findAll() STILL carries the
+	 * archived board (the boards page's Archived tab is built on it), only
+	 * findAllActive() drops it - and the mappers WOULD hand back a row for board
+	 * 9 if it were ever queried. So reverting the service to findAll() makes card
+	 * 22 reappear and this goes red.
+	 */
+	public function testFindMineExcludesArchivedBoardsEvenUnderTheArchivedFacet(): void {
+		$active = $this->board(3, 'Alpha');
+		$shelved = $this->board(9, 'Shelved');
+		$shelved->setArchived(true);
+		$this->boardService->method('findAll')->with('alice')->willReturn([$active, $shelved]);
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$active]);
+		$this->boardAccess->method('contextFor')->willReturnMap([
+			[$active, 'alice', ViewerContext::forMember('alice', 3, ViewerContext::ROLE_INTERNAL, true)],
+			[$shelved, 'alice', ViewerContext::forMember('alice', 9, ViewerContext::ROLE_INTERNAL, true)],
+		]);
+		$this->cardMapper->method('findSummariesByBoard')
+			->willReturnCallback(fn (int $boardId): array => [$this->summaryCard($boardId === 3 ? 11 : 22, $boardId)]);
+		// The archived board's card is NOT itself archived - exactly the reported
+		// case: a shelved board whose cards were never archived one by one.
+		$this->cardSummaryService->method('serialize')
+			->willReturnCallback(static fn (int $boardId): array => [
+				['id' => $boardId === 3 ? 11 : 22, 'archived' => false],
+			]);
+
+		foreach (['default' => [], 'include' => ['far' => 'include'], 'only' => ['far' => 'only']] as $label => $query) {
+			$result = $this->service->findMine('alice', 'default', 'asc', ViewFilter::fromQuery($query));
+			self::assertNotContains(22, $this->idsOf($result), 'archived board leaked with archived=' . $label);
+			self::assertNotContains(9, array_column($result['cards'], 'boardId'), 'archived board leaked with archived=' . $label);
+		}
+
+		// The ACTIVE board's card is still in the feed - both halves matter, or a
+		// filter that dropped everything would pass too.
+		$default = $this->service->findMine('alice');
+		self::assertSame([11], $this->idsOf($default));
+		self::assertSame(1, $default['total']);
+	}
+
 	public function testFindMineEmptyWhenNoReadableBoards(): void {
-		$this->boardService->method('findAll')->with('bob')->willReturn([]);
+		$this->boardService->method('findAllActive')->with('bob')->willReturn([]);
 		$this->boardAccess->expects(self::never())->method('contextFor');
 		$this->cardMapper->expects(self::never())->method('findSummariesByBoard');
 

--- a/tests/unit/rrule.test.mjs
+++ b/tests/unit/rrule.test.mjs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10045 — the recurrence editor used to re-serialize every rule it saved from
+// the five fields it parses (FREQ / INTERVAL / BYDAY / COUNT / UNTIL), so a rule
+// authored through the API with, say, BYMONTHDAY=1,15 came back as a bare
+// FREQ=MONTHLY. The editor now asks isCustomRrule() first and leaves such a rule
+// alone. These cases pin the classifier and the parse/serialize round trip.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+	rruleParts,
+	isCustomRrule,
+	parseRecurRrule,
+	buildRecurRrule,
+} from '../../src/utils/rrule.js'
+
+test('rruleParts splits into an uppercase-keyed map and ignores junk segments', () => {
+	assert.deepEqual(rruleParts('freq=WEEKLY;INTERVAL=2'), { FREQ: 'WEEKLY', INTERVAL: '2' })
+	assert.deepEqual(rruleParts('FREQ=DAILY;;GARBAGE'), { FREQ: 'DAILY' })
+	assert.deepEqual(rruleParts(''), {})
+	assert.deepEqual(rruleParts(null), {})
+})
+
+test('a rule the editor fully models is NOT custom', () => {
+	assert.equal(isCustomRrule('FREQ=WEEKLY;BYDAY=MO,WE'), false)
+	assert.equal(isCustomRrule('FREQ=DAILY'), false)
+	assert.equal(isCustomRrule('FREQ=MONTHLY;INTERVAL=3'), false)
+	assert.equal(isCustomRrule('FREQ=YEARLY;COUNT=5'), false)
+	assert.equal(isCustomRrule('FREQ=WEEKLY;UNTIL=20270101T000000Z'), false)
+})
+
+test('a part outside the modelled set makes the rule custom', () => {
+	// The card's headline case: twice a month, authored through the API.
+	assert.equal(isCustomRrule('FREQ=MONTHLY;BYMONTHDAY=1,15'), true)
+	assert.equal(isCustomRrule('FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=29'), true)
+	assert.equal(isCustomRrule('FREQ=MONTHLY;BYSETPOS=-1;BYDAY=FR'), true)
+	assert.equal(isCustomRrule('FREQ=WEEKLY;WKST=SU'), true)
+})
+
+test('BYDAY is only round-trippable on a weekly rule, and never with an ordinal', () => {
+	// "First Monday of the month" — the builder emits BYDAY for WEEKLY only, so
+	// re-serializing this dropped it entirely.
+	assert.equal(isCustomRrule('FREQ=MONTHLY;BYDAY=1MO'), true)
+	assert.equal(isCustomRrule('FREQ=MONTHLY;BYDAY=MO'), true)
+	// An ordinal the weekday checkboxes would mangle back into a bare "1MO".
+	assert.equal(isCustomRrule('FREQ=WEEKLY;BYDAY=1MO'), true)
+	assert.equal(isCustomRrule('FREQ=WEEKLY;BYDAY=-1FR'), true)
+})
+
+test('an end condition the parser cannot read back is custom, not silently dropped', () => {
+	// Parsing these loses the end condition entirely, so re-serializing would
+	// turn a bounded rule into an endless one.
+	assert.equal(isCustomRrule('FREQ=WEEKLY;UNTIL=2027-03-01T00:00:00Z'), true)
+	assert.equal(isCustomRrule('FREQ=WEEKLY;COUNT=many'), true)
+	// Likewise an empty BYDAY, which would serialize back to nothing at all.
+	assert.equal(isCustomRrule('FREQ=WEEKLY;BYDAY='), true)
+})
+
+test('an unrepresentable or missing FREQ is custom', () => {
+	assert.equal(isCustomRrule('FREQ=HOURLY'), true)
+	assert.equal(isCustomRrule('COUNT=3'), true)
+	assert.equal(isCustomRrule(''), true)
+	assert.equal(isCustomRrule(null), true)
+	// Two end conditions at once: the single "Ends" select expresses neither.
+	assert.equal(isCustomRrule('FREQ=WEEKLY;COUNT=3;UNTIL=20270101T000000Z'), true)
+})
+
+test('parse → build round-trips every rule the editor models, byte for byte', () => {
+	for (const rrule of [
+		'FREQ=DAILY',
+		'FREQ=WEEKLY;INTERVAL=2',
+		'FREQ=WEEKLY;BYDAY=MO,WE',
+		'FREQ=WEEKLY;INTERVAL=3;BYDAY=TU,TH,SA',
+		'FREQ=MONTHLY;COUNT=12',
+		'FREQ=YEARLY;UNTIL=20301231T000000Z',
+	]) {
+		assert.equal(buildRecurRrule(parseRecurRrule(rrule)), rrule, rrule)
+	}
+})
+
+// The editor decides "did the user touch the schedule?" by comparing what the
+// controls build against a REBUILD of the pristine parse, not against the stored
+// string — because these normalize. Comparing against the stored string would
+// call every one of them a change, and the backend restarts the occurrences
+// tally on any change to the rule text, semantically identical or not.
+test('a semantically identical rule normalizes, so the pristine rebuild is the baseline', () => {
+	const cases = {
+		'FREQ=WEEKLY;INTERVAL=1;COUNT=5': 'FREQ=WEEKLY;COUNT=5',
+		'BYDAY=MO;FREQ=WEEKLY': 'FREQ=WEEKLY;BYDAY=MO',
+		'freq=weekly;byday=mo': 'FREQ=WEEKLY;BYDAY=MO',
+		'FREQ=WEEKLY;COUNT=05': 'FREQ=WEEKLY;COUNT=5',
+	}
+	for (const [stored, canonical] of Object.entries(cases)) {
+		assert.equal(isCustomRrule(stored), false, stored)
+		assert.equal(buildRecurRrule(parseRecurRrule(stored)), canonical, stored)
+		// Idempotent: a second pass through parse → build is a fixed point, so
+		// the comparison the editor makes is stable.
+		assert.equal(buildRecurRrule(parseRecurRrule(canonical)), canonical, canonical)
+	}
+})
+
+test('UNTIL keeps its time of day instead of collapsing to midnight', () => {
+	const parsed = parseRecurRrule('FREQ=WEEKLY;UNTIL=20270301T235959Z')
+	assert.equal(parsed.endType, 'until')
+	assert.equal(parsed.until, '2027-03-01')
+	assert.equal(parsed.untilSuffix, 'T235959Z')
+	assert.equal(buildRecurRrule(parsed), 'FREQ=WEEKLY;UNTIL=20270301T235959Z')
+
+	// A DATE-valued UNTIL stays date-valued.
+	const dateOnly = parseRecurRrule('FREQ=WEEKLY;UNTIL=20270301')
+	assert.equal(dateOnly.untilSuffix, '')
+	assert.equal(buildRecurRrule(dateOnly), 'FREQ=WEEKLY;UNTIL=20270301')
+
+	// Changing only the date in the editor keeps the original time of day.
+	assert.equal(
+		buildRecurRrule({ ...parsed, until: '2027-04-02' }),
+		'FREQ=WEEKLY;UNTIL=20270402T235959Z',
+	)
+})
+
+test('parse falls back to safe defaults for a rule it will not be used on', () => {
+	const parsed = parseRecurRrule('FREQ=HOURLY;BYHOUR=9')
+	assert.equal(parsed.freq, 'WEEKLY')
+	assert.equal(parsed.interval, 1)
+	assert.equal(parsed.endType, 'forever')
+})
+
+test('build omits INTERVAL=1 and drops BYDAY on a non-weekly frequency', () => {
+	assert.equal(
+		buildRecurRrule({ freq: 'MONTHLY', interval: 1, weekdays: ['MO'], endType: 'forever' }),
+		'FREQ=MONTHLY',
+	)
+	assert.equal(
+		buildRecurRrule({ freq: 'WEEKLY', interval: 1, weekdays: [], endType: 'count', count: 4 }),
+		'FREQ=WEEKLY;COUNT=4',
+	)
+	// endType 'until' with no date picked yet emits no end condition.
+	assert.equal(
+		buildRecurRrule({ freq: 'DAILY', interval: 2, endType: 'until', until: '' }),
+		'FREQ=DAILY;INTERVAL=2',
+	)
+})

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4449,7 +4449,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"
@@ -5198,6 +5198,10 @@ msgstr "du kannst verwalten"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Du kannst nicht zu diesem Board kopieren."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— keine —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n-mal"
@@ -1525,6 +1525,10 @@ msgstr "Benutzerdefinierte Felder"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Eigener Zeitplan – bearbeite ihn unter Board-Einstellungen → Automatisierung."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Gefahrenbereich"
 msgid "Date"
 msgstr "Datum"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "alle"
 msgid "Every"
 msgstr "Alle"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Täglich"
 msgstr[1] "Alle %n Tage"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Monatlich"
 msgstr[1] "Alle %n Monate"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Wöchentlich"
 msgstr[1] "Alle %n Wochen"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Jährlich"
@@ -3149,7 +3153,7 @@ msgstr "Modus"
 msgid "Mon"
 msgstr "Mo"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "hat diese Karte in {value} umbenannt"
 msgid "Repeat"
 msgstr "Wiederholen"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Wiederholt sich"
@@ -5086,7 +5091,7 @@ msgstr "Webhook aktiv"
 msgid "Wed"
 msgstr "Mi"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Antwort schreiben…"
 msgid "wrote"
 msgstr "schrieb"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— ninguno —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -1525,6 +1525,10 @@ msgstr "Campos personalizados"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Periodicidad personalizada: edítala en Ajustes del tablero → Automatización."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Zona de peligro"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "cada"
 msgid "Every"
 msgstr "Cada"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Cada día"
 msgstr[1] "Cada %n días"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Cada mes"
 msgstr[1] "Cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Cada semana"
 msgstr[1] "Cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Cada año"
@@ -3149,7 +3153,7 @@ msgstr "Modo"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "ha renombrado esta tarjeta a {value}"
 msgid "Repeat"
 msgstr "Repetición"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Se repite"
@@ -5086,7 +5091,7 @@ msgstr "Webhook activo"
 msgid "Wed"
 msgstr "Mié"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Escribe una respuesta…"
 msgid "wrote"
 msgstr "escribió"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4449,7 +4449,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"
@@ -5198,6 +5198,10 @@ msgstr "puedes gestionar"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "No puedes copiar a ese tablero."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4449,7 +4449,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"
@@ -5198,6 +5198,10 @@ msgstr "vous pouvez gérer"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Vous ne pouvez pas copier vers ce tableau."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— aucun —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n fois"
@@ -1525,6 +1525,10 @@ msgstr "Champs personnalisés"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Rythme personnalisé — modifiable dans Paramètres du tableau → Automatisation."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Zone de danger"
 msgid "Date"
 msgstr "Date"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "tous les"
 msgid "Every"
 msgstr "Tous les"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Tous les jours"
 msgstr[1] "Tous les %n jours"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Tous les mois"
 msgstr[1] "Tous les %n mois"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toutes les semaines"
 msgstr[1] "Toutes les %n semaines"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Tous les ans"
@@ -3149,7 +3153,7 @@ msgstr "Mode"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "a renommé cette carte en {value}"
 msgid "Repeat"
 msgstr "Répétition"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Se répète"
@@ -5086,7 +5091,7 @@ msgstr "Webhook actif"
 msgid "Wed"
 msgstr "Mer"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Écrivez une réponse…"
 msgid "wrote"
 msgstr "a écrit"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4449,7 +4449,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"
@@ -5198,6 +5198,10 @@ msgstr "gestione consentita"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Non è possibile copiare in quella bacheca."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nessuno —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n volta"
@@ -1525,6 +1525,10 @@ msgstr "Campi personalizzati"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Pianificazione personalizzata — modificala in Impostazioni della bacheca → Automazione."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Zona pericolosa"
 msgid "Date"
 msgstr "Data"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "ogni"
 msgid "Every"
 msgstr "Ogni"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Ogni giorno"
 msgstr[1] "Ogni %n giorni"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Ogni mese"
 msgstr[1] "Ogni %n mesi"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Ogni settimana"
 msgstr[1] "Ogni %n settimane"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Ogni anno"
@@ -3149,7 +3153,7 @@ msgstr "Modalità"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "ha rinominato questa scheda in {value}"
 msgid "Repeat"
 msgstr "Ripetizione"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Si ripete"
@@ -5086,7 +5091,7 @@ msgstr "Webhook attivo"
 msgid "Wed"
 msgstr "Mer"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Scrivi una risposta…"
 msgid "wrote"
 msgstr "ha scritto"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— geen —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n keer"
@@ -1525,6 +1525,10 @@ msgstr "Aangepaste velden"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Aangepast schema — bewerk het bij Bordinstellingen → Automatisering."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Gevarenzone"
 msgid "Date"
 msgstr "Datum"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "elke"
 msgid "Every"
 msgstr "Elke"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Elke dag"
 msgstr[1] "Elke %n dagen"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Elke maand"
 msgstr[1] "Elke %n maanden"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Elke week"
 msgstr[1] "Elke %n weken"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Elk jaar"
@@ -3149,7 +3153,7 @@ msgstr "Modus"
 msgid "Mon"
 msgstr "ma"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "heeft deze kaart hernoemd naar {value}"
 msgid "Repeat"
 msgstr "Herhalen"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Herhaalt"
@@ -5086,7 +5091,7 @@ msgstr "Webhook actief"
 msgid "Wed"
 msgstr "wo"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Schrijf een antwoord…"
 msgid "wrote"
 msgstr "schreef"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4449,7 +4449,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"
@@ -5198,6 +5198,10 @@ msgstr "je kunt beheren"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Je kunt niet naar dat bord kopiëren."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -1555,7 +1555,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -3167,7 +3167,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4467,7 +4467,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5106,7 +5106,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5184,7 +5184,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"
@@ -5219,6 +5219,10 @@ msgstr "możesz zarządzać"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Nie możesz kopiować na tę tablicę."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— brak —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n raz"
@@ -1537,6 +1537,10 @@ msgstr "Pola niestandardowe"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Harmonogram niestandardowy — edytuj go w Ustawieniach tablicy → Automatyzacja."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1554,7 +1558,7 @@ msgstr "Strefa niebezpieczna"
 msgid "Date"
 msgstr "Data"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2037,28 +2041,28 @@ msgstr "co"
 msgid "Every"
 msgstr "Co"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Codziennie"
 msgstr[1] "Co %n dni"
 msgstr[2] "Co %n dni"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Co miesiąc"
 msgstr[1] "Co %n miesiące"
 msgstr[2] "Co %n miesięcy"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Co tydzień"
 msgstr[1] "Co %n tygodnie"
 msgstr[2] "Co %n tygodni"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Co rok"
@@ -3166,7 +3170,7 @@ msgstr "Tryb"
 msgid "Mon"
 msgstr "Pn"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4157,6 +4161,7 @@ msgstr "zmienił nazwę tej karty na {value}"
 msgid "Repeat"
 msgstr "Powtarzanie"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Powtarza się"
@@ -5105,7 +5110,7 @@ msgstr "Webhook aktywny"
 msgid "Wed"
 msgstr "Śr"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5183,7 +5188,7 @@ msgstr "Napisz odpowiedź…"
 msgid "wrote"
 msgstr "napisał"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4449,7 +4449,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"
@@ -5198,6 +5198,10 @@ msgstr "você pode gerenciar"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Você não pode copiar para esse quadro."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nenhum —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -1525,6 +1525,10 @@ msgstr "Campos personalizados"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Programação personalizada — edite em Configurações do quadro → Automação."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Zona de perigo"
 msgid "Date"
 msgstr "Data"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "a cada"
 msgid "Every"
 msgstr "A cada"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Todo dia"
 msgstr[1] "A cada %n dias"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Todo mês"
 msgstr[1] "A cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toda semana"
 msgstr[1] "A cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Todo ano"
@@ -3149,7 +3153,7 @@ msgstr "Modo"
 msgid "Mon"
 msgstr "Seg"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "renomeou este cartão para {value}"
 msgid "Repeat"
 msgstr "Repetir"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Repete"
@@ -5086,7 +5091,7 @@ msgstr "Webhook ativo"
 msgid "Wed"
 msgstr "Qua"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Escreva uma resposta…"
 msgid "wrote"
 msgstr "escreveu"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— нет —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· повторов: %n"
@@ -1537,6 +1537,10 @@ msgstr "Пользовательские поля"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Особое расписание — измените его в настройках доски → Автоматизация."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1554,7 +1558,7 @@ msgstr "Опасная зона"
 msgid "Date"
 msgstr "Дата"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2037,28 +2041,28 @@ msgstr "каждые"
 msgid "Every"
 msgstr "Каждые"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Каждый %n день"
 msgstr[1] "Каждые %n дня"
 msgstr[2] "Каждые %n дней"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Каждый %n месяц"
 msgstr[1] "Каждые %n месяца"
 msgstr[2] "Каждые %n месяцев"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Каждую %n неделю"
 msgstr[1] "Каждые %n недели"
 msgstr[2] "Каждые %n недель"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Каждый %n год"
@@ -3166,7 +3170,7 @@ msgstr "Режим"
 msgid "Mon"
 msgstr "Пн"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4157,6 +4161,7 @@ msgstr "переименовал эту карточку в {value}"
 msgid "Repeat"
 msgstr "Повторение"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Повторяется"
@@ -5105,7 +5110,7 @@ msgstr "Webhook активен"
 msgid "Wed"
 msgstr "Ср"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5183,7 +5188,7 @@ msgstr "Напишите ответ…"
 msgid "wrote"
 msgstr "написал"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -1555,7 +1555,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -3167,7 +3167,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4467,7 +4467,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5106,7 +5106,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5184,7 +5184,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"
@@ -5219,6 +5219,10 @@ msgstr "вы можете управлять"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "Вы не можете копировать на эту доску."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -1542,7 +1542,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -3149,7 +3149,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5086,7 +5086,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5163,7 +5163,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""
@@ -5196,6 +5196,10 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "— none —"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] ""
@@ -1524,6 +1524,10 @@ msgstr ""
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1541,7 +1545,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2023,25 +2027,25 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] ""
@@ -3148,7 +3152,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4138,6 +4142,7 @@ msgstr ""
 msgid "Repeat"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr ""
@@ -5085,7 +5090,7 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5162,7 +5167,7 @@ msgstr ""
 msgid "wrote"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -1543,7 +1543,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -3150,7 +3150,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4449,7 +4449,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5087,7 +5087,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5164,7 +5164,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"
@@ -5198,6 +5198,10 @@ msgstr "yönetebilirsin"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "O panoya kopyalayamazsın."
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— yok —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n kez"
@@ -1525,6 +1525,10 @@ msgstr "Özel alanlar"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Özel zamanlama — Pano ayarları → Otomasyon bölümünden düzenle."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1542,7 +1546,7 @@ msgstr "Tehlikeli bölge"
 msgid "Date"
 msgstr "Tarih"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2024,25 +2028,25 @@ msgstr "her"
 msgid "Every"
 msgstr "Her"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Her gün"
 msgstr[1] "Her %n günde bir"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Her ay"
 msgstr[1] "Her %n ayda bir"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Her hafta"
 msgstr[1] "Her %n haftada bir"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Her yıl"
@@ -3149,7 +3153,7 @@ msgstr "Mod"
 msgid "Mon"
 msgstr "Pzt"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4139,6 +4143,7 @@ msgstr "bu kartın adını {value} yaptı"
 msgid "Repeat"
 msgstr "Yinele"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "Yinelenme"
@@ -5086,7 +5091,7 @@ msgstr "Webhook etkin"
 msgid "Wed"
 msgstr "Çar"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5163,7 +5168,7 @@ msgstr "Bir yanıt yaz…"
 msgid "wrote"
 msgstr "yazdı"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— 无 —"
 
-#: src/components/BoardSettingsModal.vue:3816
+#: src/components/BoardSettingsModal.vue:3835
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n 次"
@@ -1513,6 +1513,10 @@ msgstr "自定义字段"
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "自定义计划 — 请在“看板设置 → 自动化”中编辑。"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom schedule — it is kept exactly as it is. The settings below can still be changed."
+msgstr ""
+
 #: src/views/BoardStats.vue
 #: src/views/ProjectStats.vue
 msgid "Cycle time — creation to done ({days}d)"
@@ -1530,7 +1534,7 @@ msgstr "危险区域"
 msgid "Date"
 msgstr "日期"
 
-#: src/components/BoardSettingsModal.vue:1824
+#: src/components/BoardSettingsModal.vue:1841
 #: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
@@ -2011,22 +2015,22 @@ msgstr "每"
 msgid "Every"
 msgstr "每"
 
-#: src/components/BoardSettingsModal.vue:3796
+#: src/components/BoardSettingsModal.vue:3815
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "每 %n 天"
 
-#: src/components/BoardSettingsModal.vue:3806
+#: src/components/BoardSettingsModal.vue:3825
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "每 %n 个月"
 
-#: src/components/BoardSettingsModal.vue:3798
+#: src/components/BoardSettingsModal.vue:3817
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "每 %n 周"
 
-#: src/components/BoardSettingsModal.vue:3808
+#: src/components/BoardSettingsModal.vue:3827
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "每 %n 年"
@@ -3132,7 +3136,7 @@ msgstr "模式"
 msgid "Mon"
 msgstr "周一"
 
-#: src/components/BoardSettingsModal.vue:1826
+#: src/components/BoardSettingsModal.vue:1843
 #: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
@@ -4121,6 +4125,7 @@ msgstr "把这张卡片重命名为 {value}"
 msgid "Repeat"
 msgstr "重复"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Repeats"
 msgstr "重复"
@@ -5067,7 +5072,7 @@ msgstr "Webhook 已启用"
 msgid "Wed"
 msgstr "周三"
 
-#: src/components/BoardSettingsModal.vue:1825
+#: src/components/BoardSettingsModal.vue:1842
 #: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
@@ -5143,7 +5148,7 @@ msgstr "写下回复…"
 msgid "wrote"
 msgstr "写道"
 
-#: src/components/BoardSettingsModal.vue:1827
+#: src/components/BoardSettingsModal.vue:1844
 #: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4090
+#: src/components/CardDetail.vue:4091
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4088
+#: src/components/CardDetail.vue:4089
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4086
+#: src/components/CardDetail.vue:4087
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -1531,7 +1531,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1824
-#: src/components/CardDetail.vue:4266
+#: src/components/CardDetail.vue:4267
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -3133,7 +3133,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1826
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4269
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4431,7 +4431,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:5707
+#: src/components/CardDetail.vue:5830
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5068,7 +5068,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1825
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4268
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5144,7 +5144,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1827
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4270
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"
@@ -5177,6 +5177,10 @@ msgstr "你可以管理"
 #: src/components/CardDetail.vue
 msgid "You cannot copy to that board."
 msgstr "你无法复制到该看板。"
+
+#: src/components/CardDetail.vue
+msgid "You have unsaved changes on this card. If you leave now, they will be lost."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need edit permission to configure workflows."


### PR DESCRIPTION
**Milestone: stop the app silently discarding things the user did not ask it to discard.**

Seven cards, seven commits. Six of the seven are the same shape of bug — a surface that quietly destroys or leaks state the user never chose — which is why they shipped together.

### Owner-filed

- **Archived boards no longer leak into any cross-board list** (`d442d4f`). v0.22.0 filtered archived *cards*; archived **boards** still showed everywhere. Root cause was one level down — `BoardMapper::findAllForUser()` filters only `deleted_at` — so the leak hit **eight** surfaces: Views, My Tasks (both feeds), Inbox, My Reviews, Search, My Steps, Projects, board folders. New sibling `BoardService::findAllActive()`; `findAll()`/`findAllWithStats()` untouched so the boards page's **Archived tab still works**. Exclusion is unconditional, deliberately not wired to the archived-cards facet.
- **Leaving a card with unsaved text now asks first** (`633c991`). No guard of any kind existed. Covers title, description, new comment, reply and inline comment edit, on X / backdrop / Escape / tab-close. Also fixes a worse adjacent bug: `<router-view>` is unkeyed, so a half-typed reply **leaked onto the next card you opened**.

### Found by validating those cards

- **Clear filters no longer wipes a filter you cannot see** (`05e1e02`). On a View it destroyed the View's own saved label filter — invisible, unrecoverable without a reload, and it widened the feed to the whole cross-board set. `clearAll()` now iterates `visibleDimensions`: a control may only clear what it renders.
- **The recurrence editor stops rewriting schedules it cannot model** (`f800a49`). An API/MCP-authored `FREQ=MONTHLY;BYDAY=1MO` became a bare `FREQ=MONTHLY` on any save. A review pass inside the card found a **second live half**: the server compares rrule *strings*, so even an equivalent-but-normalized rewrite zeroed `occurrences_spawned` — an "ends after 5" rule silently became 5 more. Custom schedules are now read-only and `rrule` is omitted from the PATCH.
- **Columns and checklist items keep a stable order between reloads** (`6729445`). Down-scoped from the filed card: the ~150-line unique-index + retry + 409 treatment was rejected as introducing a new user-visible failure mode to fix an order flicker. Two `addOrderBy('id')` calls make a duplicate sort key harmless instead of merely rarer.
- **The command palette is reachable on touch** (`337409c`). It opened only via Ctrl/Cmd+K, so on a phone the feature was unreachable — and it is advertised in the App Store listing. One item in the existing More menu; no header pressure, no new string.
- **A superseded View feed refetch is aborted in the browser** (`7c65a20`). TanStack already hands `queryFn` a signal; it was being dropped. Typed `perf`, not `fix` — the saving is client-side only, and the commit says so: the server finishes the request either way.

### Verification

Every new test proven **non-vacuous by mutation** — including the negative controls (closing a clean card must never prompt; a board where labels *are* visible must still clear them). Independently re-run before this push, not taken from worker reports:

- PHPUnit **1490 tests**, no failures (3 pre-existing PHP 8.5 deprecations)
- `test:unit` **100/100**; psalm clean; php-cs-fixer 0 of 383
- Playwright **22 passed** across the four new specs + `views.spec.js`
- `l10n:check` regenerates to a clean tree

`ImportServiceTest` / `RecurrenceServiceTest` were excluded locally — they hang under the local runner (tracked as #10093). CI runs them.

### Worth knowing before release

- `views.spec.js` previously drove the global "Clear filters" mid-test, which silently destroyed the View's identity — every assertion after it was running against an unbounded feed. Fixed.
- A new `ArchitectureTest` ratchet fails the build if a future cross-board feed calls `boardService->findAll(`.
- Browser **Back** is deliberately not covered by the unsaved-changes guard: it was implemented, measured, and removed because cancelling threw the user out of the app entirely under hash history. Filed separately.

Follow-ups filed rather than folded in: due reminders firing for archived boards, the hash-history back-navigation defect, a sub-day recurrence offset rounding to zero, and a URL-set hidden filter that can no longer be cleared.
