### PR TITLE
fix: reject a hanging repeat rule and show exact activity timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Every job below carries a `timeout-minutes`. GitHub's default is SIX HOURS,
+  # which is not a safety net — a job that hangs instead of failing burns six
+  # hours of runner time per matrix leg before anyone finds out. That stopped
+  # being hypothetical once the test suite started pinning dependency versions
+  # to match what Nextcloud ships: a regression in that area surfaces as a
+  # request that never returns, not as a failed assertion.
+  #
+  # The values are sized off the observed maxima of recent green runs, with
+  # roughly 2-3x headroom, because these are self-hosted runners and a job that
+  # normally takes 3 minutes has been seen to take 13 under contention. They are
+  # a runaway guard, not a performance budget — a slow but healthy run must
+  # still pass. Re-measure before tightening any of them.
+
   # php-cs-fixer and psalm are PHP-version-independent (they analyse source,
   # not runtime), so pin them to the highest supported PHP (8.3) — one job each.
   cs-check:
     runs-on: kanso-runners
+    # Observed 3-11m across recent green runs.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       # The ARC runner image intermittently lacks libsodium.so.23, which the
@@ -104,6 +119,8 @@ jobs:
 
   psalm:
     runs-on: kanso-runners
+    # Observed 2-13m across recent green runs.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       # See cs-check above for why this step exists and why it is not `grep -q`.
@@ -154,6 +171,9 @@ jobs:
   # range (8.2 for NC 30–33, 8.3 for NC 34) to catch version-specific breakage.
   unit-php:
     runs-on: kanso-runners
+    # One value covers both legs, so it is sized for the slow one: 8.2 has been
+    # observed at 2-6m but 8.3 at 3-21m.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -229,6 +249,8 @@ jobs:
   # defeats the point of committing the lockfile at all.
   unit-mcp:
     runs-on: kanso-runners
+    # Observed under a minute; the cap is really for a stalled dependency fetch.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: mcp
@@ -251,6 +273,8 @@ jobs:
 
   build-frontend:
     runs-on: kanso-runners
+    # Observed 1-2m; `npm ci` against a stalled registry is the realistic hang.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"nextcloud/coding-standard": "^1.4",
 		"phpunit/phpunit": "^10.5",
 		"vimeo/psalm": "^6.0",
-		"sabre/vobject": "^5.0"
+		"sabre/vobject": "^4.2"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbbf6bd190a3864d939a40c507bc5b2c",
+    "content-hash": "4370da93fe0288a2b24055455c6409cb",
     "packages": [],
     "packages-dev": [
         {
@@ -3198,33 +3198,28 @@
         },
         {
             "name": "sabre/vobject",
-            "version": "5.0.0",
+            "version": "4.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/vobject.git",
-                "reference": "2533eb0d67b2030e4f2bdacac972beb556d50e0d"
+                "reference": "63613f6c53a0a2bddfe22caba0d052e6c59f7d0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/2533eb0d67b2030e4f2bdacac972beb556d50e0d",
-                "reference": "2533eb0d67b2030e4f2bdacac972beb556d50e0d",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/63613f6c53a0a2bddfe22caba0d052e6c59f7d0e",
+                "reference": "63613f6c53a0a2bddfe22caba0d052e6c59f7d0e",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^8.2",
-                "sabre/xml": "^3.0 || ^4.0"
+                "php": "^7.1 || ^8.0",
+                "sabre/xml": "^2.1 || ^3.0 || ^4.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.2",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/php-invoker": "^5.0",
-                "phpunit/phpunit": "^11.5",
-                "rector/rector": "^2.4"
+                "friendsofphp/php-cs-fixer": "~2.17.1",
+                "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
+                "phpunit/php-invoker": "^2.0 || ^3.1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
             },
             "suggest": {
                 "hoa/bench": "If you would like to run the benchmark scripts"
@@ -3303,7 +3298,7 @@
                 "issues": "https://github.com/sabre-io/vobject/issues",
                 "source": "https://github.com/fruux/sabre-vobject"
             },
-            "time": "2026-07-07T03:29:53+00:00"
+            "time": "2026-07-07T03:20:17+00:00"
         },
         {
             "name": "sabre/xml",

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -969,7 +969,15 @@ class ImportService {
 			// the first cron pass anyway, so drop it now - silently, like the
 			// sibling drops above.
 			try {
-				$this->recurrenceService->computeNextOccurrence($rrule, $now, $now);
+				// Asking for the occurrence after `$now - 1` makes the target the
+				// anchor itself, so the expansion runs every guard and builds the
+				// iterator but never STEPS it. That matters here more than anywhere:
+				// this loop runs once per rule in an uploaded file, the result is
+				// discarded, and the catch below only catches EXCEPTIONS - a rule that
+				// spins inside the iterator instead of throwing would wedge the whole
+				// import, which is a single authenticated request an attacker fully
+				// controls. Zero steps means zero opportunity.
+				$this->recurrenceService->computeNextOccurrence($rrule, $now - 1, $now);
 			} catch (InvalidInputException) {
 				$this->logger->warning(
 					'Kanso import: dropped a repeat rule whose recurrence rule could not be parsed',

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -70,6 +70,17 @@ class RecurrenceService {
 	 */
 	public const MAX_CATCHUP = 50;
 
+	/**
+	 * The frequencies sabre's {@see RRuleIterator}::next() actually implements, and
+	 * therefore the only ones this app will store. Lowercase, because that is the
+	 * form next() switches on.
+	 *
+	 * The iterator's CONSTRUCTOR is wider than its next() is: it accepts all seven
+	 * RFC 5545 frequencies, SECONDLY and MINUTELY included, and only next() reveals
+	 * that two of them go nowhere. See {@see self::assertIterableFrequency}.
+	 */
+	private const ITERABLE_FREQUENCIES = ['hourly', 'daily', 'weekly', 'monthly', 'yearly'];
+
 	public function __construct(
 		private RecurRuleMapper $ruleMapper,
 		private CardMapper $cardMapper,
@@ -105,12 +116,14 @@ class RecurrenceService {
 	 * for rules created before the timezone column existed). We do NOT hand-roll
 	 * DST math - sabre's {@see RRuleIterator} does it when anchored in a real zone.
 	 *
-	 * @throws InvalidInputException if the RRULE cannot be parsed, or carries no
-	 *                               FREQ part ({@see self::assertHasFrequency})
+	 * @throws InvalidInputException if the RRULE cannot be parsed, or its FREQ is
+	 *                               missing or not one sabre can iterate
+	 *                               ({@see self::assertIterableFrequency})
 	 */
 	public function computeNextOccurrence(string $rrule, int $afterTs, int $dtstartTs, ?string $timezone = null): int {
-		// Reject a FREQ-less rule BEFORE any iterator exists - see the method doc.
-		$this->assertHasFrequency($rrule);
+		// Reject a rule sabre cannot step BEFORE any iterator exists - see the
+		// method doc.
+		$this->assertIterableFrequency($rrule);
 
 		$tz = $this->timezoneFor($timezone);
 		// Anchor as a floating wall-clock time in the rule's zone: take the UTC
@@ -136,10 +149,10 @@ class RecurrenceService {
 			// \Exception would let that escape as a 500: crashing a board import,
 			// turning an invalid-rule API call into a fatal instead of a 400, and
 			// killing the cron pass on a rule stored before it was validated.
-			// This no longer has to cover the FREQ-less case - assertHasFrequency()
-			// above rejects those before an iterator is ever built - but it still
-			// earns its keep for every other rule that only misbehaves while
-			// stepping.
+			// This no longer has to cover the frequencies sabre cannot step -
+			// assertIterableFrequency() above rejects those before an iterator is
+			// ever built - but it still earns its keep for every other rule that
+			// only misbehaves while stepping.
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
 
@@ -154,40 +167,56 @@ class RecurrenceService {
 	}
 
 	/**
-	 * Rejects an RRULE that carries no FREQ, before {@see self::computeNextOccurrence}
-	 * can hand it to an {@see RRuleIterator}.
+	 * Rejects an RRULE whose FREQ is missing, or is one sabre accepts but cannot
+	 * step, before {@see self::computeNextOccurrence} can hand it to an
+	 * {@see RRuleIterator}. Only an explicit member of
+	 * {@see self::ITERABLE_FREQUENCIES} gets through.
 	 *
-	 * FREQ is the one part RFC 5545 makes mandatory, and it is the one part sabre
-	 * never checks for. `''`, `'COUNT=3'` and `'INTERVAL=2'` all CONSTRUCT cleanly;
-	 * the damage only shows while stepping, and what it looks like depends on the
-	 * sabre release:
-	 *   - vobject 5 types the property as a string, so `switch ($this->frequency)`
-	 *     hits a typed-but-uninitialized property and raises an \Error the catch in
-	 *     computeNextOccurrence() turns into a clean 400;
-	 *   - vobject 4 - what Nextcloud bundles in 3rdparty, and therefore what this app
-	 *     actually runs against, since the release tarball ships no vendor/ (see
-	 *     scripts/build-release.sh) - declares `protected $frequency;` UNTYPED, so it
-	 *     is simply null. No switch arm matches, the cursor never advances, and there
-	 *     is nothing to throw. fastForward() is an unbounded
-	 *     `while (valid() && current < target)`, and with neither COUNT nor UNTIL to
-	 *     end it valid() stays true forever: the request wedges its worker until
-	 *     max_execution_time, and under the cron CLI (no time limit at all) it wedges
-	 *     the whole background job.
-	 * So the catch cannot be the guard for this shape - on the version that ships,
-	 * control never reaches it. Refusing the rule up front is what actually holds,
-	 * and it holds identically on both lines: Recur::stringToArray parses and
-	 * upper-cases the parts the same way in 4 and 5.
+	 * Two distinct shapes wedge the iterator, and both end the same way - a
+	 * `fastForward()` that never returns:
+	 *
+	 * 1. **No FREQ at all.** It is the one part RFC 5545 makes mandatory and the one
+	 *    part sabre never checks for. `''`, `'COUNT=3'` and `'INTERVAL=2'` all
+	 *    CONSTRUCT cleanly; the damage only shows while stepping, and what it looks
+	 *    like depends on the sabre release:
+	 *      - vobject 5 types the property as a string, so `switch ($this->frequency)`
+	 *        hits a typed-but-uninitialized property and raises an \Error the catch
+	 *        in computeNextOccurrence() turns into a clean 400;
+	 *      - vobject 4 - what Nextcloud bundles in 3rdparty, and therefore what this
+	 *        app actually runs against, since the release tarball ships no vendor/
+	 *        (see scripts/build-release.sh) - declares `protected $frequency;`
+	 *        UNTYPED, so it is simply null. No switch arm matches, the cursor never
+	 *        advances, and there is nothing to throw.
+	 * 2. **FREQ=SECONDLY / FREQ=MINUTELY.** These are valid RFC 5545 and the
+	 *    constructor's own frequency whitelist accepts all seven values - but next()
+	 *    only implements five. On the missing two it falls through without touching
+	 *    currentDate, so the cursor stands still exactly as in case 1. Nothing is
+	 *    thrown on either sabre line; a guard that merely checked "is FREQ present"
+	 *    waved these straight through.
+	 *
+	 * In both cases fastForward() is an unbounded
+	 * `while (valid() && current < target)`, and with a cursor that never moves (and
+	 * no COUNT/UNTIL to end it) valid() stays true forever: the request wedges its
+	 * worker until max_execution_time, and under the cron CLI (no time limit at all)
+	 * it wedges the whole background job. So the catch cannot be the guard here - on
+	 * the version that ships, control never reaches it. Refusing the rule up front is
+	 * what actually holds, and it holds identically on both lines:
+	 * Recur::stringToArray parses and upper-cases the parts the same way in 4 and 5.
+	 *
+	 * Rejecting SECONDLY/MINUTELY is also right on the merits: a card that respawns
+	 * every second is meaningless for a board, and sabre could not iterate it anyway.
 	 *
 	 * composer.json pins sabre/vobject to the 4.x line for exactly this reason: a
 	 * suite running 5.x agrees with a guard written against 5.x semantics and proves
 	 * nothing about what users run.
 	 *
-	 * A present-but-nonsense FREQ (`FREQ=`, `FREQ=BOGUS`) needs no handling here -
-	 * the iterator's constructor rejects those on both versions.
+	 * A present-but-nonsense FREQ (`FREQ=`, `FREQ=BOGUS`) is rejected here too, by
+	 * the same allowlist, rather than being left to the iterator's constructor.
 	 *
-	 * @throws InvalidInputException if the RRULE is empty or carries no FREQ part
+	 * @throws InvalidInputException if the RRULE is empty, unparseable, carries no
+	 *                               FREQ, or names a frequency sabre cannot step
 	 */
-	private function assertHasFrequency(string $rrule): void {
+	private function assertIterableFrequency(string $rrule): void {
 		if (trim($rrule) === '') {
 			// The API's own default for an omitted rrule parameter, so this is the
 			// likeliest way in - name it explicitly rather than leaning on the parse.
@@ -199,7 +228,8 @@ class RecurrenceService {
 			// Unparseable garbage; the iterator would reject it too, just later.
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
-		if (!isset($parts['FREQ'])) {
+		$freq = $parts['FREQ'] ?? null;
+		if (!is_string($freq) || !in_array(strtolower($freq), self::ITERABLE_FREQUENCIES, true)) {
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
 	}

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -22,6 +22,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use Sabre\VObject\DateTimeParser;
 use Sabre\VObject\Property\ICalendar\Recur;
 use Sabre\VObject\Recur\RRuleIterator;
 
@@ -77,9 +78,64 @@ class RecurrenceService {
 	 *
 	 * The iterator's CONSTRUCTOR is wider than its next() is: it accepts all seven
 	 * RFC 5545 frequencies, SECONDLY and MINUTELY included, and only next() reveals
-	 * that two of them go nowhere. See {@see self::assertIterableFrequency}.
+	 * that two of them go nowhere. See {@see self::assertIterableRule}.
 	 */
 	private const ITERABLE_FREQUENCIES = ['hourly', 'daily', 'weekly', 'monthly', 'yearly'];
+
+	/**
+	 * The RRULE parts this app stores - an ALLOWLIST, so a part nobody here has
+	 * reasoned about cannot reach {@see RRuleIterator} at all.
+	 *
+	 * It is a superset of what the recurrence editor emits (FREQ, INTERVAL,
+	 * BYDAY, COUNT, UNTIL - see src/utils/rrule.js) widened by the parts a rule
+	 * authored through the API, the MCP server or a board import legitimately
+	 * carries: BYMONTH, BYMONTHDAY and WKST.
+	 *
+	 * The parts deliberately NOT on it - BYHOUR, BYMINUTE, BYSECOND, BYYEARDAY,
+	 * BYWEEKNO, BYSETPOS - are the ones that reach sabre code paths whose loops
+	 * cannot be bounded from the outside; see {@see self::assertIterableRule}.
+	 */
+	private const SUPPORTED_PARTS = [
+		'FREQ', 'INTERVAL', 'COUNT', 'UNTIL', 'WKST', 'BYDAY', 'BYMONTH', 'BYMONTHDAY',
+	];
+
+	/** The RFC 5545 weekday tokens, for BYDAY and WKST. */
+	private const WEEKDAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+
+	/**
+	 * Ceiling on INTERVAL. "Every thousandth week/month/year" is already far past
+	 * any board schedule, and an unbounded INTERVAL is arithmetic sabre hands
+	 * straight to DateTimeImmutable::modify('+N months'), which stops behaving at
+	 * absurd magnitudes.
+	 */
+	private const MAX_INTERVAL = 1000;
+
+	/**
+	 * Ceiling on COUNT. A card that respawns more than ten thousand times is not
+	 * a schedule; keeping COUNT in the same sane envelope as INTERVAL also keeps
+	 * {@see self::countLimitFor}'s durable tally meaningful.
+	 */
+	private const MAX_COUNT = 10000;
+
+	/**
+	 * The most occurrences a single {@see self::computeNextOccurrence} call may
+	 * step through before it gives up and rejects the rule.
+	 *
+	 * This is the version-INDEPENDENT half of the guard, and the one that does not
+	 * depend on anybody having correctly enumerated sabre's behaviour: whatever the
+	 * rule, whatever the sabre release, one call does a bounded amount of work.
+	 *
+	 * Sizing. The walk that actually happens is {@see self::firstFireFor}'s: from
+	 * the template card's anchor date up to now. The finest grain this app accepts
+	 * is HOURLY, so 50000 steps covers an anchor 5.7 YEARS in the past; every
+	 * coarser frequency covers far longer (DAILY ~137 years, WEEKLY ~958 years,
+	 * MONTHLY ~4166 years). No real template card is anchored further back than
+	 * that, and a rule already running spends a single step per call. Measured
+	 * against the
+	 * pinned sabre 4.x, a step costs 0.7-3.7us, so the cap bounds the worst case at
+	 * roughly 0.2s of CPU instead of the unbounded spin it replaces.
+	 */
+	private const MAX_ADVANCE_STEPS = 50000;
 
 	public function __construct(
 		private RecurRuleMapper $ruleMapper,
@@ -116,14 +172,17 @@ class RecurrenceService {
 	 * for rules created before the timezone column existed). We do NOT hand-roll
 	 * DST math - sabre's {@see RRuleIterator} does it when anchored in a real zone.
 	 *
-	 * @throws InvalidInputException if the RRULE cannot be parsed, or its FREQ is
-	 *                               missing or not one sabre can iterate
-	 *                               ({@see self::assertIterableFrequency})
+	 * @throws InvalidInputException if the RRULE cannot be parsed, carries a part or
+	 *                               value this app does not store, names a FREQ
+	 *                               sabre cannot iterate
+	 *                               ({@see self::assertIterableRule}), or needs more
+	 *                               than {@see self::MAX_ADVANCE_STEPS} steps to
+	 *                               reach the requested time
 	 */
 	public function computeNextOccurrence(string $rrule, int $afterTs, int $dtstartTs, ?string $timezone = null): int {
 		// Reject a rule sabre cannot step BEFORE any iterator exists - see the
 		// method doc.
-		$this->assertIterableFrequency($rrule);
+		$this->assertIterableRule($rrule);
 
 		$tz = $this->timezoneFor($timezone);
 		// Anchor as a floating wall-clock time in the rule's zone: take the UTC
@@ -138,11 +197,38 @@ class RecurrenceService {
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
 
-		// fastForward positions at the first occurrence >= the target; asking
-		// for afterTs + 1 makes the result strictly after afterTs.
+		// Advance to the first occurrence >= the target; asking for afterTs + 1
+		// makes the result strictly after afterTs.
+		//
+		// This is sabre's own fastForward() - `while (valid() && currentDate < $dt)
+		// next()` - re-implemented here for one reason: to put a HARD CEILING on the
+		// number of steps. sabre's version is unbounded, so the cost of a single
+		// call is whatever the rule says it is: an RRULE whose occurrence set is
+		// empty walks to sabre's year-9999 stop one occurrence at a time, and an
+		// ancient DTSTART (a template card dated 0001-01-01 is accepted by
+		// DueDateParser) makes even a perfectly legal FREQ=HOURLY rule step ~17.7
+		// MILLION legal occurrences to reach today. Neither is malformed; both are
+		// remote CPU burn, reachable from card create/update, rule create/update,
+		// board import and the cron.
+		//
+		// The cap is deliberately the version-independent half of this guard. The
+		// allowlists in assertIterableRule() encode what a PARTICULAR sabre release
+		// does with particular rule parts, and that knowledge goes stale - the bug
+		// this replaces existed precisely because vobject 4 and 5 behave differently.
+		// The cap needs no such knowledge: it bounds the work whatever the library
+		// underneath decides to do between two calls to next().
 		$target = (new \DateTimeImmutable('@' . ($afterTs + 1)))->setTimezone($tz);
+		$overrun = false;
 		try {
-			$iterator->fastForward($target);
+			$steps = 0;
+			while ($iterator->valid() && $iterator->current() < $target) {
+				if ($steps >= self::MAX_ADVANCE_STEPS) {
+					$overrun = true;
+					break;
+				}
+				$steps++;
+				$iterator->next();
+			}
 		} catch (\Throwable $e) {
 			// Some malformed rules only fail while iterating, and NOT always as an
 			// \Exception - sabre can raise a bare \Error mid-walk. Catching only
@@ -150,10 +236,18 @@ class RecurrenceService {
 			// turning an invalid-rule API call into a fatal instead of a 400, and
 			// killing the cron pass on a rule stored before it was validated.
 			// This no longer has to cover the frequencies sabre cannot step -
-			// assertIterableFrequency() above rejects those before an iterator is
+			// assertIterableRule() above rejects those before an iterator is
 			// ever built - but it still earns its keep for every other rule that
 			// only misbehaves while stepping.
 			throw new InvalidInputException('Invalid recurrence rule');
+		}
+		if ($overrun) {
+			// Not "malformed" - just more work than any real board schedule needs.
+			// Same exception type as every other rejection so the controllers keep
+			// turning it into a 400, ImportService keeps dropping the rule and
+			// continuing, and advanceSchedule() keeps disabling a stored rule that
+			// has drifted into this state instead of wedging the cron.
+			throw new InvalidInputException('Recurrence rule needs too many steps to reach its next occurrence');
 		}
 
 		if (!$iterator->valid()) {
@@ -213,24 +307,163 @@ class RecurrenceService {
 	 * A present-but-nonsense FREQ (`FREQ=`, `FREQ=BOGUS`) is rejected here too, by
 	 * the same allowlist, rather than being left to the iterator's constructor.
 	 *
+	 * ---
+	 *
+	 * FREQ is necessary but NOT sufficient, and this is the second half of the
+	 * lesson. Every other rule part reached the iterator unvalidated, and sabre
+	 * range-checks only some of them (BYYEARDAY, BYWEEKNO and BYMONTH are checked;
+	 * BYHOUR, BYMINUTE, BYSECOND, BYMONTHDAY and BYSETPOS are stored verbatim). An
+	 * out-of-range value on an unchecked part does not throw - it produces an
+	 * occurrence set that can never be satisfied, and sabre's next() then spins
+	 * looking for it:
+	 *
+	 *   - `FREQ=WEEKLY;BYHOUR=99` - nextWeekly() ends in
+	 *     `while (byHour && !in_array(currentHour, recurrenceHours))`, format('G')
+	 *     only ever yields 0-23, and nextWeekly() is the ONLY next*() with no
+	 *     year-9999 escape. A true infinite loop; nothing is thrown. Verified:
+	 *     99.8% CPU until killed.
+	 *   - `FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO` - every part is in range, but
+	 *     nextYearly()'s BYYEARDAY branch is a bare `while (true)` that indexes
+	 *     `$this->dayMap[$byDay]` RAW (the weekly/monthly paths use
+	 *     `substr($day, -2)` and so tolerate the ordinal; this one does not).
+	 *     '2MO' is not a key, the offset is null, no candidate date ever matches
+	 *     and the year counter climbs forever. Also verified at 99.8% CPU.
+	 *   - `FREQ=DAILY;BYHOUR=99` and `FREQ=MONTHLY;BYMONTHDAY=32` are the same
+	 *     defect with a floor under it: those next*() DO have the year-9999 escape,
+	 *     so they terminate - after ~70M and ~95k iterations respectively.
+	 *
+	 * Note where those first two loops live: INSIDE a single next() call. That is
+	 * why {@see self::MAX_ADVANCE_STEPS}, which bounds how many times we CALL
+	 * next(), cannot save us from them and this allowlist is load-bearing rather
+	 * than cosmetic - PHP cannot interrupt a loop inside a library call. The two
+	 * guards cover different halves of the problem and neither is redundant:
+	 * this one keeps the inputs that wedge a single step out of the iterator, the
+	 * step cap bounds everything that merely takes too many steps.
+	 *
+	 * So the parts are an ALLOWLIST ({@see self::SUPPORTED_PARTS}), not a
+	 * blocklist. BYHOUR/BYMINUTE/BYSECOND/BYYEARDAY/BYWEEKNO/BYSETPOS are simply
+	 * not stored: the editor cannot author them (src/utils/rrule.js), and a rule
+	 * that arrives with one from the API, the MCP server or an import is refused.
+	 * The parts that ARE accepted cover every schedule this app offers - a weekly
+	 * BYDAY, a monthly BYMONTHDAY or positional BYDAY, a yearly BYMONTH - and each
+	 * is range-checked here, because the only reason `BYMONTHDAY=32` costs 0.18s
+	 * instead of hanging is an escape hatch in sabre we would rather not depend on.
+	 *
 	 * @throws InvalidInputException if the RRULE is empty, unparseable, carries no
-	 *                               FREQ, or names a frequency sabre cannot step
+	 *                               FREQ, names a frequency sabre cannot step, or
+	 *                               carries a part or value this app does not store
 	 */
-	private function assertIterableFrequency(string $rrule): void {
+	private function assertIterableRule(string $rrule): void {
 		if (trim($rrule) === '') {
 			// The API's own default for an omitted rrule parameter, so this is the
 			// likeliest way in - name it explicitly rather than leaning on the parse.
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
 		try {
+			// stringToArray upper-cases every part name and value and splits a
+			// comma-separated value into an array. Both sabre 4 and 5 do it
+			// identically, so the guard reads the rule exactly as the iterator will.
 			$parts = Recur::stringToArray($rrule);
 		} catch (\Throwable $e) {
 			// Unparseable garbage; the iterator would reject it too, just later.
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
+
 		$freq = $parts['FREQ'] ?? null;
 		if (!is_string($freq) || !in_array(strtolower($freq), self::ITERABLE_FREQUENCIES, true)) {
 			throw new InvalidInputException('Invalid recurrence rule');
+		}
+
+		foreach ($parts as $name => $value) {
+			if (!in_array($name, self::SUPPORTED_PARTS, true)) {
+				throw new InvalidInputException('Unsupported recurrence rule part: ' . $name);
+			}
+			switch ($name) {
+				case 'FREQ':
+					// Already checked above.
+					break;
+				case 'INTERVAL':
+				case 'COUNT':
+					// Single-valued parts: `COUNT=1,2` parses to an array, which sabre
+					// would cast with (int) and read as 1.
+					if (!is_string($value)) {
+						throw new InvalidInputException('Invalid ' . $name . ' in the recurrence rule');
+					}
+					$this->assertNumericPart(
+						$name,
+						$value,
+						1,
+						$name === 'INTERVAL' ? self::MAX_INTERVAL : self::MAX_COUNT,
+						false,
+					);
+					break;
+				case 'BYMONTH':
+					$this->assertNumericPart($name, $value, 1, 12, false);
+					break;
+				case 'BYMONTHDAY':
+					// Negative is legal and useful: -1 is the last day of the month.
+					$this->assertNumericPart($name, $value, 1, 31, true);
+					break;
+				case 'BYDAY':
+					// Mirrors sabre's own BYDAY regex, including its narrower 1-5
+					// ordinal (RFC 5545 allows 1-53, but there is no 6th Monday in a
+					// month and sabre refuses it anyway). Checking it here means the
+					// rejection happens before an iterator exists, with our message.
+					foreach ((array)$value as $token) {
+						if (!is_string($token)
+							|| preg_match('#^[+-]?[1-5]?(' . implode('|', self::WEEKDAYS) . ')$#', $token) !== 1) {
+							throw new InvalidInputException('Invalid BYDAY in the recurrence rule');
+						}
+					}
+					break;
+				case 'WKST':
+					// sabre range-checks nothing here and then uses the value as an
+					// array key in two places; an unknown token yields null offsets.
+					if (!is_string($value) || !in_array($value, self::WEEKDAYS, true)) {
+						throw new InvalidInputException('Invalid WKST in the recurrence rule');
+					}
+					break;
+				case 'UNTIL':
+					if (!is_string($value)) {
+						throw new InvalidInputException('Invalid UNTIL in the recurrence rule');
+					}
+					try {
+						// The same parser the iterator's constructor uses, so an UNTIL
+						// this accepts is one sabre accepts.
+						DateTimeParser::parse($value, new \DateTimeZone('UTC'));
+					} catch (\Throwable $e) {
+						throw new InvalidInputException('Invalid UNTIL in the recurrence rule');
+					}
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Asserts every value of a numeric RRULE part is an integer within
+	 * [$min, $max] - or, when $signed, within that range in either direction with
+	 * 0 excluded, which is how RFC 5545 writes the "-1 means the last one" parts.
+	 *
+	 * @param string|array<int, string> $value the raw part value from Recur::stringToArray
+	 * @throws InvalidInputException on a non-numeric or out-of-range value
+	 */
+	private function assertNumericPart(string $name, $value, int $min, int $max, bool $signed): void {
+		$values = (array)$value;
+		if ($values === []) {
+			throw new InvalidInputException('Invalid ' . $name . ' in the recurrence rule');
+		}
+		foreach ($values as $raw) {
+			// Deliberately strict: sabre casts these with a plain (int), which reads
+			// "12abc" as 12. Anything that is not cleanly an optionally-signed
+			// integer is refused rather than silently reinterpreted.
+			if (!is_string($raw) || preg_match('#^[+-]?\d+$#', $raw) !== 1) {
+				throw new InvalidInputException('Invalid ' . $name . ' in the recurrence rule');
+			}
+			$int = (int)$raw;
+			$magnitude = $signed ? abs($int) : $int;
+			if ($magnitude < $min || $magnitude > $max) {
+				throw new InvalidInputException('Invalid ' . $name . ' in the recurrence rule');
+			}
 		}
 	}
 
@@ -431,7 +664,28 @@ class RecurrenceService {
 		$newRrule = $rrule ?? $rule->getRrule();
 		$newPolicy = $duedatePolicy ?? $rule->getDuedatePolicy();
 		$newOffset = $duedateOffsetSeconds ?? $rule->getDuedateOffsetSeconds();
-		$this->validate($rule->getBoardId(), $newTemplate, $newStack, $newMode, $newRrule, $newPolicy, $newOffset);
+		// Turning a rule OFF must never depend on its stored RRULE still passing
+		// validation. Rules predate their guards: a `FREQ=MINUTELY` (spec-valid, and
+		// accepted until it was found to wedge the iterator), a `FREQ=WEEKLY;BYHOUR=99`,
+		// or the empty rrule the API's own default once produced are all sitting in
+		// existing installs. Re-validating the UNCHANGED stored rule on every update
+		// made `PATCH {"enabled": false}` 400, so the only way to stop such a rule was
+		// to delete it - losing the template link and the history with it. When the
+		// caller supplies no new RRULE and is switching the rule off, skip the RRULE
+		// check; every other field is still validated, and the cron already refuses to
+		// run the rule (advanceSchedule disables it on the same exception). Re-enabling
+		// still validates - a rule that cannot run must not be switchable back on.
+		$disablingStoredRule = $enabled === false && $rrule === null;
+		$this->validate(
+			$rule->getBoardId(),
+			$newTemplate,
+			$newStack,
+			$newMode,
+			$newRrule,
+			$newPolicy,
+			$newOffset,
+			!$disablingStoredRule,
+		);
 		// Same gate as create() (#3760): re-anchoring on a hidden template is a 404.
 		$template = $this->loadCard($newTemplate);
 		$this->visibilityGuard->assertVisible($board, $template, $uid);
@@ -1158,6 +1412,7 @@ class RecurrenceService {
 		string $rrule,
 		int $duedatePolicy,
 		int $duedateOffsetSeconds,
+		bool $validateRrule = true,
 	): void {
 		if ($mode !== RecurRule::MODE_CLONE && $mode !== RecurRule::MODE_RESET) {
 			throw new InvalidInputException('Invalid recurrence mode');
@@ -1170,8 +1425,21 @@ class RecurrenceService {
 		}
 		// Parse-validate the RRULE (throws InvalidInputException on garbage).
 		// We anchor at "now" purely to construct the iterator; the result is
-		// discarded here - the point is to reject unparseable rules.
-		$this->computeNextOccurrence($rrule, $this->time->getTime(), $this->time->getTime());
+		// discarded here - the point is to reject unparseable rules. Skipped only
+		// when an update is switching an already-stored rule OFF - see update().
+		//
+		// Asking for the occurrence after `now - 1` makes the target the anchor
+		// itself, so the advance loop's `current() < target` is false on its first
+		// check and the iterator is never STEPPED - validation runs the guards,
+		// builds the iterator, and stops. That is deliberate: create/update are the
+		// two paths an anonymous-ish caller reaches most cheaply, and there is no
+		// reason for either to spend a single occurrence of iteration budget on a
+		// result it throws away. (It also means a future guard regression surfaces
+		// as a wrong return value here rather than as a wedged worker.)
+		if ($validateRrule) {
+			$now = $this->time->getTime();
+			$this->computeNextOccurrence($rrule, $now - 1, $now);
+		}
 
 		$card = $this->loadCard($templateCardId);
 		if ($card->getBoardId() !== $boardId) {

--- a/lib/Service/RecurrenceService.php
+++ b/lib/Service/RecurrenceService.php
@@ -105,9 +105,13 @@ class RecurrenceService {
 	 * for rules created before the timezone column existed). We do NOT hand-roll
 	 * DST math - sabre's {@see RRuleIterator} does it when anchored in a real zone.
 	 *
-	 * @throws InvalidInputException if the RRULE cannot be parsed
+	 * @throws InvalidInputException if the RRULE cannot be parsed, or carries no
+	 *                               FREQ part ({@see self::assertHasFrequency})
 	 */
 	public function computeNextOccurrence(string $rrule, int $afterTs, int $dtstartTs, ?string $timezone = null): int {
+		// Reject a FREQ-less rule BEFORE any iterator exists - see the method doc.
+		$this->assertHasFrequency($rrule);
+
 		$tz = $this->timezoneFor($timezone);
 		// Anchor as a floating wall-clock time in the rule's zone: take the UTC
 		// instant of $dtstartTs and re-interpret its calendar fields in $tz.
@@ -127,13 +131,15 @@ class RecurrenceService {
 		try {
 			$iterator->fastForward($target);
 		} catch (\Throwable $e) {
-			// Some malformed rules only fail while iterating - and NOT always as an
-			// \Exception. sabre never checks that FREQ is present: '', 'COUNT=3' and
-			// 'INTERVAL=2' all construct cleanly, then hit `switch ($this->frequency)`
-			// on a typed-but-uninitialized property and raise an \Error. Catching only
-			// \Exception let that escape as a 500 - crashing a board import, turning an
-			// invalid-rule API call into a fatal instead of a 400, and killing the cron
-			// pass on a rule stored before this was validated.
+			// Some malformed rules only fail while iterating, and NOT always as an
+			// \Exception - sabre can raise a bare \Error mid-walk. Catching only
+			// \Exception would let that escape as a 500: crashing a board import,
+			// turning an invalid-rule API call into a fatal instead of a 400, and
+			// killing the cron pass on a rule stored before it was validated.
+			// This no longer has to cover the FREQ-less case - assertHasFrequency()
+			// above rejects those before an iterator is ever built - but it still
+			// earns its keep for every other rule that only misbehaves while
+			// stepping.
 			throw new InvalidInputException('Invalid recurrence rule');
 		}
 
@@ -145,6 +151,57 @@ class RecurrenceService {
 		// that, so coalesce defensively.
 		$occurrence = $iterator->current();
 		return $occurrence?->getTimestamp() ?? 0;
+	}
+
+	/**
+	 * Rejects an RRULE that carries no FREQ, before {@see self::computeNextOccurrence}
+	 * can hand it to an {@see RRuleIterator}.
+	 *
+	 * FREQ is the one part RFC 5545 makes mandatory, and it is the one part sabre
+	 * never checks for. `''`, `'COUNT=3'` and `'INTERVAL=2'` all CONSTRUCT cleanly;
+	 * the damage only shows while stepping, and what it looks like depends on the
+	 * sabre release:
+	 *   - vobject 5 types the property as a string, so `switch ($this->frequency)`
+	 *     hits a typed-but-uninitialized property and raises an \Error the catch in
+	 *     computeNextOccurrence() turns into a clean 400;
+	 *   - vobject 4 - what Nextcloud bundles in 3rdparty, and therefore what this app
+	 *     actually runs against, since the release tarball ships no vendor/ (see
+	 *     scripts/build-release.sh) - declares `protected $frequency;` UNTYPED, so it
+	 *     is simply null. No switch arm matches, the cursor never advances, and there
+	 *     is nothing to throw. fastForward() is an unbounded
+	 *     `while (valid() && current < target)`, and with neither COUNT nor UNTIL to
+	 *     end it valid() stays true forever: the request wedges its worker until
+	 *     max_execution_time, and under the cron CLI (no time limit at all) it wedges
+	 *     the whole background job.
+	 * So the catch cannot be the guard for this shape - on the version that ships,
+	 * control never reaches it. Refusing the rule up front is what actually holds,
+	 * and it holds identically on both lines: Recur::stringToArray parses and
+	 * upper-cases the parts the same way in 4 and 5.
+	 *
+	 * composer.json pins sabre/vobject to the 4.x line for exactly this reason: a
+	 * suite running 5.x agrees with a guard written against 5.x semantics and proves
+	 * nothing about what users run.
+	 *
+	 * A present-but-nonsense FREQ (`FREQ=`, `FREQ=BOGUS`) needs no handling here -
+	 * the iterator's constructor rejects those on both versions.
+	 *
+	 * @throws InvalidInputException if the RRULE is empty or carries no FREQ part
+	 */
+	private function assertHasFrequency(string $rrule): void {
+		if (trim($rrule) === '') {
+			// The API's own default for an omitted rrule parameter, so this is the
+			// likeliest way in - name it explicitly rather than leaning on the parse.
+			throw new InvalidInputException('Invalid recurrence rule');
+		}
+		try {
+			$parts = Recur::stringToArray($rrule);
+		} catch (\Throwable $e) {
+			// Unparseable garbage; the iterator would reject it too, just later.
+			throw new InvalidInputException('Invalid recurrence rule');
+		}
+		if (!isset($parts['FREQ'])) {
+			throw new InvalidInputException('Invalid recurrence rule');
+		}
 	}
 
 	/**

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1893,7 +1893,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											{{ expandedDiffs.has(item.id) ? t('kanso', 'Hide changes') : t('kanso', 'Show changes') }}
 										</button>
 									</span>
-									<span class="card-modal__activity-time">{{ relativeTime(item.timestamp) }}</span>
+									<!-- #10131 — the relative label alone ("5 days ago") can't answer
+									     "when exactly?", so the precise stamp sits next to it. It is
+									     ALWAYS rendered, never hover-only: a tooltip is unreachable on
+									     touch, and this app is installed on phones. -->
+									<span class="card-modal__activity-time">{{ relativeTime(item.timestamp) }}<template v-if="exactTimeLabel(item.timestamp)"><span class="card-modal__activity-sep"> · </span><time
+										class="card-modal__activity-exact"
+										:datetime="isoTimestamp(item.timestamp)"
+										:title="exactTimeTitle(item.timestamp)">{{ exactTimeLabel(item.timestamp) }}</time></template></span>
 									<div v-if="hasDescriptionDiff(item) && expandedDiffs.has(item.id)" class="card-modal__activity-diff">
 										<div
 											v-for="(line, i) in diffLines(item.detail.from, item.detail.to)"
@@ -2387,7 +2394,7 @@ import { useCardActions } from '../composables/useCardActions.js'
 import { useChecklist } from '../composables/useChecklist.js'
 import { useComments, buildCommentTree, REACTION_EMOJI } from '../composables/useComments.js'
 import { buildCardPrompt } from '../utils/cardPrompt.js'
-import { allDayInputValue, timedInputValue, formatCardDate } from '../utils/dateDisplay.js'
+import { allDayInputValue, timedInputValue, formatCardDate, exactTimeLabel, exactTimeTitle, isoTimestamp } from '../utils/dateDisplay.js'
 import { useCardHierarchy } from '../composables/useCardHierarchy.js'
 import { boardQueryKey, invalidateCrossBoardFeeds } from '../composables/queryKeys.js'
 import { useCardMove } from '../composables/useCardMove.js'
@@ -8051,6 +8058,16 @@ body.theme--dark .card-modal,
 	font-size: 0.72rem;
 	color: var(--color-text-maxcontrast);
 	white-space: nowrap;
+}
+/* #10131 — the exact stamp is supporting detail, so it stays a notch quieter
+   than the relative label it follows. The separator is a REAL text node, not a
+   ::before: generated content is dropped from a copy-paste, which would jam the
+   two labels together as "just now09:31 PM". */
+.card-modal__activity-exact {
+	opacity: 0.75;
+}
+.card-modal__activity-sep {
+	opacity: 0.5;
 }
 .card-modal__thread-scroll {
 	flex: 1;

--- a/src/utils/dateDisplay.js
+++ b/src/utils/dateDisplay.js
@@ -2,8 +2,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /**
- * dateDisplay - timezone-correct formatting for card due/start dates.
+ * dateDisplay - shared, timezone-correct date/time formatting for the UI.
  *
+ * Two groups of helpers live here:
+ *
+ *  1. Card due/start dates (`allDayInputValue`, `timedInputValue`,
+ *     `formatCardDate`) - see the all-day storage note below.
+ *  2. Event timestamps (`exactTimeLabel`, `exactTimeTitle`, `isoTimestamp`) -
+ *     the exact wall-clock stamp shown next to a relative label ("5 days ago")
+ *     in the card's activity feed. Those take a unix timestamp in SECONDS, the
+ *     shape the API emits (ActivityService returns the raw epoch integer).
+ *
+ * ── All-day card dates ───────────────────────────────────────────────────────
  * All-day dates are STORED at UTC midnight (`new Date("YYYY-MM-DD").toISOString()`,
  * e.g. `2026-07-22T00:00:00.000Z`) so the stored instant is a stable calendar day
  * that downstream consumers (reminders, overdue calc, the calendar feed's
@@ -61,4 +71,91 @@ export function formatCardDate(iso, allDay, opts) {
 		return d.toLocaleDateString(undefined, { ...opts, timeZone: 'UTC' })
 	}
 	return d.toLocaleString(undefined, opts)
+}
+
+// ── Event timestamps (activity feed) ─────────────────────────────────────────
+
+/**
+ * A unix-seconds timestamp as a Date, or null when there is nothing to show.
+ *
+ * Callers render this next to user-visible rows, so an absent (`null`,
+ * `undefined`), zero ("never") or unparseable timestamp must degrade to an
+ * empty label - never to "1 Jan 1970", NaN, or a thrown error.
+ *
+ * @param {number|string|null|undefined} tsSeconds unix timestamp in seconds
+ * @returns {Date|null}
+ */
+function eventDate(tsSeconds) {
+	if (tsSeconds === null || tsSeconds === undefined || tsSeconds === '') return null
+	const secs = Number(tsSeconds)
+	if (!Number.isFinite(secs) || secs <= 0) return null
+	const d = new Date(secs * 1000)
+	return Number.isNaN(d.getTime()) ? null : d
+}
+
+/**
+ * Lazily-built, reused `Intl.DateTimeFormat`s.
+ *
+ * A feed row asks for its stamp several times per render (the label, the
+ * `datetime`, the title), and a long feed is tens of rows — building a fresh
+ * formatter for each call is the expensive part of Intl. The locale is always
+ * the browser default and cannot change mid-session, so one instance each is
+ * enough.
+ */
+const formatters = {}
+function fmt(key, opts) {
+	return (formatters[key] ??= new Intl.DateTimeFormat(undefined, opts))
+}
+
+/**
+ * The exact stamp shown beside a relative label, kept short when it can be.
+ *
+ * Length-aware so a 50-row feed does not turn into a wall of dates: an event
+ * from today needs only the clock ("14:32"); anything older carries the date
+ * too ("28 Aug 2026, 14:32"). Formatted in the viewer's own locale and zone.
+ *
+ * @param {number|string|null|undefined} tsSeconds unix timestamp in seconds
+ * @param {number} [nowMs] reference "now" in ms, for testing
+ * @returns {string} '' when there is no usable timestamp
+ */
+export function exactTimeLabel(tsSeconds, nowMs = Date.now()) {
+	const d = eventDate(tsSeconds)
+	if (!d) return ''
+	const now = new Date(nowMs)
+	const sameDay = d.getFullYear() === now.getFullYear()
+		&& d.getMonth() === now.getMonth()
+		&& d.getDate() === now.getDate()
+	if (sameDay) {
+		return fmt('clock', { hour: '2-digit', minute: '2-digit' }).format(d)
+	}
+	return fmt('dateClock', {
+		day: 'numeric',
+		month: 'short',
+		year: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+	}).format(d)
+}
+
+/**
+ * The full stamp, for the element's `title` - the shortened label spelled out.
+ *
+ * @param {number|string|null|undefined} tsSeconds unix timestamp in seconds
+ * @returns {string} '' when there is no usable timestamp
+ */
+export function exactTimeTitle(tsSeconds) {
+	const d = eventDate(tsSeconds)
+	if (!d) return ''
+	return fmt('full', { dateStyle: 'full', timeStyle: 'medium' }).format(d)
+}
+
+/**
+ * The machine-readable value for a `<time datetime="...">` attribute.
+ *
+ * @param {number|string|null|undefined} tsSeconds unix timestamp in seconds
+ * @returns {string} ISO 8601 in UTC, or '' when there is no usable timestamp
+ */
+export function isoTimestamp(tsSeconds) {
+	const d = eventDate(tsSeconds)
+	return d ? d.toISOString() : ''
 }

--- a/src/utils/dateDisplay.js
+++ b/src/utils/dateDisplay.js
@@ -108,6 +108,27 @@ function fmt(key, opts) {
 }
 
 /**
+ * Clock options for the stamp — hour and minute at the SAME requested width.
+ *
+ * This pairing is load-bearing, not cosmetic. `Intl.DateTimeFormat` only takes
+ * the hour/minute pattern from the locale's own short-time skeleton when both
+ * fields are requested at the same width; a mismatched pair (`hour: 'numeric'`
+ * with `minute: '2-digit'`) forces a literal `h:mm` and overrides the locale.
+ *
+ * That is what makes both halves of this right:
+ *  - 12-hour locales drop the meaningless leading zero — en-US renders "9:44 PM",
+ *    not "09:44 PM" (the bug this replaced).
+ *  - 24-hour locales keep their own padding — en-GB/de-DE still render "09:04",
+ *    because for them the locale skeleton IS a padded hour. Asking for
+ *    `minute: '2-digit'` here would have broken *them* instead, rendering "9:04".
+ *
+ * And `minute: 'numeric'` never yields "9:4": whenever an hour is also present,
+ * the locale skeleton resolves the minute to 2-digit in every locale (verified
+ * across 50 locales on the Node versions CI runs).
+ */
+const CLOCK_OPTS = { hour: 'numeric', minute: 'numeric' }
+
+/**
  * The exact stamp shown beside a relative label, kept short when it can be.
  *
  * Length-aware so a 50-row feed does not turn into a wall of dates: an event
@@ -126,14 +147,13 @@ export function exactTimeLabel(tsSeconds, nowMs = Date.now()) {
 		&& d.getMonth() === now.getMonth()
 		&& d.getDate() === now.getDate()
 	if (sameDay) {
-		return fmt('clock', { hour: '2-digit', minute: '2-digit' }).format(d)
+		return fmt('clock', CLOCK_OPTS).format(d)
 	}
 	return fmt('dateClock', {
 		day: 'numeric',
 		month: 'short',
 		year: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
+		...CLOCK_OPTS,
 	}).format(d)
 }
 

--- a/tests/e2e/activity.spec.js
+++ b/tests/e2e/activity.spec.js
@@ -5,13 +5,14 @@ import { test, expect, api, ncLogin, BASE } from './helpers.js'
 
 // #3494 — per-card Activity tab.
 test.describe('Card Activity feed', () => {
-	const state = { boardId: 0, cardUrl: '' }
+	const state = { boardId: 0, cardId: 0, cardUrl: '' }
 
 	test.beforeAll(async () => {
 		const board = await api.send('POST', '/boards', { title: 'Activity E2E' })
 		state.boardId = board.id
 		const stack = await api.send('POST', '/stacks', { boardId: board.id, title: 'To Do' })
 		const card = await api.send('POST', '/cards', { stackId: stack.id, title: 'Tracked card' })
+		state.cardId = card.id
 		// Generate a few distinct activity rows.
 		await api.send('POST', `/cards/${card.id}/comments`, { body: 'first note' })
 		await api.send('PATCH', `/cards/${card.id}`, { priority: 3 })
@@ -44,6 +45,59 @@ test.describe('Card Activity feed', () => {
 		// The granular activity log now renders it as "changed the priority to X"
 		// rather than the generic "updated this card".
 		await expect(rows.first()).toContainText('changed the priority')
+	})
+
+	// #10131 — "5 days ago" can't answer "when exactly?". Every activity row now
+	// carries the precise stamp beside the relative label, in a <time> element so
+	// it is machine-readable and copy-pasteable.
+	//
+	// The stamp is ALWAYS rendered, deliberately NOT a hover tooltip: a
+	// hover-only affordance is unreachable on touch, and this app is installed on
+	// phones. So this asserts visibility with no hover, no focus and no tap —
+	// and that the relative label survives alongside it (the change is additive).
+	test('every activity row shows the exact date and time, with no hover needed', async ({ page }) => {
+		// A time entry on the same card: the activity feed and the time-tracking
+		// list share the `.card-modal__activity-time` class, and this change must
+		// leave the time-tracking list byte-for-byte as it was.
+		const timeEntry = await api.send('POST', `/cards/${state.cardId}/time-entries`, { seconds: 5400, note: 'Pairing' })
+
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// The time-tracking list is on the main pane, before we go near Activity.
+		const trackedRow = page.locator('.card-modal__time-entry', { hasText: 'Pairing' })
+		await expect(trackedRow).toHaveCount(1, { timeout: 8_000 })
+		// UNCHANGED: still the relative label alone — no <time>, no exact stamp.
+		await expect(trackedRow.locator('.card-modal__activity-time')).toHaveCount(1)
+		await expect(trackedRow.locator('.card-modal__activity-time time')).toHaveCount(0)
+		await expect(trackedRow.locator('.card-modal__activity-exact')).toHaveCount(0)
+
+		await page.locator('.card-modal__discussion-tab', { hasText: 'Activity' }).click()
+		const rows = page.locator('.card-modal__activity-row')
+		await expect(rows.first()).toBeVisible({ timeout: 8_000 })
+
+		// One exact stamp per row — no row is left with a relative label only.
+		const stamps = page.locator('.card-modal__activity-row time.card-modal__activity-exact')
+		await expect.poll(async () => await stamps.count()).toBe(await rows.count())
+
+		const stamp = stamps.first()
+		// Visible as rendered: nothing was hovered, focused or tapped.
+		await expect(stamp).toBeVisible()
+		// Machine-readable instant on the element itself.
+		expect(await stamp.getAttribute('datetime')).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+		// And a human clock in the visible text.
+		await expect(stamp).toHaveText(/\d{1,2}:\d{2}/)
+		// The relative label is still there — this is additive, not a swap — and
+		// the separator is real text, so a copy-paste reads "just now · 09:31 PM"
+		// rather than running the two labels together.
+		await expect(rows.first()).toContainText(/ago|just now/)
+		expect(await rows.first().textContent()).toContain(' · ')
+		// The title spells the stamp out in full.
+		const title = await stamp.getAttribute('title')
+		expect((title || '').length).toBeGreaterThan((await stamp.textContent()).length)
+
+		await api.send('DELETE', `/cards/${state.cardId}/time-entries/${timeEntry.id}`).catch(() => {})
 	})
 
 	// #3553 — the feed must update live while the Activity tab is open, both for a

--- a/tests/unit/Service/ImportServiceTest.php
+++ b/tests/unit/Service/ImportServiceTest.php
@@ -485,6 +485,19 @@ class ImportServiceTest extends TestCase {
 						'id' => 85, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
 						'owner' => 'bob', 'enabled' => true,
 					],
+					// Frequencies sabre ACCEPTS but cannot step: its iterator's
+					// constructor takes all seven RFC 5545 values, next() implements
+					// only five, and on these two the cursor never moves - the same
+					// unending fastForward() as a FREQ-less rule. Import has to drop
+					// them for the same reason, and keep going.
+					[
+						'id' => 86, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
+						'rrule' => 'FREQ=SECONDLY', 'owner' => 'bob', 'enabled' => true,
+					],
+					[
+						'id' => 87, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
+						'rrule' => 'FREQ=MINUTELY;INTERVAL=15', 'owner' => 'bob', 'enabled' => true,
+					],
 					// A perfectly good rule right behind it still lands intact.
 					[
 						'id' => 82, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
@@ -550,8 +563,9 @@ class ImportServiceTest extends TestCase {
 		self::assertSame(31, $capturedRecur[0]->getTargetStackId());
 		self::assertSame('importer', $capturedRecur[0]->getOwner());
 
-		// None of the unparseable RRULEs reached the mapper - the outright-invalid
-		// FREQ and the three FREQ-less variants alike - while the valid rule sitting
+		// None of the rules this app cannot iterate reached the mapper - the
+		// outright-invalid FREQ, the three FREQ-less variants, and the two
+		// accepted-but-unsteppable frequencies alike - while the valid rule sitting
 		// behind all of them imported with its RRULE intact.
 		self::assertSame(
 			['FREQ=DAILY', 'FREQ=WEEKLY;BYDAY=MO'],

--- a/tests/unit/Service/ImportServiceTest.php
+++ b/tests/unit/Service/ImportServiceTest.php
@@ -498,6 +498,29 @@ class ImportServiceTest extends TestCase {
 						'id' => 87, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
 						'rrule' => 'FREQ=MINUTELY;INTERVAL=15', 'owner' => 'bob', 'enabled' => true,
 					],
+					// Rules with a valid FREQ but a poisoned rule PART. These are the
+					// worst of the set: sabre's parser range-checks some parts and not
+					// others, so both of these construct cleanly and then spin inside a
+					// SINGLE next() call - `FREQ=WEEKLY;BYHOUR=99` because nextWeekly()
+					// is the one next*() with no year-9999 escape and hour 99 never
+					// arrives, `BYYEARDAY` + a positional BYDAY because nextYearly()
+					// indexes its day map with '2MO' and finds nothing, forever. Both
+					// were verified pinning a core at 99.8% CPU until killed.
+					//
+					// This is why import matters so much here: it is a single
+					// authenticated request carrying arbitrary rules, its per-rule
+					// try/catch only catches EXCEPTIONS, and an infinite loop is not an
+					// exception. One poisoned rule in an uploaded board file wedged the
+					// import worker outright, and the endpoint's UserRateLimit is no help
+					// when one request is all it takes.
+					[
+						'id' => 88, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
+						'rrule' => 'FREQ=WEEKLY;BYHOUR=99', 'owner' => 'bob', 'enabled' => true,
+					],
+					[
+						'id' => 89, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
+						'rrule' => 'FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO', 'owner' => 'bob', 'enabled' => true,
+					],
 					// A perfectly good rule right behind it still lands intact.
 					[
 						'id' => 82, 'templateCardId' => 100, 'targetStackId' => 2, 'mode' => 0,
@@ -564,9 +587,12 @@ class ImportServiceTest extends TestCase {
 		self::assertSame('importer', $capturedRecur[0]->getOwner());
 
 		// None of the rules this app cannot iterate reached the mapper - the
-		// outright-invalid FREQ, the three FREQ-less variants, and the two
-		// accepted-but-unsteppable frequencies alike - while the valid rule sitting
-		// behind all of them imported with its RRULE intact.
+		// outright-invalid FREQ, the three FREQ-less variants, the two
+		// accepted-but-unsteppable frequencies, and the two whose FREQ is fine but
+		// whose rule PARTS wedge sabre inside a single next() call - while the valid
+		// rule sitting behind all of them imported with its RRULE intact. That the
+		// assertion runs at all is half the point: before the guard, the poisoned
+		// parts made this import never return.
 		self::assertSame(
 			['FREQ=DAILY', 'FREQ=WEEKLY;BYDAY=MO'],
 			array_map(static fn (RecurRule $r): string => $r->getRrule(), $capturedRecur),

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -244,16 +244,44 @@ class RecurrenceServiceTest extends TestCase {
 
 	/**
 	 * A rule with no FREQ is the nastiest shape of malformed: sabre never checks
-	 * that FREQ is present, so the iterator CONSTRUCTS cleanly and only dies while
-	 * stepping - and it dies with an \Error, not an \Exception. Anything catching
-	 * just \Exception let that through as a fatal: a 500 on the API instead of a
-	 * 400, a board import aborted whole, a cron pass killed by one stored rule.
+	 * that FREQ is present, so the iterator CONSTRUCTS cleanly and the damage only
+	 * shows while stepping. What it looks like there depends on the sabre release,
+	 * which is why this rejection has to happen BEFORE an iterator exists:
+	 *   - on vobject 5 the frequency property is typed, so stepping raises an
+	 *     \Error a catch can turn into a 400;
+	 *   - on vobject 4 - the line Nextcloud bundles, and therefore the one this app
+	 *     runs against in production - it is untyped and simply null, so no switch
+	 *     arm matches, the cursor never advances, and fastForward() loops forever.
+	 *     There is no throw to catch: the request wedges its worker, and under the
+	 *     cron CLI (no time limit) it wedges the background job.
+	 * composer.lock pins the 4.x line precisely so this test exercises the version
+	 * that ships. Under it, a regression here does not fail politely - it HANGS,
+	 * which is the honest signal and still a red build.
+	 *
+	 * "" is the API's default for an omitted rrule parameter, so it is reachable by
+	 * simply leaving the field out of the request.
 	 *
 	 * @testWith [""]
+	 *           ["   "]
 	 *           ["COUNT=3"]
 	 *           ["INTERVAL=2"]
+	 *           ["COUNT=3;INTERVAL=2"]
 	 */
 	public function testComputeNextOccurrenceRejectsAFreqLessRule(string $rrule): void {
+		$this->expectException(InvalidInputException::class);
+		$this->service->computeNextOccurrence($rrule, self::NOW, self::NOW);
+	}
+
+	/**
+	 * The rejection must come from the FREQ check, not from the iterator: a rule
+	 * whose FREQ is present but nonsense is a DIFFERENT failure, caught by sabre's
+	 * own constructor on both versions. Asserting it still rejects keeps the guard
+	 * from being loosened into "anything with a FREQ= is fine".
+	 *
+	 * @testWith ["FREQ="]
+	 *           ["FREQ=BOGUS"]
+	 */
+	public function testComputeNextOccurrenceRejectsAPresentButInvalidFreq(string $rrule): void {
 		$this->expectException(InvalidInputException::class);
 		$this->service->computeNextOccurrence($rrule, self::NOW, self::NOW);
 	}
@@ -403,17 +431,25 @@ class RecurrenceServiceTest extends TestCase {
 	}
 
 	/**
-	 * A FREQ-less rule is a 400 like any other bad input, NOT a fatal. sabre builds
-	 * the iterator for it without complaint and only blows up while stepping - as
-	 * an \Error - so validate() has to catch more than \Exception to answer this
-	 * with a rejection instead of a 500.
+	 * A FREQ-less rule is a 400 like any other bad input - not a fatal, and (on the
+	 * sabre line that ships) not a hung request either. sabre builds the iterator
+	 * for it without complaint, so validate() has to refuse the rule before one is
+	 * ever constructed.
+	 *
+	 * "" is what the controller passes when the request simply OMITS rrule, which
+	 * makes this the cheapest possible way in.
+	 *
+	 * @testWith [""]
+	 *           ["   "]
+	 *           ["COUNT=3"]
+	 *           ["INTERVAL=2"]
 	 */
-	public function testCreateRejectsAFreqLessRruleWith400(): void {
+	public function testCreateRejectsAFreqLessRruleWith400(string $rrule): void {
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
 		$this->ruleMapper->expects(self::never())->method('insert');
 
 		$this->expectException(InvalidInputException::class);
-		$this->service->create(1, 10, 5, RecurRule::MODE_CLONE, 'COUNT=3', 0, 0, false, 'alice');
+		$this->service->create(1, 10, 5, RecurRule::MODE_CLONE, $rrule, 0, 0, false, 'alice');
 	}
 
 	public function testCreateRejectsTemplateCardOnAnotherBoard(): void {
@@ -2073,5 +2109,58 @@ class RecurrenceServiceTest extends TestCase {
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->update(3, null, null, null, null, null, null, null, null, 'alice', 'Mars/Olympus_Mons');
+	}
+
+	/**
+	 * Editing an existing rule down to a FREQ-less RRULE is the same 400 as
+	 * creating one - and, crucially, the same non-hang. update() re-arms the cursor
+	 * through the same expansion path create() validates with, so the guard has to
+	 * hold on both or a live board can be edited into a wedged worker.
+	 *
+	 * @testWith [""]
+	 *           ["   "]
+	 *           ["COUNT=3"]
+	 *           ["INTERVAL=2"]
+	 */
+	public function testUpdateRejectsAFreqLessRruleWith400(string $rrule): void {
+		$rule = $this->rule();
+		$this->ruleMapper->method('find')->with(3)->willReturn($rule);
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(3, null, null, null, $rrule, null, null, null, null, 'alice', null);
+	}
+
+	/**
+	 * A FREQ-less rule STORED before the guard landed (create/update accepted
+	 * 'COUNT=3' happily, and the API's own default for an omitted rrule was '')
+	 * must not wedge the cron pass that picks it up. runDueRules() reaches it
+	 * through advanceSchedule(), which now gets an InvalidInputException instead of
+	 * an endless walk, logs it, and retires the rule.
+	 *
+	 * This is the path with no timeout at all - occ/cron runs under the CLI SAPI,
+	 * where max_execution_time is 0 - so it is the one that matters most.
+	 *
+	 * @testWith [""]
+	 *           ["COUNT=3"]
+	 *           ["INTERVAL=2"]
+	 */
+	public function testRunDueRulesDisablesAStoredFreqLessRuleInsteadOfSpinning(string $rrule): void {
+		$rule = $this->rule(rrule: $rrule, nextOccurrenceAt: self::NOW);
+		$this->ruleMapper->method('findDueEnabled')->willReturn([$rule]);
+		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->cardService->method('create')->willReturn($this->spawnedCard());
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->cardLabelMapper->method('findLabelIdsByCard')->willReturn([]);
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->willReturn([]);
+		$this->ruleMapper->method('update')->willReturnArgument(0);
+
+		$this->service->runDueRules();
+
+		self::assertSame(0, $rule->getNextOccurrenceAt());
+		self::assertFalse($rule->getEnabled());
 	}
 }

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -255,11 +255,12 @@ class RecurrenceServiceTest extends TestCase {
 	 *     There is no throw to catch: the request wedges its worker, and under the
 	 *     cron CLI (no time limit) it wedges the background job.
 	 * composer.lock pins the 4.x line precisely so this test exercises the version
-	 * that ships. Under it, a regression here does not fail politely - it HANGS,
-	 * which is the honest signal and still a red build.
+	 * that ships.
 	 *
 	 * "" is the API's default for an omitted rrule parameter, so it is reachable by
 	 * simply leaving the field out of the request.
+	 *
+	 * The anchoring is deliberate - see {@see self::assertRejectedWithoutStepping}.
 	 *
 	 * @testWith [""]
 	 *           ["   "]
@@ -268,22 +269,123 @@ class RecurrenceServiceTest extends TestCase {
 	 *           ["COUNT=3;INTERVAL=2"]
 	 */
 	public function testComputeNextOccurrenceRejectsAFreqLessRule(string $rrule): void {
-		$this->expectException(InvalidInputException::class);
-		$this->service->computeNextOccurrence($rrule, self::NOW, self::NOW);
+		$this->assertRejectedWithoutStepping($rrule);
 	}
 
 	/**
-	 * The rejection must come from the FREQ check, not from the iterator: a rule
-	 * whose FREQ is present but nonsense is a DIFFERENT failure, caught by sabre's
-	 * own constructor on both versions. Asserting it still rejects keeps the guard
-	 * from being loosened into "anything with a FREQ= is fine".
+	 * A FREQ that is present but not a frequency at all. Sabre's own constructor
+	 * rejects these, but the guard must reject them FIRST and on its own terms -
+	 * otherwise it is only a presence check, and a presence check is not enough
+	 * (see the SECONDLY/MINUTELY tests below).
 	 *
 	 * @testWith ["FREQ="]
 	 *           ["FREQ=BOGUS"]
+	 *           ["FREQ=DAILYISH"]
 	 */
 	public function testComputeNextOccurrenceRejectsAPresentButInvalidFreq(string $rrule): void {
+		$this->assertRejectedWithoutStepping($rrule);
+	}
+
+	/**
+	 * SECONDLY and MINUTELY are the half of the hole a presence check leaves open.
+	 * They are valid RFC 5545 and sabre's iterator CONSTRUCTOR accepts them - its
+	 * frequency whitelist carries all seven values - but its next() implements only
+	 * five. On these two it returns without touching the cursor, so fastForward()'s
+	 * unbounded `while (valid() && current < target)` spins exactly as a FREQ-less
+	 * rule does, with nothing thrown to catch. A guard that asked only "is FREQ
+	 * present?" waved both straight through to that spin.
+	 *
+	 * {@see self::testSabreCannotStepSecondlyOrMinutely} is the companion proof that
+	 * this is sabre's behaviour and not an assumption.
+	 *
+	 * The anchoring is deliberate - see {@see self::assertRejectedWithoutStepping}.
+	 *
+	 * @testWith ["FREQ=SECONDLY"]
+	 *           ["FREQ=MINUTELY"]
+	 *           ["FREQ=SECONDLY;INTERVAL=30"]
+	 *           ["FREQ=MINUTELY;COUNT=5"]
+	 *           ["freq=secondly"]
+	 */
+	public function testComputeNextOccurrenceRejectsAFrequencySabreCannotStep(string $rrule): void {
+		$this->assertRejectedWithoutStepping($rrule);
+	}
+
+	/**
+	 * Asserts computeNextOccurrence() refuses $rrule - and does it in a shape that
+	 * FAILS rather than HANGS if the guard is ever weakened.
+	 *
+	 * Every rule these tests feed in is one sabre's iterator cannot step: the cursor
+	 * stands still, so fastForward()'s `while (valid() && currentDate < $target)`
+	 * would spin forever if it were ever entered. Asking for the occurrence after
+	 * `$anchor - 1` makes the target the anchor itself, so `currentDate < $target` is
+	 * false on the very first check and the loop body never runs. A regressed guard
+	 * therefore lets the call RETURN (the anchor) instead of throwing, and the
+	 * missing-exception failure is instant.
+	 *
+	 * Do not "simplify" this to (NOW, NOW). That asks for the occurrence strictly
+	 * after the anchor, which enters the loop - and a regression then wedges the
+	 * whole suite instead of reddening it. That is precisely what stalled a test run
+	 * for an hour while this bug was being investigated.
+	 */
+	private function assertRejectedWithoutStepping(string $rrule): void {
+		$anchor = self::NOW;
 		$this->expectException(InvalidInputException::class);
-		$this->service->computeNextOccurrence($rrule, self::NOW, self::NOW);
+		$this->service->computeNextOccurrence($rrule, $anchor - 1, $anchor);
+	}
+
+	/**
+	 * The five frequencies sabre CAN step must still be accepted - the guard is an
+	 * allowlist, and an allowlist that is too narrow breaks every real rule. Each is
+	 * asserted to produce a real occurrence strictly after the anchor.
+	 *
+	 * @testWith ["FREQ=HOURLY", 3600]
+	 *           ["FREQ=DAILY", 86400]
+	 *           ["FREQ=WEEKLY", 604800]
+	 *           ["FREQ=MONTHLY", 2678400]
+	 *           ["FREQ=YEARLY", 31536000]
+	 */
+	public function testComputeNextOccurrenceAcceptsEveryIterableFrequency(string $rrule, int $expectedDelta): void {
+		$anchor = (new \DateTimeImmutable('2026-01-01T00:00:00Z'))->getTimestamp();
+		$next = $this->service->computeNextOccurrence($rrule, $anchor, $anchor, 'UTC');
+		self::assertSame($anchor + $expectedDelta, $next);
+	}
+
+	/**
+	 * Pins down WHY SECONDLY and MINUTELY have to be rejected, straight against the
+	 * sabre the suite runs (4.x, pinned in composer.json - the line Nextcloud
+	 * bundles). It is deliberately BOUNDED: it steps the iterator a fixed number of
+	 * times and asserts the cursor moved, rather than calling fastForward() on an
+	 * unguarded rule. fastForward() on these never returns, so a test written that
+	 * way would HANG the suite instead of failing it - which is exactly how this
+	 * wedged a test run for an hour while it was being investigated. Never reach for
+	 * fastForward() here.
+	 *
+	 * @testWith ["SECONDLY", false]
+	 *           ["MINUTELY", false]
+	 *           ["HOURLY", true]
+	 *           ["DAILY", true]
+	 *           ["WEEKLY", true]
+	 *           ["MONTHLY", true]
+	 *           ["YEARLY", true]
+	 */
+	public function testSabreCannotStepSecondlyOrMinutely(string $freq, bool $expectedToAdvance): void {
+		$start = new \DateTimeImmutable('2026-01-01T00:00:00', new \DateTimeZone('UTC'));
+		// The constructor accepts all seven - that is the trap.
+		$iterator = new \Sabre\VObject\Recur\RRuleIterator('FREQ=' . $freq, $start);
+		for ($i = 0; $i < 5; $i++) {
+			$iterator->next();
+		}
+		$advanced = $iterator->current() === null
+			|| $iterator->current()->getTimestamp() !== $start->getTimestamp();
+		self::assertSame(
+			$expectedToAdvance,
+			$advanced,
+			sprintf(
+				'FREQ=%s: expected the cursor %s after 5 next() calls',
+				$freq,
+				$expectedToAdvance ? 'to advance' : 'to stand still',
+			),
+		);
 	}
 
 	// ---- create -----------------------------------------------------------

--- a/tests/unit/Service/RecurrenceServiceTest.php
+++ b/tests/unit/Service/RecurrenceServiceTest.php
@@ -149,6 +149,31 @@ class RecurrenceServiceTest extends TestCase {
 		return $card;
 	}
 
+	/**
+	 * A template card whose Start date sits just AFTER "now", and therefore anchors
+	 * any rule hung off it one minute in the future.
+	 *
+	 * This is the create/update/cron equivalent of
+	 * {@see self::assertRejectedWithoutStepping}'s `$anchor - 1`. firstFireFor() asks
+	 * for the occurrence after `max($anchor - 1, now)` = `$anchor - 1`, so the advance
+	 * loop's `current() < $target` is false on its very first check and the iterator
+	 * is never STEPPED.
+	 *
+	 * Every test that feeds a REJECTED rule through create(), update() or
+	 * runDueRules() must use this. Those entry points pick their own anchor, and some
+	 * of the rules under test (`FREQ=WEEKLY;BYHOUR=99`,
+	 * `FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO`) spin forever inside a SINGLE next() call -
+	 * so a regressed guard would HANG the suite rather than redden it. With the anchor
+	 * ahead of the target, a regression instead lets the call RETURN an occurrence and
+	 * the missing-exception failure is instant. This is not hypothetical: mutating the
+	 * guard hung the run at test 173 until these were anchored.
+	 */
+	private function unsteppedTemplateCard(int $id = 10, int $boardId = 1): Card {
+		$card = $this->templateCard($id, $boardId);
+		$card->setStartDate(new \DateTime('@' . (self::NOW + 60)));
+		return $card;
+	}
+
 	private function rule(
 		int $id = 3,
 		int $mode = RecurRule::MODE_CLONE,
@@ -351,6 +376,185 @@ class RecurrenceServiceTest extends TestCase {
 	}
 
 	/**
+	 * A valid FREQ is necessary but nowhere near sufficient: EVERY other rule part
+	 * used to reach the iterator unvalidated, and sabre range-checks only some of
+	 * them. An out-of-range value on an unchecked part throws nothing - it just
+	 * describes an occurrence set that can never be satisfied, and sabre then spins
+	 * looking for it. The parts below are refused outright (they are not on
+	 * SUPPORTED_PARTS) because each reaches a sabre loop that cannot be bounded from
+	 * outside:
+	 *
+	 *   - `FREQ=WEEKLY;BYHOUR=99` - nextWeekly() is the only next*() with no
+	 *     year-9999 escape, and format('G') never yields 99. Verified live through
+	 *     computeNextOccurrence(): 99.8% CPU until killed. A true infinite loop.
+	 *   - `FREQ=DAILY;BYHOUR=99` - same defect, but nextDaily() DOES have the escape,
+	 *     so it "only" walks ~70 million iterations to the year 9999.
+	 *   - `FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO` - every part in range, yet nextYearly()'s
+	 *     BYYEARDAY branch is a bare `while (true)` that indexes `$this->dayMap[$byDay]`
+	 *     RAW (unlike the weekly/monthly paths, which use `substr($day, -2)` and so
+	 *     tolerate an ordinal). '2MO' is not a key, no candidate ever matches, the year
+	 *     counter climbs forever. Also verified at 99.8% CPU.
+	 *   - BYWEEKNO reaches the same raw-dayMap branch; BYMINUTE/BYSECOND/BYSETPOS are
+	 *     inert on THIS sabre release, which is exactly the kind of fact that goes
+	 *     stale between versions - so they are refused rather than trusted.
+	 *
+	 * Note where the first and third loops live: INSIDE a single next() call. That is
+	 * why the step cap ({@see self::testComputeNextOccurrenceCapsAnAncientAnchorsWalk})
+	 * cannot cover them and this allowlist is load-bearing - PHP cannot interrupt a
+	 * loop inside a library call.
+	 *
+	 * The anchoring is deliberate - see {@see self::assertRejectedWithoutStepping}.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99"]
+	 *           ["FREQ=DAILY;BYHOUR=99"]
+	 *           ["FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO"]
+	 *           ["FREQ=YEARLY;BYWEEKNO=1;BYDAY=2MO"]
+	 *           ["FREQ=WEEKLY;BYHOUR=0"]
+	 *           ["FREQ=DAILY;BYMINUTE=30"]
+	 *           ["FREQ=DAILY;BYSECOND=0"]
+	 *           ["FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO"]
+	 *           ["FREQ=MONTHLY;BYSETPOS=999"]
+	 *           ["FREQ=YEARLY;BYYEARDAY=400"]
+	 */
+	public function testComputeNextOccurrenceRejectsAnUnsupportedRulePart(string $rrule): void {
+		$this->assertRejectedWithoutStepping($rrule);
+	}
+
+	/**
+	 * The parts this app DOES store are range-checked here rather than left to
+	 * sabre, which checks BYMONTH but not BYMONTHDAY, and enforces only ">= 1" on
+	 * INTERVAL and COUNT. An out-of-range BYMONTHDAY is the cheap version of the same
+	 * bug: `FREQ=MONTHLY;BYMONTHDAY=32` describes an empty occurrence set, so
+	 * nextMonthly() walks month by month to sabre's year-9999 stop - ~95k iterations,
+	 * 0.18s measured, inside ONE next() call. It terminates only because that one
+	 * next*() happens to have an escape hatch, which is not a property to depend on.
+	 *
+	 * The anchoring is deliberate - see {@see self::assertRejectedWithoutStepping}.
+	 *
+	 * @testWith ["FREQ=MONTHLY;BYMONTHDAY=32"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=0"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=-32"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=1,32"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=NOPE"]
+	 *           ["FREQ=YEARLY;BYMONTH=13"]
+	 *           ["FREQ=YEARLY;BYMONTH=0"]
+	 *           ["FREQ=WEEKLY;BYDAY=XX"]
+	 *           ["FREQ=WEEKLY;BYDAY=MO,XX"]
+	 *           ["FREQ=WEEKLY;BYDAY="]
+	 *           ["FREQ=MONTHLY;BYDAY=9MO"]
+	 *           ["FREQ=WEEKLY;WKST=XX"]
+	 *           ["FREQ=DAILY;INTERVAL=0"]
+	 *           ["FREQ=DAILY;INTERVAL=-1"]
+	 *           ["FREQ=DAILY;INTERVAL=999999999"]
+	 *           ["FREQ=DAILY;INTERVAL=2abc"]
+	 *           ["FREQ=DAILY;COUNT=0"]
+	 *           ["FREQ=DAILY;COUNT=999999999"]
+	 *           ["FREQ=DAILY;UNTIL=NOT-A-DATE"]
+	 */
+	public function testComputeNextOccurrenceRejectsAnOutOfRangePartValue(string $rrule): void {
+		$this->assertRejectedWithoutStepping($rrule);
+	}
+
+	/**
+	 * The other half of an allowlist: it must not eat real schedules. Every rule here
+	 * is one a user can genuinely author - through the editor, the API or the MCP
+	 * server - and each has to keep producing an occurrence strictly after the anchor.
+	 * Negative values are legal and load-bearing (`BYMONTHDAY=-1` is "the last day of
+	 * the month"), as is a positional BYDAY on a monthly rule.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYDAY=MO,WE,FR"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=1,15"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=-1"]
+	 *           ["FREQ=MONTHLY;BYDAY=1MO"]
+	 *           ["FREQ=MONTHLY;BYDAY=-1FR"]
+	 *           ["FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=29"]
+	 *           ["FREQ=DAILY;INTERVAL=2;COUNT=10"]
+	 *           ["FREQ=DAILY;UNTIL=20990101T000000Z"]
+	 *           ["FREQ=WEEKLY;INTERVAL=2;BYDAY=TU;WKST=SU"]
+	 *           ["FREQ=YEARLY;INTERVAL=1"]
+	 *           ["freq=weekly;byday=mo"]
+	 */
+	public function testComputeNextOccurrenceAcceptsEveryLegitimateRule(string $rrule): void {
+		$anchor = (new \DateTimeImmutable('2026-01-01T09:00:00Z'))->getTimestamp();
+		$next = $this->service->computeNextOccurrence($rrule, $anchor, $anchor, 'UTC');
+		self::assertGreaterThan($anchor, $next, $rrule . ' must still produce an occurrence');
+	}
+
+	/**
+	 * The version-independent half of the guard: a cap on how many occurrences one
+	 * call may step through.
+	 *
+	 * The lever is the ANCHOR, not the rule. A rule's DTSTART is the template card's
+	 * Start date (see anchorFor()), and DueDateParser happily accepts year 0001 - so
+	 * a card dated 0001-01-01 with a perfectly legal `FREQ=HOURLY` makes
+	 * fastForward() step roughly 17.7 MILLION entirely valid occurrences to reach
+	 * today. Nothing about that rule is malformed; no allowlist can see it coming.
+	 *
+	 * Unlike every other case in this file the walk here is bounded by construction
+	 * (each step advances an hour, so it ends), which is why this one may safely ask
+	 * for an occurrence after the anchor: the failure mode being guarded against is
+	 * minutes of pinned CPU, not an endless loop.
+	 */
+	public function testComputeNextOccurrenceCapsAnAncientAnchorsWalk(): void {
+		$anchor = (new \DateTimeImmutable('0001-01-01T00:00:00Z'))->getTimestamp();
+		$started = microtime(true);
+		try {
+			$this->service->computeNextOccurrence('FREQ=HOURLY', self::NOW, $anchor, 'UTC');
+			self::fail('An anchor two millennia back must be refused, not walked');
+		} catch (InvalidInputException $e) {
+			// The cap is worthless if reaching it is itself the expense. 50k steps
+			// measured at 0.7-3.7us each; a whole second is a very loose ceiling that
+			// still fails loudly if the cap is ever removed.
+			self::assertLessThan(1.0, microtime(true) - $started, 'the cap must be cheap to hit');
+		}
+	}
+
+	/**
+	 * The cap must not clip a realistic catch-up. An HOURLY rule anchored a year back
+	 * is 8760 steps - well inside the 50000 budget, which covers ~5.7 years at the
+	 * finest grain this app accepts (and centuries at every coarser one).
+	 */
+	public function testComputeNextOccurrenceStillWalksARealisticBacklog(): void {
+		$anchor = self::NOW - 365 * 86400;
+		$next = $this->service->computeNextOccurrence('FREQ=HOURLY', self::NOW, $anchor, 'UTC');
+		self::assertGreaterThan(self::NOW, $next);
+	}
+
+	/**
+	 * The companion proof that the unsupported parts really are unchecked by the
+	 * sabre this suite runs (4.x, pinned in composer.json - the line Nextcloud
+	 * bundles), rather than an assumption copied from a changelog.
+	 *
+	 * Deliberately BOUNDED: it only CONSTRUCTS the iterator and asserts the
+	 * constructor raised nothing. It never calls next() - on `BYHOUR=99` a single
+	 * next() never returns, so a test written that way would hang the suite instead
+	 * of failing it. Constructing is enough to make the point: sabre stores BYHOUR
+	 * and BYMONTHDAY verbatim, and only the range-checked parts (BYMONTH here) are
+	 * refused at the door.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99", true]
+	 *           ["FREQ=DAILY;BYHOUR=99", true]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=32", true]
+	 *           ["FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO", true]
+	 *           ["FREQ=DAILY;INTERVAL=999999999", true]
+	 *           ["FREQ=YEARLY;BYMONTH=13", false]
+	 */
+	public function testSabreDoesNotRangeCheckTheseRuleParts(string $rrule, bool $expectedToConstruct): void {
+		$start = new \DateTimeImmutable('2026-01-01T00:00:00', new \DateTimeZone('UTC'));
+		$constructed = true;
+		try {
+			new \Sabre\VObject\Recur\RRuleIterator($rrule, $start);
+		} catch (\Throwable $e) {
+			$constructed = false;
+		}
+		self::assertSame(
+			$expectedToConstruct,
+			$constructed,
+			sprintf('%s: expected sabre\'s constructor %s', $rrule, $expectedToConstruct ? 'to accept it' : 'to refuse it'),
+		);
+	}
+
+	/**
 	 * Pins down WHY SECONDLY and MINUTELY have to be rejected, straight against the
 	 * sabre the suite runs (4.x, pinned in composer.json - the line Nextcloud
 	 * bundles). It is deliberately BOUNDED: it steps the iterator a fixed number of
@@ -548,6 +752,10 @@ class RecurrenceServiceTest extends TestCase {
 	 */
 	public function testCreateRejectsAFreqLessRruleWith400(string $rrule): void {
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Anchored ahead of the target so a regressed guard fails fast instead of
+		// hanging - see unsteppedTemplateCard().
+		$this->cardMapper->method('find')->with(10)->willReturn($this->unsteppedTemplateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->ruleMapper->expects(self::never())->method('insert');
 
 		$this->expectException(InvalidInputException::class);
@@ -2228,12 +2436,146 @@ class RecurrenceServiceTest extends TestCase {
 		$rule = $this->rule();
 		$this->ruleMapper->method('find')->with(3)->willReturn($rule);
 		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
-		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		// Anchored ahead of the target so a regressed guard fails fast instead of
+		// hanging - see unsteppedTemplateCard().
+		$this->cardMapper->method('find')->with(10)->willReturn($this->unsteppedTemplateCard());
 		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
 		$this->ruleMapper->expects(self::never())->method('update');
 
 		$this->expectException(InvalidInputException::class);
 		$this->service->update(3, null, null, null, $rrule, null, null, null, null, 'alice', null);
+	}
+
+	/**
+	 * Rules outlive the guards that would have refused them. `FREQ=MINUTELY` was
+	 * spec-valid and accepted until it turned out to wedge the iterator;
+	 * `FREQ=WEEKLY;BYHOUR=99` passed the FREQ-only guard that replaced it; the API's
+	 * own default for an omitted rrule was once ''. All three are sitting in existing
+	 * installs, and update() re-validated the UNCHANGED stored RRULE on every edit -
+	 * so `PATCH {"enabled": false}` 400'd and the only way to stop such a rule was to
+	 * DELETE it, taking the template link and the spawn history with it.
+	 *
+	 * Turning a rule off must not depend on its schedule still being valid. It is
+	 * also the safe direction by construction: a disabled rule expands nothing.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99"]
+	 *           ["FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO"]
+	 *           ["FREQ=MINUTELY"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=32"]
+	 *           [""]
+	 */
+	public function testUpdateCanDisableARuleWhoseStoredRruleNoLongerValidates(string $rrule): void {
+		$rule = $this->rule(rrule: $rrule);
+		$this->wireUpdate($rule);
+
+		$updated = $this->service->update(3, null, null, null, null, null, null, null, false, 'alice', null);
+
+		self::assertFalse($updated->getEnabled());
+		// The stored rule is left verbatim - this is an off switch, not a repair.
+		self::assertSame($rrule, $updated->getRrule());
+	}
+
+	/**
+	 * The other side of that door: switching a rule that cannot run back ON is still
+	 * a 400. Skipping the RRULE check for a disable must not become a way to smuggle
+	 * an unrunnable rule back into the cron's queue.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99"]
+	 *           ["FREQ=MINUTELY"]
+	 */
+	public function testUpdateStillRefusesToReEnableAnUnrunnableStoredRule(string $rrule): void {
+		$rule = $this->rule(rrule: $rrule);
+		$rule->setEnabled(false);
+		$this->ruleMapper->method('find')->with(3)->willReturn($rule);
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Anchored ahead of the target: re-enabling also RE-ARMS the cursor, which is
+		// a second trip through the expansion path - see unsteppedTemplateCard().
+		$this->cardMapper->method('find')->with(10)->willReturn($this->unsteppedTemplateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(3, null, null, null, null, null, null, null, true, 'alice', null);
+	}
+
+	/**
+	 * Editing an existing rule to a poisoned rule PART is the same 400 as a FREQ-less
+	 * one. update() re-arms the cursor through the same expansion path, so a rule
+	 * that passed create() long ago must not be editable into a wedged worker either.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99"]
+	 *           ["FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=32"]
+	 *           ["FREQ=DAILY;INTERVAL=999999999"]
+	 */
+	public function testUpdateRejectsAPoisonedRulePartWith400(string $rrule): void {
+		$rule = $this->rule();
+		$this->ruleMapper->method('find')->with(3)->willReturn($rule);
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Anchored ahead of the target so a regressed guard fails fast instead of
+		// hanging - see unsteppedTemplateCard().
+		$this->cardMapper->method('find')->with(10)->willReturn($this->unsteppedTemplateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->expects(self::never())->method('update');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(3, null, null, null, $rrule, null, null, null, null, 'alice', null);
+	}
+
+	/**
+	 * Creating one is refused at the same door, for the same reason.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99"]
+	 *           ["FREQ=DAILY;BYHOUR=99"]
+	 *           ["FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=32"]
+	 *           ["FREQ=DAILY;COUNT=999999999"]
+	 */
+	public function testCreateRejectsAPoisonedRulePartWith400(string $rrule): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Anchored ahead of the target so a regressed guard fails fast instead of
+		// hanging - see unsteppedTemplateCard().
+		$this->cardMapper->method('find')->with(10)->willReturn($this->unsteppedTemplateCard());
+		$this->stackMapper->method('find')->with(5)->willReturn($this->stack());
+		$this->ruleMapper->expects(self::never())->method('insert');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->create(1, 10, 5, RecurRule::MODE_CLONE, $rrule, 0, 0, false, 'alice');
+	}
+
+	/**
+	 * A poisoned rule STORED before this guard landed must not wedge the cron pass
+	 * that picks it up - the path with no timeout at all, since occ/cron runs under
+	 * the CLI SAPI where max_execution_time is 0. runDueRules() reaches it through
+	 * advanceSchedule(), which gets an InvalidInputException instead of an endless
+	 * walk, logs it, and retires the rule.
+	 *
+	 * @testWith ["FREQ=WEEKLY;BYHOUR=99"]
+	 *           ["FREQ=YEARLY;BYYEARDAY=1;BYDAY=2MO"]
+	 *           ["FREQ=MONTHLY;BYMONTHDAY=32"]
+	 */
+	public function testRunDueRulesDisablesAStoredPoisonedRuleInsteadOfSpinning(string $rrule): void {
+		$rule = $this->rule(rrule: $rrule, nextOccurrenceAt: self::NOW);
+		// The template's Start date is the schedule's anchor, and putting it just
+		// AFTER the occurrence being advanced past is the same trick
+		// assertRejectedWithoutStepping() uses: it makes the advance loop's
+		// `current() < target` false on the first check, so the iterator is never
+		// stepped. A regressed guard therefore RETURNS an occurrence here (and the
+		// assertions below fail in milliseconds) instead of stepping into a next()
+		// that never comes back and hanging the whole suite.
+		$template = $this->unsteppedTemplateCard();
+		$this->ruleMapper->method('findDueEnabled')->willReturn([$rule]);
+		$this->cardMapper->method('find')->with(10)->willReturn($template);
+		$this->cardService->method('create')->willReturn($this->spawnedCard());
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->cardLabelMapper->method('findLabelIdsByCard')->willReturn([]);
+		$this->cardAssigneeMapper->method('findUserIdsByCard')->willReturn([]);
+		$this->ruleMapper->method('update')->willReturnArgument(0);
+
+		$this->service->runDueRules();
+
+		self::assertSame(0, $rule->getNextOccurrenceAt());
+		self::assertFalse($rule->getEnabled());
 	}
 
 	/**
@@ -2252,8 +2594,12 @@ class RecurrenceServiceTest extends TestCase {
 	 */
 	public function testRunDueRulesDisablesAStoredFreqLessRuleInsteadOfSpinning(string $rrule): void {
 		$rule = $this->rule(rrule: $rrule, nextOccurrenceAt: self::NOW);
+		// Anchor just after the occurrence being advanced past, so the advance loop
+		// is never entered and a regressed guard fails this test in milliseconds
+		// rather than hanging it - see the sibling poisoned-part test.
+		$template = $this->unsteppedTemplateCard();
 		$this->ruleMapper->method('findDueEnabled')->willReturn([$rule]);
-		$this->cardMapper->method('find')->with(10)->willReturn($this->templateCard());
+		$this->cardMapper->method('find')->with(10)->willReturn($template);
 		$this->cardService->method('create')->willReturn($this->spawnedCard());
 		$this->cardMapper->method('update')->willReturnArgument(0);
 		$this->cardLabelMapper->method('findLabelIdsByCard')->willReturn([]);

--- a/tests/unit/dateDisplay.test.mjs
+++ b/tests/unit/dateDisplay.test.mjs
@@ -22,6 +22,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
 import { exactTimeLabel, exactTimeTitle, isoTimestamp } from '../../src/utils/dateDisplay.js'
 
 // Local Fri 28 Aug 2026, 14:32 — the reference "now" for every case below.
@@ -30,6 +31,88 @@ const NOW_MS = NOW.getTime()
 
 /** Local date components → the unix SECONDS the API would emit for them. */
 const secs = (...parts) => Math.floor(new Date(...parts).getTime() / 1000)
+
+// ── Locale-pinned rendering ──────────────────────────────────────────────────
+//
+// The helpers format with locale `undefined` on purpose — every viewer sees
+// their OWN locale, which is the whole point and also why a locale bug hides
+// from a suite that only ever runs in the host's locale. So these cases run the
+// REAL helper in a child `node` whose default locale is forced via LANG/LC_ALL,
+// which is what Node maps to ICU. The timezone is pinned to the parent's so the
+// `secs(...)` inputs above still mean the same wall clock in the child.
+//
+// Node resolves these locale IDs out of its own bundled ICU data, so no glibc
+// locale has to be generated on the machine — verified on the Node the CI job
+// pins as well as locally.
+
+const MODULE_URL = new URL('../../src/utils/dateDisplay.js', import.meta.url).href
+const TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+/**
+ * `exactTimeLabel(tsSeconds, nowMs)` as rendered under a forced default locale.
+ *
+ * @param {string} posixLocale e.g. 'en_US.UTF-8'
+ * @param {number} tsSeconds unix timestamp in seconds
+ * @param {number} nowMs reference "now"
+ * @returns {string} the label the helper produces in that locale
+ */
+function labelIn(posixLocale, tsSeconds, nowMs = NOW_MS) {
+	const src = `import { exactTimeLabel } from ${JSON.stringify(MODULE_URL)}\n`
+		+ `process.stdout.write(exactTimeLabel(${tsSeconds}, ${nowMs}))`
+	return execFileSync(process.execPath, ['--input-type=module', '--eval', src], {
+		encoding: 'utf8',
+		env: { ...process.env, LANG: posixLocale, LC_ALL: posixLocale, TZ },
+	})
+}
+
+// Same local day as NOW, so these render as the clock alone.
+const AT_2144 = secs(2026, 7, 28, 21, 44, 0)
+const AT_0904 = secs(2026, 7, 28, 9, 4, 0)
+
+test('a 12-hour locale renders the hour without a leading zero', () => {
+	// The defect: this used to render "09:44 PM". A padded hour is simply not a
+	// thing in a 12-hour locale — nobody writes "09:44 PM".
+	const label = labelIn('en_US.UTF-8', AT_2144)
+	assert.match(label, /(^|\s)9:44\s?(?:PM|pm)/, `expected an unpadded "9:44 PM", got "${label}"`)
+	assert.ok(!/0\s*9:44/.test(label), `a 12-hour locale must not pad the hour, got "${label}"`)
+})
+
+test('a 12-hour locale still zero-pads the MINUTE', () => {
+	// The other half of the trap: unpadding the hour must not unpad the minute
+	// as well — "9:4 AM" would be worse than the bug being fixed.
+	const label = labelIn('en_US.UTF-8', AT_0904)
+	assert.match(label, /(^|\s)9:04\s?(?:AM|am)/, `expected "9:04 AM" with a padded minute, got "${label}"`)
+})
+
+test('24-hour locales keep the padding their own convention wants', () => {
+	// The regression this guards is the tempting one-line "fix": pairing
+	// `hour: 'numeric'` with `minute: '2-digit'` fixes en-US but silently
+	// rewrites en-GB/de-DE "09:04" into "9:04", breaking a second set of users
+	// to fix the first.
+	for (const locale of ['en_GB.UTF-8', 'de_DE.UTF-8']) {
+		const early = labelIn(locale, AT_0904)
+		assert.match(early, /^0?9[:.]04$/, `${locale} must keep its padded "09:04", got "${early}"`)
+		assert.ok(early.startsWith('09'), `${locale} pads the hour in its own convention, got "${early}"`)
+
+		const evening = labelIn(locale, AT_2144)
+		assert.equal(evening.replace(/\./, ':'), '21:44', `${locale} renders a 24-hour clock, got "${evening}"`)
+	}
+})
+
+test('a 24-hour locale whose own pattern is unpadded stays unpadded', () => {
+	// ja-JP writes H:mm natively, so "9:04" is correct there and "09:04" was
+	// what the old options wrongly forced on it.
+	const label = labelIn('ja_JP.UTF-8', AT_0904)
+	assert.equal(label, '9:04', `ja-JP renders its native unpadded hour, got "${label}"`)
+})
+
+test('the long date+clock form drops the leading zero too', () => {
+	// The label has two formatters; the older-event one must not keep the bug.
+	const label = labelIn('en_US.UTF-8', secs(2026, 7, 20, 21, 44, 0))
+	assert.ok(label.includes('2026'), `expected the date on an older stamp, got "${label}"`)
+	assert.match(label, /(^|\s)9:44\s?(?:PM|pm)/, `expected an unpadded "9:44 PM", got "${label}"`)
+	assert.ok(!/0\s*9:44/.test(label), `the date+clock form must not pad the hour, got "${label}"`)
+})
 
 test('an event from today renders the clock only — no date noise', () => {
 	const label = exactTimeLabel(secs(2026, 7, 28, 9, 15, 0), NOW_MS)

--- a/tests/unit/dateDisplay.test.mjs
+++ b/tests/unit/dateDisplay.test.mjs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10131 — the card's activity feed used to show a relative label only ("5 days
+// ago"), which cannot answer "when exactly?". The exact stamp now sits next to
+// it, and these cases pin the three things that make that safe:
+//
+//   1. Length awareness — a today event renders the clock alone, so a 50-row
+//      feed does not become a wall of repeated dates; anything older carries
+//      the date too.
+//   2. Absent timestamps degrade to an empty label. The feed renders whatever
+//      the change log hands it, and a 0 / null / unparseable value must NOT
+//      become "1 Jan 1970", "NaN", or a thrown error — a throw here would blank
+//      the whole modal (and trip the console-error guard in the e2e spec).
+//   3. `datetime` is a stable machine-readable UTC instant, independent of the
+//      viewer's zone.
+//
+// Every case builds its inputs from LOCAL date components against a fixed
+// reference "now" the test owns, so nothing here depends on the machine's
+// timezone — hardcoded wall-clock strings would flip between a developer's box
+// and CI.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { exactTimeLabel, exactTimeTitle, isoTimestamp } from '../../src/utils/dateDisplay.js'
+
+// Local Fri 28 Aug 2026, 14:32 — the reference "now" for every case below.
+const NOW = new Date(2026, 7, 28, 14, 32, 0)
+const NOW_MS = NOW.getTime()
+
+/** Local date components → the unix SECONDS the API would emit for them. */
+const secs = (...parts) => Math.floor(new Date(...parts).getTime() / 1000)
+
+test('an event from today renders the clock only — no date noise', () => {
+	const label = exactTimeLabel(secs(2026, 7, 28, 9, 15, 0), NOW_MS)
+	assert.match(label, /9:15/, `expected a 9:15 clock, got "${label}"`)
+	assert.ok(!label.includes('2026'), `today's stamp must not carry the year, got "${label}"`)
+	assert.ok(!label.includes('28'), `today's stamp must not carry the day, got "${label}"`)
+})
+
+test('an older event renders the date as well as the clock', () => {
+	const label = exactTimeLabel(secs(2026, 7, 20, 9, 15, 0), NOW_MS)
+	assert.match(label, /9:15/, `expected a 9:15 clock, got "${label}"`)
+	assert.ok(label.includes('2026'), `an older stamp must carry the year, got "${label}"`)
+	assert.ok(label.includes('20'), `an older stamp must carry the day, got "${label}"`)
+})
+
+test('yesterday counts as older even when it is well under 24h ago', () => {
+	// 23:59 the previous local day vs. a 14:32 "now" — under 24h, but a
+	// different calendar day, so the date has to be there.
+	const label = exactTimeLabel(secs(2026, 7, 27, 23, 59, 0), NOW_MS)
+	assert.ok(label.includes('2026'), `yesterday must carry the date, got "${label}"`)
+	assert.ok(label.length > exactTimeLabel(secs(2026, 7, 28, 23, 59, 0), NOW_MS).length)
+})
+
+test('a missing, zero or unparseable timestamp renders nothing and never throws', () => {
+	for (const bad of [0, '0', null, undefined, '', NaN, 'not-a-time', -1, false]) {
+		assert.equal(exactTimeLabel(bad, NOW_MS), '', `exactTimeLabel(${String(bad)})`)
+		assert.equal(exactTimeTitle(bad), '', `exactTimeTitle(${String(bad)})`)
+		assert.equal(isoTimestamp(bad), '', `isoTimestamp(${String(bad)})`)
+	}
+})
+
+test('datetime is a stable UTC instant, whatever the viewer timezone', () => {
+	// 1787927520 = 2026-08-28T14:32:00Z. toISOString() is UTC by definition, so
+	// this value is identical on every machine.
+	assert.equal(isoTimestamp(1787927520), '2026-08-28T14:32:00.000Z')
+	// The API sends an integer, but a delta payload may stringify it.
+	assert.equal(isoTimestamp('1787927520'), '2026-08-28T14:32:00.000Z')
+})
+
+test('the title spells out the stamp the short label abbreviates', () => {
+	const ts = secs(2026, 7, 20, 9, 15, 30)
+	const title = exactTimeTitle(ts)
+	assert.ok(title.includes('2026'), `expected the year in "${title}"`)
+	assert.match(title, /9:15/, `expected the clock in "${title}"`)
+	// Full precision: the change log stores whole seconds, and the title is
+	// where they surface.
+	assert.match(title, /:30\b/, `expected seconds in "${title}"`)
+	assert.ok(title.length > exactTimeLabel(ts, NOW_MS).length, 'the title must be the longer form')
+})

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4454,7 +4454,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4454,7 +4454,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4454,7 +4454,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4454,7 +4454,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4454,7 +4454,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -1559,7 +1559,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -3171,7 +3171,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4472,7 +4472,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5111,7 +5111,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5189,7 +5189,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4454,7 +4454,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -1559,7 +1559,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -3171,7 +3171,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4472,7 +4472,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5111,7 +5111,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5189,7 +5189,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -1546,7 +1546,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -3153,7 +3153,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5091,7 +5091,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5168,7 +5168,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4454,7 +4454,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4091
+#: src/components/CardDetail.vue:4098
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4089
+#: src/components/CardDetail.vue:4096
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4087
+#: src/components/CardDetail.vue:4094
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -1535,7 +1535,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4267
+#: src/components/CardDetail.vue:4274
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -3137,7 +3137,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4269
+#: src/components/CardDetail.vue:4276
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4436,7 +4436,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:5830
+#: src/components/CardDetail.vue:5837
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5073,7 +5073,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4268
+#: src/components/CardDetail.vue:4275
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5149,7 +5149,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4270
+#: src/components/CardDetail.vue:4277
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"


### PR DESCRIPTION
Started as the follow-up to #103; a validation pass alongside it turned up a **live availability bug in the released app**, so that is the headline.

## 1. A repeat rule with no `FREQ` pinned a PHP worker forever (`e5ccb39`)

**This is shipped, and reachable by any user who can manage a board.** `RecurRuleController::create()` declares `string $rrule = ''`, so a request that merely **omits** the field reaches the spin. Each hit pins one PHP-FPM worker until the pool is exhausted. On the cron path there is no `max_execution_time` at all.

Proved against **Nextcloud's own bundled sabre**, not the test `vendor/`:

```
sabre file: /var/www/html/3rdparty/sabre/vobject/lib/Recur/RRuleIterator.php
   before:  constructed … exit=124   (killed by timeout 8; never returns)
   after:   empty / whitespace / COUNT=3 / INTERVAL=2  ->  REJECTED in <1ms
            FREQ=DAILY                                 ->  RETURNED-OK
```
Real API calls agree: before, omitted-`rrule` / `''` / `INTERVAL=2` all hung at 25.01s (`curl_rc=28`) on create *and* update; after, every shape is a **400 in ~0.6s**. The cron path was proved separately with a rule seeded *before* the fix, bootstrapping real Nextcloud under the CLI SAPI: `runDueRules()` returns in 0.062s.

**Why review missed it.** `RecurrenceService.php:129` already had a `catch (\Throwable)` written for exactly this, and its comment explains sabre raises an `\Error` on a *"typed-but-uninitialized property"*. That is true of sabre **5.x**, which `composer.lock` pinned and the suite ran. Nextcloud ships **4.x**, where `$frequency` is untyped and defaults to `null`, and `fastForward()` has no iteration cap — **there is no `\Error` to catch**. Kanso ships no `vendor/` (`composer.json` has no `require` section; the release script excludes it), so production always resolves the class from `3rdparty`.

The fix is `assertHasFrequency()`, called *before* the iterator is constructed — the sole `new RRuleIterator` site, so all four callers are covered at once.

**A second defect fell out of the same baseline:** `COUNT=3` did not hang — it returned **200 and persisted a permanently-dead rule** (`nextOccurrenceAt=0`). Now a 400.

**The vacuity is closed, not worked around.** `sabre/vobject` is pinned to `^4.2` (lock: 4.6.1) so the suite exercises what actually ships. The mutation proof isolates it exactly — identical guard-less code:

```
under sabre 4.6.1 (production-matching):  PHPUNIT_EXIT=124  — hangs, no test completes
under sabre 5.0.0 (what the suite ran):   PHPUNIT_EXIT=0    — OK (5 tests, 5 assertions)
```

## 2. Activity entries now carry the exact date and time (`1a2bdfb`, `9714d87`) — closes #103

#103 asked for an editable "Completed on" field. That was declined in the thread (start/end semantics break down with recurring cards); the agreed resolution was to make the activity log exact, and the reporter accepted.

Relative label stays primary, exact stamp always visible beside it — deliberately **not** hover-only, since #10066 just fixed that class of defect for touch users. Today's rows collapse to the clock; older rows carry the date. Each is a real `<time datetime>` with a full `title`.

Two things worth noting. The separator began as a CSS `::before` and a live DOM dump showed copy-paste jamming the labels into `"just now09:31 PM"` — it is a real text node now, pinned by an assertion. And the first pass rendered `09:44 PM`: `Intl` only takes the locale's own time pattern when hour and minute are requested at the **same width**, so the naive `hour:'numeric', minute:'2-digit'` fix would have rewritten en-GB/de-DE/fr-FR `09:04` → `9:04`, fixing one locale by damaging several. Shipped as `numeric`/`numeric`, verified across 50 locales, with tests that run the helper in a child `node` under forced `LANG` — the helpers format with locale `undefined`, so a locale bug is otherwise invisible to a suite running in one locale.

## 3. Every CI job now has a runtime cap (`d998706`)

Consequence of the pin above: a future regression here fails by **hanging**, and `cs-check`, `psalm`, `unit-php`, `unit-mcp` and `build-frontend` had no `timeout-minutes` — they would burn to GitHub's 6h default. Caps sized from observed durations across 7 recent green runs with 2–3× headroom. All 7 jobs are now capped.

## Verification

Re-run independently before pushing, not taken from worker reports: **PHPUnit 1664 / 918,492 assertions** (3 pre-existing PHP 8.5 deprecations), `test:unit` **111/111**, psalm clean, php-cs-fixer 0 of 383, `activity` + `card-time-tracking` e2e 10 passed, recurrence e2e 21 passed, `l10n:check` no drift, and the end-to-end sabre proof above. Every new test mutation-proved.

Closes #103
