### PR TITLE
fix: match both issue and pull-request URL spellings on forge links

### DIFF
--- a/lib/Service/AbstractForgeWebhookService.php
+++ b/lib/Service/AbstractForgeWebhookService.php
@@ -324,14 +324,7 @@ abstract class AbstractForgeWebhookService {
 			// poll: addLink() only polls on INSERT, so the second delivery for a
 			// PR (opened -> merged) hits its unique-constraint branch and would
 			// otherwise never refresh the state.
-			if ($event->htmlUrl !== '') {
-				try {
-					$link = $this->cardLinkService->addLink($cardId, $event->htmlUrl, $board->getOwner());
-					$this->cacheLinkState($link, $event);
-				} catch (\Throwable) {
-					// Non-critical - a bad/duplicate URL must not fail the webhook.
-				}
-			}
+			$this->attachOrRefreshPrLink($cardId, $event, $board->getOwner());
 			[$cardMoved, $reason] = $this->applyPrAutoMove($boardId, $cardId, $event, $board->getOwner());
 			if ($cardMoved) {
 				$moved = true;
@@ -565,6 +558,48 @@ abstract class AbstractForgeWebhookService {
 	}
 
 	// ---- shared helpers ----------------------------------------------------
+
+	/**
+	 * Records the PR as a link on the card and caches its state/title straight
+	 * from the delivery.
+	 *
+	 * If the card ALREADY carries a link to this pull request under a different
+	 * URL spelling, that row is refreshed instead of a second one being attached.
+	 * Forges share one number sequence between issues and pull requests and
+	 * redirect the spellings to each other, so someone can legitimately paste
+	 * `/issues/5` for a pull request; matching only the delivered spelling used to
+	 * leave that link stuck on `unknown` forever with a duplicate beside it.
+	 *
+	 * The payload is authoritative and free, so state must not be left to the
+	 * read-time poll: addLink() only polls on INSERT, so the second delivery for
+	 * a PR (opened -> merged) hits its unique-constraint branch and would
+	 * otherwise never refresh the state.
+	 *
+	 * Best-effort throughout - a bad or duplicate URL must not fail the delivery.
+	 */
+	protected function attachOrRefreshPrLink(int $cardId, ForgeEvent $event, string $actorUid): void {
+		if ($event->htmlUrl === '') {
+			return;
+		}
+		try {
+			// An exact-URL match is handled by addLink's idempotency, so only the
+			// ALTERNATE spellings are worth a lookup - and only when the event
+			// carries a candidate set at all.
+			$alternates = array_diff($event->urlCandidates, [$event->htmlUrl]);
+			if ($alternates !== []) {
+				foreach ($this->cardLinkMapper->findByCard($cardId) as $existing) {
+					if (in_array($existing->getUrl(), $alternates, true)) {
+						$this->cacheLinkState($existing, $event);
+						return;
+					}
+				}
+			}
+			$link = $this->cardLinkService->addLink($cardId, $event->htmlUrl, $actorUid);
+			$this->cacheLinkState($link, $event);
+		} catch (\Throwable) {
+			// Non-critical - a bad/duplicate URL must not fail the webhook.
+		}
+	}
 
 	/**
 	 * Caches a link's state/title straight from the delivery and stamps

--- a/lib/Service/GithubWebhookService.php
+++ b/lib/Service/GithubWebhookService.php
@@ -119,14 +119,17 @@ class GithubWebhookService extends AbstractForgeWebhookService {
 				|| !empty($pr['merged_at'])
 				|| $action === 'merged';
 
+			$htmlUrl = is_string($pr['html_url'] ?? null) ? $pr['html_url'] : '';
+
 			return new ForgeEvent(
 				kind: ForgeEvent::KIND_PR,
 				action: $action,
 				branch: $branch,
-				htmlUrl: is_string($pr['html_url'] ?? null) ? $pr['html_url'] : '',
+				htmlUrl: $htmlUrl,
 				title: is_string($pr['title'] ?? null) ? $pr['title'] : null,
 				state: $merged ? CardLink::STATE_MERGED : $this->mapState($pr['state'] ?? null),
 				merged: $merged,
+				urlCandidates: $this->urlCandidatesFor($htmlUrl),
 			);
 		}
 
@@ -152,7 +155,7 @@ class GithubWebhookService extends AbstractForgeWebhookService {
 				title: is_string($issue['title'] ?? null) ? $issue['title'] : null,
 				state: $this->mapState($issue['state'] ?? null),
 				labels: $this->labelNames($issue['labels'] ?? null),
-				urlCandidates: $this->issueUrlCandidates($owner, $repo, $number),
+				urlCandidates: $this->urlCandidates($owner, $repo, $number),
 			);
 		}
 
@@ -188,20 +191,49 @@ class GithubWebhookService extends AbstractForgeWebhookService {
 	}
 
 	/**
-	 * The URL spellings under which a github.com issue may have been attached
-	 * as a link (host www or not, trailing slash or not). Matching by candidate
-	 * set keeps the reverse lookup a plain indexed `url IN (...)` while still
-	 * being repo + issue-number based.
+	 * The URL spellings under which a github.com issue OR pull request may have
+	 * been attached as a link.
+	 *
+	 * BOTH `/issues/{n}` and `/pull/{n}` are candidates, because github.com
+	 * shares one number sequence between them and redirects each spelling to the
+	 * other: someone can legitimately paste `/issues/5` for a pull request, and
+	 * matching only the delivered spelling would leave that link stuck on
+	 * `unknown` forever while a second link was attached beside it. Host `www`
+	 * or not, trailing slash or not, as before. Matching by candidate set keeps
+	 * the reverse lookup a plain indexed `url IN (...)`.
 	 *
 	 * @return string[]
 	 */
-	private function issueUrlCandidates(string $owner, string $repo, int $number): array {
-		$path = '/' . $owner . '/' . $repo . '/issues/' . $number;
-		return [
-			'https://github.com' . $path,
-			'https://github.com' . $path . '/',
-			'https://www.github.com' . $path,
-			'https://www.github.com' . $path . '/',
-		];
+	private function urlCandidates(string $owner, string $repo, int $number): array {
+		$candidates = [];
+		foreach (['issues', 'pull'] as $segment) {
+			$path = '/' . $owner . '/' . $repo . '/' . $segment . '/' . $number;
+			foreach (['https://github.com', 'https://www.github.com'] as $host) {
+				$candidates[] = $host . $path;
+				$candidates[] = $host . $path . '/';
+			}
+		}
+		return $candidates;
+	}
+
+	/**
+	 * {@see urlCandidates} for an already-formed github.com issue/PR URL. An
+	 * unparseable URL yields no candidates, which simply means "match nothing".
+	 *
+	 * @return string[]
+	 */
+	private function urlCandidatesFor(string $url): array {
+		if ($url === '') {
+			return [];
+		}
+		try {
+			[$kind, $owner, $repo, $number] = CardLinkService::parseGitHubUrl($url);
+		} catch (InvalidInputException) {
+			return [];
+		}
+		if ($kind === CardLink::KIND_OTHER) {
+			return [];
+		}
+		return $this->urlCandidates($owner, $repo, $number);
 	}
 }

--- a/tests/unit/Service/ForgejoWebhookServiceTest.php
+++ b/tests/unit/Service/ForgejoWebhookServiceTest.php
@@ -105,7 +105,7 @@ class ForgejoWebhookServiceTest extends TestCase {
 		return hash_hmac('sha256', $body, self::SECRET);
 	}
 
-	private function prBody(string $action, string $branch, bool $merged = false): string {
+	private function prBody(string $action, string $branch, bool $merged = false, string $title = ''): string {
 		return json_encode([
 			'action' => $action,
 			'pull_request' => [
@@ -113,8 +113,15 @@ class ForgejoWebhookServiceTest extends TestCase {
 				'html_url' => self::BASE . '/pulls/3',
 				'state' => $merged ? 'closed' : 'open',
 				'merged' => $merged,
+				'title' => $title,
 			],
 		]);
+	}
+
+	private function prefixBoard(string $prefix = 'KANSO'): Board {
+		$b = $this->board();
+		$b->setPrefix($prefix);
+		return $b;
 	}
 
 	private function issueBody(string $action, string $url, string $state = 'closed', string $title = 'A bug'): string {
@@ -274,6 +281,85 @@ class ForgejoWebhookServiceTest extends TestCase {
 		$this->cardService->expects(self::never())->method('move');
 
 		$body = $this->prBody('opened', 'feature/unrelated');
+		$result = $this->service->handleWebhook(1, $this->sign($body), $body);
+		self::assertFalse($result['handled']);
+		self::assertSame(ForgejoWebhookService::REASON_NO_CARD_MATCH, $result['reason']);
+	}
+
+	// ---- PR title references (#9855), inherited by every forge -------------
+
+	/**
+	 * `PREFIX-<seq>` title matching lives in AbstractForgeWebhookService, so
+	 * Forgejo gets it for free - the reference rides the PR title, which every
+	 * provider's payload carries. Pinned here so a change to the shared matcher
+	 * cannot quietly regress the Forgejo half.
+	 */
+	public function testOpenedPrWithTitleReferenceLinksAndMovesThatCard(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->prefixBoard('KANSO'));
+		$this->cardService->expects(self::once())->method('findByRef')
+			->with(1, 'KANSO-14', 'alice')->willReturn($this->card(77, 1));
+		$this->stackMapper->method('findByBoardAndRole')->with(1, Stack::ROLE_REVIEW)
+			->willReturn($this->stack(4, Stack::ROLE_REVIEW));
+		$this->cardLinkService->expects(self::once())->method('addLink')
+			->with(77, self::BASE . '/pulls/3', 'alice');
+		$this->cardService->expects(self::once())->method('move')
+			->with(77, 4, null, 'alice')->willReturn($this->card(77, 1));
+
+		$body = $this->prBody('opened', 'my-random-branch', title: 'Fix the crash (KANSO-14)');
+		$result = $this->service->handleWebhook(1, $this->sign($body), $body);
+
+		self::assertTrue($result['handled']);
+		self::assertTrue($result['moved']);
+		self::assertSame(77, $result['cardId']);
+	}
+
+	/** The branch and title matches are unioned, deduped, and both are moved. */
+	public function testBranchAndTitleMatchesAreBothHandled(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->prefixBoard('KANSO'));
+		$this->cardService->method('find')->with(9, 'alice')->willReturn($this->card(9, 1));
+		$this->cardService->method('findByRef')->with(1, 'KANSO-14', 'alice')
+			->willReturn($this->card(77, 1));
+		$this->stackMapper->method('findByBoardAndRole')->with(1, Stack::ROLE_DONE)
+			->willReturn($this->stack(5, Stack::ROLE_DONE));
+
+		$moved = [];
+		$this->cardService->expects(self::exactly(2))->method('move')
+			->willReturnCallback(function (int $cardId) use (&$moved): Card {
+				$moved[] = $cardId;
+				return $this->card($cardId, 1);
+			});
+
+		$body = $this->prBody('closed', 'kanso-9-fix', true, 'Also closes KANSO-14');
+		$result = $this->service->handleWebhook(1, $this->sign($body), $body);
+
+		self::assertTrue($result['moved']);
+		self::assertSame([9, 77], $moved);
+		// The branch id is an echo of what the sender supplied, so it may be named.
+		self::assertSame(9, $result['cardId']);
+	}
+
+	/**
+	 * Case-sensitivity is a correctness rule, not pedantry: a board titled
+	 * "Kanso" derives prefix KANSO, which case-insensitively collides with the
+	 * lowercase `kanso-<id>` BRANCH spelling a title may quote.
+	 */
+	public function testQuotedLowercaseBranchInTitleIsNotReadAsAReference(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->prefixBoard('KANSO'));
+		$this->cardService->method('find')->with(9, 'alice')->willReturn($this->card(9, 1));
+		$this->cardService->expects(self::never())->method('findByRef');
+		$this->stackMapper->method('findByBoardAndRole')->willReturn(null);
+
+		$body = $this->prBody('opened', 'kanso-9-fix', false, 'Merge kanso-42 into main');
+		self::assertTrue($this->service->handleWebhook(1, $this->sign($body), $body)['handled']);
+	}
+
+	/** An unknown / trashed / hidden reference resolves to null and is no match. */
+	public function testUnresolvableTitleReferenceIsAcceptedNoOp(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->prefixBoard('KANSO'));
+		$this->cardService->method('findByRef')->willReturn(null);
+		$this->cardService->expects(self::never())->method('move');
+
+		$body = $this->prBody('opened', 'no-convention', false, 'Fixes KANSO-99');
 		$result = $this->service->handleWebhook(1, $this->sign($body), $body);
 		self::assertFalse($result['handled']);
 		self::assertSame(ForgejoWebhookService::REASON_NO_CARD_MATCH, $result['reason']);

--- a/tests/unit/Service/GithubWebhookServiceTest.php
+++ b/tests/unit/Service/GithubWebhookServiceTest.php
@@ -906,6 +906,73 @@ class GithubWebhookServiceTest extends TestCase {
 		self::assertSame(9, $result['cardId']);
 	}
 
+	// ---- issue/PR URL spelling --------------------------------------------
+
+	/**
+	 * github.com shares one number sequence between issues and pull requests and
+	 * redirects the spellings to each other, so someone can legitimately paste
+	 * `/issues/5` for a pull request. The PR delivery carries `/pull/5`: without
+	 * matching both spellings it attached a SECOND link and left the pasted one
+	 * on `unknown` forever.
+	 */
+	public function testPrDeliveryRefreshesALinkPastedWithTheIssueSpelling(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardService->method('find')->with(9, 'alice')->willReturn($this->card(9, 1));
+		$this->stackMapper->method('findByBoardAndRole')->willReturn(null);
+
+		$pasted = new CardLink();
+		$pasted->setId(3);
+		$pasted->setCardId(9);
+		$pasted->setUrl('https://github.com/octo/app/issues/3');
+		$pasted->setKind(CardLink::KIND_ISSUE);
+		$pasted->setState(CardLink::STATE_UNKNOWN);
+		$this->cardLinkMapper->method('findByCard')->with(9)->willReturn([$pasted]);
+
+		// No duplicate is attached...
+		$this->cardLinkService->expects(self::never())->method('addLink');
+		// ...and the pasted row is the one that gets the merged state.
+		$this->cardLinkMapper->expects(self::once())->method('update')
+			->willReturnCallback(function (CardLink $l): CardLink {
+				self::assertSame(3, $l->getId());
+				self::assertSame(CardLink::STATE_MERGED, $l->getState());
+				return $l;
+			});
+
+		$body = $this->prBody('closed', 'kanso-9-fix', true);
+		self::assertTrue($this->service->handleWebhook(1, $this->sign($body), $body)['handled']);
+	}
+
+	/** With no pre-existing link under either spelling, the PR is attached as usual. */
+	public function testPrDeliveryStillAttachesWhenNoLinkExists(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$this->cardService->method('find')->with(9, 'alice')->willReturn($this->card(9, 1));
+		$this->stackMapper->method('findByBoardAndRole')->willReturn(null);
+		$this->cardLinkMapper->method('findByCard')->with(9)->willReturn([]);
+
+		$this->cardLinkService->expects(self::once())->method('addLink')
+			->with(9, 'https://github.com/octo/app/pull/3', 'alice');
+
+		$body = $this->prBody('closed', 'kanso-9-fix', true);
+		self::assertTrue($this->service->handleWebhook(1, $this->sign($body), $body)['handled']);
+	}
+
+	/** A link stored with the /pull/ spelling is matched by an issues delivery. */
+	public function testIssueDeliveryMatchesALinkStoredWithThePullSpelling(): void {
+		$this->boardMapper->method('find')->with(1)->willReturn($this->board());
+		$seen = [];
+		$this->cardLinkMapper->method('findByBoardAndUrls')
+			->willReturnCallback(function (int $b, array $urls) use (&$seen): array {
+				$seen = $urls;
+				return [];
+			});
+
+		$body = $this->issueBody('closed', state: 'closed');
+		$this->service->handleWebhook(1, $this->sign($body), $body);
+
+		self::assertContains('https://github.com/octo/app/issues/7', $seen);
+		self::assertContains('https://github.com/octo/app/pull/7', $seen);
+	}
+
 	// ---- PR title references (#9855) --------------------------------------
 
 	private function prefixBoard(string $prefix = 'KAN'): Board {


### PR DESCRIPTION
Follow-up to #111, closing the gaps I flagged when that merged.

## What changed

**`fix:` — a PR link pasted with the issue spelling now stays fresh.**

A forge shares one number sequence between issues and pull requests and redirects each spelling to the other, so pasting `…/issues/5` for a pull request is a legitimate thing to do. The delivery then carries `…/pull/5`, which matched nothing — so `addLink` attached a **second** link beside the pasted one, and the pasted one sat on `unknown` permanently.

Both spellings are now candidates. An existing link is refreshed in place rather than duplicated, and an `issues` delivery matches a link stored either way. This was GitHub-only; Forgejo already matched both spellings, which is what made the GitHub side visible by comparison.

**`test:` — the shared title matching is now pinned for Forgejo.**

`PREFIX-<seq>` matching lives in `AbstractForgeWebhookService`, so Forgejo has had it since #111 landed — but only the GitHub suite covered it, leaving the Forgejo half free to regress silently. Adds the branch/title union, the case-sensitivity rule that stops a quoted `kanso-<id>` branch being read as a seq reference, and the unresolvable-reference no-op.

## One thing I did NOT do

I had also flagged that **issue intake bypasses the per-card link cap**. On re-reading the merged code that claim is wrong: `intakeIssue` creates a brand-new card and puts exactly one link on it, and that is the only direct mapper insert in the base class. A fresh card has zero links, so `MAX_PER_CARD` is unreachable there. Adding a guard would have been dead code, so there is no change for it.

## Verification

- `phpunit` **1859 green** (+7)
- `psalm` 0 errors, `php-cs-fixer` 0 of 394
- No UI strings touched, so no l10n or bundle changes

Both behaviours were **proved by mutation**, not just asserted:

- forcing the alternate-spelling lookup to find nothing → `testPrDeliveryRefreshesALinkPastedWithTheIssueSpelling` fails
- narrowing the candidate set back to `issues` only → `testIssueDeliveryMatchesALinkStoredWithThePullSpelling` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
