### PR TITLE
fix(recurrence): keep a sub-day due-date lead time when editing a repeat rule

### DIFF
--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -2028,19 +2028,33 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</select>
 						</div>
 
-						<!-- Offset days (only when policy = offset after) -->
-						<div v-if="newRecurDuedatePolicy === 1" class="automation__form-row">
-							<label class="automation__form-label" :for="`recur-due-offset-${boardId}`">
-								{{ t('kanso', 'Offset (days)') }}
-							</label>
-							<input
-								:id="`recur-due-offset-${boardId}`"
-								v-model.number="newRecurDuedateOffsetDays"
-								type="number"
-								min="0"
-								step="1"
-								class="workflow__wip-input" />
-						</div>
+						<!-- Offset (only when policy = offset after) -->
+						<template v-if="newRecurDuedatePolicy === 1">
+							<!-- An offset that isn't a whole number of days (set via the
+							     API/MCP) can't be represented by the days control, so it is
+							     shown read-only and kept exactly as stored (#10130). -->
+							<div v-if="isEditingCustomOffset" class="automation__form-row automation__form-row--top">
+								<label class="automation__form-label">{{ t('kanso', 'Offset') }}</label>
+								<div class="automation__custom-schedule">
+									<code class="automation__custom-rrule">{{ editingRecurOffsetLabel }}</code>
+									<span class="automation__custom-note">
+										{{ t('kanso', 'Custom offset — it is kept exactly as it is.') }}
+									</span>
+								</div>
+							</div>
+							<div v-else class="automation__form-row">
+								<label class="automation__form-label" :for="`recur-due-offset-${boardId}`">
+									{{ t('kanso', 'Offset (days)') }}
+								</label>
+								<input
+									:id="`recur-due-offset-${boardId}`"
+									v-model.number="newRecurDuedateOffsetDays"
+									type="number"
+									min="0"
+									step="1"
+									class="workflow__wip-input" />
+							</div>
+						</template>
 
 						<!-- Skip while open (clone mode only) -->
 						<div v-if="newRecurMode === 0" class="automation__form-row">
@@ -4178,6 +4192,29 @@ const isEditingRecurRule = computed(() => editingRecurRuleId.value !== null)
 const editingRecurRrule = ref('')
 const isEditingCustomSchedule = ref(false)
 
+// Same shape one field down (#10130): the API and MCP accept an arbitrary
+// due-date offset in seconds, but this editor only models whole days. A stored
+// offset that is not a whole number of days (e.g. a 1-hour lead time) would be
+// rounded away by the days control, so it is shown read-only and left out of the
+// save — the server then keeps the exact stored seconds.
+const editingRecurDuedateOffsetSeconds = ref(0)
+const isEditingCustomOffset = ref(false)
+
+// Locale-neutral duration rendering of an offset the days control can't model,
+// e.g. 5400 → "1h 30m". The translatable explanation sits in the note beside it.
+const editingRecurOffsetLabel = computed(() => {
+	let s = Math.max(0, Number(editingRecurDuedateOffsetSeconds.value) || 0)
+	const d = Math.floor(s / 86400); s -= d * 86400
+	const h = Math.floor(s / 3600); s -= h * 3600
+	const m = Math.floor(s / 60); s -= m * 60
+	const parts = []
+	if (d) parts.push(`${d}d`)
+	if (h) parts.push(`${h}h`)
+	if (m) parts.push(`${m}m`)
+	if (s) parts.push(`${s}s`)
+	return parts.join(' ') || '0s'
+})
+
 /** Close the settings modal and open the rule's template card (to edit it). */
 function openRecurTemplateCard(rule) {
 	emit('close')
@@ -4192,7 +4229,13 @@ function startEditRecurRule(rule) {
 	newRecurMode.value = rule.mode
 	newRecurSkipWhileOpen.value = rule.skipWhileOpen ?? false
 	newRecurDuedatePolicy.value = rule.duedatePolicy ?? 0
-	newRecurDuedateOffsetDays.value = rule.duedateOffsetSeconds ? Math.round(rule.duedateOffsetSeconds / 86400) : 1
+	// A sub-day / non-day-multiple offset can't be represented by the days control,
+	// so flag it as custom and keep the raw seconds for the read-only display; the
+	// days input is only trusted (and re-sent) for whole-day offsets (#10130).
+	const offsetSeconds = rule.duedateOffsetSeconds ?? 0
+	editingRecurDuedateOffsetSeconds.value = offsetSeconds
+	isEditingCustomOffset.value = offsetSeconds > 0 && offsetSeconds % 86400 !== 0
+	newRecurDuedateOffsetDays.value = offsetSeconds ? Math.round(offsetSeconds / 86400) : 1
 	// Parse rrule back into form fields. A schedule these controls cannot
 	// represent is shown read-only instead — re-serializing it from the five
 	// fields below would silently drop the parts we never parsed.
@@ -4225,6 +4268,8 @@ function cancelEditRecurRule() {
 	newRecurSkipWhileOpen.value = false
 	editingRecurRrule.value = ''
 	isEditingCustomSchedule.value = false
+	editingRecurDuedateOffsetSeconds.value = 0
+	isEditingCustomOffset.value = false
 	createRecurRuleError.value = ''
 }
 
@@ -4270,7 +4315,12 @@ async function submitCreateRecurRule() {
 				data.rrule = rrule
 			}
 		}
-		if (newRecurDuedatePolicy.value === 1) {
+		// Only re-send the offset when the days control actually owns it. A stored
+		// offset that is not a whole number of days is left out entirely, so the
+		// server keeps the exact seconds instead of the days control rounding it to
+		// zero (or to the wrong day) on an unrelated save (#10130). update() treats
+		// an absent offset as "leave unchanged".
+		if (newRecurDuedatePolicy.value === 1 && !isEditingCustomOffset.value) {
 			data.duedateOffsetSeconds = newRecurDuedateOffsetDays.value * 86400
 		}
 		if (newRecurMode.value === 0) {

--- a/tests/e2e/recur-rule-custom-offset.spec.js
+++ b/tests/e2e/recur-rule-custom-offset.spec.js
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10130 — the same failure mode as #10045, one field down. The Automation
+// recurrence editor models the due-date offset in whole DAYS, but the API and
+// MCP accept an arbitrary offset in seconds (e.g. a 1-hour lead time). Opening
+// such a rule loaded the offset through `Math.round(seconds / 86400)` and, since
+// `duedatePolicy === 1` always re-sent `duedateOffsetSeconds`, saving the rule
+// for an unrelated reason wrote the rounded value back — silently zeroing (or
+// changing) the user's lead time.
+//
+// As with #10045 the assertion that matters is the API read-back, not the UI:
+// the panel never renders the lost precision, so "the form still looks right"
+// passes against the broken build. Only the stored seconds tell the two apart.
+
+import { test, expect, BASE, api, ncLogin } from './helpers.js'
+
+const SUB_DAY_OFFSET = 3600 // one hour — not a whole number of days
+
+async function openRuleEditor(page, boardId, cardTitle) {
+	await ncLogin(page)
+	await page.goto(`${BASE}/index.php/apps/kanso#/board/${boardId}`)
+	await page.getByRole('button', { name: 'More' }).click()
+	await page.getByRole('menuitem', { name: /board settings/i }).click()
+	await page.getByRole('tab', { name: /automation/i }).click()
+	await page.getByRole('button', { name: /Recurring cards/ }).click()
+	const recurring = page.locator('#bs-automation-recurring')
+	const item = recurring.locator('.automation__rule-item').filter({ hasText: cardTitle })
+	await expect(item).toBeVisible({ timeout: 8_000 })
+	await item.getByRole('button', { name: /^Edit$/ }).click()
+	return recurring
+}
+
+test.describe('Editing a rule with a sub-day due-date offset (#10130)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Offset RRULE ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Prep' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Ready' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'Warm up the oven' })).id
+
+		// The kind of rule only the API / MCP can author today: a one-hour lead time.
+		const rule = await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY',
+			duedatePolicy: 1,
+			duedateOffsetSeconds: SUB_DAY_OFFSET,
+		})
+		state.ruleId = rule.id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	const storedRule = async () => {
+		const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+		return rules.find((r) => Number(r.id) === Number(state.ruleId)) ?? null
+	}
+
+	test('changing only the target column leaves the sub-day offset intact', async ({ page }) => {
+		const before = await storedRule()
+		expect(Number(before.duedateOffsetSeconds)).toBe(SUB_DAY_OFFSET)
+
+		const recurring = await openRuleEditor(page, state.boardId, 'Warm up the oven')
+
+		// The offset is shown read-only: the raw duration with a note, and the
+		// whole-day number input is not rendered at all.
+		await expect(recurring.locator('.automation__custom-note')).toBeVisible()
+		await expect(recurring.locator('.automation__custom-rrule')).toHaveText('1h')
+		await expect(page.locator(`#recur-due-offset-${state.boardId}`)).toHaveCount(0)
+
+		// Change an unrelated field — the target column — and save.
+		await page.locator(`#recur-stack-${state.boardId}`).selectOption(String(state.otherStackId))
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		// Read the rule back: the column moved, the offset survived byte for byte.
+		await expect.poll(
+			async () => Number((await storedRule())?.targetStackId),
+			{ timeout: 8_000 },
+		).toBe(Number(state.otherStackId))
+
+		const after = await storedRule()
+		expect(Number(after.duedateOffsetSeconds)).toBe(SUB_DAY_OFFSET)
+		expect(Number(after.duedatePolicy)).toBe(1)
+	})
+})
+
+test.describe('Editing a rule with a whole-day due-date offset (#10130)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+	const TWO_DAYS = 2 * 86400
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Day offset ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Todo' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Filed' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'File the report' })).id
+		state.ruleId = (await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY',
+			duedatePolicy: 1,
+			duedateOffsetSeconds: TWO_DAYS,
+		})).id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	// A whole-day offset stays fully editable through the days control, exactly
+	// as before: the custom read-only branch must not swallow the ordinary case.
+	test('the days control still edits a whole-day offset', async ({ page }) => {
+		const recurring = await openRuleEditor(page, state.boardId, 'File the report')
+
+		// The editable number input, populated from the stored offset — no note.
+		await expect(recurring.locator('.automation__custom-note')).toHaveCount(0)
+		const input = page.locator(`#recur-due-offset-${state.boardId}`)
+		await expect(input).toHaveValue('2')
+
+		// Bump it to three days and save.
+		await input.fill('3')
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		await expect.poll(async () => {
+			const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+			return Number(rules.find((r) => Number(r.id) === Number(state.ruleId))?.duedateOffsetSeconds ?? 0)
+		}, { timeout: 8_000 }).toBe(3 * 86400)
+	})
+})

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— keine —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n-mal"
@@ -1539,6 +1539,10 @@ msgstr "Strg+Eingabe zum Senden"
 msgid "Custom fields"
 msgstr "Benutzerdefinierte Felder"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Eigener Zeitplan – bearbeite ihn unter Board-Einstellungen → Automatisierung."
@@ -2046,25 +2050,25 @@ msgstr "alle"
 msgid "Every"
 msgstr "Alle"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Täglich"
 msgstr[1] "Alle %n Tage"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Monatlich"
 msgstr[1] "Alle %n Monate"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Wöchentlich"
 msgstr[1] "Alle %n Wochen"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Jährlich"
@@ -3680,6 +3684,10 @@ msgstr "Zahl"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Aus — keine Karten erstellen"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— ninguno —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Intro para publicar"
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Periodicidad personalizada: edítala en Ajustes del tablero → Automatización."
@@ -2046,25 +2050,25 @@ msgstr "cada"
 msgid "Every"
 msgstr "Cada"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Cada día"
 msgstr[1] "Cada %n días"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Cada mes"
 msgstr[1] "Cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Cada semana"
 msgstr[1] "Cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Cada año"
@@ -3680,6 +3684,10 @@ msgstr "Número"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Desactivada: no crear tarjetas"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— aucun —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n fois"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Entrée pour publier"
 msgid "Custom fields"
 msgstr "Champs personnalisés"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Rythme personnalisé — modifiable dans Paramètres du tableau → Automatisation."
@@ -2046,25 +2050,25 @@ msgstr "tous les"
 msgid "Every"
 msgstr "Tous les"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Tous les jours"
 msgstr[1] "Tous les %n jours"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Tous les mois"
 msgstr[1] "Tous les %n mois"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toutes les semaines"
 msgstr[1] "Toutes les %n semaines"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Tous les ans"
@@ -3680,6 +3684,10 @@ msgstr "Nombre"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Désactivé — ne pas créer de cartes"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nessuno —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n volta"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Invio per pubblicare"
 msgid "Custom fields"
 msgstr "Campi personalizzati"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Pianificazione personalizzata — modificala in Impostazioni della bacheca → Automazione."
@@ -2046,25 +2050,25 @@ msgstr "ogni"
 msgid "Every"
 msgstr "Ogni"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Ogni giorno"
 msgstr[1] "Ogni %n giorni"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Ogni mese"
 msgstr[1] "Ogni %n mesi"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Ogni settimana"
 msgstr[1] "Ogni %n settimane"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Ogni anno"
@@ -3680,6 +3684,10 @@ msgstr "Numero"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Disattivato — non creare schede"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— geen —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n keer"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Enter om te plaatsen"
 msgid "Custom fields"
 msgstr "Aangepaste velden"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Aangepast schema — bewerk het bij Bordinstellingen → Automatisering."
@@ -2046,25 +2050,25 @@ msgstr "elke"
 msgid "Every"
 msgstr "Elke"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Elke dag"
 msgstr[1] "Elke %n dagen"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Elke maand"
 msgstr[1] "Elke %n maanden"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Elke week"
 msgstr[1] "Elke %n weken"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Elk jaar"
@@ -3680,6 +3684,10 @@ msgstr "Getal"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Uit — geen kaarten aanmaken"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— brak —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n raz"
@@ -1552,6 +1552,10 @@ msgstr "Ctrl+Enter, aby opublikować"
 msgid "Custom fields"
 msgstr "Pola niestandardowe"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Harmonogram niestandardowy — edytuj go w Ustawieniach tablicy → Automatyzacja."
@@ -2060,28 +2064,28 @@ msgstr "co"
 msgid "Every"
 msgstr "Co"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Codziennie"
 msgstr[1] "Co %n dni"
 msgstr[2] "Co %n dni"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Co miesiąc"
 msgstr[1] "Co %n miesiące"
 msgstr[2] "Co %n miesięcy"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Co tydzień"
 msgstr[1] "Co %n tygodnie"
 msgstr[2] "Co %n tygodni"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Co rok"
@@ -3699,6 +3703,10 @@ msgstr "Liczba"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Wyłączone — nie twórz kart"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nenhum —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Enter para publicar"
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Programação personalizada — edite em Configurações do quadro → Automação."
@@ -2046,25 +2050,25 @@ msgstr "a cada"
 msgid "Every"
 msgstr "A cada"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Todo dia"
 msgstr[1] "A cada %n dias"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Todo mês"
 msgstr[1] "A cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toda semana"
 msgstr[1] "A cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Todo ano"
@@ -3680,6 +3684,10 @@ msgstr "Número"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Desligado — não criar cartões"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— нет —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· повторов: %n"
@@ -1552,6 +1552,10 @@ msgstr "Ctrl+Enter — отправить"
 msgid "Custom fields"
 msgstr "Пользовательские поля"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Особое расписание — измените его в настройках доски → Автоматизация."
@@ -2060,28 +2064,28 @@ msgstr "каждые"
 msgid "Every"
 msgstr "Каждые"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Каждый %n день"
 msgstr[1] "Каждые %n дня"
 msgstr[2] "Каждые %n дней"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Каждый %n месяц"
 msgstr[1] "Каждые %n месяца"
 msgstr[2] "Каждые %n месяцев"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Каждую %n неделю"
 msgstr[1] "Каждые %n недели"
 msgstr[2] "Каждые %n недель"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Каждый %n год"
@@ -3699,6 +3703,10 @@ msgstr "Число"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Выключено — не создавать карточки"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "— none —"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] ""
@@ -1538,6 +1538,10 @@ msgstr ""
 msgid "Custom fields"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr ""
@@ -2045,25 +2049,25 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] ""
@@ -3678,6 +3682,10 @@ msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— yok —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n kez"
@@ -1539,6 +1539,10 @@ msgstr "Göndermek için Ctrl+Enter"
 msgid "Custom fields"
 msgstr "Özel alanlar"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Özel zamanlama — Pano ayarları → Otomasyon bölümünden düzenle."
@@ -2046,25 +2050,25 @@ msgstr "her"
 msgid "Every"
 msgstr "Her"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Her gün"
 msgstr[1] "Her %n günde bir"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Her ay"
 msgstr[1] "Her %n ayda bir"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Her hafta"
 msgstr[1] "Her %n haftada bir"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Her yıl"
@@ -3680,6 +3684,10 @@ msgstr "Sayı"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Kapalı — kart oluşturma"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— 无 —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n 次"
@@ -1526,6 +1526,10 @@ msgstr "Ctrl+Enter 发布"
 msgid "Custom fields"
 msgstr "自定义字段"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "自定义计划 — 请在“看板设置 → 自动化”中编辑。"
@@ -2032,22 +2036,22 @@ msgstr "每"
 msgid "Every"
 msgstr "每"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "每 %n 天"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "每 %n 个月"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "每 %n 周"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "每 %n 年"
@@ -3661,6 +3665,10 @@ msgstr "数字"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "关闭 — 不创建卡片"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"


### PR DESCRIPTION
## What

The Automation recurrence editor models the due-date offset in whole days, but the API and MCP accept an arbitrary offset in seconds (e.g. a one-hour lead time). Opening such a rule rounded the offset to zero days, and because the "offset after" policy always re-sent it, saving the rule for any unrelated reason (a new target column, a paused schedule) wrote that rounded value back and **silently wiped the lead time**.

## Fix

An offset that is not a whole number of days is now shown read-only and omitted from the PATCH on save, so the server keeps the exact stored seconds. Whole-day offsets stay fully editable through the days control exactly as before. Mirrors the custom-schedule guard one field up (#10045's shipped pattern).

Frontend-only — `RecurrenceService::update()` already treats a null/absent offset as "leave unchanged", so no server change was needed.

## Tests

- JS unit 111/0, frontend build clean.
- New API-read-back e2e `tests/e2e/recur-rule-custom-offset.spec.js` (2 passed) — asserts against the stored value via `GET /api/boards/{id}/recur-rules`, not the UI (a UI assertion false-passes here).
- Proven non-vacuous by mutation: reverting the guard turns the sub-day test red (`Expected 3600, Received 0`) while the whole-day test stays green.
- No `<version>` bump; l10n regenerated for two new strings.

Resolves Kanso board card #10130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)