### PR TITLE
Fix two shipped fatals, cap unbounded input, and add resolvable discussion threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,76 @@ jobs:
           fi
           docker compose version
 
+      # Warm the local image cache BEFORE booting the stack, retrying a failed
+      # pull, because `dev/setup.sh` cannot: it boots with `docker compose
+      # ... up -d` under `set -eu` (dev/setup.sh:19,67), where the pull is
+      # implicit and has NO retry. One transient registry hiccup therefore kills
+      # the whole job — observed on PR #101, run 33560679687, 6m46s into `e2e`
+      # (the ~1.5h required check) after five minutes of layers downloading
+      # fine: `Get "https://registry-1.docker.io/v2/": net/http: request
+      # canceled while waiting for connection (Client.Timeout exceeded while
+      # awaiting headers)`, exit 18. That red is indistinguishable from a real
+      # regression until a human opens the log and re-runs by hand.
+      #
+      # Deliberately HERE and not inside dev/setup.sh: the script is the shared
+      # local-dev entry point and stays free of CI-only retry plumbing. Please
+      # do not "tidy" this into it.
+      #
+      # Also deliberately NOT a retry around `./dev/setup.sh` itself — re-running
+      # that script after a partial boot is not a claim this makes. Only the
+      # network fetch is retried, and a fetch is safe to repeat.
+      #
+      # Best-effort by construction (`exit 0` at the end, plus
+      # continue-on-error): this warms a cache, it does not gate anything. If
+      # all three attempts fail, `up -d` still gets its own try and any honest
+      # failure surfaces there, under the step whose name says "Boot".
+      - name: Pre-pull dev stack images (with retry)
+        working-directory: dev
+        # Belt and braces with the `exit 0` below: this step must not be able to
+        # redden the job even if the script itself breaks before reaching it.
+        continue-on-error: true
+        run: |
+          set -u
+          # Load-bearing, not defensive. docker-compose.yml declares
+          # `env_file: .db.env` on the nextcloud service, and setup.sh only
+          # writes that file when IT runs. Compose v2.29.7 — the version the
+          # step above pins for runners without the plugin — refuses to load
+          # the model without it and dies
+          # with `env file .../.db.env not found`, exit 14, BEFORE pulling a
+          # single byte. So without this placeholder all three attempts below
+          # would fail instantly and this whole step would be silently vacuous.
+          # (Compose v5 tolerates a missing env_file for `pull`, so this would
+          # look fine on a newer runner and do nothing on the pinned one — the
+          # worst kind of CI bug.) setup.sh overwrites the file moments later
+          # with the real driver env.
+          [ -f .db.env ] || : > .db.env
+
+          # The profile setup.sh derives from KANSO_DB (its `case` block); unset
+          # means postgres, its default. Only the selected DB's image is pulled.
+          profile="${KANSO_DB:-postgres}"
+          if [ "$profile" = "mariadb" ]; then profile=mysql; fi
+
+          pulled=0
+          for attempt in 1 2 3; do
+            echo "Pre-pull attempt ${attempt}/3 (profile=${profile}, NC_VERSION=${NC_VERSION:-34})"
+            if docker compose --profile "$profile" pull; then
+              pulled=1
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Pull attempt ${attempt} failed; retrying in 15s"
+              sleep 15
+            fi
+          done
+
+          if [ "$pulled" = 1 ]; then
+            echo "Dev stack images are in the local cache."
+          else
+            echo "Pre-pull did not succeed after 3 attempts — continuing anyway;"
+            echo "dev/setup.sh's own 'docker compose up -d' will retry the pull."
+          fi
+          exit 0
+
       # Boot NC <version> on <db>, enable Kanso (runs the migrations).
       - name: Boot Nextcloud ${{ matrix.nc-version }} on ${{ matrix.db }}
         run: ./dev/setup.sh
@@ -476,6 +546,43 @@ jobs:
             chmod +x ~/.docker/cli-plugins/docker-compose
           fi
           docker compose version
+
+      # See install-matrix above for why this step exists, why the retry lives
+      # in the workflow rather than in dev/setup.sh, and why it cannot fail the
+      # job. This is the job the registry timeout actually killed. No KANSO_DB
+      # is set here, so the profile resolves to setup.sh's postgres default.
+      - name: Pre-pull dev stack images (with retry)
+        working-directory: dev
+        continue-on-error: true
+        run: |
+          set -u
+          # setup.sh writes dev/.db.env; compose won't parse the model without
+          # it, so seed a placeholder (setup.sh overwrites it). See install-matrix.
+          [ -f .db.env ] || : > .db.env
+
+          profile="${KANSO_DB:-postgres}"
+          if [ "$profile" = "mariadb" ]; then profile=mysql; fi
+
+          pulled=0
+          for attempt in 1 2 3; do
+            echo "Pre-pull attempt ${attempt}/3 (profile=${profile}, NC_VERSION=${NC_VERSION:-34})"
+            if docker compose --profile "$profile" pull; then
+              pulled=1
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Pull attempt ${attempt} failed; retrying in 15s"
+              sleep 15
+            fi
+          done
+
+          if [ "$pulled" = 1 ]; then
+            echo "Dev stack images are in the local cache."
+          else
+            echo "Pre-pull did not succeed after 3 attempts — continuing anyway;"
+            echo "dev/setup.sh's own 'docker compose up -d' will retry the pull."
+          fi
+          exit 0
 
       # Boot the same throwaway Nextcloud stack used locally (dev/setup.sh):
       # postgres + redis + notify_push + nextcloud:34-apache, app enabled,

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -281,14 +281,28 @@ Kanso 是一款为速度而生的 Nextcloud 看板应用。看板、列和卡片
 	<screenshot>https://raw.githubusercontent.com/aktasfatih/kanso/main/docs/kanso-timeline.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/aktasfatih/kanso/main/docs/kanso-analytics.png</screenshot>
 	<dependencies>
-		<!-- Floor is 32, not 30: Kanso calls two IQueryBuilder APIs that do not
-		     exist before NC 32 - PARAM_DATETIME_MUTABLE (bound by the boards-list
-		     stats, i.e. opening the app) and forUpdate() (the rebalance path). On
-		     NC 30/31 both are a fatal PHP Error, so the app never worked there
-		     even though this range claimed it did. 32 is also the oldest release
+		<!-- Floor is 32, not 30: opening the app binds
+		     IQueryBuilder::PARAM_DATETIME_MUTABLE in the boards-list stats, and
+		     that constant is only @since 31.0.0 - so on NC 30 the very first
+		     screen is a fatal PHP Error, and the app never worked there even
+		     though this range claimed it did. 32 is also the oldest release
 		     Nextcloud itself still supports, so nothing on a supported server
-		     loses Kanso. dev/smoke.sh now executes both paths in the install
-		     matrix, so a future API gap fails CI instead of shipping. -->
+		     loses Kanso.
+
+		     The rebalance path does NOT set this floor, contrary to what this
+		     comment used to claim: IQueryBuilder::forUpdate() is @since 32.0.7 on
+		     stable32 (and @since 33.0.0 on stable33), i.e. it is missing on
+		     32.0.0-32.0.6, which are inside this very range. Raising the floor is
+		     the wrong fix for that - patch-level min-versions would strand
+		     supported servers - so CardMapper::supportsRowLock() guards the call
+		     with method_exists() instead and documents why the rebalance stays
+		     correct without the lock. Same guard covers SQLite, which has no
+		     SELECT ... FOR UPDATE on any version.
+
+		     Neither gap is visible to psalm or PHPUnit: composer maps OCP\ to
+		     vendor/nextcloud/ocp pinned to the NEWEST server. dev/smoke.sh
+		     executes both paths on every DB in the install matrix, so a future
+		     API gap fails CI instead of shipping. -->
 		<nextcloud min-version="32" max-version="34"/>
 	</dependencies>
 	<!-- Element order below is fixed by the App Store schema's xs:sequence

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -272,7 +272,18 @@ Kanso 是一款为速度而生的 Nextcloud 看板应用。看板、列和卡片
 	<types>
 		<dav/>
 	</types>
+	<!-- An app is listed on the browse page of EVERY category it declares, so
+	     these are the store pages Kanso can be found on. Valid slugs are fixed
+	     by the App Store: the enumeration in scripts/schema/info.xsd (the
+	     vendored copy of the store's own schema) and the live category list at
+	     https://apps.nextcloud.com/api/v1/categories.json agree on the same 15,
+	     and an unknown slug is rejected at release upload. Kept deliberately
+	     short - an over-categorised app reads as spam. `tools` is valid but
+	     holds small single-purpose utilities, not full apps with their own
+	     navigation entry and data model; `workflow` (Flow) is for apps that
+	     register Flow operations/checks, which Kanso does not. -->
 	<category>organization</category>
+	<category>office</category>
 	<website>https://github.com/aktasfatih/kanso</website>
 	<bugs>https://github.com/aktasfatih/kanso/issues</bugs>
 	<repository type="git">https://github.com/aktasfatih/kanso.git</repository>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -277,6 +277,11 @@ return [
 		['name' => 'comment#update', 'url' => '/api/comments/{commentId}', 'verb' => 'PATCH'],
 		['name' => 'comment#destroy', 'url' => '/api/comments/{commentId}', 'verb' => 'DELETE'],
 
+		// Mark a discussion thread resolved / reopen it. Idempotent toggle on the
+		// TOP-LEVEL comment only - the thread, not the message, is the unit.
+		['name' => 'comment#resolve', 'url' => '/api/comments/{commentId}/resolve', 'verb' => 'PUT'],
+		['name' => 'comment#unresolve', 'url' => '/api/comments/{commentId}/resolve', 'verb' => 'DELETE'],
+
 		// Emoji reactions on comments (#3550): idempotent toggle. The {emoji}
 		// segment is URL-encoded by the client (a multi-byte emoji); the service
 		// validates it against a FIXED allowed set. React=PUT, unreact=DELETE.

--- a/dev/smoke.sh
+++ b/dev/smoke.sh
@@ -128,12 +128,16 @@ echo "schema OK — now exercising app code"
 #    of Kanso PHP runs in it, so a server API the app calls but this Nextcloud
 #    does not have is invisible to it. That blind spot is real, not theoretical:
 #    info.xml claimed NC 30 support for months while the app fataled on its very
-#    first screen, because two IQueryBuilder APIs only exist from NC 32 —
-#      * IQueryBuilder::PARAM_DATETIME_MUTABLE, bound by CardMapper's overdue
-#        aggregates and reached from BoardService::findAllWithStats(), i.e. the
-#        boards-list payload the app loads on open;
-#      * IQueryBuilder::forUpdate(), called by CardMapper::findByStackForUpdate()
-#        and reached from CardService::rebalanceStack().
+#    first screen, because two IQueryBuilder APIs are newer than that floor —
+#      * IQueryBuilder::PARAM_DATETIME_MUTABLE (@since 31.0.0), bound by
+#        CardMapper's overdue aggregates and reached from
+#        BoardService::findAllWithStats(), i.e. the boards-list payload the app
+#        loads on open;
+#      * IQueryBuilder::forUpdate() (@since 32.0.7 on stable32, 33.0.0 on
+#        stable33 — so missing on 32.0.0–32.0.6, INSIDE our supported range),
+#        called by CardMapper::findByStackForUpdate() and reached from
+#        CardService::rebalanceStack() and from the CSV import's overflow
+#        recovery. It is also unsupported by SQLite on every version.
 #    PHPUnit and psalm cannot see it either: composer.json maps OCP\ to
 #    vendor/nextcloud/ocp pinned ^34, so both type-check against the NEWEST
 #    server's API and never the oldest supported one. This matrix, on the real
@@ -208,21 +212,64 @@ grep -q '"stats"' "$API_BODY" \
 echo "  ok: boards list with stats (PARAM_DATETIME_MUTABLE)"
 
 # 4b. The rebalance — CardService::rebalanceStack() →
-#     CardMapper::findByStackForUpdate(), which calls forUpdate(). occ exits
-#     non-zero if it throws, and `set -e` turns that into a failed build.
+#     CardMapper::findByStackForUpdate(). occ exits non-zero if it throws, and
+#     `set -e` turns that into a failed build.
 #
-#     NOT on SQLite: `SELECT ... FOR UPDATE` has no SQLite equivalent, so the
-#     platform rejects it outright ("Operation 'FOR UPDATE' is not supported by
-#     platform") on EVERY Nextcloud version — a database limitation, not a
-#     version-support signal, so asserting it here would just paint the whole
-#     sqlite matrix red. Postgres runs on every NC version in the matrix, so
-#     forUpdate() is still covered on every version we claim to support.
-if [ "$KANSO_DB" = "sqlite" ]; then
-	echo "  skip: occ kanso:rebalance — SQLite has no SELECT ... FOR UPDATE"
-else
-	$OCC kanso:rebalance --board "$SMOKE_BOARD" \
-		|| fail "occ kanso:rebalance --board $SMOKE_BOARD failed (CardMapper::findByStackForUpdate / forUpdate())"
-	echo "  ok: occ kanso:rebalance (forUpdate)"
-fi
+#     Runs on EVERY database, sqlite included. It used to be skipped there
+#     because `SELECT ... FOR UPDATE` has no SQLite equivalent and the platform
+#     rejects it outright — but that skip was hiding a real, shipped bug rather
+#     than accommodating a database limitation: rebalance is the ONLY recovery
+#     from the 409 `rebalance_required` sort-key wall, so an overflowed stack was
+#     permanently stuck on every sqlite install. CardMapper::supportsRowLock()
+#     now omits the row lock where it is unavailable (sqlite; and NC 32.0.0–
+#     32.0.6, where forUpdate() does not exist yet on ANY database), so this must
+#     be green everywhere — and if the guard ever regresses, this is what catches
+#     it.
+$OCC kanso:rebalance --board "$SMOKE_BOARD" \
+	|| fail "occ kanso:rebalance --board $SMOKE_BOARD failed (CardMapper::findByStackForUpdate / forUpdate())"
+echo "  ok: occ kanso:rebalance"
+
+# 4c. The OTHER caller of the same locking read: the CSV import's overflow
+#     recovery (CsvImportService::import() → catch(\OverflowException) →
+#     rebalanceStack()). Reaching it needs the target stack's tail key to already
+#     be at SortKeyService::MAX_KEY_LENGTH (64), which no amount of API traffic
+#     produces cheaply — so park the tail key at the wall directly in the DB,
+#     then import. A broken guard here is an HTTP 500, not an occ exit code, so
+#     this covers a user-facing path the occ run above cannot.
+#     Both values below are locally derived, never external input: MAX_KEY is a
+#     fixed 64-'Z' literal (a valid key at exactly MAX_KEY_LENGTH, so after()
+#     cannot extend it) and SMOKE_STACK is the numeric id this script just
+#     created and asserted non-empty. The sqlite path still binds them as
+#     parameters, matching the table-name helpers above.
+MAX_KEY="$(printf '%064d' 0 | tr '0' 'Z')"
+
+park_tail_key_postgres() {
+	docker exec "$DB_CONTAINER" psql -U nextcloud -d nextcloud -tAc \
+		"UPDATE oc_kanso_cards SET sort_key='$MAX_KEY' WHERE stack_id=$SMOKE_STACK;"
+}
+park_tail_key_mysql() {
+	docker exec "$DB_CONTAINER" mariadb -unextcloud -pnextcloud -N -B nextcloud -e \
+		"UPDATE oc_kanso_cards SET sort_key='$MAX_KEY' WHERE stack_id=$SMOKE_STACK;"
+}
+park_tail_key_sqlite() {
+	docker exec -u www-data "$CONTAINER" php -r '
+		$db = new PDO("sqlite:/var/www/html/data/nextcloud.db");
+		$s = $db->prepare("UPDATE oc_kanso_cards SET sort_key = ? WHERE stack_id = ?");
+		$s->execute([$argv[1], (int)$argv[2]]);
+	' "$MAX_KEY" "$SMOKE_STACK"
+}
+
+case "$KANSO_DB" in
+	postgres)      park_tail_key_postgres >/dev/null ;;
+	mysql|mariadb) park_tail_key_mysql >/dev/null ;;
+	sqlite)        park_tail_key_sqlite ;;
+esac
+
+api POST /api/csv-import \
+	"{\"document\":\"imported card\",\"boardId\":${SMOKE_BOARD},\"stackId\":${SMOKE_STACK},\"mapping\":{\"title\":0},\"hasHeader\":false}"
+expect_200 'POST /api/csv-import (CsvImportService overflow → rebalanceStack)'
+grep -q '"cards":1' "$API_BODY" \
+	|| fail "CSV import did not report the imported card: $(head -c 500 "$API_BODY")"
+echo "  ok: CSV import overflow → rebalance recovery"
 
 echo "SMOKE OK: NC=${NC_VERSION:-?} DB=${KANSO_DB} — kanso enabled, migrations applied, schema present, app code runs."

--- a/lib/Controller/CommentController.php
+++ b/lib/Controller/CommentController.php
@@ -71,6 +71,29 @@ class CommentController extends Controller {
 	}
 
 	/**
+	 * Marks the comment's thread resolved. Idempotent - resolving an already
+	 * resolved thread returns it unchanged.
+	 */
+	#[NoAdminRequired]
+	public function resolve(int $commentId): JSONResponse {
+		return $this->respond(function () use ($commentId): JSONResponse {
+			$comment = $this->commentService->setResolved($commentId, true, $this->currentUserId());
+			return new JSONResponse($this->serialize($comment));
+		});
+	}
+
+	/**
+	 * Reopens a resolved thread. Idempotent, like {@see self::resolve()}.
+	 */
+	#[NoAdminRequired]
+	public function unresolve(int $commentId): JSONResponse {
+		return $this->respond(function () use ($commentId): JSONResponse {
+			$comment = $this->commentService->setResolved($commentId, false, $this->currentUserId());
+			return new JSONResponse($this->serialize($comment));
+		});
+	}
+
+	/**
 	 * @param Comment[] $comments
 	 * @return array<int, array<string, mixed>>
 	 */

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -361,9 +361,10 @@ class CardMapper extends QBMapper {
 
 	/**
 	 * Live cards of a stack in display order, taking a row-level write lock
-	 * (SELECT ... FOR UPDATE) on each returned row - the read half of a
+	 * (SELECT ... FOR UPDATE) on each returned row WHERE THE SERVER AND DATABASE
+	 * OFFER ONE - the read half of a
 	 * {@see \OCA\Kanso\Service\CardService::rebalanceStack()} inside a
-	 * transaction. Locking the stack's rows serialises the rebalance against a
+	 * transaction. Where the lock is taken it serialises the rebalance against a
 	 * concurrent move deriving a key from the same neighbours, without a new
 	 * global lock: it matches the app's READ-COMMITTED move posture, just
 	 * pessimistically for the (rare) rebalance path.
@@ -377,10 +378,66 @@ class CardMapper extends QBMapper {
 			->from($this->getTableName())
 			->where($qb->expr()->eq('stack_id', $qb->createNamedParameter($stackId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
-			->orderBy('sort_key', 'ASC')
-			->forUpdate();
+			->orderBy('sort_key', 'ASC');
+
+		if ($this->supportsRowLock($qb)) {
+			$qb->forUpdate();
+		}
 
 		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Whether this (server, database) pair can take the rebalance's row-level
+	 * write lock. Both halves are hard failures, not degradations, if ignored -
+	 * and the rebalance is the ONLY recovery from the 409 `rebalance_required`
+	 * wall ({@see \OCA\Kanso\Service\SortKeyService::MAX_KEY_LENGTH}), so a
+	 * fatal here leaves an overflowed stack permanently stuck:
+	 *
+	 *   1. SQLite has no `SELECT ... FOR UPDATE` at all - the platform rejects it
+	 *      outright ("Operation 'FOR UPDATE' is not supported by platform"), and
+	 *      SQLite is the default for small self-hosted installs.
+	 *   2. Nextcloud 32.0.0-32.0.6 has no IQueryBuilder::forUpdate() yet: it is
+	 *      `@since 32.0.7` on stable32 and `@since 33.0.0` on stable33. info.xml
+	 *      declares min-version="32", so on those patch releases the call is a
+	 *      fatal PHP \Error on EVERY database. Neither psalm nor PHPUnit can see
+	 *      this: composer maps OCP\ to vendor/nextcloud/ocp pinned to the NEWEST
+	 *      server, where the method always exists.
+	 *
+	 * Skipping the lock is SAFE, not merely unavoidable. A rebalance reads the
+	 * stack's live rows in sort order and rewrites every one of them by id, in
+	 * two passes, inside ONE transaction. The only thing a concurrent writer can
+	 * interleave is a single-row `sort_key`/`stack_id` UPDATE from
+	 * {@see \OCA\Kanso\Service\CardService::persistMove()}, so a stale snapshot
+	 * has exactly two hazards: a card that ARRIVED in the stack after the read
+	 * keeps its long key and could collide with a freshly issued short one, and a
+	 * card that LEFT the stack after the read would still have its key rewritten
+	 * - which is why {@see self::updateSortKeyById()} also filters on `stack_id`,
+	 * so a departed row simply no longer matches.
+	 *
+	 * On SQLite neither hazard can commit, because SQLite admits ONE writer at a
+	 * time for the whole database: a competing move either commits before the
+	 * rebalance takes its write lock, or blocks until the rebalance commits, or
+	 * (in WAL mode) invalidates the deferred read snapshot so the lock upgrade
+	 * fails SQLITE_BUSY and the entire rebalance rolls back - never a partial
+	 * rewrite. The database-level lock subsumes the row lock, so `FOR UPDATE`
+	 * there is unnecessary rather than missing.
+	 *
+	 * On a pre-32.0.7 server with an MVCC database the rebalance falls back to
+	 * the app's normal, shipped move posture: READ COMMITTED plus the
+	 * (stack_id, sort_key, deleted_at) unique index, which is already what makes
+	 * concurrent moves correct (optimistic write, unique violation, one retry -
+	 * see persistMove()). A collision aborts the rebalance's transaction and
+	 * rolls it back whole; the admin re-runs `occ kanso:rebalance`. `FOR UPDATE`
+	 * is a pessimistic extra on a rare maintenance path, not the thing that makes
+	 * moves safe - so this fallback never weakens the mysql/postgres posture on
+	 * any server that has the API.
+	 */
+	private function supportsRowLock(IQueryBuilder $qb): bool {
+		// getDatabaseProvider() is @since 28.0.0 and is the documented
+		// replacement for getDatabasePlatform(), which it deprecated in 30.0.0.
+		return $this->db->getDatabaseProvider() !== IDBConnection::PLATFORM_SQLITE
+			&& method_exists($qb, 'forUpdate');
 	}
 
 	/**
@@ -389,13 +446,20 @@ class CardMapper extends QBMapper {
 	 * only the reordering column and never clobbers fields absent from the
 	 * summary payload.
 	 *
+	 * Scoped to $stackId as well as $cardId: without the row lock (see
+	 * {@see self::supportsRowLock()}) a card can be moved OUT of the stack
+	 * between the rebalance's read and this write, and rewriting its key would
+	 * then corrupt the ordering of whichever stack it moved into. The extra
+	 * predicate makes that row simply not match.
+	 *
 	 * @throws Exception
 	 */
-	public function updateSortKeyById(int $cardId, string $sortKey): void {
+	public function updateSortKeyById(int $cardId, int $stackId, string $sortKey): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->update($this->getTableName())
 			->set('sort_key', $qb->createNamedParameter($sortKey))
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('stack_id', $qb->createNamedParameter($stackId, IQueryBuilder::PARAM_INT)));
 		$qb->executeStatement();
 	}
 

--- a/lib/Db/Change.php
+++ b/lib/Db/Change.php
@@ -74,6 +74,12 @@ class Change extends Entity {
 	public const VERB_ESTIMATE_CHANGED = 21;
 	public const VERB_TYPE_CHANGED = 22;
 
+	// Discussion-thread resolution. Distinct verbs rather than VERB_COMMENTED:
+	// reusing that would render a false "commented" in the Activity tab for an
+	// act that adds no message.
+	public const VERB_THREAD_RESOLVED = 23;
+	public const VERB_THREAD_REOPENED = 24;
+
 	// Properties default to null (not to 0 / a constant): Entity::setter()
 	// skips values equal to the current one, so e.g. a default of
 	// ACTION_CREATE would silently drop `action` from INSERTs of create

--- a/lib/Db/Comment.php
+++ b/lib/Db/Comment.php
@@ -33,6 +33,8 @@ use OCP\DB\Types;
  * @method void setEditedAt(int $editedAt)
  * @method int getDeletedAt()
  * @method void setDeletedAt(int $deletedAt)
+ * @method int getResolvedAt()
+ * @method void setResolvedAt(int $resolvedAt)
  */
 class Comment extends Entity implements \JsonSerializable {
 	// Properties default to null (not to the column defaults): Entity::setter()
@@ -45,6 +47,9 @@ class Comment extends Entity implements \JsonSerializable {
 	protected ?int $createdAt = null;
 	protected ?int $editedAt = null;
 	protected ?int $deletedAt = null;
+	// Non-zero only on a top-level comment: resolving is a thread-level act, so
+	// the service refuses to stamp it on a reply.
+	protected ?int $resolvedAt = null;
 
 	public function __construct() {
 		$this->addType('cardId', Types::INTEGER);
@@ -54,10 +59,11 @@ class Comment extends Entity implements \JsonSerializable {
 		$this->addType('createdAt', Types::INTEGER);
 		$this->addType('editedAt', Types::INTEGER);
 		$this->addType('deletedAt', Types::INTEGER);
+		$this->addType('resolvedAt', Types::INTEGER);
 	}
 
 	/**
-	 * @return array{id: int, cardId: ?int, parentCommentId: ?int, author: ?string, body: ?string, createdAt: int, editedAt: int}
+	 * @return array{id: int, cardId: ?int, parentCommentId: ?int, author: ?string, body: ?string, createdAt: int, editedAt: int, resolvedAt: int}
 	 */
 	#[\Override]
 	public function jsonSerialize(): array {
@@ -69,6 +75,9 @@ class Comment extends Entity implements \JsonSerializable {
 			'body' => $this->body,
 			'createdAt' => $this->createdAt ?? 0,
 			'editedAt' => $this->editedAt ?? 0,
+			// 0 = the thread is open. Clients derive the collapsed rendering from
+			// this alone; no collapse state is persisted anywhere.
+			'resolvedAt' => $this->resolvedAt ?? 0,
 		];
 	}
 }

--- a/lib/Migration/Version005800Date20260914000000.php
+++ b/lib/Migration/Version005800Date20260914000000.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Resolved discussion threads (`kanso_comments.resolved_at`).
+ *
+ * A unix timestamp stamped when a top-level comment's thread is marked
+ * resolved, back to 0 when it is reopened. 0 means "unresolved", so every
+ * existing row is already in the right state and no backfill is needed.
+ *
+ * The flag lives on the comment - not in a per-user preference - because
+ * "resolved" is a signal to the whole team, and it reaches other clients for
+ * free through the card-targeted `kanso_changes` row the resolve already
+ * writes. The collapsed rendering is derived from it client-side; nothing about
+ * the collapse itself is stored.
+ *
+ * Only a top-level comment ever carries a non-zero value (the service rejects
+ * resolving a reply) - the thread, not the individual message, is the unit.
+ *
+ * Guarded (hasTable/hasColumn) so the step is idempotent.
+ */
+class Version005800Date20260914000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::getTable() is
+	 *  docblocked as Doctrine\DBAL\Schema\Table, not part of the OCP stubs.
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('kanso_comments')) {
+			$table = $schema->getTable('kanso_comments');
+			if (!$table->hasColumn('resolved_at')) {
+				$table->addColumn('resolved_at', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -1966,11 +1966,15 @@ class CardService {
 	 * two-character keys, restoring generous gaps so subsequent between()/after()
 	 * inserts no longer overflow.
 	 *
-	 * Concurrency: the stack's rows are read with SELECT ... FOR UPDATE inside a
-	 * single transaction (no new global lock - it matches the app's
-	 * READ-COMMITTED move posture used by {@see self::persistMove()}, just
-	 * pessimistically for this rare maintenance path), so a concurrent move
-	 * blocks on the same rows until the rebalance commits.
+	 * Concurrency: the stack's rows are read inside a single transaction, with
+	 * SELECT ... FOR UPDATE where the server and database offer it (no new global
+	 * lock - it matches the app's READ-COMMITTED move posture used by
+	 * {@see self::persistMove()}, just pessimistically for this rare maintenance
+	 * path), so a concurrent move blocks on the same rows until the rebalance
+	 * commits. SQLite and Nextcloud 32.0.0-32.0.6 have no such lock to take;
+	 * {@see \OCA\Kanso\Db\CardMapper::supportsRowLock()} documents why the
+	 * rebalance is still correct there, and why every UPDATE below is scoped to
+	 * $stackId as well as the card id.
 	 *
 	 * The (stack_id, sort_key, deleted_at) unique index forbids two live rows in
 	 * a stack sharing a key even transiently, so the rewrite runs in two passes:
@@ -2010,14 +2014,14 @@ class CardService {
 			// from every current key, so no UPDATE collides with a
 			// not-yet-rewritten row.
 			foreach ($cards as $index => $card) {
-				$this->cardMapper->updateSortKeyById($card->getId(), $tempKeys[$index]);
+				$this->cardMapper->updateSortKeyById($card->getId(), $stackId, $tempKeys[$index]);
 			}
 			// Pass 2: write the final evenly-spaced keys, order preserved. The
 			// finals are the short two-character grid and the temp band the
 			// three-character grid, so the two are disjoint and this pass never
 			// collides either.
 			foreach ($cards as $index => $card) {
-				$this->cardMapper->updateSortKeyById($card->getId(), $freshKeys[$index]);
+				$this->cardMapper->updateSortKeyById($card->getId(), $stackId, $freshKeys[$index]);
 			}
 
 			// One stack-level MOVE change row is enough for delta-sync clients to

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -42,6 +42,30 @@ class CardService {
 	// Public: the webhook's issue intake pre-truncates external titles to it.
 	public const MAX_TITLE_LENGTH = 100;
 
+	// Cap on a card description written through update(), which is the only place
+	// a client submits NEW description TEXT (create() takes no description at
+	// all). The paths that carry an EXISTING description across - copy(),
+	// createFromTemplate(), a cross-board move(), the recurrence writer and the
+	// CSV/Deck/Trello importers - set the column directly and stay UNCAPPED on
+	// purpose, so importing a legitimately long description from another tool, or
+	// duplicating a card that predates this cap, never fails. The trade that buys:
+	// copying a grandfathered/imported over-cap card still mints new over-cap
+	// rows, so this guard bounds the description a user can TYPE, not every row in
+	// the table (the outer bound on an import stays ImportService's document-size
+	// limit).
+	//
+	// 64 KiB: 6.5x the comment cap because a card description is a document rather
+	// than a remark (~11k English words), while still bounding the two places a
+	// description is amplified - search snippets regex the full text of up to
+	// SOURCE_CAP=100 rows (SearchService::snippet()), and every `@mention` in it
+	// costs an ACL query (MentionService). The column itself is a length-less
+	// TEXT, i.e. LONGTEXT/4 GiB on MySQL, so nothing below this bounds it.
+	// Multibyte-safe (counted in characters, like the title and comment caps).
+	//
+	// Public like MAX_TITLE_LENGTH, but for a narrower reason: the unit tests pin
+	// the boundary against it rather than re-hardcoding the number.
+	public const MAX_DESCRIPTION_LENGTH = 65536;
+
 	// Max insert attempts in create(): absorbs sort-key AND board-wide board_seq
 	// unique collisions under concurrency before surfacing a retryable 409.
 	private const MAX_CREATE_ATTEMPTS = 5;
@@ -953,8 +977,8 @@ class CardService {
 	 *
 	 * @throws DoesNotExistException if the card or its board does not exist or is deleted
 	 * @throws NotPermittedException if the user may not edit the board, or the review gate blocks completion while the card has unapproved reviews
-	 * @throws InvalidInputException on invalid title, duedate, cover colour or type
-	 * @throws DescriptionConflictException if the description write is based on a stale version
+	 * @throws InvalidInputException on invalid title, duedate, cover colour or type, or a description over MAX_DESCRIPTION_LENGTH
+	 * @throws DescriptionConflictException if the description write is based on a stale version - checked BEFORE the length cap, so a stale over-long write reports the conflict (the actionable error) rather than the length
 	 */
 	public function update(
 		int $id,
@@ -1058,6 +1082,21 @@ class CardService {
 		}
 		$descriptionChanged = false;
 		if ($description !== null && $description !== $card->getDescription()) {
+			// Deliberately checked only when the text actually CHANGES, not on
+			// every write that carries a description: a card stored before this
+			// cap existed stays readable, an unrelated title/date/priority save on
+			// it never trips the limit, and its author can still edit it - as long
+			// as the new text is within the cap, so an over-long row can be edited
+			// DOWN but never re-saved as-is or grown further.
+			if (mb_strlen($description) > self::MAX_DESCRIPTION_LENGTH) {
+				// The message names the number, like every other length validator
+				// here: it is surfaced verbatim by ApiErrorTrait and rendered by the
+				// card editor, and since this ships no character counter it is the
+				// only way a user learns what the limit is.
+				throw new InvalidInputException(
+					'Description must not exceed ' . self::MAX_DESCRIPTION_LENGTH . ' characters'
+				);
+			}
 			$card->setDescription($description);
 			$descriptionChanged = true;
 		}

--- a/lib/Service/CommentService.php
+++ b/lib/Service/CommentService.php
@@ -21,7 +21,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
  * replies, no deeper nesting). Reading needs READ on the card's board; posting
  * and replying need EDIT; a comment may be edited only by its author, and
  * deleted by its author or a board MANAGE-holder. Deleting a top-level comment
- * cascades a soft-delete over its replies so no reply is orphaned. Every
+ * cascades a soft-delete over its replies so no reply is orphaned. A thread can
+ * also be marked resolved (EDIT, top-level only) - a shared signal that clients
+ * render as a collapsed thread. Every
  * mutation appends a card-targeted row to the `kanso_changes` log (reusing
  * ENTITY_CARD/ACTION_UPDATE - a comment change is a card change for sync) so the
  * board ETag bumps and realtime clients refetch.
@@ -93,6 +95,7 @@ class CommentService {
 		$comment->setCreatedAt(time());
 		$comment->setEditedAt(0);
 		$comment->setDeletedAt(0);
+		$comment->setResolvedAt(0);
 		$saved = $this->commentMapper->insert($comment);
 
 		$this->notifyCard($card, $actorUid);
@@ -182,14 +185,60 @@ class CommentService {
 		$this->notifyCard($card, $actorUid);
 	}
 
-	private function notifyCard(Card $card, string $actorUid): void {
+	/**
+	 * Marks a thread resolved or reopens it. The unit is the THREAD, so only a
+	 * top-level comment carries the flag - resolving a reply is rejected, the
+	 * same way the delete cascade treats a thread as atomic.
+	 *
+	 * Any board EDIT-holder may resolve, not just the thread's author: this
+	 * hides nothing permanently and anyone may reopen it, so it sits with the
+	 * reversible, non-destructive signals (reactions) rather than with editing
+	 * someone's words. Author-only would also strand every thread whose author
+	 * has left the team.
+	 *
+	 * Idempotent: already being in the requested state writes no row and no
+	 * change-log entry.
+	 *
+	 * @throws DoesNotExistException if the comment, card or board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not edit the board
+	 * @throws InvalidInputException if the comment is a reply
+	 */
+	public function setResolved(int $commentId, bool $resolved, string $actorUid): Comment {
+		$comment = $this->loadComment($commentId);
+		$card = $this->loadCard($comment->getCardId());
+		$board = $this->loadBoard($card->getBoardId());
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_EDIT);
+		$this->visibilityGuard->assertVisible($board, $card, $actorUid);
+
+		if ($comment->getParentCommentId() !== null) {
+			throw new InvalidInputException('Only a top-level comment can be resolved');
+		}
+
+		$isResolved = $comment->getResolvedAt() > 0;
+		if ($isResolved === $resolved) {
+			return $comment;
+		}
+
+		$comment->setResolvedAt($resolved ? time() : 0);
+		$saved = $this->commentMapper->update($comment);
+
+		$this->notifyCard(
+			$card,
+			$actorUid,
+			$resolved ? Change::VERB_THREAD_RESOLVED : Change::VERB_THREAD_REOPENED,
+		);
+
+		return $saved;
+	}
+
+	private function notifyCard(Card $card, string $actorUid, int $verb = Change::VERB_COMMENTED): void {
 		$this->changeNotifier->notify(
 			$card->getBoardId(),
 			Change::ENTITY_CARD,
 			$card->getId(),
 			Change::ACTION_UPDATE,
 			$actorUid,
-			verb: Change::VERB_COMMENTED,
+			verb: $verb,
 		);
 	}
 

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -164,9 +164,12 @@ class CsvImportService {
 				// and attempt() has already rolled its transaction back - nothing was
 				// written and, critically, NO transaction is open at this point.
 				// That is what makes the recovery safe: rebalanceStack() opens its
-				// OWN transaction and takes SELECT ... FOR UPDATE locks on the
-				// stack's rows, so it must never be called from inside the import's
-				// transaction. Reset the stack to short keys here, between attempts,
+				// OWN transaction (and, where the server and database offer one,
+				// takes SELECT ... FOR UPDATE locks on the stack's rows), so it
+				// must never be called from inside the import's transaction. On
+				// SQLite that matters even more: it admits a single writer, so
+				// nesting would deadlock rather than merely nest.
+				// Reset the stack to short keys here, between attempts,
 				// then replay the import ONCE (still all-or-nothing). A second
 				// overflow is genuine and propagates as the 409 it always was.
 				$this->cardService->rebalanceStack($stackId);

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -256,6 +256,10 @@ class ExportService {
 				'body' => $comment->getBody(),
 				'createdAt' => $comment->getCreatedAt(),
 				'editedAt' => $comment->getEditedAt(),
+				// Whether the thread was marked resolved. Carried so an
+				// export/import round-trip does not silently reopen every
+				// settled discussion on the board.
+				'resolvedAt' => $comment->getResolvedAt(),
 			];
 		}
 

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -680,6 +680,8 @@ class ImportService {
 			$comment->setCreatedAt((int)($c['createdAt'] ?? time()));
 			$comment->setEditedAt((int)($c['editedAt'] ?? 0));
 			$comment->setDeletedAt(0);
+			// Older archives predate the field; absent means "open".
+			$comment->setResolvedAt((int)($c['resolvedAt'] ?? 0));
 
 			$oldParent = $c['parentCommentId'] ?? null;
 			$comment->setParentCommentId($oldParent !== null ? ($commentIdMap[(int)$oldParent] ?? null) : null);

--- a/lib/Service/MentionService.php
+++ b/lib/Service/MentionService.php
@@ -32,6 +32,21 @@ class MentionService {
 	 */
 	private const MENTION_PATTERN = '/(?<![\w@])@([a-zA-Z0-9_.-]+)/';
 
+	/**
+	 * How many distinct mentions one body may act on. Each one that survives
+	 * dedup costs an uncached ACL resolution
+	 * ({@see PermissionService::getPermissions()}), so without a bound the
+	 * mention count - not the number of board members - sets the query count for
+	 * a single write. A 10,000-char comment - already at CommentService's own cap
+	 * - still holds a couple of thousand distinct `@u1`-style tokens, so this
+	 * bound is load-bearing on the comment path in its own right, not only for
+	 * the (separately length-capped) card description.
+	 * Fifty is far above any real "cc the room" body. Mentions past the bound are
+	 * ignored rather than rejected, matching how a mention of a non-member is
+	 * already silently inert.
+	 */
+	public const MAX_MENTIONS = 50;
+
 	public function __construct(
 		private PermissionService $permissionService,
 		private SubscriptionService $subscriptionService,
@@ -42,7 +57,10 @@ class MentionService {
 
 	/**
 	 * The unique candidate usernames mentioned in a raw body, in first-seen
-	 * order. Pure - no permission check, no side effects.
+	 * order, capped at {@see self::MAX_MENTIONS}. Pure - no permission check, no
+	 * side effects. The cap lives HERE, at the single extraction point, so both
+	 * mention surfaces (comment bodies and card descriptions) are bounded by one
+	 * guard.
 	 *
 	 * @return string[]
 	 */
@@ -50,7 +68,7 @@ class MentionService {
 		if (!preg_match_all(self::MENTION_PATTERN, $body, $matches)) {
 			return [];
 		}
-		return array_values(array_unique($matches[1]));
+		return array_slice(array_values(array_unique($matches[1])), 0, self::MAX_MENTIONS);
 	}
 
 	/**
@@ -63,6 +81,10 @@ class MentionService {
 	 * oracle (a bell entry + a watch row) for a card they cannot open. The
 	 * visibility check is one batched role resolution
 	 * ({@see CardVisibilityGuard::filterVisible()}), not per-mention queries.
+	 *
+	 * At most {@see self::MAX_MENTIONS} distinct mentions are acted on; the rest
+	 * are ignored, so one body can never turn into an unbounded run of ACL
+	 * lookups.
 	 */
 	public function handleMentions(Card $card, Board $board, string $body, string $actorUid): void {
 		$readable = [];

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -82,6 +82,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							:value="draftByStack[rows[vRow.index].stackId] ?? ''"
 							class="card-composer__input"
 							type="text"
+							maxlength="100"
 							:placeholder="t('kanso', 'Add card…')"
 							:disabled="isPendingByStack[rows[vRow.index].stackId] ?? false"
 							:data-stack-id="rows[vRow.index].stackId"

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1928,7 +1928,38 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									:key="topComment.id"
 									:id="`comment-${topComment.id}`"
 									class="card-modal__comment-group"
-									:class="{ 'card-modal__comment-group--highlight': highlightedCommentId === topComment.id }">
+									:class="{
+										'card-modal__comment-group--highlight': highlightedCommentId === topComment.id,
+										'card-modal__comment-group--resolved': isThreadResolved(topComment),
+									}">
+									<!-- A resolved thread collapses to a single summary row: the
+									     decluttering the whole feature is for. Everything below is
+									     derived from `resolvedAt` plus the transient local peek set —
+									     no collapse state is stored anywhere. -->
+									<div v-if="isThreadCollapsed(topComment)" class="card-modal__thread-summary">
+										<button
+											type="button"
+											class="card-modal__thread-summary-toggle"
+											:aria-expanded="false"
+											:title="t('kanso', 'Show this resolved thread')"
+											@click="toggleThreadExpanded(topComment)">
+											<CheckCircleOutlineIcon :size="16" class="card-modal__thread-summary-icon" />
+											<span class="card-modal__thread-summary-author">{{ topComment.authorDisplayName || topComment.author }}</span>
+											<span class="card-modal__thread-summary-state">{{ t('kanso', 'Resolved') }}</span>
+											<span v-if="replies.length > 0" class="card-modal__thread-summary-replies">{{ n('kanso', '%n reply', '%n replies', replies.length) }}</span>
+											<span class="card-modal__thread-summary-show">{{ t('kanso', 'Show') }}</span>
+										</button>
+										<button
+											v-if="canEdit"
+											type="button"
+											class="card-modal__comment-link-btn"
+											:disabled="resolveThread.isPending.value"
+											@click="handleToggleResolved(topComment)">
+											{{ t('kanso', 'Reopen') }}
+										</button>
+									</div>
+
+									<template v-else>
 									<div class="card-modal__comment">
 										<NcAvatar
 											:user="topComment.author"
@@ -1968,6 +1999,23 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 													class="card-modal__comment-link-btn"
 													@click="openReplyBox(topComment, topComment)">
 													{{ t('kanso', 'Reply') }}
+												</button>
+												<!-- Resolve / Reopen — a shared signal, so any board editor may
+												     flip it, not only the thread's author. -->
+												<button
+													v-if="canEdit && editingCommentId !== topComment.id"
+													class="card-modal__comment-link-btn card-modal__comment-resolve-btn"
+													:disabled="resolveThread.isPending.value"
+													@click="handleToggleResolved(topComment)">
+													{{ isThreadResolved(topComment) ? t('kanso', 'Reopen') : t('kanso', 'Resolve') }}
+												</button>
+												<!-- Only reachable while peeking into a resolved thread. -->
+												<button
+													v-if="isThreadResolved(topComment)"
+													class="card-modal__comment-link-btn"
+													:aria-expanded="true"
+													@click="toggleThreadExpanded(topComment)">
+													{{ t('kanso', 'Hide') }}
 												</button>
 												<!-- Personal "remind me" about this comment (#3816). Any
 												     reader can set a private reminder - not gated by canEdit. -->
@@ -2155,6 +2203,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											<NcButton @click="closeReplyBox">{{ t('kanso', 'Cancel') }}</NcButton>
 										</div>
 									</div>
+									</template>
 								</div>
 							</div>
 
@@ -3912,6 +3961,8 @@ const ACTIVITY_VERBS = {
 	20: () => t('kanso', 'changed the status'),
 	21: () => t('kanso', 'changed the estimate'),
 	22: () => t('kanso', 'changed the card type'),
+	23: () => t('kanso', 'resolved a thread'),
+	24: () => t('kanso', 'reopened a thread'),
 }
 function activityVerbText(item) {
 	const fn = ACTIVITY_VERBS[item.verb]
@@ -4109,6 +4160,8 @@ const {
 	deleteComment,
 	toggleReaction,
 	toggleCommentReaction,
+	resolveThread,
+	toggleThreadResolved,
 } = useComments(computed(() => props.cardId), boardId)
 
 // Emoji reactions on comments (#3550). The fixed picker set + which comment has
@@ -4352,6 +4405,53 @@ async function handleVisibilityChange(visibility) {
 const flatComments = computed(() => commentsQuery.data.value ?? [])
 const commentThread = computed(() => buildCommentTree(flatComments.value))
 
+// ── Resolved threads ─────────────────────────────────────────────────────────
+// A resolved thread (server-side `resolvedAt > 0` on its top-level comment)
+// renders collapsed to a one-line summary. `expandedThreads` is a peek: a user
+// can open a resolved thread to read it without reopening it for everyone.
+// Deliberately TRANSIENT — component-local, never written to localStorage and
+// never sent to the server, so it dies with the modal. The shared, persisted
+// fact is `resolvedAt`; how one reader is currently looking at it is not.
+const expandedThreads = ref(new Set())
+
+function isThreadResolved(topComment) {
+	return Number(topComment?.resolvedAt ?? 0) > 0
+}
+
+function isThreadCollapsed(topComment) {
+	return isThreadResolved(topComment) && !expandedThreads.value.has(topComment.id)
+}
+
+function toggleThreadExpanded(topComment) {
+	const next = new Set(expandedThreads.value)
+	if (next.has(topComment.id)) {
+		next.delete(topComment.id)
+	} else {
+		next.add(topComment.id)
+	}
+	expandedThreads.value = next
+}
+
+async function handleToggleResolved(topComment) {
+	commentError.value = ''
+	const wasResolved = isThreadResolved(topComment)
+	try {
+		await toggleThreadResolved(topComment)
+		// Reopening drops the manual peek: the thread is open on its own merit
+		// now, so a stale expand entry would silently outlive what needed it.
+		if (wasResolved && expandedThreads.value.has(topComment.id)) {
+			const next = new Set(expandedThreads.value)
+			next.delete(topComment.id)
+			expandedThreads.value = next
+		}
+	} catch (err) {
+		commentError.value = err?.response?.data?.error
+			|| (wasResolved
+				? t('kanso', 'Failed to reopen this thread.')
+				: t('kanso', 'Failed to resolve this thread.'))
+	}
+}
+
 // ── Scroll-to-comment deep links (#3870) ─────────────────────────────────────
 // A reminder notification links to the card with a `#comment-<id>` fragment (see
 // Notifier::cardLink). The fragment-free deep-link boot (main.js) stashes that id
@@ -4385,6 +4485,18 @@ async function scrollToTargetComment() {
 	if (!flatComments.value.some((c) => Number(c.id) === id)) return
 	// Ensure the discussion tab (not activity) is showing so the node is rendered.
 	discussionTab.value = 'discussion'
+	// A RESOLVED thread renders collapsed, and a collapsed thread does not render
+	// its body or its replies at all — so a mention or reminder link pointing into
+	// one would scroll to a node that never appears. Force the thread open for
+	// this visit. Transient, exactly like the discussion-pane reveal below: it
+	// expands the view, it does NOT reopen the thread for anyone.
+	const target = flatComments.value.find((c) => Number(c.id) === id)
+	const rootId = Number(target?.parentCommentId ?? 0) || Number(target?.id ?? 0)
+	if (rootId && !expandedThreads.value.has(rootId)) {
+		const next = new Set(expandedThreads.value)
+		next.add(rootId)
+		expandedThreads.value = next
+	}
 	// The v-for nodes are patched asynchronously after the query data lands, so a
 	// single nextTick can run before the DOM node exists; poll a few frames for it
 	// before giving up rather than silently no-op'ing on a slow first paint.
@@ -8117,6 +8229,57 @@ body.theme--dark .card-modal,
 .card-modal__comment--highlight {
 	animation: kanso-comment-flash 3.6s ease-out 1;
 	border-radius: 8px;
+}
+/* A resolved thread recedes: muted chrome, and when collapsed it is a single
+   clickable summary row instead of the full comment + replies. */
+.card-modal__comment-group--resolved {
+	border-color: var(--color-border-dark, var(--color-border));
+	background: var(--color-background-hover);
+}
+.card-modal__thread-summary {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 14px;
+	min-width: 0;
+}
+.card-modal__thread-summary-toggle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex: 1;
+	min-width: 0;
+	background: transparent;
+	border: none;
+	padding: 2px 0;
+	font-size: 13px;
+	color: var(--color-text-maxcontrast);
+	cursor: pointer;
+	text-align: start;
+}
+.card-modal__thread-summary-toggle:hover,
+.card-modal__thread-summary-toggle:focus-visible {
+	color: var(--color-main-text);
+}
+.card-modal__thread-summary-icon {
+	flex-shrink: 0;
+	color: var(--color-success, var(--color-primary-element));
+}
+.card-modal__thread-summary-author {
+	font-weight: 600;
+	color: var(--color-main-text);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.card-modal__thread-summary-state,
+.card-modal__thread-summary-replies {
+	flex-shrink: 0;
+}
+.card-modal__thread-summary-show {
+	margin-inline-start: auto;
+	flex-shrink: 0;
+	text-decoration: underline;
 }
 @keyframes kanso-comment-flash {
 	0% {

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -188,6 +188,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 								v-model="draftTitle"
 								class="card-modal__title-input"
 								type="text"
+								maxlength="100"
 								@keydown.enter.prevent="saveTitle"
 								@keydown.escape.stop="cancelTitleEdit"
 								@blur="saveTitle">
@@ -1440,6 +1441,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									v-model="newChildTitle"
 									class="card-modal__dashed-input"
 									type="text"
+									maxlength="100"
 									:placeholder="t('kanso', 'Add a sub-card…')"
 									:disabled="addChildMutation.isPending.value"
 									@keydown.enter.prevent="handleAddChild">

--- a/src/components/StackColumn.vue
+++ b/src/components/StackColumn.vue
@@ -206,6 +206,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					v-model="newCardTitle"
 					class="card-composer__input"
 					type="text"
+					maxlength="100"
 					:placeholder="t('kanso', 'Add card…')"
 					:disabled="isPending"
 					@paste="onComposerPaste"

--- a/src/composables/useComments.js
+++ b/src/composables/useComments.js
@@ -34,6 +34,8 @@ import {
 	deleteComment as apiDeleteComment,
 	reactToComment as apiReactToComment,
 	unreactToComment as apiUnreactToComment,
+	resolveThread as apiResolveThread,
+	unresolveThread as apiUnresolveThread,
 } from '../services/api.js'
 import { boardQueryKey } from './queryKeys.js'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -373,6 +375,53 @@ export function useComments(cardId, boardId) {
 		return toggleReaction.mutateAsync({ commentId: comment.id, emoji, adding })
 	}
 
+	// ── resolveThread ───────────────────────────────────────────────────────────
+	// Mark a discussion thread resolved / reopen it. Same optimistic shape as
+	// toggleReaction: patch the ONE top-level comment's `resolvedAt` in the
+	// comments cache, roll back on error, invalidate on settle so the server's
+	// timestamp wins. The collapsed rendering is derived from `resolvedAt` in the
+	// component — nothing about collapse is cached or persisted here.
+	const resolveThread = useMutation({
+		mutationFn: ({ commentId, resolved }) =>
+			resolved ? apiResolveThread(commentId) : apiUnresolveThread(commentId),
+
+		onMutate: async ({ commentId, resolved }) => {
+			const commentsKey = getCommentsKey()
+			await queryClient.cancelQueries({ queryKey: commentsKey })
+			const previousComments = queryClient.getQueryData(commentsKey)
+			queryClient.setQueryData(commentsKey, (old) => {
+				if (!Array.isArray(old)) return old
+				return old.map((c) =>
+					c.id === commentId
+						? { ...c, resolvedAt: resolved ? Math.floor(Date.now() / 1000) : 0 }
+						: c,
+				)
+			})
+			return { previousComments }
+		},
+
+		onError: (_err, _vars, context) => {
+			if (context?.previousComments !== undefined) {
+				queryClient.setQueryData(getCommentsKey(), context.previousComments)
+			}
+		},
+
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: getCommentsKey() })
+		},
+	})
+
+	/**
+	 * Toggle the resolved state of a thread from its top-level comment.
+	 * @param {object} comment the TOP-LEVEL comment of the thread
+	 */
+	function toggleResolved(comment) {
+		return resolveThread.mutateAsync({
+			commentId: comment.id,
+			resolved: !(Number(comment.resolvedAt) > 0),
+		})
+	}
+
 	return {
 		comments,
 		addComment,
@@ -380,6 +429,8 @@ export function useComments(cardId, boardId) {
 		deleteComment,
 		toggleReaction,
 		toggleCommentReaction: toggle,
+		resolveThread,
+		toggleThreadResolved: toggleResolved,
 		currentUid,
 	}
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -283,6 +283,14 @@ export const reactToComment = (commentId, emoji) =>
 export const unreactToComment = (commentId, emoji) =>
 	axios.delete(url(`/api/comments/${commentId}/reactions/${encodeURIComponent(emoji)}`)).then((r) => r.data)
 
+// Thread resolution — idempotent, top-level comments only. `commentId` is the
+// thread's root comment; the server rejects a reply.
+export const resolveThread = (commentId) =>
+	axios.put(url(`/api/comments/${commentId}/resolve`)).then((r) => r.data)
+
+export const unresolveThread = (commentId) =>
+	axios.delete(url(`/api/comments/${commentId}/resolve`)).then((r) => r.data)
+
 // Subscriptions (card watchers)
 export const subscribeCard = (cardId) =>
 	axios.put(url(`/api/cards/${cardId}/subscription`)).then((r) => r.data)

--- a/tests/e2e/card-title-limit.spec.js
+++ b/tests/e2e/card-title-limit.spec.js
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// Card titles are capped at 100 characters server-side (CardService::MAX_TITLE_LENGTH,
+// backed by a VARCHAR(100) column). Every card title input now carries maxlength="100"
+// so the cap is felt while typing instead of as a 400 after Enter — matching the column
+// and board title inputs, which already had it.
+//
+// The four inputs covered here are the complete set of card-title entry points:
+// the kanban composer, the list-view composer, the card-detail rename, and the
+// sub-card composer.
+// Distinct filler per input so one test's persisted 100-char title can never
+// satisfy another's assertion.
+const tooLong = (ch) => ch.repeat(150)
+const capped = (ch) => ch.repeat(100)
+
+test.describe('Card title length cap', () => {
+	const state = { boardId: 0, stackId: 0, cardId: 0, boardUrl: '' }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Title Cap E2E ' + Date.now() })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'To Do' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'Rename me' })).id
+		state.boardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	// Persisted titles (source of truth) — proves the cap survived the round trip
+	// rather than only looking right in the DOM.
+	async function titles() {
+		const board = await api.get(`/boards/${state.boardId}`)
+		return board.cards.filter((c) => !c.archived).map((c) => c.title)
+	}
+
+	test('kanban composer truncates at 100 and creates the 100-char card', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.stack-column', { timeout: 15_000 })
+
+		const composer = page.locator('.stack-column').first().locator('.card-composer__input')
+		await expect(composer).toBeVisible({ timeout: 10_000 })
+		await expect(composer).toHaveAttribute('maxlength', '100')
+
+		// fill() sets the value through the real input pipeline, so maxlength applies.
+		await composer.fill(tooLong('a'))
+		await expect(composer).toHaveValue(capped('a'))
+
+		await composer.press('Enter')
+
+		// Created with exactly the 100-character prefix — no 400, no truncation surprise.
+		await expect.poll(() => titles(), { timeout: 10_000 }).toContain(capped('a'))
+	})
+
+	test('list-view composer truncates at 100', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		// Switch to List view — its per-group quick-add row carries its own composer.
+		await page.locator('.board-view__display-menu button').first().click()
+		await page.getByRole('menuitemradio', { name: 'List', exact: true }).click()
+		await page.keyboard.press('Escape')
+
+		// Scope to the list table — the kanban composer stays in the DOM (hidden)
+		// behind the view switch, so an unscoped locator would match that one.
+		const composer = page.locator('.board-list-table .card-composer__input').first()
+		await expect(composer).toBeVisible({ timeout: 10_000 })
+		await expect(composer).toHaveAttribute('maxlength', '100')
+
+		await composer.fill(tooLong('b'))
+		await expect(composer).toHaveValue(capped('b'))
+	})
+
+	test('card-detail rename and sub-card composer truncate at 100', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${state.cardId}`)
+		await page.waitForSelector('.card-modal', { timeout: 15_000 })
+
+		// Sub-card composer.
+		const addChild = page.getByPlaceholder('Add a sub-card…')
+		await expect(addChild).toBeVisible({ timeout: 10_000 })
+		await expect(addChild).toHaveAttribute('maxlength', '100')
+		await addChild.fill(tooLong('c'))
+		await expect(addChild).toHaveValue(capped('c'))
+		// Leave no half-typed draft behind for the rename step.
+		await addChild.fill('')
+
+		// Title rename: click the heading to swap it for the input.
+		await page.locator('.card-modal__title').click()
+		const titleInput = page.locator('.card-modal__title-input')
+		await expect(titleInput).toBeVisible({ timeout: 5_000 })
+		await expect(titleInput).toHaveAttribute('maxlength', '100')
+		await titleInput.fill(tooLong('d'))
+		await expect(titleInput).toHaveValue(capped('d'))
+
+		await titleInput.press('Enter')
+		await expect.poll(() => titles(), { timeout: 10_000 }).toContain(capped('d'))
+	})
+})

--- a/tests/e2e/comment-resolve.spec.js
+++ b/tests/e2e/comment-resolve.spec.js
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Resolving a discussion thread collapses it under the card.
+ *
+ * The point of the feature is decluttering, so the assertions are about what
+ * DISAPPEARS: once a thread is resolved its body, its replies and its reply
+ * composer are gone, leaving one summary row. The reload in the middle is the
+ * load-bearing step — it proves the state came back from the server rather than
+ * living in this tab's memory.
+ */
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+const GROUP = '.card-modal__comment-group'
+const SUMMARY = '.card-modal__thread-summary'
+const REPLIES = '.card-modal__replies .card-modal__comment--reply'
+
+test.describe('Comment threads / resolve', () => {
+	const state = { boardId: 0, cardId: 0, topId: 0, replyId: 0, cardUrl: '' }
+
+	test.beforeAll(async () => {
+		for (const b of await api.get('/boards')) {
+			if (b.title === 'Resolve E2E Board') await api.delete(`/boards/${b.id}`)
+		}
+		const board = await api.post('/boards', { title: 'Resolve E2E Board' })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'To Do' })
+		const card = await api.post('/cards', { stackId: stack.id, title: 'Card With Resolvable Thread' })
+		state.cardId = card.id
+		// Seed through the API so the UI test starts from a known thread.
+		const top = await api.post(`/cards/${card.id}/comments`, { body: 'Should we ship this?' })
+		state.topId = top.id
+		const reply = await api.post(`/cards/${card.id}/comments`, {
+			body: 'Yes, settled.',
+			parentCommentId: top.id,
+		})
+		state.replyId = reply.id
+		state.cardUrl = `${BASE}/index.php/apps/kanso#/board/${board.id}/card/${card.id}`
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('resolve collapses the thread, survives a reload, and reopen restores it', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(state.cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// Open to begin with: body + reply visible, no summary row.
+		await expect(page.locator(REPLIES)).toHaveCount(1, { timeout: 8000 })
+		await expect(page.locator(SUMMARY)).toHaveCount(0)
+
+		// Resolve it from the top-level comment's controls.
+		const group = page.locator(GROUP).first()
+		await group.locator('.card-modal__comment-resolve-btn').click()
+
+		// Collapsed: one summary row, no reply rendered at all.
+		await expect(page.locator(SUMMARY)).toHaveCount(1, { timeout: 6000 })
+		await expect(page.locator(SUMMARY)).toContainText('Resolved')
+		await expect(page.locator(REPLIES)).toHaveCount(0)
+		await expect(page.locator('.card-modal__comment-body')).toHaveCount(0)
+
+		// THE load-bearing assertion: a full reload throws away every scrap of
+		// client state, so a thread still collapsed here is collapsed because the
+		// SERVER said so (resolved_at), not because this tab remembered.
+		await page.reload()
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+		await expect(page.locator(SUMMARY)).toHaveCount(1, { timeout: 8000 })
+		await expect(page.locator(REPLIES)).toHaveCount(0)
+
+		// The API agrees — resolvedAt is set on the top-level comment only.
+		const afterResolve = await api.get(`/cards/${state.cardId}/comments`)
+		const top = afterResolve.find((c) => c.id === state.topId)
+		const reply = afterResolve.find((c) => c.id === state.replyId)
+		expect(top.resolvedAt).toBeGreaterThan(0)
+		expect(reply.resolvedAt).toBe(0)
+
+		// Peek: expanding locally reveals the thread WITHOUT reopening it.
+		await page.locator('.card-modal__thread-summary-toggle').click()
+		await expect(page.locator(REPLIES)).toHaveCount(1, { timeout: 6000 })
+		const stillResolved = await api.get(`/cards/${state.cardId}/comments`)
+		expect(stillResolved.find((c) => c.id === state.topId).resolvedAt).toBeGreaterThan(0)
+
+		// Reopen for everyone: the summary row goes away and stays away.
+		await page.locator(GROUP).first().locator('.card-modal__comment-resolve-btn').click()
+		await expect(page.locator(SUMMARY)).toHaveCount(0, { timeout: 6000 })
+		await expect(page.locator(REPLIES)).toHaveCount(1)
+
+		await page.reload()
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+		await expect(page.locator(REPLIES)).toHaveCount(1, { timeout: 8000 })
+		await expect(page.locator(SUMMARY)).toHaveCount(0)
+
+		const afterReopen = await api.get(`/cards/${state.cardId}/comments`)
+		expect(afterReopen.find((c) => c.id === state.topId).resolvedAt).toBe(0)
+	})
+
+	test('a deep link into a resolved thread force-expands it', async ({ page }) => {
+		// A mention or reminder notification must never land on a card that
+		// renders nothing. Resolve server-side, then arrive via ?comment=<replyId>.
+		await api.put(`/comments/${state.topId}/resolve`)
+
+		await ncLogin(page)
+		await page.goto(`${state.cardUrl}?comment=${state.replyId}`)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		// The linked reply is rendered and reachable, despite the thread being
+		// resolved — and the thread is still resolved for everyone else.
+		await expect(page.locator(`#comment-${state.replyId}`)).toBeVisible({ timeout: 10_000 })
+		await expect(page.locator(SUMMARY)).toHaveCount(0)
+		const comments = await api.get(`/cards/${state.cardId}/comments`)
+		expect(comments.find((c) => c.id === state.topId).resolvedAt).toBeGreaterThan(0)
+
+		await api.delete(`/comments/${state.topId}/resolve`)
+	})
+
+	test('the resolve endpoints are idempotent and refuse a reply', async () => {
+		// Idempotent: a repeated PUT/DELETE is a 200 no-op, not an error.
+		const first = await api.put(`/comments/${state.topId}/resolve`)
+		expect(first.resolvedAt).toBeGreaterThan(0)
+		const again = await api.put(`/comments/${state.topId}/resolve`)
+		expect(again.resolvedAt).toBe(first.resolvedAt)
+
+		expect((await api.delete(`/comments/${state.topId}/resolve`))).toBeNull()
+		const reopened = await api.get(`/cards/${state.cardId}/comments`)
+		expect(reopened.find((c) => c.id === state.topId).resolvedAt).toBe(0)
+		await api.delete(`/comments/${state.topId}/resolve`)
+
+		// The THREAD is the unit: a reply has no resolved state of its own.
+		const r = await api.raw('PUT', `/comments/${state.replyId}/resolve`)
+		expect(r.status).toBe(400)
+	})
+})

--- a/tests/unit/Controller/CommentControllerTest.php
+++ b/tests/unit/Controller/CommentControllerTest.php
@@ -117,4 +117,40 @@ class CommentControllerTest extends TestCase {
 		$data = $this->controller->index(9)->getData();
 		self::assertSame([], $data[0]['reactions']);
 	}
+
+	public function testIndexEmitsResolvedAtSoClientsCanDeriveTheCollapse(): void {
+		$open = $this->comment(50);
+		$resolved = $this->comment(51);
+		$resolved->setResolvedAt(1700000000);
+		$this->commentService->method('listForCard')->willReturn([$open, $resolved]);
+		$this->reactionMapper->method('findByComments')->willReturn([]);
+
+		$data = $this->controller->index(9)->getData();
+		self::assertSame(0, $data[0]['resolvedAt']);
+		self::assertSame(1700000000, $data[1]['resolvedAt']);
+	}
+
+	public function testResolveDelegatesWithTrueAndReturnsTheUpdatedComment(): void {
+		$resolved = $this->comment(50);
+		$resolved->setResolvedAt(1700000000);
+		$this->commentService->expects(self::once())
+			->method('setResolved')
+			->with(50, true, 'alice')
+			->willReturn($resolved);
+
+		$response = $this->controller->resolve(50);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame(1700000000, $response->getData()['resolvedAt']);
+	}
+
+	public function testUnresolveDelegatesWithFalseAndReturnsTheUpdatedComment(): void {
+		$this->commentService->expects(self::once())
+			->method('setResolved')
+			->with(50, false, 'alice')
+			->willReturn($this->comment(50));
+
+		$response = $this->controller->unresolve(50);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame(0, $response->getData()['resolvedAt']);
+	}
 }

--- a/tests/unit/Db/CardMapperTest.php
+++ b/tests/unit/Db/CardMapperTest.php
@@ -623,4 +623,93 @@ class CardMapperTest extends TestCase {
 			$this->mapper->countByStack(7, self::viewer())
 		);
 	}
+
+	// ---- the rebalance's locking read + scoped write -----------------------
+	//
+	// SCOPE NOTE, so these are not read as more than they are: IDBConnection and
+	// IQueryBuilder are mocked here, so these tests pin WHICH calls the mapper
+	// makes per database provider, not what the database does with them. Two
+	// things they structurally CANNOT prove and that are covered by the install
+	// matrix instead (dev/smoke.sh runs occ kanso:rebalance on every DB):
+	//   * that SQLite really rejects `SELECT ... FOR UPDATE` - the mock accepts it;
+	//   * the method_exists() half of the guard, which closes the NC 32.0.0-32.0.6
+	//     gap - a createMock() of IQueryBuilder is built from the vendored ocp
+	//     stub pinned to the NEWEST server, where forUpdate() always exists.
+
+	/**
+	 * Builds a mapper whose connection reports $provider, over a QB mock that also
+	 * answers forUpdate(). Returns the QB so the test can assert on it.
+	 */
+	private function mapperOnProvider(string $provider, ?IQueryBuilder &$qbOut = null): CardMapper {
+		$qb = $this->buildQb([]);
+		$qb->method('forUpdate')->willReturnSelf();
+		$qbOut = $qb;
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getDatabaseProvider')->willReturn($provider);
+		$db->method('getQueryBuilder')->willReturn($qb);
+
+		return new CardMapper($db, new CardVisibilityScope());
+	}
+
+	public function testFindByStackForUpdateTakesTheRowLockOnPostgres(): void {
+		$qb = null;
+		$mapper = $this->mapperOnProvider(IDBConnection::PLATFORM_POSTGRES, $qb);
+		$qb->expects(self::once())->method('forUpdate');
+
+		self::assertSame([], $mapper->findByStackForUpdate(5));
+	}
+
+	public function testFindByStackForUpdateTakesTheRowLockOnMysql(): void {
+		$qb = null;
+		$mapper = $this->mapperOnProvider(IDBConnection::PLATFORM_MYSQL, $qb);
+		$qb->expects(self::once())->method('forUpdate');
+
+		self::assertSame([], $mapper->findByStackForUpdate(5));
+	}
+
+	/**
+	 * SQLite has no `SELECT ... FOR UPDATE`; asking for one throws
+	 * "Operation 'FOR UPDATE' is not supported by platform" and takes down
+	 * `occ kanso:rebalance`, the ONLY recovery from the sort-key wall. The read
+	 * must therefore be issued WITHOUT the lock there - see
+	 * CardMapper::supportsRowLock() for why that is still correct.
+	 */
+	public function testFindByStackForUpdateOmitsTheRowLockOnSqlite(): void {
+		$qb = null;
+		$mapper = $this->mapperOnProvider(IDBConnection::PLATFORM_SQLITE, $qb);
+		$qb->expects(self::never())->method('forUpdate');
+
+		self::assertSame([], $mapper->findByStackForUpdate(5));
+	}
+
+	/**
+	 * The rebalance's write half must match on the stack as well as the card:
+	 * without the row lock a card can be moved out of the stack between the read
+	 * and the write, and rewriting its key would then corrupt the ordering of the
+	 * stack it moved into.
+	 */
+	public function testUpdateSortKeyByIdIsScopedToTheStackNotJustTheCard(): void {
+		$columns = [];
+		$qb = $this->createMock(IQueryBuilder::class);
+		foreach (['update', 'set', 'where', 'andWhere'] as $method) {
+			$qb->method($method)->willReturnSelf();
+		}
+		$qb->method('expr')->willReturn(self::spyExpr($columns));
+		$qb->method('createNamedParameter')->willReturn('?');
+		$qb->method('executeStatement')->willReturn(1);
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getQueryBuilder')->willReturn($qb);
+		$mapper = new CardMapper($db, new CardVisibilityScope());
+
+		$mapper->updateSortKeyById(9, 5, 'A1');
+
+		self::assertContains('id', $columns);
+		self::assertContains(
+			'stack_id',
+			$columns,
+			'the rebalance write must be scoped to the stack it read, not the card id alone'
+		);
+	}
 }

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -748,6 +748,113 @@ class CardServiceTest extends TestCase {
 		self::assertGreaterThan(0, $updated->getLastModified());
 	}
 
+	// ---- description length cap -------------------------------------------
+	//
+	// update() is the ONLY client-facing description write (create() takes no
+	// description; the copy/template/recurrence writers and the CSV/Deck/Trello
+	// importers set it directly and stay uncapped so importing a long
+	// description from another tool keeps working). The cap is checked only when
+	// the text actually changes, which is what keeps a row stored before the cap
+	// existed readable, saveable on its other fields, and editable DOWN.
+
+	public function testUpdateAcceptsARealisticMultiKilobyteDescription(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+
+		// A long but ordinary card description - a spec, not an attack.
+		$long = str_repeat('Kanso card description paragraph. ', 250); // ~8 KiB
+		$updated = $this->service->update(9, null, $long, null, null, null, 'alice');
+		self::assertSame($long, $updated->getDescription());
+	}
+
+	public function testUpdateAcceptsADescriptionExactlyAtTheCap(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+
+		// Asserted by identity, not by length: a "silently truncate to the cap"
+		// implementation must not pass this.
+		$atCap = str_repeat('x', CardService::MAX_DESCRIPTION_LENGTH);
+		$updated = $this->service->update(9, null, $atCap, null, null, null, 'alice');
+		self::assertSame($atCap, $updated->getDescription());
+	}
+
+	public function testUpdateRejectsADescriptionOverTheCap(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Refused before anything is persisted or logged - a 400, not a write.
+		$this->cardMapper->expects(self::never())->method('update');
+		$this->changeNotifier->expects(self::never())->method('recordChange');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(
+			9,
+			null,
+			str_repeat('x', CardService::MAX_DESCRIPTION_LENGTH + 1),
+			null,
+			null,
+			null,
+			'alice',
+		);
+	}
+
+	public function testUpdateCountsTheDescriptionCapInCharactersNotBytes(): void {
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+
+		// Multibyte-safe, like the title and comment caps: a description of
+		// exactly MAX characters is accepted even though it is twice that in
+		// bytes - a non-ASCII writer does not get half the room.
+		$atCap = str_repeat('é', CardService::MAX_DESCRIPTION_LENGTH);
+		self::assertGreaterThan(CardService::MAX_DESCRIPTION_LENGTH, strlen($atCap));
+		$updated = $this->service->update(9, null, $atCap, null, null, null, 'alice');
+		self::assertSame($atCap, $updated->getDescription());
+	}
+
+	public function testUpdateLeavesAGrandfatheredOverLongDescriptionSaveableAndEditableDown(): void {
+		$overLong = str_repeat('x', CardService::MAX_DESCRIPTION_LENGTH + 500);
+		// A FRESH entity per load, as a real mapper would hand back - so the three
+		// saves below are independent and reordering them cannot change what they
+		// prove.
+		$this->cardMapper->method('find')->with(9)
+			->willReturnCallback(fn (int $cardId): Card => $this->describedCard($overLong, 200));
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+
+		// 1. An unrelated field save on the over-long row is not blocked, and the
+		//    stored text is left untouched.
+		$renamed = $this->service->update(9, 'Renamed', null, null, null, null, 'alice');
+		self::assertSame('Renamed', $renamed->getTitle());
+		self::assertSame($overLong, $renamed->getDescription());
+
+		// 2. Re-sending the identical over-long text is a no-op, not a 400 - the
+		//    editor can round-trip the row it just loaded.
+		$resaved = $this->service->update(9, null, $overLong, null, null, null, 'alice');
+		self::assertSame($overLong, $resaved->getDescription());
+
+		// 3. And it can be edited DOWN to something within the cap.
+		$trimmed = $this->service->update(9, null, 'trimmed', null, null, null, 'alice');
+		self::assertSame('trimmed', $trimmed->getDescription());
+	}
+
+	public function testUpdateRejectsGrowingAnAlreadyOverLongDescription(): void {
+		$overLong = str_repeat('x', CardService::MAX_DESCRIPTION_LENGTH + 500);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->describedCard($overLong, 200));
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardMapper->expects(self::never())->method('update');
+
+		// Grandfathering is read/shrink only: appending to an over-long row is
+		// still refused, so the row cannot keep growing.
+		$this->expectException(InvalidInputException::class);
+		$this->service->update(9, null, $overLong . 'more', null, null, null, 'alice');
+	}
+
 	// ---- description optimistic concurrency (#9845) -----------------------
 	//
 	// `baseLastModified` is OPTIONAL: omitting it keeps the historical
@@ -3103,6 +3210,35 @@ class CardServiceTest extends TestCase {
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->copy(9, 7, 'bob');
+	}
+
+	public function testCopyCarriesAnOverCapDescriptionUnchanged(): void {
+		// The MAX_DESCRIPTION_LENGTH cap deliberately lives in update() only - the
+		// boundary where a client submits NEW text. copy() carries an EXISTING
+		// description across, so a row that predates the cap (or arrived through an
+		// importer) must still be duplicable. Pinning it here so the cap cannot
+		// later be pushed down into a shared writer or into Card::setDescription().
+		$overLong = str_repeat('x', CardService::MAX_DESCRIPTION_LENGTH + 500);
+		$board = $this->board(1);
+		$source = $this->card(9, 5, 1);
+		$source->setTitle('Imported spec');
+		$source->setDescription($overLong);
+
+		$this->cardMapper->method('find')->willReturnMap([[9, $source]]);
+		$this->stackMapper->method('find')->with(7)->willReturn($this->stack(7, 1));
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->cardMapper->method('findLastInStack')->with(7)->willReturn(null);
+		$this->cardMapper->method('insert')->willReturnCallback(static function (Card $c): Card {
+			$c->setId(42);
+			return $c;
+		});
+		$this->cardMapper->method('update')->willReturnArgument(0);
+		$this->changeNotifier->method('recordChange')->willReturn(new Change());
+		$this->cardLabelMapper->method('findLabelIdsByCard')->with(9)->willReturn([]);
+		$this->checklistItemMapper->method('findByCard')->with(9)->willReturn([]);
+
+		$copy = $this->service->copy(9, 7, 'alice');
+		self::assertSame($overLong, $copy->getDescription());
 	}
 
 	// ---- moveToBoard (#3679) ----------------------------------------------

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -3548,9 +3548,11 @@ class CardServiceTest extends TestCase {
 
 		// Capture every sort-key write in order (pass 1 temp keys + pass 2 finals).
 		$writes = [];
+		$writtenStackIds = [];
 		$this->cardMapper->method('updateSortKeyById')
-			->willReturnCallback(static function (int $id, string $key) use (&$writes): void {
+			->willReturnCallback(static function (int $id, int $stackId, string $key) use (&$writes, &$writtenStackIds): void {
 				$writes[] = [$id, $key];
+				$writtenStackIds[] = $stackId;
 			});
 
 		$this->changeNotifier->expects(self::once())
@@ -3567,6 +3569,12 @@ class CardServiceTest extends TestCase {
 
 		// Two passes of 3 writes each.
 		self::assertCount(6, $writes);
+
+		// Every write is scoped to the stack being rebalanced. Without the row
+		// lock (sqlite, and NC 32.0.0-32.0.6) a card can be moved OUT of the stack
+		// between the read and the write; the stack id turns that into a no-match
+		// instead of a key rewrite that would corrupt its NEW stack's ordering.
+		self::assertSame([5, 5, 5, 5, 5, 5], $writtenStackIds);
 
 		// Pass 1 parks each row at a distinct three-character temporary key,
 		// disjoint from the current keys and (by length) from the finals, so no

--- a/tests/unit/Service/CommentServiceTest.php
+++ b/tests/unit/Service/CommentServiceTest.php
@@ -89,6 +89,7 @@ class CommentServiceTest extends TestCase {
 		$comment->setCreatedAt(1000);
 		$comment->setEditedAt(0);
 		$comment->setDeletedAt(0);
+		$comment->setResolvedAt(0);
 		return $comment;
 	}
 
@@ -329,5 +330,130 @@ class CommentServiceTest extends TestCase {
 
 		$this->expectException(NotPermittedException::class);
 		$this->service->deleteComment(50, 'carol');
+	}
+
+	// ---- setResolved ------------------------------------------------------
+
+	public function testResolveStampsResolvedAtAndWritesThreadResolvedChangeRow(): void {
+		$comment = $this->comment(50, 9, null, 'bob');
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->commentMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(function (Comment $c): Comment {
+				self::assertGreaterThan(0, $c->getResolvedAt());
+				return $c;
+			});
+		// A distinct verb, NOT VERB_COMMENTED - resolving adds no message and must
+		// not render as "commented" in the activity feed.
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'carol', true, Change::VERB_THREAD_RESOLVED)
+			->willReturn(new Change());
+
+		$saved = $this->service->setResolved(50, true, 'carol');
+		self::assertGreaterThan(0, $saved->getResolvedAt());
+	}
+
+	public function testUnresolveClearsResolvedAtAndWritesThreadReopenedChangeRow(): void {
+		$comment = $this->comment(50, 9, null, 'bob');
+		$comment->setResolvedAt(1700000000);
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->commentMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(function (Comment $c): Comment {
+				self::assertSame(0, $c->getResolvedAt());
+				return $c;
+			});
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'carol', true, Change::VERB_THREAD_REOPENED)
+			->willReturn(new Change());
+
+		$this->service->setResolved(50, false, 'carol');
+	}
+
+	public function testResolveRejectsAReply(): void {
+		// The THREAD is the unit (like the delete cascade); a reply has no
+		// coherent resolved state of its own.
+		$reply = $this->comment(51, 9, 50, 'bob');
+		$this->commentMapper->method('find')->with(51)->willReturn($reply);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->commentMapper->expects(self::never())->method('update');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->setResolved(51, true, 'carol');
+	}
+
+	public function testResolvingAnAlreadyResolvedThreadIsANoOp(): void {
+		$comment = $this->comment(50, 9, null, 'bob');
+		$comment->setResolvedAt(1700000000);
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		// Idempotent: no write, and crucially NO change row - a repeated PUT must
+		// not churn the board ETag or spam the activity feed.
+		$this->commentMapper->expects(self::never())->method('update');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$saved = $this->service->setResolved(50, true, 'carol');
+		self::assertSame(1700000000, $saved->getResolvedAt());
+	}
+
+	public function testUnresolvingAnOpenThreadIsANoOp(): void {
+		$comment = $this->comment(50, 9, null, 'bob');
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->commentMapper->expects(self::never())->method('update');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$this->service->setResolved(50, false, 'carol');
+	}
+
+	public function testResolveAssertsActorEditPermission(): void {
+		$comment = $this->comment(50, 9, null, 'bob');
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$board = $this->board();
+		$this->boardMapper->method('find')->with(1)->willReturn($board);
+		$this->permissionService->expects(self::once())
+			->method('assertPermission')
+			->with($board, 'mallory', PermissionService::PERMISSION_EDIT)
+			->willThrowException(new NotPermittedException());
+		$this->commentMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->setResolved(50, true, 'mallory');
+	}
+
+	public function testResolveOnHiddenCardReadsAsNotFound(): void {
+		// Mirrors addComment (#3743): a card the actor cannot see fails exactly
+		// like a missing id, never a 403 existence oracle.
+		$comment = $this->comment(50, 9, null, 'bob');
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->cardMapper->method('find')->with(9)->willReturn($this->card());
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->visibilityGuard->method('assertVisible')
+			->willThrowException(new DoesNotExistException('hidden'));
+		$this->commentMapper->expects(self::never())->method('update');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->service->setResolved(50, true, 'bob');
+	}
+
+	public function testResolveRejectsDeletedComment(): void {
+		$comment = $this->comment(50, 9, null, 'bob');
+		$comment->setDeletedAt(1234);
+		$this->commentMapper->method('find')->with(50)->willReturn($comment);
+		$this->commentMapper->expects(self::never())->method('update');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->service->setResolved(50, true, 'bob');
 	}
 }

--- a/tests/unit/Service/DeckImportServiceTest.php
+++ b/tests/unit/Service/DeckImportServiceTest.php
@@ -22,6 +22,7 @@ use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCA\Kanso\Service\AttachmentSanitizer;
 use OCA\Kanso\Service\BoardService;
+use OCA\Kanso\Service\CardService;
 use OCA\Kanso\Service\DeckImportService;
 use OCA\Kanso\Service\DeckReader;
 use OCA\Kanso\Service\InvalidInputException;
@@ -273,6 +274,18 @@ class DeckImportServiceTest extends TestCase {
 		self::assertSame(100, mb_strlen($card->getTitle()));
 		// No trailing blank lines when the original description was empty.
 		self::assertSame('Full title: ' . $longTitle, $card->getDescription());
+	}
+
+	public function testImportKeepsADescriptionLongerThanTheEditorCap(): void {
+		// CardService::MAX_DESCRIPTION_LENGTH caps what a user can TYPE into a card
+		// (enforced in CardService::update()). The importer must stay uncapped, or
+		// migrating a board whose cards hold long descriptions would silently lose
+		// or reject content. Pinned so the cap cannot later be pushed down into a
+		// shared writer.
+		$huge = str_repeat('d', CardService::MAX_DESCRIPTION_LENGTH + 1000);
+		$card = $this->importSingleCard('Imported spec', $huge);
+
+		self::assertSame($huge, $card->getDescription());
 	}
 
 	public function testImportEmptyCardTitleBecomesPlaceholder(): void {

--- a/tests/unit/Service/ExportServiceTest.php
+++ b/tests/unit/Service/ExportServiceTest.php
@@ -182,6 +182,7 @@ class ExportServiceTest extends TestCase {
 		$comment->setBody('looks good');
 		$comment->setCreatedAt(520);
 		$comment->setEditedAt(0);
+		$comment->setResolvedAt(1700000000);
 		$this->commentMapper->method('findByCard')->with(41)->willReturn([$comment]);
 
 		$review = new CardReview();
@@ -270,6 +271,8 @@ class ExportServiceTest extends TestCase {
 		);
 		self::assertSame('looks good', $card['comments'][0]['body']);
 		self::assertSame('carol', $card['comments'][0]['author']);
+		// Without this the importer reopens every settled thread on the board.
+		self::assertSame(1700000000, $card['comments'][0]['resolvedAt']);
 		self::assertSame('dave', $card['reviews'][0]['reviewer']);
 		self::assertSame(31, $card['reviews'][0]['reviewTypeId']);
 

--- a/tests/unit/Service/ImportServiceTest.php
+++ b/tests/unit/Service/ImportServiceTest.php
@@ -444,7 +444,7 @@ class ImportServiceTest extends TestCase {
 							'assignedAt' => 1, 'doneAt' => 2,
 						]],
 						'comments' => [
-							['id' => 200, 'parentCommentId' => null, 'author' => 'carol', 'body' => 'top'],
+							['id' => 200, 'parentCommentId' => null, 'author' => 'carol', 'body' => 'top', 'resolvedAt' => 1700000000],
 							['id' => 201, 'parentCommentId' => 200, 'author' => 'ghost', 'body' => 'reply'],
 						],
 						'reviews' => [['reviewer' => 'dave', 'state' => 'pending', 'requestedBy' => 'bob', 'reviewTypeId' => 6]],
@@ -579,6 +579,10 @@ class ImportServiceTest extends TestCase {
 		self::assertNull($capturedComments[0]->getParentCommentId());
 		self::assertSame('importer', $capturedComments[1]->getAuthor());
 		self::assertSame($capturedComments[0]->getId(), $capturedComments[1]->getParentCommentId());
+		// A resolved thread stays resolved across an export/import round-trip;
+		// an archive predating the field imports as open (the reply here).
+		self::assertSame(1700000000, $capturedComments[0]->getResolvedAt());
+		self::assertSame(0, $capturedComments[1]->getResolvedAt());
 
 		// Recur rule remapped its template card + target stack, and its unknown
 		// owner fell back to the importer.

--- a/tests/unit/Service/MentionServiceTest.php
+++ b/tests/unit/Service/MentionServiceTest.php
@@ -110,6 +110,48 @@ class MentionServiceTest extends TestCase {
 		self::assertSame([], $this->service->extractUsernames('no mentions here'));
 	}
 
+	// ---- mention bound ----------------------------------------------------
+	//
+	// Each distinct mention costs one uncached ACL resolution, so without a cap
+	// the mention count in a body - not the board's size - decides how many
+	// queries a single write runs. The bound lives in extractUsernames() so BOTH
+	// mention surfaces get it: a card description (separately length-capped) and
+	// a comment body, which at its own 10,000-char limit still holds ~3,300
+	// distinct `@u1` tokens.
+
+	public function testExtractCapsTheNumberOfDistinctMentions(): void {
+		$body = implode(' ', array_map(static fn (int $i): string => '@u' . $i, range(1, 5000)));
+		$extracted = $this->service->extractUsernames($body);
+
+		self::assertCount(MentionService::MAX_MENTIONS, $extracted);
+		// First-N, in document order - the ones a human actually typed first.
+		self::assertSame('u1', $extracted[0]);
+		self::assertSame('u' . MentionService::MAX_MENTIONS, $extracted[MentionService::MAX_MENTIONS - 1]);
+	}
+
+	public function testExtractCapCountsDistinctUsersNotRepeats(): void {
+		// Dedup happens before the cap, so repeating one name does not consume
+		// the budget and push a real second mention out.
+		$body = str_repeat('@alice ', 500) . '@bob';
+		self::assertSame(['alice', 'bob'], $this->service->extractUsernames($body));
+	}
+
+	public function testHandleMentionsIssuesABoundedNumberOfPermissionLookups(): void {
+		$board = $this->board();
+		$lookups = 0;
+		$this->permissionService->method('getPermissions')
+			->willReturnCallback(function (Board $b, string $uid) use (&$lookups): int {
+				$lookups++;
+				return 0; // nobody is a member: isolate the query count itself
+			});
+
+		$body = implode(' ', array_map(static fn (int $i): string => '@u' . $i, range(1, 5000)));
+		$this->service->handleMentions($this->card(), $board, $body, 'alice');
+
+		// 5,000 distinct mentions, at most MAX_MENTIONS ACL resolutions.
+		self::assertSame(MentionService::MAX_MENTIONS, $lookups);
+	}
+
 	// ---- handleMentions (authz + side effects) ---------------------------
 
 	public function testHandleMentionsSubscribesAndNotifiesReadableParticipant(): void {

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
 msgstr[1] "%n Projekte"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "Review-Typ konnte nicht umbenannt werden."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Element konnte nicht neu sortiert werden."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Review konnte nicht angefordert werden."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Ausgeblendete Karte"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Änderungen ausblenden"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "hat diese Karte in {value} umbenannt"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Wiederholen"
 
@@ -4181,6 +4207,18 @@ msgstr "Zurücksetzen"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Diskussionsbereich skalieren"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Schreibgeschützt geteilt über Kanso"
 msgid "Sharing"
 msgstr "Freigabe"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Tastaturkürzel-Übersicht ein-/ausblenden"
@@ -4454,7 +4496,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -4467,6 +4509,10 @@ msgstr "Gesamten Zeitraum anzeigen"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Dieses Board in meinem Kalender anzeigen"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n Punkt"
 msgstr[1] "%n Punkte"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n nicht geplante Karte"
 msgstr[1] "%n nicht geplante Karten"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n Beobachter"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4454,7 +4454,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n punto"
 msgstr[1] "%n puntos"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n tarjeta sin planificar"
 msgstr[1] "%n tarjetas sin planificar"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n observador"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4454,7 +4454,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
 msgstr[1] "%n proyectos"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "Error al renombrar el tipo de revisión."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Error al reordenar el elemento."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Error al solicitar la revisión."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Tarjeta oculta"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Ocultar los cambios"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "ha renombrado esta tarjeta a {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Repetición"
 
@@ -4181,6 +4207,18 @@ msgstr "Reiniciar"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Redimensionar el panel de conversación"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Compartido en modo de solo lectura con Kanso"
 msgid "Sharing"
 msgstr "Compartir"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Mostrar u ocultar esta lista de atajos"
@@ -4454,7 +4496,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -4467,6 +4509,10 @@ msgstr "Mostrar todo el rango de fechas"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Mostrar este tablero en mi calendario"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n point"
 msgstr[1] "%n points"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n projet"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n carte non planifiée"
 msgstr[1] "%n cartes non planifiées"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n observateur"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4454,7 +4454,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n projet"
 msgstr[1] "%n projets"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "Échec du renommage du type de revue."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Échec de la réorganisation de l'élément."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Échec de la demande de revue."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Carte masquée"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Masquer les modifications"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "a renommé cette carte en {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Répétition"
 
@@ -4181,6 +4207,18 @@ msgstr "Réinitialisation"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Redimensionner le panneau de discussion"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Partagé en lecture seule via Kanso"
 msgid "Sharing"
 msgstr "Partage"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Afficher / masquer cette liste de raccourcis"
@@ -4454,7 +4496,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -4467,6 +4509,10 @@ msgstr "Afficher toute la plage de dates"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Afficher ce tableau dans mon calendrier"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n punto"
 msgstr[1] "%n punti"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n progetto"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n scheda non pianificata"
 msgstr[1] "%n schede non pianificate"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n osservatore"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4454,7 +4454,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n progetto"
 msgstr[1] "%n progetti"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "Impossibile rinominare il tipo di revisione."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Impossibile riordinare l'elemento."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Impossibile richiedere la revisione."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Scheda nascosta"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Nascondi le modifiche"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "ha rinominato questa scheda in {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Ripetizione"
 
@@ -4181,6 +4207,18 @@ msgstr "Reimposta"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Ridimensiona il pannello della discussione"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Condivisa in sola lettura tramite Kanso"
 msgid "Sharing"
 msgstr "Condivisione"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Mostra / nascondi questo riquadro delle scorciatoie"
@@ -4454,7 +4496,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -4467,6 +4509,10 @@ msgstr "Mostra l'intero intervallo di date"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Mostra questa bacheca nel mio calendario"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n project"
 msgstr[1] "%n projecten"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "Kan het reviewtype niet hernoemen."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Kan de volgorde van het item niet wijzigen."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Kan de review niet aanvragen."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Verborgen kaart"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Wijzigingen verbergen"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "heeft deze kaart hernoemd naar {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Herhalen"
 
@@ -4181,6 +4207,18 @@ msgstr "Resetten"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Formaat van het discussiepaneel wijzigen"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Alleen-lezen gedeeld via Kanso"
 msgid "Sharing"
 msgstr "Delen"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Dit sneltoetsoverzicht tonen / verbergen"
@@ -4454,7 +4496,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -4467,6 +4509,10 @@ msgstr "Het volledige datumbereik tonen"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Dit bord in mijn agenda tonen"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n punt"
 msgstr[1] "%n punten"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n project"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n ongeplande kaart"
 msgstr[1] "%n ongeplande kaarten"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n volger"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4454,7 +4454,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -307,7 +307,7 @@ msgstr[0] "%n punkt"
 msgstr[1] "%n punkty"
 msgstr[2] "%n punktów"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n projekt"
@@ -321,7 +321,7 @@ msgstr[0] "%n niezaplanowana karta"
 msgstr[1] "%n niezaplanowane karty"
 msgstr[2] "%n niezaplanowanych kart"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n obserwujący"
@@ -1559,7 +1559,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -3171,7 +3171,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4472,7 +4472,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5111,7 +5111,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5189,7 +5189,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -313,6 +313,13 @@ msgid_plural "%n projects"
 msgstr[0] "%n projekt"
 msgstr[1] "%n projekty"
 msgstr[2] "%n projektów"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1559,7 +1566,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -2420,12 +2427,20 @@ msgid "Failed to rename review type."
 msgstr "Nie udało się zmienić nazwy typu recenzji."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Nie udało się zmienić kolejności elementu."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Nie udało się poprosić o recenzję."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2802,6 +2817,10 @@ msgid "Hidden card"
 msgstr "Ukryta karta"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Ukryj zmiany"
 
@@ -3171,7 +3190,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4158,6 +4177,14 @@ msgid "renamed this card to {value}"
 msgstr "zmienił nazwę tej karty na {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Powtarzanie"
 
@@ -4199,6 +4226,18 @@ msgstr "Resetuj"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Zmień rozmiar panelu dyskusji"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4452,6 +4491,10 @@ msgstr "Udostępnione tylko do odczytu przez Kanso"
 msgid "Sharing"
 msgstr "Udostępnianie"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Pokaż / ukryj tę nakładkę ze skrótami"
@@ -4472,7 +4515,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -4486,6 +4529,10 @@ msgstr "Pokaż pełny zakres dat"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Pokazuj tę tablicę w moim kalendarzu"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5111,7 +5158,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5189,7 +5236,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n projeto"
 msgstr[1] "%n projetos"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "Não foi possível renomear o tipo de revisão."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Não foi possível reordenar o item."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Não foi possível solicitar a revisão."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Cartão oculto"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Ocultar alterações"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "renomeou este cartão para {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Repetir"
 
@@ -4181,6 +4207,18 @@ msgstr "Reiniciar"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Redimensionar o painel de discussão"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Compartilhado somente para leitura pelo Kanso"
 msgid "Sharing"
 msgstr "Compartilhamento"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Mostrar / ocultar esta lista de atalhos"
@@ -4454,7 +4496,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -4467,6 +4509,10 @@ msgstr "Mostrar todo o intervalo de datas"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Mostrar este quadro no meu calendário"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n ponto"
 msgstr[1] "%n pontos"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n projeto"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n cartão sem agendamento"
 msgstr[1] "%n cartões sem agendamento"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n observador"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4454,7 +4454,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -307,7 +307,7 @@ msgstr[0] "%n балл"
 msgstr[1] "%n балла"
 msgstr[2] "%n баллов"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n проект"
@@ -321,7 +321,7 @@ msgstr[0] "%n карточка без дат"
 msgstr[1] "%n карточки без дат"
 msgstr[2] "%n карточек без дат"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n наблюдатель"
@@ -1559,7 +1559,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -3171,7 +3171,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4472,7 +4472,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5111,7 +5111,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5189,7 +5189,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -313,6 +313,13 @@ msgid_plural "%n projects"
 msgstr[0] "%n проект"
 msgstr[1] "%n проекта"
 msgstr[2] "%n проектов"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1559,7 +1566,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -2420,12 +2427,20 @@ msgid "Failed to rename review type."
 msgstr "Не удалось переименовать тип проверки."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Не удалось изменить порядок пунктов."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "Не удалось запросить проверку."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2802,6 +2817,10 @@ msgid "Hidden card"
 msgstr "Скрытая карточка"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Скрыть изменения"
 
@@ -3171,7 +3190,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4158,6 +4177,14 @@ msgid "renamed this card to {value}"
 msgstr "переименовал эту карточку в {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Повторение"
 
@@ -4199,6 +4226,18 @@ msgstr "Сброс"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Изменить размер панели обсуждения"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4452,6 +4491,10 @@ msgstr "Доступ только для чтения через Kanso"
 msgid "Sharing"
 msgstr "Общий доступ"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Показать / скрыть эту подсказку по сочетаниям клавиш"
@@ -4472,7 +4515,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -4486,6 +4529,10 @@ msgstr "Показать весь диапазон дат"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Показывать эту доску в моем календаре"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5111,7 +5158,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5189,7 +5236,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -300,6 +300,12 @@ msgstr[1] ""
 #: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1546,7 +1552,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -2402,11 +2408,19 @@ msgid "Failed to rename review type."
 msgstr ""
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
 msgstr ""
 
 #: src/views/TrashView.vue
@@ -2784,6 +2798,10 @@ msgid "Hidden card"
 msgstr ""
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr ""
 
@@ -3153,7 +3171,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4139,6 +4157,14 @@ msgid "renamed this card to {value}"
 msgstr ""
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr ""
 
@@ -4179,6 +4205,18 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
 msgstr ""
 
 #: src/views/TrashView.vue
@@ -4433,6 +4471,10 @@ msgstr ""
 msgid "Sharing"
 msgstr ""
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr ""
@@ -4453,7 +4495,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -4465,6 +4507,10 @@ msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
 msgstr ""
 
 #: src/components/CardDetail.vue
@@ -5091,7 +5137,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5168,7 +5214,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -297,7 +297,7 @@ msgid_plural "%n points"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] ""
@@ -309,7 +309,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] ""
@@ -1546,7 +1546,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -3153,7 +3153,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5091,7 +5091,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5168,7 +5168,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -303,6 +303,12 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n proje"
 msgstr[1] "%n proje"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1547,7 +1553,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -2403,12 +2409,20 @@ msgid "Failed to rename review type."
 msgstr "İnceleme türü yeniden adlandırılamadı."
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "Öğe yeniden sıralanamadı."
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "İnceleme istenemedi."
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2785,6 +2799,10 @@ msgid "Hidden card"
 msgstr "Gizli kart"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "Değişiklikleri gizle"
 
@@ -3154,7 +3172,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4140,6 +4158,14 @@ msgid "renamed this card to {value}"
 msgstr "bu kartın adını {value} yaptı"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "Yinele"
 
@@ -4181,6 +4207,18 @@ msgstr "Sıfırla"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "Tartışma panelini yeniden boyutlandır"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4434,6 +4472,10 @@ msgstr "Kanso ile salt okunur paylaşıldı"
 msgid "Sharing"
 msgstr "Paylaşım"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "Bu kısayol katmanını göster / gizle"
@@ -4454,7 +4496,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -4467,6 +4509,10 @@ msgstr "Tüm tarih aralığını göster"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "Bu panoyu takvimimde göster"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5092,7 +5138,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5169,7 +5215,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -298,7 +298,7 @@ msgid_plural "%n points"
 msgstr[0] "%n puan"
 msgstr[1] "%n puan"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n proje"
@@ -310,7 +310,7 @@ msgid_plural "%n unscheduled cards"
 msgstr[0] "%n zamanlanmamış kart"
 msgstr[1] "%n zamanlanmamış kart"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n izleyici"
@@ -1547,7 +1547,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -3154,7 +3154,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4454,7 +4454,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5092,7 +5092,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5169,7 +5169,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4100
+#: src/components/CardDetail.vue:4151
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4149
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4147
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -293,6 +293,11 @@ msgstr[0] "%n 点"
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
+
+#: src/components/CardDetail.vue:1949
+msgid "%n reply"
+msgid_plural "%n replies"
+msgstr[0] ""
 
 #: src/components/BoardTimelineView.vue:306
 msgid "%n unscheduled card"
@@ -1535,7 +1540,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4329
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -2386,12 +2391,20 @@ msgid "Failed to rename review type."
 msgstr "重命名评审类型失败。"
 
 #: src/components/CardDetail.vue
+msgid "Failed to reopen this thread."
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Failed to reorder item."
 msgstr "重新排序清单项失败。"
 
 #: src/components/CardDetail.vue
 msgid "Failed to request review."
 msgstr "请求评审失败。"
+
+#: src/components/CardDetail.vue
+msgid "Failed to resolve this thread."
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Failed to restore card."
@@ -2768,6 +2781,10 @@ msgid "Hidden card"
 msgstr "隐藏的卡片"
 
 #: src/components/CardDetail.vue
+msgid "Hide"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Hide changes"
 msgstr "隐藏改动"
 
@@ -3137,7 +3154,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4278
+#: src/components/CardDetail.vue:4331
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4122,6 +4139,14 @@ msgid "renamed this card to {value}"
 msgstr "把这张卡片重命名为 {value}"
 
 #: src/components/CardDetail.vue
+msgid "Reopen"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "reopened a thread"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "Repeat"
 msgstr "重复"
 
@@ -4163,6 +4188,18 @@ msgstr "重置"
 #: src/components/CardDetail.vue
 msgid "Resize discussion panel"
 msgstr "调整讨论面板大小"
+
+#: src/components/CardDetail.vue
+msgid "Resolve"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Resolved"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "resolved a thread"
+msgstr ""
 
 #: src/views/TrashView.vue
 msgid "Restore"
@@ -4416,6 +4453,10 @@ msgstr "通过 Kanso 以只读方式共享"
 msgid "Sharing"
 msgstr "共享"
 
+#: src/components/CardDetail.vue
+msgid "Show"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Show / hide this shortcuts overlay"
 msgstr "显示/隐藏此快捷键浮层"
@@ -4436,7 +4477,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:5839
+#: src/components/CardDetail.vue:5951
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -4448,6 +4489,10 @@ msgstr "显示完整日期范围"
 #: src/components/BoardSettingsModal.vue
 msgid "Show this board in my calendar"
 msgstr "在我的日历中显示此看板"
+
+#: src/components/CardDetail.vue
+msgid "Show this resolved thread"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Show watchers"
@@ -5073,7 +5118,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4330
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5149,7 +5194,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4279
+#: src/components/CardDetail.vue:4332
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4098
+#: src/components/CardDetail.vue:4100
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4096
+#: src/components/CardDetail.vue:4098
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4094
+#: src/components/CardDetail.vue:4096
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -289,7 +289,7 @@ msgid "%n point"
 msgid_plural "%n points"
 msgstr[0] "%n 点"
 
-#: src/components/CardDetail.vue:1011
+#: src/components/CardDetail.vue:1012
 msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
@@ -299,7 +299,7 @@ msgid "%n unscheduled card"
 msgid_plural "%n unscheduled cards"
 msgstr[0] "%n 张未排期的卡片"
 
-#: src/components/CardDetail.vue:275
+#: src/components/CardDetail.vue:276
 msgid "%n watcher"
 msgid_plural "%n watchers"
 msgstr[0] "%n 位关注者"
@@ -1535,7 +1535,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1841
-#: src/components/CardDetail.vue:4274
+#: src/components/CardDetail.vue:4276
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -3137,7 +3137,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1843
-#: src/components/CardDetail.vue:4276
+#: src/components/CardDetail.vue:4278
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4436,7 +4436,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:5837
+#: src/components/CardDetail.vue:5839
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5073,7 +5073,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1842
-#: src/components/CardDetail.vue:4275
+#: src/components/CardDetail.vue:4277
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5149,7 +5149,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1844
-#: src/components/CardDetail.vue:4277
+#: src/components/CardDetail.vue:4279
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"


### PR DESCRIPTION
A `/pm` session drained six cards off the Kanso board onto one branch. Two shipped fatals, one hardening fix, one CI reliability fix, one App Store listing fix, and one feature.

## What's here

| Commit | Card | |
|---|---|---|
| `69cdd60` | #10149 | `fix(rebalance)` — repair sort-key rebalance on SQLite and on Nextcloud 32.0.0–32.0.6 |
| `c7a234f` | #10144 | `fix(cards)` — cap description length and bound how many mentions one save resolves |
| `96ce580` | #10168 | `ci(e2e)` — pre-pull the dev stack images with a retry |
| `90bbb16` | #10164 | `fix(appstore)` — list Kanso under Office & text as well as Organization |
| `2f772c9` | #10166 | `fix(cards)` — `maxlength` on the four card-title inputs |
| `2d6bbc1` | #10165 | `feat(comments)` — mark a discussion thread resolved to collapse it |

No `<version>` bump anywhere (release-only); the one migration lands unbumped.

## The two shipped fatals

**#10149** started as "`occ kanso:rebalance` fatals on SQLite". Validation found a second fatal on the *same line*: `IQueryBuilder::forUpdate()` is `@since 33.0.0` on master but only `@since 32.0.7` on `stable32`, while the declared floor is `32` — so `CardMapper.php:381` was a fatal `\Error` on NC 32.0.0–32.0.6 **on every database**. `install-matrix` can't see it because it pulls `nextcloud:32`, the latest patch. Both halves are now guarded (`getDatabaseProvider()` + `method_exists`), and dropping either one alone leaves the other case red — they're independently load-bearing.

The user-visible harm was never the `occ` exit code: on SQLite the *only* documented recovery from the 64-char sort-key wall was unavailable, so an overflowed stack was permanently stuck for that install.

Also here: the sqlite gate added to `dev/smoke.sh` by PR #106 is removed (it was hiding exactly what it should catch), `updateSortKeyById()` gained a `stack_id` predicate, and the now-false `min-version` rationale comment in `info.xml` is corrected — `forUpdate()` is `@since 32.0.7`, `PARAM_DATETIME_MUTABLE` is `@since 31.0.0`. **`min-version="32"` itself is unchanged.**

**#10144** capped descriptions at 65,536 characters. Two hypotheses that would have made the card moot were tested and both are false: the column is a length-less `Types::TEXT` (→ LONGTEXT/4 GiB on MySQL), and there was no frontend cap either. The card's own prescription needed three corrections — `CardService::create()` takes no `$description` at all, the importer paths must stay uncapped or Deck/Trello import of long descriptions breaks, and the mention bound belongs in `extractUsernames()` because `handleMentions` was *already* an unbounded ACL-query amplifier on the **comment** path (10,000 chars holds ~3,300 distinct `@tokens`).

## Verification

Every card was proved by mutation — break the guard, re-run, confirm red, restore. Highlights:

- **#10149** ran against four throwaway containers (NC 34 + sqlite, NC 32.0.6 + postgres, NC 34 + postgres, NC 34 + mariadb), with both fatals reproduced as red baselines first. Postgres `log_statement='all'` confirms `… ORDER BY "sort_key" ASC FOR UPDATE` is *still issued* after the fix — the mysql/postgres posture is not weakened.
- **#10144**: deleting the mention cap makes a test count **5,000 real ACL lookups instead of 50** — it invokes `getPermissions` rather than stubbing it.
- **#10168**: the step's `run:` block was extracted from the parsed YAML and executed verbatim under the **CI-pinned** Compose v2.29.7. This caught a trap: `docker-compose.yml` declares `env_file: .db.env`, which `setup.sh` only writes when it runs, so a naive pre-pull dies with exit 14 *before pulling a byte* — while host Compose v5.1.1 tolerates it, meaning the broken version would have looked fine locally and been dead on the runner.
- **#10164**: valid category slugs confirmed against two independent sources that agree exactly — the live App Store API and the XSD vendored at `scripts/schema/info.xsd`. The repo's own `lint:info-xml` guard was run *and* proved non-vacuous (`officex` → enumeration error).
- **#10165**: 3 new e2e green, 19 in a regression sweep, 7 more on activity/mentions; seven mutation proofs including "never collapse" and "no deep-link expand", each verified red through a rebuilt frontend.

## Known limits, stated plainly

- PHPUnit mocks `IDBConnection`, so #10149's mapper tests pin *which calls the mapper makes per provider*, not what the database does. That SQLite really rejects `FOR UPDATE`, and the `method_exists` half, are covered only by the container runs and the install matrix. This is written into the test file.
- #10144's cap bounds what a user **types**, not every row — copy/template/import paths still carry long descriptions across by design, so the search amplifier is not fully bounded. Tracked as a separate board card with a steer toward fixing it at the search layer (a SQL-side `SUBSTRING`) instead of policing every writer.
- Workers ran targeted e2e specs (~30 tests), not the full ~1.5h suite. CI owns that.
- #10165's export/import round-trip is PHPUnit-only. The local PHP runner has no `ext-zip`, so the archive/backup suites are red on clean `HEAD` too and could not run.

## Reviewer notes

- **#10165 includes one deliberate addition beyond its spec** (~2 lines + 2 assertions): `ExportService` emits `resolvedAt` and `ImportService` reads it back. Without it, a board export/import round-trip silently reopens every settled thread — a data-loss defect the feature itself would have introduced. Both directions are mutation-proved; an older archive without the field imports as open.
- In `CardDetail.vue`, the expanded-thread branch is wrapped in `<template v-else>` **without re-indenting its 165 lines**, to keep the diff readable. Functionally correct; the re-indent is worth a separate whitespace commit if you want it.
- `dev/setup.sh` is deliberately untouched throughout — there is uncommitted local work in it — which is why the pre-pull retry lives in `ci.yml`. That constraint is recorded in the commit message and in an in-file comment so it doesn't get "tidied" into the script later.
