### PR TITLE
fix: require Nextcloud 32 or newer, the oldest version Kanso actually runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,10 +317,11 @@ jobs:
         run: npm run l10n:lint
 
   # Cross-version × cross-DB install/migration matrix. This is what actually
-  # VALIDATES the info.xml claim of NC 30–34: for each (version, db) combo it
+  # VALIDATES the info.xml claim of NC 32–34: for each (version, db) combo it
   # builds the frontend, boots a throwaway Nextcloud on that DB, enables Kanso
   # (running every migration via the app-enable + `occ upgrade`), then asserts
-  # the schema was really created (dev/smoke.sh). It deliberately does NOT run
+  # the schema was really created AND that app code actually runs against that
+  # server's API (dev/smoke.sh). It deliberately does NOT run
   # Playwright — the full browser e2e is slow and stays on 34+postgres only (the
   # `e2e` job below). PHPUnit is covered separately by the `unit-php` job (across
   # PHP 8.2 and 8.3); it is NOT re-run inside these containers because the ARC
@@ -340,7 +341,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nc-version: ['30', '31', '32', '33', '34']
+        nc-version: ['32', '33', '34']
         db: ['sqlite', 'postgres']
         include:
           - nc-version: '34'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Kanso
 
 Kanso is an open-source kanban app for Nextcloud (app id `kanso`) — a from-scratch,
-performance-first kanban board. AGPL, targets Nextcloud 30–34.
+performance-first kanban board. AGPL, targets Nextcloud 32–34.
 
 ## Stack & conventions
 - Backend: PHP 8.2+, Nextcloud app framework (`OCA\Kanso`), own tables prefixed `kanso_`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,14 @@ pass — verify the app on the new version, then raise `max-version` in
 Dependabot PR auto-merges; each one runs the full CI (psalm, PHPUnit, e2e) and
 is reviewed before merge.
 
+`min-version` moves for the same reason, in the other direction: drop a major
+once Nextcloud stops supporting it, or sooner if the code uses a server API that
+major doesn't have. **Nothing but the install matrix can catch that** — the `ocp`
+pin means psalm and PHPUnit always type-check against the *newest* server's API,
+never the oldest one we claim. So `dev/smoke.sh` executes real app code (the
+boards list and `occ kanso:rebalance`) on every `(version, db)` combo; when you
+add a call to a newer server API, that is what turns red.
+
 ## Commit messages
 
 Conventional-ish messages (`fix:`, `feat:`, `docs:`, `chore:`…), one logical

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/aktasfatih/kanso/actions/workflows/ci.yml/badge.svg)](https://github.com/aktasfatih/kanso/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-![Nextcloud 30–34](https://img.shields.io/badge/Nextcloud-30–34-0082c9)
+![Nextcloud 32–34](https://img.shields.io/badge/Nextcloud-32–34-0082c9)
 
 Instant drag & drop, payloads sized for large boards, realtime sync: a
 from-scratch kanban board that stays out of your way.
@@ -117,7 +117,7 @@ your work, on your own Nextcloud, laid out plainly.
 
 ## Installation
 
-Kanso targets **Nextcloud 30–34** and **PHP 8.2–8.3**. It isn't on the Nextcloud
+Kanso targets **Nextcloud 32–34** and **PHP 8.2–8.3**. It isn't on the Nextcloud
 App Store yet — until it is, install the pre-built tarball from
 [GitHub Releases](https://github.com/aktasfatih/kanso/releases) (no Node or
 Composer needed on your server):
@@ -184,7 +184,7 @@ cross-version matrix uses):
 
 ```sh
 NC_VERSION=32 KANSO_DB=postgres ./setup.sh   # NC 32 on Postgres
-NC_VERSION=30 KANSO_DB=sqlite   ./setup.sh   # NC 30 on SQLite (no db container)
+NC_VERSION=32 KANSO_DB=sqlite   ./setup.sh   # NC 32 on SQLite (no db container)
 NC_VERSION=34 KANSO_DB=mysql    ./setup.sh   # NC 34 on MariaDB
 ```
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -281,7 +281,15 @@ Kanso 是一款为速度而生的 Nextcloud 看板应用。看板、列和卡片
 	<screenshot>https://raw.githubusercontent.com/aktasfatih/kanso/main/docs/kanso-timeline.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/aktasfatih/kanso/main/docs/kanso-analytics.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="30" max-version="34"/>
+		<!-- Floor is 32, not 30: Kanso calls two IQueryBuilder APIs that do not
+		     exist before NC 32 - PARAM_DATETIME_MUTABLE (bound by the boards-list
+		     stats, i.e. opening the app) and forUpdate() (the rebalance path). On
+		     NC 30/31 both are a fatal PHP Error, so the app never worked there
+		     even though this range claimed it did. 32 is also the oldest release
+		     Nextcloud itself still supports, so nothing on a supported server
+		     loses Kanso. dev/smoke.sh now executes both paths in the install
+		     matrix, so a future API gap fails CI instead of shipping. -->
+		<nextcloud min-version="32" max-version="34"/>
 	</dependencies>
 	<!-- Element order below is fixed by the App Store schema's xs:sequence
 	     (background-jobs before commands, etc.). scripts/validate-info-xml.mjs

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -3,7 +3,7 @@
 #
 # Throwaway development Nextcloud with this app mounted from the checkout.
 # Defaults mirror the newest supported target (nextcloud:34-apache / PHP 8.3 +
-# postgres 16). The app supports NC 30–34; CI e2e boots this same stack. No
+# postgres 16). The app supports NC 32–34; CI e2e boots this same stack. No
 # volumes are persisted: `docker compose down` resets everything.
 #
 #   cd dev && ./setup.sh          # start + enable the app
@@ -11,7 +11,7 @@
 #
 # Cross-version / cross-DB matrix (used by CI, works locally too):
 #   NC_VERSION=32 KANSO_DB=postgres ./setup.sh   # NC 32 on postgres
-#   NC_VERSION=30 KANSO_DB=sqlite   ./setup.sh   # NC 30 on sqlite (no db service)
+#   NC_VERSION=32 KANSO_DB=sqlite   ./setup.sh   # NC 32 on sqlite (no db service)
 #   NC_VERSION=34 KANSO_DB=mysql    ./setup.sh   # NC 34 on mariadb
 #
 # NC_VERSION selects the nextcloud:<tag>-apache image (default 34).

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -14,8 +14,8 @@
 #
 # Examples:
 #   ./setup.sh                                  # NC 34 + postgres (default)
-#   NC_VERSION=30 KANSO_DB=sqlite ./setup.sh    # NC 30 + sqlite (no db service)
-#   NC_VERSION=32 KANSO_DB=mysql  ./setup.sh    # NC 32 + mariadb
+#   NC_VERSION=32 KANSO_DB=sqlite ./setup.sh    # NC 32 + sqlite (no db service)
+#   NC_VERSION=33 KANSO_DB=mysql  ./setup.sh    # NC 33 + mariadb
 set -eu
 cd "$(dirname "$0")"
 

--- a/dev/smoke.sh
+++ b/dev/smoke.sh
@@ -3,17 +3,29 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # Post-install smoke assertion for the cross-version / cross-DB CI matrix.
-# Verifies that enabling Kanso on this (NC_VERSION, KANSO_DB) combo actually
-# ran the migrations and CREATED THE TABLES — the exact failure mode we hit once
-# (a default-named PRIMARY KEY blew the 23-char index-name limit and silently
-# created ZERO tables on a fresh install).
+# Two things are asserted, in this order:
+#
+#   SCHEMA  — enabling Kanso on this (NC_VERSION, KANSO_DB) combo actually ran
+#             the migrations and CREATED THE TABLES. That is the failure mode we
+#             hit once: a default-named PRIMARY KEY blew the 23-char index-name
+#             limit and silently created ZERO tables on a fresh install.
+#   APP CODE — real Kanso code paths actually EXECUTE against this server's API.
+#             Counting tables proves nothing about whether the app runs: it let
+#             info.xml claim NC 30 support while opening the app was a fatal
+#             PHP Error on a server API that did not exist yet (see step 4).
 #
 # Run against the stack booted by dev/setup.sh. Exits non-zero on any failure.
 set -eu
 cd "$(dirname "$0")"
 
 KANSO_DB="${KANSO_DB:-postgres}"
-CONTAINER=kanso-dev
+# Overridable so this can be pointed at a throwaway stack (a different container
+# name / published port) without disturbing a running dev stack. Defaults are
+# exactly what dev/setup.sh + dev/docker-compose.yml boot.
+CONTAINER="${KANSO_CONTAINER:-kanso-dev}"
+DB_CONTAINER="${KANSO_DB_CONTAINER:-kanso-dev-db}"
+BASE_URL="${KANSO_BASE_URL:-http://localhost:8891}"
+ADMIN_AUTH="${KANSO_ADMIN_AUTH:-admin:admin}"
 OCC="docker exec -u www-data $CONTAINER php occ"
 
 fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
@@ -25,7 +37,7 @@ $OCC app:list --enabled 2>/dev/null | grep -q 'kanso' \
 	|| fail "kanso is not in 'occ app:list' (enabled apps)"
 
 # 2. Every migration must be recorded as applied. NC has no per-app
-#    'migrations:status' occ command across 30–34, so verify directly: the
+#    'migrations:status' occ command across 32–34, so verify directly: the
 #    oc_migrations table must hold one row per migration file. This proves the
 #    migrator ran end-to-end (not just that app:enable returned 0).
 # cwd is dev/ (the script cd'd here), so migrations are one level up.
@@ -38,49 +50,49 @@ CORE="kanso_boards kanso_stacks kanso_cards kanso_changes"
 MIN_TABLES=20   # 28 tables today; a generous floor that still catches "zero".
 
 count_migrations_postgres() {
-	docker exec kanso-dev-db psql -U nextcloud -d nextcloud -tAc \
+	docker exec "$DB_CONTAINER" psql -U nextcloud -d nextcloud -tAc \
 		"SELECT count(*) FROM oc_migrations WHERE app='kanso';"
 }
 count_migrations_mysql() {
-	docker exec kanso-dev-db mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
+	docker exec "$DB_CONTAINER" mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
 		"SELECT count(*) FROM oc_migrations WHERE app='kanso';"
 }
 count_migrations_sqlite() {
-	docker exec -u www-data kanso-dev php -r '
+	docker exec -u www-data "$CONTAINER" php -r '
 		$db = new PDO("sqlite:/var/www/html/data/nextcloud.db");
 		echo (int)$db->query("SELECT count(*) FROM oc_migrations WHERE app=\"kanso\"")->fetchColumn();
 	'
 }
 
 count_tables_postgres() {
-	docker exec kanso-dev-db psql -U nextcloud -d nextcloud -tAc \
+	docker exec "$DB_CONTAINER" psql -U nextcloud -d nextcloud -tAc \
 		"SELECT count(*) FROM information_schema.tables WHERE table_name LIKE 'oc_kanso\_%';"
 }
 has_table_postgres() {
-	docker exec kanso-dev-db psql -U nextcloud -d nextcloud -tAc \
+	docker exec "$DB_CONTAINER" psql -U nextcloud -d nextcloud -tAc \
 		"SELECT to_regclass('public.oc_$1') IS NOT NULL;" | grep -q t
 }
 
 count_tables_mysql() {
-	docker exec kanso-dev-db mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
+	docker exec "$DB_CONTAINER" mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
 		"SELECT count(*) FROM information_schema.tables WHERE table_schema='nextcloud' AND table_name LIKE 'oc_kanso\_%';"
 }
 has_table_mysql() {
-	docker exec kanso-dev-db mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
+	docker exec "$DB_CONTAINER" mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
 		"SELECT count(*) FROM information_schema.tables WHERE table_schema='nextcloud' AND table_name='oc_$1';" | grep -q 1
 }
 
 # SQLite lives inside the NC container; query it via PDO. Table name (when
 # checking a specific table) is passed as argv[1], never interpolated into SQL.
 count_tables_sqlite() {
-	docker exec -u www-data kanso-dev php -r '
+	docker exec -u www-data "$CONTAINER" php -r '
 		$db = new PDO("sqlite:/var/www/html/data/nextcloud.db");
 		$q = $db->query("SELECT count(*) FROM sqlite_master WHERE type=\"table\" AND name LIKE \"oc_kanso_%\"");
 		echo (int)$q->fetchColumn();
 	'
 }
 has_table_sqlite() {
-	docker exec -u www-data kanso-dev php -r '
+	docker exec -u www-data "$CONTAINER" php -r '
 		$db = new PDO("sqlite:/var/www/html/data/nextcloud.db");
 		$s = $db->prepare("SELECT count(*) FROM sqlite_master WHERE type=\"table\" AND name=?");
 		$s->execute(["oc_" . $argv[1]]);
@@ -110,4 +122,107 @@ for t in $CORE; do
 	fi
 done
 
-echo "SMOKE OK: NC=${NC_VERSION:-?} DB=${KANSO_DB} — kanso enabled, migrations applied, schema present."
+echo "schema OK — now exercising app code"
+
+# 4. EXECUTE APP CODE. Everything above proves the SCHEMA exists; not one line
+#    of Kanso PHP runs in it, so a server API the app calls but this Nextcloud
+#    does not have is invisible to it. That blind spot is real, not theoretical:
+#    info.xml claimed NC 30 support for months while the app fataled on its very
+#    first screen, because two IQueryBuilder APIs only exist from NC 32 —
+#      * IQueryBuilder::PARAM_DATETIME_MUTABLE, bound by CardMapper's overdue
+#        aggregates and reached from BoardService::findAllWithStats(), i.e. the
+#        boards-list payload the app loads on open;
+#      * IQueryBuilder::forUpdate(), called by CardMapper::findByStackForUpdate()
+#        and reached from CardService::rebalanceStack().
+#    PHPUnit and psalm cannot see it either: composer.json maps OCP\ to
+#    vendor/nextcloud/ocp pinned ^34, so both type-check against the NEWEST
+#    server's API and never the oldest supported one. This matrix, on the real
+#    server, is the only place that can catch it — so drive both paths here.
+#
+#    A missing API is a PHP \Error. Neither swallows it: ApiErrorTrait maps only
+#    Kanso's own service exceptions (never \Error), so the request is a 500; and
+#    Symfony's console returns non-zero when a command throws. Both are asserted
+#    below, so this goes RED instead of silently green.
+#
+#    Auth is admin BasicAuth + the OCS-APIRequest header, which is how Nextcloud
+#    lets a non-browser client skip the CSRF token.
+API_BODY="$(mktemp)"
+SMOKE_BOARD=''
+cleanup() {
+	# Leave the instance as we found it. Best-effort: a failed run has already
+	# reported the real error and must keep its exit status.
+	if [ -n "$SMOKE_BOARD" ]; then
+		curl -s -o /dev/null -u "$ADMIN_AUTH" -H 'OCS-APIRequest: true' \
+			-X DELETE "$BASE_URL/apps/kanso/api/boards/$SMOKE_BOARD" || true
+	fi
+	rm -f "$API_BODY"
+}
+trap cleanup EXIT
+
+# api <METHOD> <path> [json body] — body lands in $API_BODY, status in $API_STATUS.
+api() {
+	if [ $# -ge 3 ]; then
+		API_STATUS="$(curl -s -o "$API_BODY" -w '%{http_code}' \
+			-u "$ADMIN_AUTH" -H 'OCS-APIRequest: true' -H 'Content-Type: application/json' \
+			-X "$1" -d "$3" "$BASE_URL/apps/kanso$2")"
+	else
+		API_STATUS="$(curl -s -o "$API_BODY" -w '%{http_code}' \
+			-u "$ADMIN_AUTH" -H 'OCS-APIRequest: true' \
+			-X "$1" "$BASE_URL/apps/kanso$2")"
+	fi
+}
+
+# Assert 200 and surface the body on failure — a 500 body names the missing
+# API/class, which is the whole diagnostic.
+expect_200() {
+	[ "$API_STATUS" = "200" ] \
+		|| fail "$1 → HTTP $API_STATUS. Response: $(head -c 500 "$API_BODY")"
+}
+
+# First "id" in a JSON object response is the created entity's own id.
+created_id() { grep -o '"id":[0-9]*' "$API_BODY" | head -1 | cut -d: -f2; }
+
+api POST /api/boards '{"title":"smoke probe"}'
+expect_200 'POST /api/boards (BoardService::create)'
+SMOKE_BOARD="$(created_id)"
+[ -n "$SMOKE_BOARD" ] || fail "POST /api/boards returned no board id: $(head -c 500 "$API_BODY")"
+
+api POST /api/stacks "{\"boardId\":${SMOKE_BOARD},\"title\":\"Smoke\"}"
+expect_200 'POST /api/stacks (StackService::create)'
+SMOKE_STACK="$(created_id)"
+[ -n "$SMOKE_STACK" ] || fail "POST /api/stacks returned no stack id: $(head -c 500 "$API_BODY")"
+
+# An overdue due date, so the DATETIME comparison below has a row to match
+# rather than only being parsed.
+api POST /api/cards "{\"stackId\":${SMOKE_STACK},\"title\":\"smoke card\",\"duedate\":\"2020-01-01T00:00:00+00:00\"}"
+expect_200 'POST /api/cards (CardService::create)'
+
+# 4a. The boards list — BoardService::findAllWithStats(), which binds
+#     PARAM_DATETIME_MUTABLE in the overdue aggregate. Note the ORDER: that
+#     aggregate short-circuits on an empty board-id set, so it is only reached
+#     once the board above exists. Running this first would prove nothing.
+api GET /api/boards
+expect_200 'GET /api/boards (BoardService::findAllWithStats)'
+grep -q '"stats"' "$API_BODY" \
+	|| fail "GET /api/boards returned no per-board stats block: $(head -c 500 "$API_BODY")"
+echo "  ok: boards list with stats (PARAM_DATETIME_MUTABLE)"
+
+# 4b. The rebalance — CardService::rebalanceStack() →
+#     CardMapper::findByStackForUpdate(), which calls forUpdate(). occ exits
+#     non-zero if it throws, and `set -e` turns that into a failed build.
+#
+#     NOT on SQLite: `SELECT ... FOR UPDATE` has no SQLite equivalent, so the
+#     platform rejects it outright ("Operation 'FOR UPDATE' is not supported by
+#     platform") on EVERY Nextcloud version — a database limitation, not a
+#     version-support signal, so asserting it here would just paint the whole
+#     sqlite matrix red. Postgres runs on every NC version in the matrix, so
+#     forUpdate() is still covered on every version we claim to support.
+if [ "$KANSO_DB" = "sqlite" ]; then
+	echo "  skip: occ kanso:rebalance — SQLite has no SELECT ... FOR UPDATE"
+else
+	$OCC kanso:rebalance --board "$SMOKE_BOARD" \
+		|| fail "occ kanso:rebalance --board $SMOKE_BOARD failed (CardMapper::findByStackForUpdate / forUpdate())"
+	echo "  ok: occ kanso:rebalance (forUpdate)"
+fi
+
+echo "SMOKE OK: NC=${NC_VERSION:-?} DB=${KANSO_DB} — kanso enabled, migrations applied, schema present, app code runs."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -151,7 +151,7 @@ What still matters before you press *Run workflow*:
 - [ ] The releasable commits since the last tag have **correct Conventional
       types** (`fix:`/`feat:` for user-facing; a mistyped `chore:` won't ship).
       `npm run release:dry` shows the computed version + notes.
-- [ ] `appinfo/info.xml` `<dependencies>` still `min-version="30" max-version="34"`.
+- [ ] `appinfo/info.xml` `<dependencies>` still `min-version="32" max-version="34"`.
 - [ ] `README.md` / `info.xml` copy still matches the shipped feature set.
 - [ ] `scripts/build-release.sh` runs clean and the tarball installs on a stock
       Nextcloud (see the smoke test below).


### PR DESCRIPTION
Kanso declared support for Nextcloud 30 and **could not run there**. Two `IQueryBuilder` APIs it calls don't exist on NC 30:

- `PARAM_DATETIME_MUTABLE` — `CardMapper.php:1058/1391/1501`, reached from `BoardService::findAllWithStats()`, the boards-list payload. That is *opening the app*.
- `forUpdate()` — `CardMapper.php:381`, reached from `CardService::rebalanceStack()` and `CsvImportService`.

## The floor is now 32, and that is a deliberate choice

Per [Nextcloud's maintenance schedule](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule): NC 30 went EOL 2025-10, NC 31 in 2026-02. So the breakage only ever affected people on a Nextcloud upstream stopped patching 7–11 months ago.

**32 rather than 33**, even though 32 reaches EOL on 2026-09-30: cutting to 33 today would make Kanso uninstallable for people on a version that is *still supported*. 32 is the oldest release upstream supports **and** Kanso actually runs on. Raising it again after the 30th is a one-liner.

Verified `occ app:enable kanso` is now refused on NC 30 — the floor works as an install gate.

## The real fix is the third commit-worth of change: CI now runs app code

`install-matrix` has been booting NC 30 on every PR for months and reporting green, because `dev/smoke.sh` only counted database tables. It never executed a line of Kanso.

It now creates a board, stack and overdue card over the HTTP API, then exercises both APIs:
- `GET /api/boards` → `findAllWithStats()` → `PARAM_DATETIME_MUTABLE`
- `occ kanso:rebalance --board <id>` → `findByStackForUpdate()` → `forUpdate()`

**Proven non-vacuous by running it against real containers** — this is the whole point, since a smoke check that passes on a broken platform is worse than none:

```
NC 30 →  kanso_* tables present: 34
         ok: kanso_boards / kanso_stacks / kanso_cards / kanso_changes   <- old smoke.sh stopped here, GREEN
         schema OK — now exercising app code
         SMOKE FAIL: GET /api/boards → HTTP 500     EXIT=1
```
Server log: `Undefined constant IQueryBuilder::PARAM_DATETIME_MUTABLE in CardMapper.php line 1391`.

```
NC 32 →  ok: boards list with stats (PARAM_DATETIME_MUTABLE)
         ok: occ kanso:rebalance (forUpdate)
         SMOKE OK: NC=32 DB=postgres     EXIT=0
```
Also green on NC 32 + sqlite.

## Incidental find, filed separately

`occ kanso:rebalance` **fatals on every SQLite Nextcloud, all versions** — `Operation 'FOR UPDATE' is not supported by platform`. The documented recovery for sort-key overflow is unusable on SQLite installs. The new smoke step is gated to skip on sqlite rather than paint that matrix leg red; postgres runs on every NC version, so `forUpdate()` stays covered.

## Also caught
`docs/RELEASING.md:154` carried a release-checklist assertion that `min-version="30"` — it would have failed the next release. Stale range claims in `README.md`, `CLAUDE.md`, `dev/docker-compose.yml` and `dev/setup.sh` updated too, and `CONTRIBUTING.md` gained a short note on *why* only the install matrix can catch this class: the `nextcloud/ocp` pin means psalm and PHPUnit always check against the newest API, never the oldest supported one.

Dropping the two EOL legs also removes 4 of 11 install jobs, so CI gets faster.

No app `<version>` bump, no `CHANGELOG.md` edit. `info.xml` validated against the App Store XSD.
