### PR TITLE
fix: realtime polling honesty, sub-day recurrence offsets, and a stricter public-share guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,8 +694,9 @@ jobs:
       # postgres + redis + notify_push + nextcloud:34-apache, app enabled,
       # firstrunwizard disabled, tester user + push wired up. Idempotent.
       #
-      # setup.sh also side-loads the optional apps two specs need — deck (for
-      # deck-import.spec.js) and contacts (for card-contacts.spec.js) — via
+      # setup.sh also side-loads the optional apps a few specs need — deck (for
+      # deck-import.spec.js and deck-import-ui.spec.js) and contacts (for
+      # card-contacts.spec.js) — via
       # dev/install-optional-apps.sh. That used to be two steps here, which
       # meant a local stack silently lacked both and those specs were red for
       # everyone but CI; the pins now live in the script, in one place. It still

--- a/README.md
+++ b/README.md
@@ -230,7 +230,20 @@ is **not** bundled into the installed Nextcloud app.
 
 The dev stack mounts your checkout as `custom_apps/kanso`, so a rebuild
 (`npm run build`) plus a browser reload picks up frontend changes; PHP changes
-apply immediately. `docker compose down` in `dev/` resets the instance.
+apply immediately. In `dev/`:
+
+```sh
+docker compose down && ./setup.sh                    # restart: install + data survive
+docker compose --profile '*' down -v && ./setup.sh   # reset: wipes everything
+```
+
+`--profile '*'` on the reset matters — `-v` only removes the volumes of services
+in active profiles, so a bare `docker compose down -v` deletes the webroot but
+leaves the database, and the next boot fails trying to install over it. Reset
+(not restart) after switching `NC_VERSION` or `KANSO_DB`, and after **adding a
+migration**: `setup.sh` only re-enables the app, and Nextcloud re-runs an app's
+migrations only when `info.xml`'s `<version>` grows, which feature branches never
+do. `./seed.sh` refills a reset stack; `./smoke.sh` reports a schema left behind.
 
 PHP tooling runs via Docker (no host PHP needed):
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -81,7 +81,25 @@ services:
   # for postgres (its DATABASE_URL is postgres-specific and realtime push is
   # not exercised by the cross-version install matrix).
   notify_push:
-    image: icewind1991/notify_push
+    # Pinned deliberately, and it needs a MANUAL bump — in lockstep with
+    # NOTIFY_PUSH_VERSION/NOTIFY_PUSH_URL in setup.sh, which side-loads the
+    # Nextcloud-side notify_push *app* at this same version. The two halves are
+    # one pin; never move one without the other.
+    #
+    # Why: setup.sh's boot check `occ notify_push:self-test` compares the
+    # daemon's version against the app's and fails when the major.minor differ.
+    # Leaving either side floating (untagged here means :latest — whatever
+    # upstream tagged last, or a months-old cached layer compose never re-pulls)
+    # eventually reddens that check on a stack where nothing is wrong, and a
+    # boot warning that is usually wrong gets ignored on the day it is right.
+    #
+    # When the two DO drift, the warning is CORRECT: bump this tag and setup.sh's
+    # NOTIFY_PUSH_VERSION together, then re-run ./setup.sh. Do NOT silence, skip
+    # or filter the version check to quiet it — a major/minor skew is a real
+    # protocol mismatch (upstream already tolerates patch drift), and muting it
+    # is how the stack goes back to lying about push. See setup.sh for the app
+    # half and for what the failure actually looks like on a boot.
+    image: icewind1991/notify_push:1.4.0
     container_name: kanso-dev-push
     profiles: ["postgres"]
     environment:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -3,11 +3,30 @@
 #
 # Throwaway development Nextcloud with this app mounted from the checkout.
 # Defaults mirror the newest supported target (nextcloud:34-apache / PHP 8.3 +
-# postgres 16). The app supports NC 32–34; CI e2e boots this same stack. No
-# volumes are persisted: `docker compose down` resets everything.
+# postgres 16). The app supports NC 32–34; CI e2e boots this same stack.
 #
 #   cd dev && ./setup.sh          # start + enable the app
 #   http://localhost:8891         # login: admin / admin
+#
+# Restart vs. reset — they are DIFFERENT commands, and picking the wrong one
+# used to brick the stack:
+#
+#   docker compose down && ./setup.sh                    # restart: install + data survive
+#   docker compose --profile '*' down -v && ./setup.sh   # reset: destroys everything
+#
+# The `--profile '*'` on the reset is not decoration. `-v` only removes the
+# volumes of services in ACTIVE profiles, so a bare `docker compose down -v`
+# deletes the webroot while leaving the (profiled) database container running
+# with all its data — which is the exact half-wiped state that bricks the next
+# boot. The wildcard selects every profile, so one command clears whichever
+# driver was last used. Verified on compose v5.1.1; `--remove-orphans` does NOT
+# do this. See the `volumes:` block at the bottom of this file.
+#
+# Neither command re-runs Kanso's migrations: setup.sh only re-enables the app,
+# and Nextcloud runs an app's migrations only when info.xml's <version> is newer
+# than the installed one (feature branches never bump it — see CLAUDE.md). So
+# after ADDING a migration, reset rather than restart, or you get new PHP code
+# against the previous schema. `./smoke.sh` says so out loud when that happens.
 #
 # Cross-version / cross-DB matrix (used by CI, works locally too):
 #   NC_VERSION=32 KANSO_DB=postgres ./setup.sh   # NC 32 on postgres
@@ -42,6 +61,8 @@ services:
       interval: 3s
       timeout: 5s
       retries: 30
+    volumes:
+      - db_postgres:/var/lib/postgresql/data
 
   # MariaDB is Nextcloud's MySQL-compatible target. Same logical hostname alias
   # ("db") as postgres so the nextcloud service's *_HOST wiring is uniform; only
@@ -66,6 +87,8 @@ services:
       timeout: 5s
       retries: 30
       start_period: 30s
+    volumes:
+      - db_mysql:/var/lib/mysql
     networks:
       default:
         aliases:
@@ -129,6 +152,11 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: localhost
       REDIS_HOST: redis
     volumes:
+      # The Nextcloud webroot: its code, config/config.php, data/ and the
+      # side-loaded custom_apps (notify_push, deck, contacts). NAMED so that
+      # `docker compose down` && `up` reattaches the SAME install — see the
+      # `volumes:` block at the bottom of this file.
+      - nextcloud_html:/var/www/html
       # The app tree Nextcloud runs. Defaults to this checkout, which is what
       # every local run and every other CI job wants. dev/upgrade-check.sh points
       # it at a staging directory instead so it can boot the last RELEASED
@@ -152,3 +180,56 @@ services:
       db-mysql:
         condition: service_healthy
         required: false
+
+# Every bit of stack state lives in one of these, and they are NAMED on purpose.
+#
+# The nextcloud and postgres/mariadb images all declare their data directory as
+# a Dockerfile `VOLUME`, so leaving them out of this file does not mean "no
+# state" — it means an ANONYMOUS volume per container, and anonymous volumes
+# have a lifecycle nothing reattaches to:
+#
+#   docker compose down        # container gone, its anonymous volume orphaned
+#   docker compose up -d       # fresh container, BLANK anonymous volume
+#
+# For the webroot that was a booby trap. `down` (without `--profile`) does not
+# touch the profiled `db` service, so postgres kept running with a fully
+# populated database while the new nextcloud container came up with an empty
+# /var/www/html. The entrypoint sees no config.php, concludes "not installed",
+# and re-runs `maintenance:install` against that live database:
+#
+#   PDOException: SQLSTATE[42501]: Insufficient privilege: 7
+#     ERROR: permission denied for table oc_migrations
+#   Retrying install...
+#   Installing of nextcloud failed!            (container Exited (1))
+#
+# — which reads like a database-permissions bug and is really a volume-lifecycle
+# one. `down -v` was the only reliable recovery, i.e. the only way to restart the
+# stack was to destroy the database too.
+#
+# Named, the webroot and the database data reattach together on the next `up`,
+# so `down` is a restart. Nothing else in the tree depends on the old behaviour:
+# dev/upgrade-check.sh already opens with an explicit `--profile <db> down -v`
+# (it must install the released version onto a pristine database), and CI boots
+# each job on a docker daemon that has never run this stack — which is why the
+# parallel install-matrix legs can all claim host port 8891 and the container
+# name `kanso-dev` without colliding.
+#
+# The reset is `--profile '*' down -v`, NOT a bare `down -v`, for the reason in
+# the header: volume removal follows the active profiles. Two consequences worth
+# knowing:
+#   * `--profile postgres down -v` never removes `db_mysql` (and vice versa), so
+#     a machine that has used both drivers keeps a stale data dir for the other
+#     one until a wildcard reset.
+#   * there is no service with `profiles: ["sqlite"]`, so a sqlite reset only
+#     needs the profile-less services — but for sqlite the database IS the
+#     webroot (data/nextcloud.db), so removing `nextcloud_html` is a full reset.
+#
+# The other cost of persistence is that a webroot installed against a DIFFERENT
+# KANSO_DB or a different NC major also survives, and Nextcloud would happily
+# boot it and report itself healthy while running something nobody asked for.
+# dev/setup.sh asserts against both after the boot rather than letting it pass
+# quietly.
+volumes:
+  nextcloud_html:
+  db_postgres:
+  db_mysql:

--- a/dev/install-optional-apps.sh
+++ b/dev/install-optional-apps.sh
@@ -5,9 +5,9 @@
 # Side-load the optional Nextcloud apps two e2e specs need, into the running
 # dev stack (container `kanso-dev`). Idempotent — safe to re-run.
 #
-#   deck     → tests/e2e/deck-import.spec.js  (its beforeAll seeds a source
-#              board through the real Deck API, so the whole describe errors
-#              out when Deck is missing)
+#   deck     → tests/e2e/deck-import.spec.js and deck-import-ui.spec.js (their
+#              beforeAll seeds a source board through the real Deck API, so the
+#              whole describe errors out when Deck is missing)
 #   contacts → tests/e2e/card-contacts.spec.js (ContactService::isAvailable()
 #              is false without the app, so the picker search returns an empty
 #              list and the spec's option assertion times out)

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -156,6 +156,12 @@ fi
 # block (no appstore reachable there anyway); when it isn't set, a failed
 # install only warns — see the guard below. Only wired for postgres (the
 # notify_push service only runs under the postgres profile).
+#
+# Do NOT make skipping the default to line local timings up with CI: this block
+# is the only place the push path is exercised anywhere, so a skipping default
+# would mean tests/e2e/realtime.spec.js's push-positive test never runs (locally
+# it would skip, in CI it already does). Whoever wants the quiet already has
+# KANSO_SKIP_NOTIFY_PUSH=1 ./setup.sh.
 if [ "${KANSO_SKIP_NOTIFY_PUSH:-0}" = "1" ] || [ "$KANSO_DB" != "postgres" ]; then
 	echo "Skipping notify_push setup (KANSO_SKIP_NOTIFY_PUSH=${KANSO_SKIP_NOTIFY_PUSH:-0}, db=${KANSO_DB})"
 else
@@ -170,14 +176,22 @@ ProxyPass /push/ http://notify_push:7867/
 ProxyPassReverse /push/ http://notify_push:7867/
 CONF
 	grep -q "Listen 8891" /etc/apache2/ports.conf || echo "Listen 8891" >> /etc/apache2/ports.conf
+	# `graceful` on purpose; do NOT "fix" this to `apache2ctl -k restart`. Both
+	# halves were measured on this image (Apache/2.4.68, Debian): a graceful
+	# reload DOES bind a freshly appended `Listen` (append `Listen 8892` here and
+	# :8892 answers straight after), and `-k restart` run in this exec breaks the
+	# boot — the exec came back 129 (128+SIGHUP) and `set -eu` aborted setup.sh on
+	# this very line, with the stderr that would have explained it swallowed by
+	# the `2>/dev/null` below. If push is ever unreachable at :8891 on a first
+	# boot, the reproducible cause is the app store, just below — not this line.
 	apache2ctl graceful
 ' 2>/dev/null
 
 # Best-effort install: `occ app:install` needs the container to reach
-# apps.nextcloud.com, which it often can't (no egress, a stale appstore cache,
-# or appstoreenabled=false) — the same wall install-optional-apps.sh side-steps
-# with tarballs. Under `set -eu` a failure here would kill the whole boot, so
-# it only downgrades realtime instead.
+# apps.nextcloud.com, which it can't everywhere (no egress, a stale appstore
+# cache) — the same wall install-optional-apps.sh side-steps with tarballs.
+# Under `set -eu` a failure here would kill the whole boot, so it only
+# downgrades realtime instead.
 #
 # EVERY step below can flip the flag off, not just the install. `occ app:list`
 # prints DISABLED apps too, so matching notify_push there does not mean it is
@@ -187,6 +201,21 @@ CONF
 # So gate on the commands actually WORKING, and warn once at the end.
 notify_push_ready=1
 if ! $OCC app:list | grep -q notify_push; then
+	# `app:install` also needs an ENABLED app store, and this stack boots with it
+	# off: hooks/pre-installation/00-apps-writable.sh writes
+	# config/kanso-appstore.config.php with appstoreenabled => false, which it only
+	# needs for the duration of maintenance:install. Nextcloud merges
+	# config/*.config.php OVER config.php, so that partial outlives the install,
+	# and `config:system:set appstoreenabled --value=true` then reports success
+	# while `config:system:get` keeps answering false. The install fails with
+	# "Could not download app notify_push, it was not found on the appstore",
+	# which reads like a delisted app or a blocked network and is neither — this
+	# container reaches the store fine. Drop the partial, then set the real value.
+	# Only an actual install pays for this, and only on a postgres stack booted
+	# without KANSO_SKIP_NOTIFY_PUSH — which both CI jobs and upgrade-check.sh
+	# set, so nothing that has no egress ever turns the store on.
+	docker exec kanso-dev rm -f /var/www/html/config/kanso-appstore.config.php || notify_push_ready=0
+	$OCC config:system:set appstoreenabled --value=true --type=boolean >/dev/null || notify_push_ready=0
 	$OCC app:install notify_push || notify_push_ready=0
 fi
 
@@ -202,6 +231,34 @@ if [ "$notify_push_ready" = "1" ]; then
 	$OCC config:system:set trusted_domains 1 --value nextcloud
 	# The gate that actually matters: whether the command runs at all.
 	$OCC notify_push:setup http://localhost:8891/push || notify_push_ready=0
+fi
+
+# `notify_push:setup` exiting 0 only proves the command RAN. Once it has
+# succeeded once, Nextcloud advertises the notify_push capability from then on,
+# so every client takes the push path even if the daemon later goes dark — a
+# stack that lies about push is worse than one that has none, because the lie is
+# invisible until an e2e assertion with a sub-30s budget goes red. self-test is
+# the only check that walks the whole path (redis → daemon → Nextcloud → trusted
+# proxy → version match), so run it and print it. It exits non-zero on a real
+# break (measured: 1 for an unreachable daemon, 2 for an untrusted proxy) and 0
+# on the two http/localhost notes this stack always prints.
+if [ "$notify_push_ready" = "1" ]; then
+	echo
+	echo "Verifying the push path (occ notify_push:self-test)."
+	echo "The unencrypted-http and localhost notes are expected in the dev stack:"
+	if ! $OCC notify_push:self-test; then
+		echo >&2
+		echo "WARNING: notify_push is installed and ADVERTISED, but self-test FAILED." >&2
+		echo "  * The capability stays advertised, so clients take the push path" >&2
+		echo "    and may never receive a frame." >&2
+		echo "  * tests/e2e/realtime.spec.js's push test will FAIL (it only skips on" >&2
+		echo "    KANSO_SKIP_NOTIFY_PUSH=1), and so may any spec with a short budget." >&2
+		echo "  * Check the daemon: docker logs kanso-dev-push" >&2
+		echo "  * Check the proxy:  docker exec kanso-dev curl -si http://localhost:8891/push/test/cookie | head -1" >&2
+		echo "    A 400 there is healthy (the daemon answers); a connection failure" >&2
+		echo "    means apache never bound :8891 inside the container." >&2
+		echo >&2
+	fi
 fi
 
 if [ "$notify_push_ready" != "1" ]; then

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -187,36 +187,104 @@ CONF
 	apache2ctl graceful
 ' 2>/dev/null
 
-# Best-effort install: `occ app:install` needs the container to reach
-# apps.nextcloud.com, which it can't everywhere (no egress, a stale appstore
-# cache) — the same wall install-optional-apps.sh side-steps with tarballs.
-# Under `set -eu` a failure here would kill the whole boot, so it only
-# downgrades realtime instead.
+# Best-effort install: it needs egress (github.com for the pinned tarball, or
+# apps.nextcloud.com for the fallback), which not every host has. Under `set -eu`
+# a failure here would kill the whole boot, so it only downgrades realtime
+# instead.
 #
-# EVERY step below can flip the flag off, not just the install. `occ app:list`
-# prints DISABLED apps too, so matching notify_push there does not mean it is
-# usable: an installed-but-disabled app skips the install entirely, and then
-# `notify_push:setup` is an unregistered command whose non-zero exit would kill
-# the boot under `set -e` — exactly the failure this block exists to remove.
-# So gate on the commands actually WORKING, and warn once at the end.
+# EVERY step below can flip the flag off, not just the install — keep it that
+# way. `occ app:list` prints DISABLED apps too, so the app being listed does not
+# mean it is usable: skip the install on a mere name match and `notify_push:setup`
+# is then an unregistered command whose non-zero exit kills the boot under
+# `set -e` — exactly the failure this block exists to remove. So gate on the
+# commands actually WORKING, and warn once at the end.
+#
+# The app version is PINNED, in lockstep with the daemon image tag in
+# docker-compose.yml — see the long comment on that service for why both halves
+# have to move together (short version: self-test compares the two versions, so
+# either side floating turns the boot warning into noise). Bump the version and
+# the URL here together with the compose tag, and nothing else.
+NOTIFY_PUSH_VERSION=1.4.0
+NOTIFY_PUSH_URL="https://github.com/nextcloud-releases/notify_push/releases/download/v${NOTIFY_PUSH_VERSION}/notify_push-v${NOTIFY_PUSH_VERSION}.tar.gz"
+
 notify_push_ready=1
-if ! $OCC app:list | grep -q notify_push; then
-	# `app:install` also needs an ENABLED app store, and this stack boots with it
-	# off: hooks/pre-installation/00-apps-writable.sh writes
-	# config/kanso-appstore.config.php with appstoreenabled => false, which it only
-	# needs for the duration of maintenance:install. Nextcloud merges
-	# config/*.config.php OVER config.php, so that partial outlives the install,
-	# and `config:system:set appstoreenabled --value=true` then reports success
-	# while `config:system:get` keeps answering false. The install fails with
-	# "Could not download app notify_push, it was not found on the appstore",
-	# which reads like a delisted app or a blocked network and is neither — this
-	# container reaches the store fine. Drop the partial, then set the real value.
-	# Only an actual install pays for this, and only on a postgres stack booted
-	# without KANSO_SKIP_NOTIFY_PUSH — which both CI jobs and upgrade-check.sh
-	# set, so nothing that has no egress ever turns the store on.
-	docker exec kanso-dev rm -f /var/www/html/config/kanso-appstore.config.php || notify_push_ready=0
-	$OCC config:system:set appstoreenabled --value=true --type=boolean >/dev/null || notify_push_ready=0
-	$OCC app:install notify_push || notify_push_ready=0
+# Match on the PINNED version, not the bare app name: `occ app:list` prints
+# disabled apps too, and a long-lived stack still carrying the previous pin has
+# to be re-installed or the version-match check below fails by construction.
+# Same guard shape as install-optional-apps.sh.
+if ! $OCC app:list | grep -q "^  - notify_push: $NOTIFY_PUSH_VERSION"; then
+	# Preferred path: side-load the pinned release tarball, the same mechanism
+	# install-optional-apps.sh uses for deck/contacts (download on the host,
+	# `docker cp` it in). That makes the app version a pin in this file instead
+	# of whatever the App Store happens to serve for this Nextcloud major.
+	echo "Installing notify_push v${NOTIFY_PUSH_VERSION} (pinned to the daemon image tag)..."
+	if ! curl -fsSL "$NOTIFY_PUSH_URL" -o /tmp/notify_push.tar.gz; then
+		# Fallback for a host that can't reach github.com. Unpinned by nature —
+		# say so, because the self-test may then legitimately report a version
+		# skew against the pinned daemon image.
+		echo "Could not download the pinned notify_push v${NOTIFY_PUSH_VERSION} tarball; falling back to the App Store." >&2
+		echo "  * The store serves whatever version it likes for this Nextcloud" >&2
+		echo "    major, so the self-test's version-match check may then fail" >&2
+		echo "    against the pinned daemon image. That is a real mismatch, not" >&2
+		echo "    a false alarm — pull the tarball, or align the compose tag." >&2
+		# `app:install` also needs an ENABLED app store, and this stack boots with it
+		# off: hooks/pre-installation/00-apps-writable.sh writes
+		# config/kanso-appstore.config.php with appstoreenabled => false, which it only
+		# needs for the duration of maintenance:install. Nextcloud merges
+		# config/*.config.php OVER config.php, so that partial outlives the install,
+		# and `config:system:set appstoreenabled --value=true` then reports success
+		# while `config:system:get` keeps answering false. The install fails with
+		# "Could not download app notify_push, it was not found on the appstore",
+		# which reads like a delisted app or a blocked network and is neither — this
+		# container reaches the store fine. Drop the partial, then set the real value.
+		# Only an actual install pays for this, and only on a postgres stack booted
+		# without KANSO_SKIP_NOTIFY_PUSH — which both CI jobs and upgrade-check.sh
+		# set, so nothing that runs unattended ever turns the store on.
+		#
+		# And only when the app is genuinely ABSENT: `occ app:install` returns 1
+		# on an app that is already present (core Command/App/Install.php: "already
+		# installed"), so running it against a stack that merely carries a
+		# different version would flip notify_push_ready off and make the boot
+		# claim push is dead on a stack where it works. Keeping the version we
+		# already have is the right call here — it may skew against the pinned
+		# daemon, which the self-test will then say out loud.
+		if $OCC app:list | grep -q "^  - notify_push:"; then
+			echo "  * notify_push is already present at another version — keeping it." >&2
+		else
+			docker exec kanso-dev rm -f /var/www/html/config/kanso-appstore.config.php || notify_push_ready=0
+			$OCC config:system:set appstoreenabled --value=true --type=boolean >/dev/null || notify_push_ready=0
+			$OCC app:install notify_push || notify_push_ready=0
+		fi
+	elif ! docker cp /tmp/notify_push.tar.gz kanso-dev:/tmp/notify_push.tar.gz \
+		|| ! docker exec kanso-dev bash -ec '
+			rm -rf /var/www/html/custom_apps/notify_push
+			tar -xzf /tmp/notify_push.tar.gz -C /var/www/html/custom_apps
+			chown -R www-data:www-data /var/www/html/custom_apps/notify_push
+		'; then
+		# `bash -ec`, and the copy chained into the same condition, on purpose.
+		# The tree is `rm -rf`'d before the untar (so a version bump can't leave
+		# the previous release's orphaned files behind), which means a tar that
+		# dies half-way has already destroyed a working install. Without `-e` the
+		# exec's status would be `chown`'s — and chown succeeds on a half-extracted
+		# directory, so the boot would sail on with a broken app and still report
+		# push as healthy. Both halves live in the `if` condition rather than the
+		# body because `set -e` does not apply to conditions: a docker failure has
+		# to downgrade realtime, never abort the boot.
+		echo >&2
+		echo "WARNING: unpacking notify_push v${NOTIFY_PUSH_VERSION} into the container failed." >&2
+		echo "  * custom_apps/notify_push may be half-extracted — re-run ./setup.sh." >&2
+		notify_push_ready=0
+	else
+		# `app:enable` short-circuits on an app that is already enabled (core
+		# Command/App/Enable.php returns before Installer::installApp()), and
+		# installApp() is what writes appconfig `installed_version` — the value
+		# `occ app:list` prints and the guard above matches on. So on a stack that
+		# already had notify_push enabled at the previous pin, a bump would extract
+		# the new tree, leave the recorded version at the old one, and re-download
+		# on every boot forever while the app's repair steps never re-ran. Disable
+		# first so the enable below is a real install. No-op on a fresh stack.
+		$OCC app:disable notify_push >/dev/null 2>&1 || true
+	fi
 fi
 
 # Idempotent, and the step that turns "present" into "usable".
@@ -268,11 +336,18 @@ if [ "$notify_push_ready" != "1" ]; then
 	echo "  * tests/e2e/realtime.spec.js's push test will now FAIL rather than skip" >&2
 	echo "    (it only skips on the env var), so run the suite with" >&2
 	echo "    KANSO_SKIP_NOTIFY_PUSH=1 for a clean local result." >&2
-	echo "  * The usual cause is this container not reaching apps.nextcloud.com," >&2
-	echo "    NOT a missing release: notify_push v1.4.0 supports Nextcloud 30-35." >&2
+	echo "  * If the output above ends in a push server / app VERSION MISMATCH," >&2
+	echo "    the cause is the two pins having drifted apart, not the network:" >&2
+	echo "    set the image tag in docker-compose.yml and NOTIFY_PUSH_VERSION" >&2
+	echo "    here to the SAME version, then re-run. (Measured: a skew fails" >&2
+	echo "    \`notify_push:setup\` outright, so the boot lands here rather than" >&2
+	echo "    in the self-test warning — the mismatch line is the one to read.)" >&2
+	echo "  * Otherwise the usual cause is this host reaching neither github.com nor" >&2
+	echo "    apps.nextcloud.com, NOT a missing release: the pinned" >&2
+	echo "    notify_push v${NOTIFY_PUSH_VERSION} supports Nextcloud 30-35." >&2
 	echo "    To side-load it by hand, unpack this into the container's" >&2
 	echo "    custom_apps and re-run:" >&2
-	echo "    https://github.com/nextcloud-releases/notify_push/releases/download/v1.4.0/notify_push-v1.4.0.tar.gz" >&2
+	echo "    ${NOTIFY_PUSH_URL}" >&2
 	echo >&2
 fi
 fi

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -42,6 +42,9 @@ OCC="docker exec -u www-data kanso-dev php occ"
 case "$KANSO_DB" in
 	postgres)
 		COMPOSE_PROFILE=postgres
+		# What Nextcloud records in config.php's `dbtype` for this driver — used
+		# by the webroot check further down.
+		EXPECTED_DBTYPE=pgsql
 		cat > .db.env <<-'ENV'
 			POSTGRES_HOST=db
 			POSTGRES_DB=nextcloud
@@ -51,6 +54,7 @@ case "$KANSO_DB" in
 		;;
 	mysql|mariadb)
 		COMPOSE_PROFILE=mysql
+		EXPECTED_DBTYPE=mysql
 		cat > .db.env <<-'ENV'
 			MYSQL_HOST=db
 			MYSQL_DATABASE=nextcloud
@@ -60,6 +64,7 @@ case "$KANSO_DB" in
 		;;
 	sqlite)
 		COMPOSE_PROFILE=sqlite
+		EXPECTED_DBTYPE=sqlite3
 		cat > .db.env <<-'ENV'
 			SQLITE_DATABASE=nextcloud
 		ENV
@@ -96,20 +101,96 @@ echo "Booting Nextcloud ${NC_VERSION} on ${KANSO_DB}..."
 # db service so only redis + nextcloud come up.
 docker compose --profile "$COMPOSE_PROFILE" up -d
 
+# The reset every message below points at. NOT a bare `down -v`: compose only
+# removes the volumes of services whose profile is active, so `down -v` without
+# a profile deletes the webroot and leaves the (profiled) database container up
+# with all its data — the half-wiped state that bricks the next boot. `'*'`
+# selects every profile, so it clears whichever driver was last used.
+RESET_CMD="docker compose --profile '*' down -v && NC_VERSION=${NC_VERSION} KANSO_DB=${KANSO_DB} ./setup.sh"
+
 echo "Waiting for Nextcloud to finish installing..."
 # Generous budget: on a cold, slow CI runner the older NC images pull fresh and
 # their first-boot install (Postgres especially) can take well over 7 minutes.
 # 180 * 5s = 15 min, comfortably inside the install-matrix job's 30-min cap.
+#
+# The budget is for a SLOW boot, not a dead one. When the entrypoint's install
+# fails it exits the container, and every remaining second of that 15 minutes is
+# spent polling a port nothing is listening on — so stop as soon as the
+# container is gone and let the diagnosis below print. (That wait is how the
+# blank-webroot brick used to present: a quarter of an hour of silence, then a
+# generic "did not come up".)
 for i in $(seq 1 180); do
 	if curl -sf http://localhost:8891/status.php 2>/dev/null | grep -q '"installed":true'; then
 		break
 	fi
+	case "$(docker inspect -f '{{.State.Status}}' kanso-dev 2>/dev/null || echo missing)" in
+		running|created|restarting) ;;
+		*) echo "The kanso-dev container is no longer running — not waiting out the rest." >&2
+		   break ;;
+	esac
 	sleep 5
 done
 curl -sf http://localhost:8891/status.php | grep -q '"installed":true' || {
 	echo "Nextcloud did not come up; check: docker logs kanso-dev" >&2
+	echo >&2
+	echo "If the log ends in 'Installing of nextcloud failed!' (typically with" >&2
+	echo "'permission denied for table oc_migrations'), the entrypoint found an" >&2
+	echo "EMPTY webroot next to a populated database and tried to install over it." >&2
+	echo "That means the two were reset separately — usually a bare 'down -v',"  >&2
+	echo "which only removes the volumes of the active profiles. Reset both:" >&2
+	echo "  ${RESET_CMD}" >&2
+	echo "That destroys the dev database too — dev/seed.sh reseeds it." >&2
 	exit 1
 }
+
+# --- is this the stack that was asked for? -----------------------------------
+# The webroot is a NAMED volume (see docker-compose.yml), so it deliberately
+# outlives `docker compose down`. That is what makes `down` a restart instead of
+# the trap it used to be — but it also means a webroot installed against another
+# driver, or another NC major, survives, and Nextcloud will boot it without
+# complaint. Everything downstream — smoke.sh, the install matrix, the e2e suite
+# — would then pass against a stack nobody asked for. Assert, don't trust.
+
+# 1. The database driver. `KANSO_DB=sqlite ./setup.sh` over a postgres install:
+#    the entrypoint sees a config.php, skips the install, keeps the old dbtype,
+#    and the stack comes up "healthy" while still talking to postgres.
+#    No `|| true` and no swallowed stderr: on an install that answered
+#    status.php `"installed":true`, dbtype is always set, so failing to read it
+#    means something is wrong with occ — and a guard that quietly stops guarding
+#    is worse than no guard.
+ACTUAL_DBTYPE="$($OCC config:system:get dbtype | tr -d '\r\n ')"
+if [ "$ACTUAL_DBTYPE" != "$EXPECTED_DBTYPE" ]; then
+	echo >&2
+	echo "This Nextcloud is installed on '${ACTUAL_DBTYPE}', but KANSO_DB=${KANSO_DB}" >&2
+	echo "asked for '${EXPECTED_DBTYPE}'. The webroot volume is left over from an" >&2
+	echo "earlier boot on the other driver; switching drivers needs a reset, not a" >&2
+	echo "restart:" >&2
+	echo "  ${RESET_CMD}" >&2
+	echo "That destroys the dev database too — dev/seed.sh reseeds it." >&2
+	exit 1
+fi
+
+# 2. The Nextcloud major. This one is asymmetric, and only one half is loud:
+#    a webroot NEWER than the image makes the entrypoint refuse to start (caught
+#    by the boot check above), but a webroot one major OLDER is silently rsynced
+#    and `occ upgrade`d — so `NC_VERSION=33 ./setup.sh` over an NC 32 webroot
+#    yields a healthy, correct-looking NC 33 whose Kanso migrations never ran on
+#    NC 33 at all. That is exactly what the install matrix exists to check, so it
+#    is exactly the run that must not pass quietly. The entrypoint says so in its
+#    log; a same-major patch bump (34.0.3 → 34.0.4) is a legitimate upgrade and
+#    deliberately does NOT trip this.
+CARRIED_FROM="$(docker logs kanso-dev 2>&1 \
+	| sed -n 's/.*Upgrading nextcloud from \([0-9][0-9]*\)\..*/\1/p' | tail -1)"
+if [ -n "$CARRIED_FROM" ] && [ "$CARRIED_FROM" != "$NC_VERSION" ]; then
+	echo >&2
+	echo "This webroot was installed on Nextcloud ${CARRIED_FROM} and the entrypoint just" >&2
+	echo "upgraded it in place to ${NC_VERSION}. An upgraded instance is not a fresh" >&2
+	echo "install: Kanso's migrations ran on ${CARRIED_FROM}, not on ${NC_VERSION}, so anything" >&2
+	echo "this stack proves about NC ${NC_VERSION} is worth nothing. Reset:" >&2
+	echo "  ${RESET_CMD}" >&2
+	echo "(dev/upgrade-check.sh is the script that tests upgrades on purpose.)" >&2
+	exit 1
+fi
 
 # Docker pre-creates the mountpoint parent as root; hand it to the web user
 docker exec kanso-dev chown www-data:www-data /var/www/html/custom_apps

--- a/dev/upgrade-check.sh
+++ b/dev/upgrade-check.sh
@@ -126,7 +126,11 @@ step "3. Install the RELEASED version on a pristine Nextcloud ${NC_VERSION}/${KA
 # Same KANSO_DB → compose-profile mapping setup.sh uses.
 COMPOSE_PROFILE="$KANSO_DB"
 if [ "$COMPOSE_PROFILE" = "mariadb" ]; then COMPOSE_PROFILE=mysql; fi
-docker compose --profile "$COMPOSE_PROFILE" down -v >/dev/null 2>&1 || true
+# The pristine-database precondition this whole script rests on. `|| true`
+# because there may be nothing to tear down, but stderr is NOT discarded: if the
+# reset half-fails, that message is the only warning that everything below is
+# now running against leftover state.
+docker compose --profile "$COMPOSE_PROFILE" down -v >/dev/null || true
 KANSO_APP_SRC="./${STAGE}" \
 	KANSO_SKIP_NOTIFY_PUSH=1 KANSO_SKIP_OPTIONAL_APPS=1 \
 	./setup.sh || fail "dev/setup.sh could not boot the released version"

--- a/lib/Db/CardFeatures.php
+++ b/lib/Db/CardFeatures.php
@@ -19,11 +19,11 @@ use OCA\Kanso\Service\InvalidInputException;
  *
  * Switching a feature off is a pure PRESENTATION flag: it hides the feature's
  * UI and nothing else. Existing attachments, contact links, GitHub links, time
- * entries and cover colours stay in the database untouched and come back
- * exactly as they were when the feature is re-enabled. There is deliberately no
- * cascade delete anywhere, a running timer is NOT stopped when time tracking is
- * switched off, and historical activity entries ("linked a contact") stay
- * readable.
+ * entries, cover colours and checklist items stay in the database untouched and
+ * come back exactly as they were when the feature is re-enabled. There is
+ * deliberately no cascade delete anywhere, a running timer is NOT stopped when
+ * time tracking is switched off, and historical activity entries ("linked a
+ * contact") stay readable.
  *
  * ## Enforcement: CLIENT-SIDE ONLY (deliberate)
  *
@@ -46,7 +46,8 @@ use OCA\Kanso\Service\InvalidInputException;
  *
  * Only the DISABLED keys are persisted, as a small JSON array
  * (`["attachments","github"]`). NULL / an empty array = everything enabled, so
- * existing boards need no backfill and a sixth feature costs no migration.
+ * existing boards need no backfill and a further feature costs no migration
+ * ({@see self::CHECKLIST}, added after the column shipped, needed none).
  * Unknown keys read back from storage are ignored, so a downgraded instance
  * still renders - but they are NOT preserved: {@see self::encode()} writes only
  * the keys it knows, so the first flip of any switch on a downgraded instance
@@ -58,9 +59,14 @@ final class CardFeatures {
 	public const GITHUB = 'github';
 	public const TIME_TRACKING = 'timeTracking';
 	public const COVER_COLOR = 'coverColor';
+	public const CHECKLIST = 'checklist';
 
 	/**
 	 * Every toggleable key, in the order the board settings UI lists them.
+	 *
+	 * New keys go on the END: this order is what {@see self::encode()} writes and
+	 * what {@see self::decode()} hands the client, so inserting in the middle
+	 * would churn stored values for no gain.
 	 *
 	 * @var string[]
 	 */
@@ -70,6 +76,7 @@ final class CardFeatures {
 		self::GITHUB,
 		self::TIME_TRACKING,
 		self::COVER_COLOR,
+		self::CHECKLIST,
 	];
 
 	/**

--- a/lib/Migration/Version005600Date20260912000000.php
+++ b/lib/Migration/Version005600Date20260912000000.php
@@ -16,14 +16,17 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Per-board built-in card feature switches (`kanso_boards.disabled_card_features`).
  *
- * A board manager can hide card sections the team never uses (contacts,
- * attachments, GitHub links, time tracking, cover colour). The column stores a
- * small JSON array of the DISABLED keys, e.g. `["attachments","github"]`.
+ * A board manager can hide card sections the team never uses. This step shipped
+ * with five (contacts, attachments, GitHub links, time tracking, cover colour);
+ * the live set is whatever {@see \OCA\Kanso\Db\CardFeatures::ALL} lists today.
+ * The column stores a small JSON array of the DISABLED keys, e.g.
+ * `["attachments","github"]`.
  *
  * NULL (the default for every existing row) means "nothing disabled" - every
  * feature stays on - so this is purely additive with no backfill and no
  * behaviour change on upgrade. Storing only the disabled keys also means a
- * sixth feature can be added later without another migration.
+ * further feature can be added without another migration - `checklist` was, and
+ * needed none.
  *
  * Guarded (hasColumn) so the step is idempotent.
  */

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -131,9 +131,9 @@ class CsvImportService {
 	 * created - counted in `labelsSkipped` (DISTINCT names, the same unit
 	 * `labelsCreated` uses). Deliberately a partial success rather than a refusal:
 	 * the rows are the point of the import, and a member who cannot define labels
-	 * can still populate the board. The count is reported for a caller that wants
-	 * to surface the shortfall; today's board-list modal does not read it yet, so
-	 * the skip is currently silent in the UI.
+	 * can still populate the board. The count is reported so the shortfall reaches
+	 * a human: the board-list CSV modal renders it (with `skipped`) as a warning on
+	 * its summary step, rather than navigating away as if nothing was lost.
 	 *
 	 * If the target stack's existing keys are already at the sort-key wall the
 	 * first attempt overflows before writing anything; the stack is then

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -13,7 +13,6 @@ use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\Change;
-use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
@@ -55,12 +54,24 @@ use OCP\IUserManager;
  *   - title       REQUIRED. A row with a blank title is skipped, not fatal.
  *   - description optional.
  *   - duedate     optional; a spreadsheet date/datetime → the card due date.
- *   - labels      optional; comma-separated names, match-or-CREATE on the board
- *                 (mirrors the whole-board importers, which create the labels
- *                 they reference rather than dropping them).
+ *   - labels      optional; comma-separated names, match-or-CREATE on the board -
+ *                 but creating a label DEFINITION is a board-MANAGE concern
+ *                 ({@see LabelService::create}), and this importer only requires
+ *                 EDIT. A name that already exists is reused; an unseen one is
+ *                 created only when the actor ALSO holds MANAGE, and otherwise
+ *                 dropped from the card and counted in `labelsSkipped`. The
+ *                 whole-board importers create the labels they reference because
+ *                 they mint a FRESH board owned by the importer; this one appends
+ *                 into an existing - possibly someone else's - board, so that
+ *                 rationale does not carry over.
  *   - assignees   optional; comma-separated uids, match-or-DROP filtered by READ
  *                 on the target board (mirrors the Deck importer's assignee rule
  *                 and never leaks a uid onto a board they cannot see).
+ *
+ * The EDIT/MANAGE split matters at this importer's scale: {@see self::MAX_ROWS}
+ * rows with a per-row-unique label column would otherwise let any EDIT-level
+ * member mint that many board-level label definitions, every one of which then
+ * ships in the board payload's `labels` array to EVERY viewer of the board.
  */
 class CsvImportService {
 	/**
@@ -95,6 +106,9 @@ class CsvImportService {
 		private SortKeyService $sortKeyService,
 		private ChangeNotifier $changeNotifier,
 		private PermissionService $permissionService,
+		// Label CREATION goes through the service, never the mapper: it owns the
+		// MANAGE gate, the color validation and the ENTITY_LABEL change row.
+		private LabelService $labelService,
 		// Only for rebalanceStack(): the recovery when the target stack's tail
 		// sort key is already at the varchar(64) wall (see import()).
 		private CardService $cardService,
@@ -111,12 +125,22 @@ class CsvImportService {
 	 * that field is not mapped); `title` MUST be mapped. When $hasHeader is true
 	 * the first parsed row is treated as headers and skipped.
 	 *
+	 * A mapped label column NEVER escalates the actor's rights: the import stays
+	 * EDIT-gated, but minting a label definition needs MANAGE, so an EDIT-only
+	 * member's unknown label names are dropped from their cards rather than
+	 * created - counted in `labelsSkipped` (DISTINCT names, the same unit
+	 * `labelsCreated` uses). Deliberately a partial success rather than a refusal:
+	 * the rows are the point of the import, and a member who cannot define labels
+	 * can still populate the board. The count is reported for a caller that wants
+	 * to surface the shortfall; today's board-list modal does not read it yet, so
+	 * the skip is currently silent in the UI.
+	 *
 	 * If the target stack's existing keys are already at the sort-key wall the
 	 * first attempt overflows before writing anything; the stack is then
 	 * rebalanced and the import replayed once (see below).
 	 *
 	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
-	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
+	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int, labelsSkipped: int}
 	 * @throws InvalidInputException on an oversized/malformed CSV, a missing title mapping, or too many rows
 	 * @throws NotPermittedException if the actor lacks EDIT on the board
 	 * @throws \OverflowException if the sort keys still overflow after the rebalance
@@ -198,7 +222,7 @@ class CsvImportService {
 	 *
 	 * @param resource $handle a rewound CSV stream positioned at the first record
 	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
-	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
+	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int, labelsSkipped: int}
 	 */
 	private function attempt($handle, bool $hasHeader, Board $board, Stack $stack, array $mapping, string $actorUid, int $dataRows): array {
 		$this->db->beginTransaction();
@@ -221,7 +245,7 @@ class CsvImportService {
 	 * @param array{title: int, description?: ?int, duedate?: ?int, labels?: ?int, assignees?: ?int} $mapping
 	 * @param int $dataRows the number of data rows counted in the pre-pass; sizes
 	 *                      the sort-key block so it never runs short
-	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int}
+	 * @return array{boardId: int, stackId: int, cards: int, skipped: int, labelsCreated: int, labelsSkipped: int}
 	 */
 	private function rebuild($handle, bool $hasHeader, Board $board, Stack $stack, array $mapping, string $actorUid, int $dataRows): array {
 		$boardId = $board->getId();
@@ -234,7 +258,29 @@ class CsvImportService {
 		foreach ($this->labelMapper->findByBoard($boardId) as $label) {
 			$labelIdByName[$this->labelKey((string)$label->getTitle())] = $label->getId();
 		}
+		// Creating a board-level label is a MANAGE concern (LabelService::create),
+		// while the import itself only needs EDIT. Resolve the actor's MANAGE bit
+		// ONCE here, before the row loop, rather than per row: an EDIT-only member
+		// keeps the useful part of their import (every row, plus the label names
+		// that already exist on the board) and simply cannot mint a definition they
+		// could not have created through the labels endpoint.
+		//
+		// Note this needs NO separate internal-side assert (the shape
+		// StackService::assertInternal applies to its EDIT-gated stack mutations):
+		// PermissionService::getPermissions() already strips SHARE|MANAGE from a
+		// member whose effective role folds to external, so a MANAGE bit surviving
+		// that fold IS an internal-side bit. See PermissionService's class doc.
+		$mayCreateLabels = ($this->permissionService->getPermissions($board, $actorUid)
+			& PermissionService::PERMISSION_MANAGE) !== 0;
 		$labelsCreated = 0;
+		/**
+		 * Distinct label names an EDIT-only actor could not create, as a key set so
+		 * a name repeated across rows is reported once (mirroring $labelsCreated,
+		 * which counts distinct labels created).
+		 *
+		 * @var array<string, true> $skippedLabelKeys
+		 */
+		$skippedLabelKeys = [];
 
 		// Append after the current tail of the stack. The whole block's sort keys
 		// are laid out in one shot as a bounded, evenly-spaced sequence past the
@@ -313,7 +359,10 @@ class CsvImportService {
 					$this->splitList($this->cell($row, $labelsIdx)),
 					$newCardId,
 					$boardId,
+					$actorUid,
+					$mayCreateLabels,
 					$labelIdByName,
+					$skippedLabelKeys,
 				);
 			}
 			if ($assigneesIdx !== null) {
@@ -333,20 +382,52 @@ class CsvImportService {
 			'cards' => $cards,
 			'skipped' => $skipped,
 			'labelsCreated' => $labelsCreated,
+			'labelsSkipped' => count($skippedLabelKeys),
 		];
 	}
 
 	/**
 	 * Match-or-create each label name on the board: a name that already exists
 	 * (case-insensitively) is reused, an unseen one is created once and cached so
-	 * repeated names across rows share one label. Mirrors the whole-board
-	 * importers, which create the labels they reference.
+	 * repeated names across rows share one label.
+	 *
+	 * The create half is gated: $mayCreate carries the actor's MANAGE bit
+	 * (resolved once in {@see self::rebuild}), because a label DEFINITION is a
+	 * board-management write. Without it an unseen name is dropped from the card
+	 * and recorded in $skippedLabelKeys instead - the import is not failed over it.
+	 *
+	 * Creates go through {@see LabelService::create} rather than
+	 * {@see LabelMapper::insert} so the MANAGE assert, {@see ColorValidator} and
+	 * the {@see Change::ENTITY_LABEL} change row all come from the one place that
+	 * owns label creation - the missing change row is why a delta client used to
+	 * receive card upserts naming label ids absent from its cache instead of the
+	 * resync a label change forces. `push: false` because the change row lands
+	 * inside the import's transaction; the single post-commit
+	 * {@see ChangeNotifier::pushBoardChanged} in {@see self::import} covers it.
+	 * That routing costs a board load + an ACL fetch per NEWLY CREATED label
+	 * (never per row, and never for a reused name), which is the price of having
+	 * exactly one gate rather than two implementations of it.
 	 *
 	 * @param string[] $names
+	 * @param bool $mayCreate whether the actor holds MANAGE and so may define labels
 	 * @param array<string, int> $labelIdByName label key → id, updated by reference
+	 * @param array<string, true> $skippedLabelKeys distinct un-creatable names, updated by reference
 	 * @return int the number of labels newly created
+	 * @throws NotPermittedException if LabelService refuses the create. $mayCreate
+	 *                               tests the same bit, so in practice this needs
+	 *                               MANAGE to be revoked between the two reads; the
+	 *                               import then fails whole rather than skipping -
+	 *                               the safe direction, and rare enough to accept.
 	 */
-	private function attachLabels(array $names, int $cardId, int $boardId, array &$labelIdByName): int {
+	private function attachLabels(
+		array $names,
+		int $cardId,
+		int $boardId,
+		string $actorUid,
+		bool $mayCreate,
+		array &$labelIdByName,
+		array &$skippedLabelKeys,
+	): int {
 		$created = 0;
 		$seen = [];
 		foreach ($names as $name) {
@@ -357,11 +438,13 @@ class CsvImportService {
 			$key = $this->labelKey($name);
 			$labelId = $labelIdByName[$key] ?? null;
 			if ($labelId === null) {
-				$label = new Label();
-				$label->setBoardId($boardId);
-				$label->setTitle($name);
-				$label->setColor(self::DEFAULT_LABEL_COLOR);
-				$labelId = $this->labelMapper->insert($label)->getId();
+				if (!$mayCreate) {
+					$skippedLabelKeys[$key] = true;
+					continue;
+				}
+				$labelId = $this->labelService
+					->create($boardId, $name, self::DEFAULT_LABEL_COLOR, $actorUid, push: false)
+					->getId();
 				$labelIdByName[$key] = $labelId;
 				$created++;
 			}

--- a/lib/Service/DeckImportService.php
+++ b/lib/Service/DeckImportService.php
@@ -43,8 +43,10 @@ use Psr\Log\LoggerInterface;
  * kinds of card attachment: `deck_file` uploads (bytes copied out of Deck's
  * app-data into Kanso's own) AND `file` user-Files references (Deck stores these
  * as shares; the referenced file's bytes are read from the owner's Files and
- * copied in the same way). A reference whose source file is gone/unreadable is
- * logged and skipped (counted in `skippedFileAttachments`), never fatal. Board
+ * copied in the same way). An attachment of EITHER kind whose source is
+ * gone/oversized/unreadable is logged and skipped - counted in
+ * `skippedAttachments`, one honest total across both paths, so a degraded
+ * import can never look like a complete one - but never fatal. Board
  * SHARING/ACL is still out of scope for v1 (it needs participant remapping).
  */
 class DeckImportService {
@@ -100,7 +102,7 @@ class DeckImportService {
 	/**
 	 * Imports one Deck board into a new Kanso board owned by the actor.
 	 *
-	 * @return array{boardId: int, title: string, stacks: int, cards: int, labels: int, comments: int, attachments: int, skippedFileAttachments: int}
+	 * @return array{boardId: int, title: string, stacks: int, cards: int, labels: int, comments: int, attachments: int, skippedAttachments: int}
 	 * @throws InvalidInputException if Deck is not available
 	 * @throws NotPermittedException if the actor cannot read the Deck board
 	 * @throws DoesNotExistException if the Deck board does not exist
@@ -214,8 +216,8 @@ class DeckImportService {
 			$this->importLabelAssignments($deckCardIds, $cardIdMap, $labelIdMap);
 			$this->importUserAssignees($deckCardIds, $cardIdMap);
 			$commentCount = $this->importComments($deckCardIds, $cardIdMap, $actorUid);
-			$attachmentCount = $this->importAttachments($deckCardIds, $cardIdMap, $actorUid, $writtenObjects);
-			[$fileRefCount, $skippedFileAttachments] = $this->importFileReferenceAttachments($deckCardIds, $cardIdMap, $actorUid, $writtenObjects);
+			[$attachmentCount, $skippedDeckFiles] = $this->importAttachments($deckCardIds, $cardIdMap, $actorUid, $writtenObjects);
+			[$fileRefCount, $skippedFileRefs] = $this->importFileReferenceAttachments($deckCardIds, $cardIdMap, $actorUid, $writtenObjects);
 
 			$result = [
 				'boardId' => $boardId,
@@ -225,7 +227,10 @@ class DeckImportService {
 				'labels' => count($labelIdMap),
 				'comments' => $commentCount,
 				'attachments' => $attachmentCount + $fileRefCount,
-				'skippedFileAttachments' => $skippedFileAttachments,
+				// ONE honest total across both attachment paths. Reported even when
+				// zero, so the UI can always say "nothing was lost" rather than
+				// leaving the user to infer it from a count they cannot check.
+				'skippedAttachments' => $skippedDeckFiles + $skippedFileRefs,
 			];
 			$this->db->commit();
 			return $result;
@@ -329,8 +334,9 @@ class DeckImportService {
 	 * {@see self::importFileReferenceAttachments()} (Deck stores it as a share).
 	 *
 	 * A `deck_attachment` row whose source object is MISSING - or whose source
-	 * exceeds {@see AttachmentSanitizer::MAX_SIZE} - is skipped and NOT counted,
-	 * never failing the whole import. The copied filename/MIME run through
+	 * exceeds {@see AttachmentSanitizer::MAX_SIZE}, or whose bytes cannot be read
+	 * - is logged and skipped (counted as skipped, exactly like the file-reference
+	 * path), never failing the whole import. The copied filename/MIME run through
 	 * {@see AttachmentSanitizer} for the same hardening as the upload path (an
 	 * imported `.html`/`.svg` can never become stored XSS), and the filename is
 	 * sanitized BEFORE it is used to look the source object up. Every object we do
@@ -340,17 +346,23 @@ class DeckImportService {
 	 * @param int[] $deckCardIds
 	 * @param array<int, int> $cardIdMap deck card id → kanso card id
 	 * @param list<array{cardId: int, storageKey: string}> $writtenObjects tracked, by-reference
-	 * @return int the number of attachments copied + linked
+	 * @return array{0: int, 1: int} [imported count, skipped count]
 	 */
-	private function importAttachments(array $deckCardIds, array $cardIdMap, string $actorUid, array &$writtenObjects): int {
+	private function importAttachments(array $deckCardIds, array $cardIdMap, string $actorUid, array &$writtenObjects): array {
 		$attachments = $this->deckReader->readAttachments($deckCardIds);
 		if ($attachments === []) {
-			return 0;
+			return [0, 0];
 		}
 		$deckAppData = $this->appDataFactory->get('deck');
 
 		$count = 0;
+		$skipped = 0;
 		foreach ($attachments as $att) {
+			// NOT counted as skipped: the attachments were read for exactly the
+			// $deckCardIds that were just inserted into $cardIdMap, so a miss here
+			// means "not part of this import", not "lost". If card insertion ever
+			// becomes conditional, this has to start counting (same for the
+			// identical guard in importFileReferenceAttachments()).
 			$newCardId = $cardIdMap[$att['cardId']] ?? null;
 			if ($newCardId === null) {
 				continue;
@@ -375,6 +387,7 @@ class DeckImportService {
 					'Kanso Deck import: skipping deck_file attachment with missing source object',
 					['deckCardId' => $att['cardId'], 'data' => $att['data']]
 				);
+				$skipped++;
 				continue;
 			}
 
@@ -386,6 +399,7 @@ class DeckImportService {
 					'Kanso Deck import: skipping oversized deck_file attachment',
 					['deckCardId' => $att['cardId'], 'data' => $att['data'], 'size' => (int)$sourceFile->getSize()]
 				);
+				$skipped++;
 				continue;
 			}
 
@@ -399,6 +413,7 @@ class DeckImportService {
 					'Kanso Deck import: could not read deck_file attachment bytes',
 					['deckCardId' => $att['cardId'], 'data' => $att['data'], 'exception' => $e]
 				);
+				$skipped++;
 				continue;
 			}
 
@@ -415,7 +430,7 @@ class DeckImportService {
 			);
 			$count++;
 		}
-		return $count;
+		return [$count, $skipped];
 	}
 
 	/**

--- a/lib/Service/LabelService.php
+++ b/lib/Service/LabelService.php
@@ -46,13 +46,26 @@ class LabelService {
 	}
 
 	/**
-	 * Creates a label on the board.
+	 * Creates a label on the board. This is the ONE place a board-level label
+	 * definition is minted, so the MANAGE gate, the color validation and the
+	 * ENTITY_LABEL change row always travel together - a caller that inserts
+	 * through {@see LabelMapper} directly would skip all three (see
+	 * {@see CsvImportService::attachLabels()}, which routes its match-or-create
+	 * through here for exactly that reason).
 	 *
+	 * @param bool $push whether to broadcast the realtime board-changed event right
+	 *                   away. Pass false when creating from INSIDE a caller-managed
+	 *                   transaction, or when batching several creates behind ONE
+	 *                   push, and call {@see ChangeNotifier::pushBoardChanged()}
+	 *                   after the commit instead - otherwise a client could refetch
+	 *                   pre-commit state, or get an event for a create that rolled
+	 *                   back. The change row is written either way, so delta sync
+	 *                   and the ETag stay correct regardless.
 	 * @throws DoesNotExistException if the board does not exist or is deleted
 	 * @throws NotPermittedException if the user may not manage the board
 	 * @throws InvalidInputException on invalid title or color
 	 */
-	public function create(int $boardId, string $title, ?string $color, string $uid): Label {
+	public function create(int $boardId, string $title, ?string $color, string $uid, bool $push = true): Label {
 		$board = $this->loadBoard($boardId);
 		$this->permissionService->assertPermission($board, $uid, PermissionService::PERMISSION_MANAGE);
 
@@ -67,7 +80,8 @@ class LabelService {
 			Change::ENTITY_LABEL,
 			$label->getId(),
 			Change::ACTION_CREATE,
-			$uid
+			$uid,
+			$push,
 		);
 
 		return $label;

--- a/lib/Service/MentionService.php
+++ b/lib/Service/MentionService.php
@@ -29,8 +29,22 @@ class MentionService {
 	/**
 	 * A `@` that is not preceded by a word char or another `@` (so `foo@bar`
 	 * email-style text does not match), followed by a conservative uid charset.
+	 *
+	 * PUBLIC because {@see PublicShareService::redactMentions()} reuses this exact
+	 * pattern to rewrite mentions out of the anonymous payload. A second, private
+	 * copy of the regex would drift from this one, and only one of the two would be
+	 * covered by the tests - so "what counts as a mention" is defined here once,
+	 * for both the extraction that acts on mentions and the redaction that hides
+	 * the uid behind them.
+	 *
+	 * The CLIENT keeps a third, hand-synced copy (src/services/markdown.js) for the
+	 * cosmetic chip. It cannot be shared with PHP, and the two do disagree in one
+	 * place worth knowing: markdown-it registers the chip as an INLINE rule, so a
+	 * mention inside a code span is not chipped for an authenticated reader, while
+	 * the server-side redaction still substitutes there (it must - the uid is the
+	 * uid wherever it sits).
 	 */
-	private const MENTION_PATTERN = '/(?<![\w@])@([a-zA-Z0-9_.-]+)/';
+	public const MENTION_PATTERN = '/(?<![\w@])@([a-zA-Z0-9_.-]+)/';
 
 	/**
 	 * How many distinct mentions one body may act on. Each one that survives

--- a/lib/Service/PublicShareService.php
+++ b/lib/Service/PublicShareService.php
@@ -35,7 +35,9 @@ use OCP\Security\ISecureRandom;
  * the token gets a STRIPPED, read-only snapshot of the board through
  * {@see self::getPublicBoard()}.
  *
- * Security posture (this is the app's only unauthenticated *read* surface):
+ * Security posture (the app's only unauthenticated read surface for board CONTENT
+ * - {@see \OCA\Kanso\Controller\CalendarFeedController} is also a public page, but
+ * it emits titles and a link, never free text):
  *  - OFF by default; enabling/rotating/disabling all require MANAGE.
  *  - The token column is UNIQUE, so a token resolves to EXACTLY one board - it
  *    can never be pivoted to another board.
@@ -52,7 +54,26 @@ use OCP\Security\ISecureRandom;
  *    link with the `public_share_comments` toggle (OFF by default). When ON, and
  *    only then, each public card also carries a read-only comment thread - author
  *    DISPLAY NAME only (never a uid), body, timestamps, one-level parent link;
- *    still no reactions, members or activity. OFF keeps the person-free baseline.
+ *    still no reactions, members or activity. OFF keeps comments out entirely.
+ *  - The two FREE-TEXT fields are the one place a uid can ride board content
+ *    rather than a person field, because a `@mention` has no entity table and is
+ *    stored as a literal `@uid` inside the text itself. Both are therefore run
+ *    through {@see self::redactMentions()} on the way out, so the "uid never
+ *    leaves" invariant covers the description and the comment body too, not just
+ *    the author byline. The stored rows are untouched - this is payload-only.
+ *    NOTE the deliberate trade this makes: a mentioned person's DISPLAY NAME can now
+ *    appear on a description even with the comments opt-in off, where previously the
+ *    same text carried their login uid. A name is not nothing - but it is the thing
+ *    the person publishes as, whereas a uid is half of a credential pair and the
+ *    handle for user enumeration against the login form, so the baseline is
+ *    person-LIGHT rather than person-free, on purpose.
+ *  - Only those two fields are redacted. A `@name` typed into a card/stack/board
+ *    title or a label name is served VERBATIM, as all board content is: those are
+ *    not mention surfaces ({@see MentionService} is only wired to descriptions and
+ *    comment bodies), the autocomplete never writes a uid there, and the suite pins
+ *    titles as byte-exact (the "substring-immune" case in
+ *    tests/e2e/public-share.spec.js). Redacting them would mangle ordinary text for
+ *    no mention to fix.
  *  - An unknown/disabled/rotated/expired token raises DoesNotExistException,
  *    which the controller maps to a throttled 404 (no oracle beyond the throttle,
  *    and no distinction between "wrong token" and "disabled board").
@@ -154,8 +175,10 @@ class PublicShareService {
 	/**
 	 * The STRIPPED, read-only public snapshot of the board a token points at.
 	 * This is the ONLY method that runs without a session, so it is deliberately
-	 * conservative: it builds its own narrow payload and never reads people,
-	 * comments, ACL, reviews, activity or webhook data.
+	 * conservative: it builds its own narrow payload and never reads comments (until
+	 * opted in), ACL, members, reviews, activity or webhook data. The one people
+	 * lookup it does make is {@see self::resolveDisplayName()}, and it exists to
+	 * REMOVE uids from the payload, never to add anything to it.
 	 *
 	 * When the board's `public_share_comments` opt-in is ON (#3949), each card
 	 * also carries a `comments` list - a read-only thread of author DISPLAY NAME
@@ -163,6 +186,10 @@ class PublicShareService {
 	 * public card set via {@see CommentMapper::findByBoardPublicOnly()}. No
 	 * reactions, no members, no activity. When OFF (default), no `comments` key
 	 * is added and the person-free baseline holds.
+	 *
+	 * Both free-text fields - every card `description` and, when opted in, every
+	 * comment `body` - pass through {@see self::redactMentions()}, which substitutes
+	 * display names for the `@uid` mentions stored inside them.
 	 *
 	 * @return array{
 	 *   board: array{title: ?string, color: ?string, prefix: string, commentsEnabled: bool, cardFeatures: array<string, bool>},
@@ -204,6 +231,12 @@ class PublicShareService {
 		// PUBLIC cards only, so a hidden card's discussion never surfaces.
 		$commentsEnabled = $board->getPublicShareComments() ?? false;
 		$commentsByCard = $commentsEnabled ? $this->commentMapper->findByBoardPublicOnly($boardId) : [];
+		// uid => display name, or NULL when the account no longer resolves. Shared
+		// by every uid lookup this request makes - comment authors AND the mentions
+		// redacted out of free text - so one uid costs at most one
+		// IUserManager::get() no matter how many cards or comments name it. The null
+		// is cached too: an unresolvable token must not be re-looked-up per card.
+		/** @var array<string, ?string> $displayNames */
 		$displayNames = [];
 
 		// Only NON-archived stacks, in display order; drop the internal board id.
@@ -248,9 +281,13 @@ class PublicShareService {
 				'id' => $cardId,
 				'stackId' => $card->getStackId(),
 				'title' => $card->getTitle(),
-				// Descriptions ARE part of the public snapshot per the share model
-				// (board content, not a person identifier). Nothing else is added.
-				'description' => $card->getDescription(),
+				// Descriptions ARE part of the public snapshot per the share model -
+				// board content, and nothing else is added. But board content is not
+				// automatically person-FREE: a `@mention` has no entity table and lives
+				// as a literal `@uid` inside the description text, so the raw column
+				// would hand an anonymous reader a real login uid. It goes out with
+				// those mentions redacted; the stored row is untouched.
+				'description' => $this->redactMentions($card->getDescription(), $displayNames),
 				'labels' => $labels,
 				'duedate' => $card->getDuedate()?->format(\DateTimeInterface::ATOM),
 				// Presentational, non-person card attributes (#3951): a cover colour
@@ -310,30 +347,238 @@ class PublicShareService {
 	 * falling back to the raw uid, so a deleted account's uid never leaks onto an
 	 * unauthenticated link (the "uid never leaves" invariant holds even then).
 	 *
+	 * The BODY is free text and carries mentions as literal `@uid` tokens, so it is
+	 * redacted on the way out exactly like a card description
+	 * ({@see self::redactMentions()}) - the author byline was never the only place a
+	 * uid could ride a public comment.
+	 *
 	 * @param Comment[] $comments
-	 * @param array<string, string> $displayNames uid => display name cache, reused across cards
+	 * @param array<string, ?string> $displayNames uid => display name (null = no such account) cache, reused across cards
 	 * @return list<array{id: int, parentCommentId: ?int, author: string, body: ?string, createdAt: int, editedAt: int}>
 	 */
 	private function serializeComments(array $comments, array &$displayNames): array {
 		$out = [];
 		foreach ($comments as $comment) {
 			$uid = (string)$comment->getAuthor();
-			if (!isset($displayNames[$uid])) {
-				$user = $this->userManager->get($uid);
-				// A deleted author resolves to null; never leak the raw uid on the
-				// public link - substitute a generic, translatable label instead.
-				$displayNames[$uid] = $user !== null ? $user->getDisplayName() : $this->l10n->t('Former user');
-			}
+			// A deleted author resolves to null; never leak the raw uid on the public
+			// link - substitute a generic, translatable label instead. Unlike a bare
+			// `@token` in free text, this field is KNOWN to be a uid, so the fallback
+			// is unambiguous here.
+			$author = $this->resolveDisplayName($uid, $displayNames) ?? $this->l10n->t('Former user');
 			$out[] = [
 				'id' => (int)$comment->getId(),
 				'parentCommentId' => $comment->getParentCommentId(),
-				'author' => $displayNames[$uid],
-				'body' => $comment->getBody(),
+				'author' => $author,
+				'body' => $this->redactMentions($comment->getBody(), $displayNames),
 				'createdAt' => $comment->getCreatedAt() ?? 0,
 				'editedAt' => $comment->getEditedAt() ?? 0,
 			];
 		}
 		return $out;
+	}
+
+	/**
+	 * One uid's display name, or NULL when no such account exists (deleted, or
+	 * never existed). The ONLY place this class resolves a uid, and it is memoised
+	 * in the caller's request-scoped cache: one {@see IUserManager::get()} per
+	 * DISTINCT uid per public read, whatever names it in however many places. The
+	 * null result is cached too - `array_key_exists`, not `isset`, is what makes
+	 * that work.
+	 *
+	 * @param array<string, ?string> $displayNames uid => display name (null = no such account)
+	 */
+	private function resolveDisplayName(string $uid, array &$displayNames): ?string {
+		if (!array_key_exists($uid, $displayNames)) {
+			$user = $this->userManager->get($uid);
+			$displayNames[$uid] = $user?->getDisplayName();
+		}
+		return $displayNames[$uid];
+	}
+
+	/**
+	 * Free text (a card description or a comment body) with every `@mention` of a
+	 * REAL account rewritten to that account's display name. Payload-only: the
+	 * stored row is never rewritten, so the mention keeps notifying, keeps
+	 * rendering as a chip for authenticated viewers, and no migration ever touches
+	 * user content.
+	 *
+	 * This is the free-text half of the "uid never leaves" invariant. A mention has
+	 * no entity table - it IS the literal string `@uid` inside these two fields
+	 * ({@see MentionService::MENTION_PATTERN}, reused here rather than restated so
+	 * the two cannot drift) - and the anonymous page renders those tokens as chips.
+	 * So a description reading "@jsmith please review" used to hand an
+	 * unauthenticated token holder a real LOGIN uid for somebody who appears
+	 * nowhere else in the payload, in the DEFAULT configuration (descriptions ship
+	 * with comments toggled off).
+	 *
+	 * A token that does NOT resolve to an account is left BYTE-IDENTICAL. `@2pm`,
+	 * `@nextcloud`, a price, a social handle and `foo@bar.com` are ordinary board
+	 * content, and mangling them would be its own bug - so unlike the comment-author
+	 * byline there is no "Former user" fallback here: a bare `@token` is
+	 * indistinguishable from prose, and a mention of a DELETED account therefore
+	 * keeps its literal text. That residue is the weakest of the three cases (the
+	 * account cannot be logged into, so it is not half of a credential pair) and
+	 * the alternative - rewriting every unresolvable `@word` - would corrupt real
+	 * descriptions on every board.
+	 *
+	 * The substituted name goes through {@see self::inlineSafeName()}, because it is
+	 * spliced into somebody ELSE's markdown: a mentioned user who renames themselves
+	 * `[click](https://evil.example)` must not thereby inject a link into another
+	 * author's description on an anonymous page.
+	 *
+	 * Two behaviours are deliberate rather than accidental, and both are shared with
+	 * the mention feature itself (same pattern, so the public view cannot disagree
+	 * with what the app calls a mention):
+	 *  - A resolving uid is substituted even inside a URL path or a code span
+	 *    (`https://forge.example/@jsmith`, `` `@jsmith` ``). The token really is that
+	 *    person's uid there, so hiding it wins over keeping the link clickable - and
+	 *    the authenticated renderer already chips the URL case (src/services/markdown.js).
+	 *  - A `@`-token that is not a mention by that pattern is not redacted, so a uid
+	 *    shape the pattern cannot express - an email-shaped or space-bearing uid, as
+	 *    LDAP/SAML instances issue - survives. Such a uid never notified anyone either
+	 *    ({@see MentionService} says so); widening the charset is a change to what a
+	 *    mention IS, app-wide, not to this method.
+	 *
+	 * Note the display name can legitimately BE the uid - Nextcloud falls back to
+	 * the uid when an account has no display name set - in which case the
+	 * substitution is a no-op and the uid still shows. Not fixable here: on such an
+	 * instance the uid IS the person's name everywhere else in the product, and
+	 * answering with a generic label instead would blank every mention on the board.
+	 *
+	 * @param array<string, ?string> $displayNames uid => display name (null = no such account), shared cache
+	 */
+	private function redactMentions(?string $text, array &$displayNames): ?string {
+		if ($text === null) {
+			return null;
+		}
+		// Cheap bail-out for the overwhelmingly common mention-free field, so the
+		// regex only ever runs over text that could possibly hold a mention.
+		if (!str_contains($text, '@')) {
+			return $text;
+		}
+
+		// The per-FIELD bound on how many NEW uids one field may resolve. Reusing
+		// MentionService::MAX_MENTIONS is not cosmetic: past that count the write path
+		// already ignores a mention entirely (no notification, no subscription), so
+		// this redacts exactly the tokens the app treats as mentions at all. Per FIELD
+		// rather than per request on purpose - a bound shared across the board would
+		// let ONE card padded with junk `@tokens` (a pasted log, a CSV) spend the
+		// budget and silently de-redact every LATER card's real mentions.
+		$newLookups = 0;
+
+		$redacted = preg_replace_callback(
+			MentionService::MENTION_PATTERN,
+			function (array $match) use (&$displayNames, &$newLookups): string {
+				// `.`, `-` and `_` are legal uid characters, so a mention that ENDS a
+				// sentence swallows the punctuation: "cc @jsmith." captures the token
+				// `jsmith.`, which resolves to nothing and would have shipped the uid
+				// verbatim - a plain bypass of this redaction, reachable by writing
+				// ordinary English (and the same for a trailing `-` or `_`). So the
+				// trailing punctuation run is trimmed and the shorter candidate tried
+				// too, with only the resolved part substituted and the punctuation put
+				// back. (`_@jsmith_` is a different matter: the pattern's negative
+				// lookbehind means a `@` preceded by a word char is not a mention
+				// ANYWHERE in the app - no notification, no chip - so widening that
+				// belongs to MentionService, not here.)
+				//
+				// Exactly two candidates, never a scan of every prefix: `@bob.smith`
+				// does not END in punctuation, so it is looked up once, as itself, and
+				// can never be split into "Bob Builder.smith".
+				$candidates = [$match[1] => ''];
+				$trimmed = rtrim($match[1], '._-');
+				if ($trimmed !== '' && $trimmed !== $match[1]) {
+					$candidates[$trimmed] = substr($match[1], strlen($trimmed));
+				}
+
+				foreach ($candidates as $uid => $tail) {
+					if (!array_key_exists($uid, $displayNames)) {
+						// A uid this request has not seen: the one costly step, so it is
+						// what the bound counts. An already-cached uid still substitutes
+						// below (free), and a comment-author byline never spends the bound
+						// because the counter is local to this field.
+						if ($newLookups >= MentionService::MAX_MENTIONS) {
+							break;
+						}
+						$newLookups++;
+					}
+					$name = $this->resolveDisplayName((string)$uid, $displayNames);
+					if ($name === null) {
+						// No such account: ordinary text, left byte-identical.
+						continue;
+					}
+					return $this->inlineSafeName($name) . $tail;
+				}
+
+				return $match[0];
+			},
+			$text,
+		);
+
+		// preg_replace_callback returns null only on a PCRE failure (e.g. the
+		// backtrack limit). Serving the RAW text then would silently un-fix the leak,
+		// so this fails CLOSED - the null propagates and the field ships empty rather
+		// than unredacted. (The pattern has no nested quantifier, so it cannot
+		// actually backtrack; this is belt-and-braces for a null the signature allows.)
+		return $redacted;
+	}
+
+	/**
+	 * A resolved display name, in a form that is safe to splice into a markdown
+	 * body as LITERAL text.
+	 *
+	 * Almost every real name comes back untouched: hyphens, apostrophes,
+	 * parentheses and sentence dots cannot open a markdown construct, and this
+	 * value is served into fields that BOTH render as markdown (the card detail,
+	 * via v-html after DOMPurify) and print as raw source (the board tile, which
+	 * interpolates the description as plain text - src/views/PublicBoard.vue:51).
+	 * Escaping unconditionally would therefore show "Anne\-Marie Dubois" to every
+	 * anonymous visitor, so a name that needs no escaping gets none.
+	 *
+	 * A name that COULD open a construct is escaped instead of dropped, so the
+	 * reader still sees who it is. That matters because the name is spliced into
+	 * somebody ELSE's text: without this, a mentioned user could rename themselves
+	 * to `[click](https://evil.example)` and inject a link into another author's
+	 * description on an anonymous page. (No XSS either way - markdown-it runs with
+	 * html:false and DOMPurify strips the rest - the exposure is markdown-level
+	 * link/formatting injection.)
+	 *
+	 * A name with nothing displayable falls back to the same generic label the
+	 * author byline uses, never to the raw uid.
+	 */
+	private function inlineSafeName(string $name): string {
+		if (trim($name) === '') {
+			// Defensive: Nextcloud falls back to the uid for a nameless account, so an
+			// empty/blank name should be unreachable. Never answer it with the uid.
+			return $this->l10n->t('Former user');
+		}
+		if (!$this->needsMarkdownEscape($name)) {
+			return $name;
+		}
+		// Escape every ASCII punctuation character - exhaustive by construction, since
+		// CommonMark treats exactly that set as escapable and renders each escape as
+		// the bare character. A PCRE failure here would hand back the UNescaped name,
+		// i.e. precisely the payload this defends against, so it fails closed.
+		return preg_replace('/([!-\/:-@\[-`{-~])/', '\\\\$1', $name) ?? $this->l10n->t('Former user');
+	}
+
+	/**
+	 * Whether a display name has to be escaped before it can be spliced into
+	 * markdown. True for anything that can open an inline construct - a backslash,
+	 * code span, emphasis, link/image bracket, autolink or raw HTML angle, entity
+	 * `&`, strikethrough `~`, table pipe or heading `#` - and for anything
+	 * markdown-it's `linkify: true` would turn into a live link on its own
+	 * (`www.evil.example`, `x.io`, `name@evil.example`), which is the reason a plain
+	 * `.` is not enough on its own but a domain-shaped one is.
+	 *
+	 * Also true for a newline, which would otherwise break the surrounding text into
+	 * new markdown blocks. The check is byte-oriented (no `/u`): every character it
+	 * looks for is ASCII, and a multi-byte sequence cannot contain an ASCII byte, so
+	 * an accented or CJK name is judged safe exactly as it should be.
+	 */
+	private function needsMarkdownEscape(string $name): bool {
+		// preg_match returns false on failure; !== 0 treats that as "escape it".
+		return preg_match('/[\\\\`*_\[\]<>&~|#\r\n]/', $name) !== 0
+			|| preg_match('/[a-z0-9-]\.[a-z]{2,}|@/i', $name) !== 0;
 	}
 
 	/**

--- a/lib/Service/ReviewService.php
+++ b/lib/Service/ReviewService.php
@@ -178,7 +178,7 @@ class ReviewService {
 	 * subscribers are notified and it lands in the discussion.
 	 *
 	 * @throws DoesNotExistException if the card, its board, or the review does not exist
-	 * @throws NotPermittedException if the actor is not the reviewer or cannot read the board
+	 * @throws NotPermittedException if the actor cannot read the board or is not the reviewer (checked in that order)
 	 * @throws InvalidInputException if $state is not a settable verdict
 	 */
 	public function setState(int $cardId, int $reviewId, string $state, string $actorUid, ?string $reason = null): void {
@@ -188,6 +188,14 @@ class ReviewService {
 
 		$card = $this->loadCard($cardId);
 		$board = $this->loadBoard($card->getBoardId());
+		// Membership FIRST, then visibility - the ordering the siblings above use
+		// and {@see CardVisibilityGuard} documents. A reviewer needs READ to act,
+		// and asserting it before the guard (and before the review lookup) stops a
+		// non-member telling 403 from 404 and so probing whether review R exists
+		// on card N.
+		if (($this->permissionService->getPermissions($board, $actorUid) & PermissionService::PERMISSION_READ) === 0) {
+			throw new NotPermittedException('User has no access to this board');
+		}
 		$this->visibilityGuard->assertVisible($board, $card, $actorUid);
 
 		$review = $this->cardReviewMapper->findById($reviewId);
@@ -196,10 +204,6 @@ class ReviewService {
 		}
 		if ($actorUid !== $review->getReviewer()) {
 			throw new NotPermittedException('Only the reviewer may set their review state');
-		}
-		// The reviewer must still be able to read the board to act on the review.
-		if (($this->permissionService->getPermissions($board, $actorUid) & PermissionService::PERMISSION_READ) === 0) {
-			throw new NotPermittedException('User has no access to this board');
 		}
 
 		$reason = $reason !== null ? trim($reason) : null;

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -20,11 +20,31 @@ export default defineConfig({
 	// namespaces all of that per worker — then E2E_WORKERS can be raised safely.
 	//   E2E_ISOLATE=1 E2E_WORKERS=4 npx playwright test
 	workers: process.env.E2E_WORKERS ? Number(process.env.E2E_WORKERS) : 1,
-	// 120s per test: the self-hosted CI runner is ~4-5x slower than a dev box,
-	// so a test that takes ~10s locally can approach the old 60s cap there and
-	// flake. Locally tests still finish in a few seconds, so this only adds
-	// headroom on slow infra (and avoids the retry churn a tight cap caused).
-	timeout: 120_000,
+	// 240s per test: the self-hosted CI runner is ~4-5x slower than a dev box to
+	// begin with, and when the runner POOL is saturated it degrades a further
+	// 1.8-3x on top of that — measured, not guessed: with no code change at all,
+	// `main`'s own e2e job went 39m → 106-119m and its browser-free `unit-php`
+	// job went 1m → 7-8m (2.61x) over one day, and one `e2e` job sat queued 18h
+	// waiting for a runner. Under that load the old 120s cap was inside the
+	// measured range for the suite's longest tests (timeline-view's tall board:
+	// 72s healthy → 120s+ saturated, i.e. it timed out deterministically on all
+	// three attempts), so the cap itself became the failure. 240s keeps ~3x
+	// headroom over the worst duration observed on a saturated runner.
+	//
+	// This costs nothing when the suite is green — a test only spends its budget
+	// when it is already failing. The handful of tests measured close to even
+	// this cap carry their own explicit, commented `test.setTimeout(...)`.
+	timeout: 240_000,
+	// Assertion budget. Playwright's default is 5s, which is the same trap one
+	// level down: an `expect(...)` with no explicit timeout gets 5s to cover a
+	// round-trip that costs ~0.3s healthy and ~1s on a saturated runner, and
+	// several specs lost a whole CI run to exactly that. 15s restores ~3x
+	// headroom for every assertion that never stated a budget of its own.
+	// Raising a timeout can only ever lengthen a wait, so no assertion becomes
+	// weaker: a positive assertion gets longer to succeed, and a negative one
+	// (`not.toBeVisible`, `toHaveCount(0)`) gets longer to catch the thing it
+	// forbids. Only a FAILING assertion spends the extra time.
+	expect: { timeout: 15_000 },
 	// Warm the app once before any spec so the first spec doesn't race
 	// PHP/route-cache cold-start (a long-standing flake on `checklist`, which
 	// runs first alphabetically).

--- a/src/components/BoardListView.vue
+++ b/src/components/BoardListView.vue
@@ -985,7 +985,10 @@ function cardHumanId(card) {
 
 // Per-card progress: prefer the checklist, fall back to child-card progress.
 function cardProgress(card) {
-	if (card.checklist && card.checklist.total > 0) return card.checklist
+	// A board that switched checklists off (#5894) shows no checklist progress —
+	// but sub-card progress is a different feature and still counts, so this falls
+	// through to it rather than dropping the badge.
+	if (cardFeatures.value.checklist && card.checklist && card.checklist.total > 0) return card.checklist
 	if (card.childProgress && card.childProgress.total > 0) return card.childProgress
 	return null
 }

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -2028,19 +2028,33 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</select>
 						</div>
 
-						<!-- Offset days (only when policy = offset after) -->
-						<div v-if="newRecurDuedatePolicy === 1" class="automation__form-row">
-							<label class="automation__form-label" :for="`recur-due-offset-${boardId}`">
-								{{ t('kanso', 'Offset (days)') }}
-							</label>
-							<input
-								:id="`recur-due-offset-${boardId}`"
-								v-model.number="newRecurDuedateOffsetDays"
-								type="number"
-								min="0"
-								step="1"
-								class="workflow__wip-input" />
-						</div>
+						<!-- Offset (only when policy = offset after) -->
+						<template v-if="newRecurDuedatePolicy === 1">
+							<!-- An offset that isn't a whole number of days (set via the
+							     API/MCP) can't be represented by the days control, so it is
+							     shown read-only and kept exactly as stored (#10130). -->
+							<div v-if="isEditingCustomOffset" class="automation__form-row automation__form-row--top">
+								<label class="automation__form-label">{{ t('kanso', 'Offset') }}</label>
+								<div class="automation__custom-schedule">
+									<code class="automation__custom-rrule">{{ editingRecurOffsetLabel }}</code>
+									<span class="automation__custom-note">
+										{{ t('kanso', 'Custom offset — it is kept exactly as it is.') }}
+									</span>
+								</div>
+							</div>
+							<div v-else class="automation__form-row">
+								<label class="automation__form-label" :for="`recur-due-offset-${boardId}`">
+									{{ t('kanso', 'Offset (days)') }}
+								</label>
+								<input
+									:id="`recur-due-offset-${boardId}`"
+									v-model.number="newRecurDuedateOffsetDays"
+									type="number"
+									min="0"
+									step="1"
+									class="workflow__wip-input" />
+							</div>
+						</template>
 
 						<!-- Skip while open (clone mode only) -->
 						<div v-if="newRecurMode === 0" class="automation__form-row">
@@ -4178,6 +4192,29 @@ const isEditingRecurRule = computed(() => editingRecurRuleId.value !== null)
 const editingRecurRrule = ref('')
 const isEditingCustomSchedule = ref(false)
 
+// Same shape one field down (#10130): the API and MCP accept an arbitrary
+// due-date offset in seconds, but this editor only models whole days. A stored
+// offset that is not a whole number of days (e.g. a 1-hour lead time) would be
+// rounded away by the days control, so it is shown read-only and left out of the
+// save — the server then keeps the exact stored seconds.
+const editingRecurDuedateOffsetSeconds = ref(0)
+const isEditingCustomOffset = ref(false)
+
+// Locale-neutral duration rendering of an offset the days control can't model,
+// e.g. 5400 → "1h 30m". The translatable explanation sits in the note beside it.
+const editingRecurOffsetLabel = computed(() => {
+	let s = Math.max(0, Number(editingRecurDuedateOffsetSeconds.value) || 0)
+	const d = Math.floor(s / 86400); s -= d * 86400
+	const h = Math.floor(s / 3600); s -= h * 3600
+	const m = Math.floor(s / 60); s -= m * 60
+	const parts = []
+	if (d) parts.push(`${d}d`)
+	if (h) parts.push(`${h}h`)
+	if (m) parts.push(`${m}m`)
+	if (s) parts.push(`${s}s`)
+	return parts.join(' ') || '0s'
+})
+
 /** Close the settings modal and open the rule's template card (to edit it). */
 function openRecurTemplateCard(rule) {
 	emit('close')
@@ -4192,7 +4229,13 @@ function startEditRecurRule(rule) {
 	newRecurMode.value = rule.mode
 	newRecurSkipWhileOpen.value = rule.skipWhileOpen ?? false
 	newRecurDuedatePolicy.value = rule.duedatePolicy ?? 0
-	newRecurDuedateOffsetDays.value = rule.duedateOffsetSeconds ? Math.round(rule.duedateOffsetSeconds / 86400) : 1
+	// A sub-day / non-day-multiple offset can't be represented by the days control,
+	// so flag it as custom and keep the raw seconds for the read-only display; the
+	// days input is only trusted (and re-sent) for whole-day offsets (#10130).
+	const offsetSeconds = rule.duedateOffsetSeconds ?? 0
+	editingRecurDuedateOffsetSeconds.value = offsetSeconds
+	isEditingCustomOffset.value = offsetSeconds > 0 && offsetSeconds % 86400 !== 0
+	newRecurDuedateOffsetDays.value = offsetSeconds ? Math.round(offsetSeconds / 86400) : 1
 	// Parse rrule back into form fields. A schedule these controls cannot
 	// represent is shown read-only instead — re-serializing it from the five
 	// fields below would silently drop the parts we never parsed.
@@ -4225,6 +4268,8 @@ function cancelEditRecurRule() {
 	newRecurSkipWhileOpen.value = false
 	editingRecurRrule.value = ''
 	isEditingCustomSchedule.value = false
+	editingRecurDuedateOffsetSeconds.value = 0
+	isEditingCustomOffset.value = false
 	createRecurRuleError.value = ''
 }
 
@@ -4270,7 +4315,12 @@ async function submitCreateRecurRule() {
 				data.rrule = rrule
 			}
 		}
-		if (newRecurDuedatePolicy.value === 1) {
+		// Only re-send the offset when the days control actually owns it. A stored
+		// offset that is not a whole number of days is left out entirely, so the
+		// server keeps the exact seconds instead of the days control rounding it to
+		// zero (or to the wrong day) on an unrelated save (#10130). update() treats
+		// an absent offset as "leave unchanged".
+		if (newRecurDuedatePolicy.value === 1 && !isEditingCustomOffset.value) {
 			data.duedateOffsetSeconds = newRecurDuedateOffsetDays.value * 86400
 		}
 		if (newRecurMode.value === 0) {

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -3030,9 +3030,9 @@ async function onEstimateScaleChange(newScale) {
 // A board that never links a contact or attaches a file shouldn't have to look
 // at those controls. Each switch hides ONE built-in card section board-wide.
 // Hiding is not deleting: attachments, contact links, GitHub links, time
-// entries and cover colours stay in the database and reappear untouched when
-// the switch goes back on, and a running timer is never stopped. Enforcement is
-// client-side only — see lib/Db/CardFeatures.php for why.
+// entries, cover colours and checklist items stay in the database and reappear
+// untouched when the switch goes back on, and a running timer is never stopped.
+// Enforcement is client-side only — see lib/Db/CardFeatures.php for why.
 const builtinCardFeatures = [
 	{ key: 'contacts', label: t('kanso', 'Contacts') },
 	{ key: 'attachments', label: t('kanso', 'Attachments') },
@@ -3041,6 +3041,7 @@ const builtinCardFeatures = [
 	{ key: 'github', label: t('kanso', 'Code links') },
 	{ key: 'timeTracking', label: t('kanso', 'Time tracking') },
 	{ key: 'coverColor', label: t('kanso', 'Cover colour') },
+	{ key: 'checklist', label: t('kanso', 'Checklist') },
 ]
 // Reads straight off the board payload, so a change another manager makes
 // arrives through the normal delta/realtime path with no reload.

--- a/src/components/BulkActionBar.vue
+++ b/src/components/BulkActionBar.vue
@@ -8,8 +8,19 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			{{ t('kanso', '{count} selected', { count }) }}
 		</span>
 
+		<!-- The bar is icon-only, so every control also carries a `title` for the
+		     hover tooltip a sighted mouse user relies on (#10275). On NcActions
+		     `title` is a fall-through attribute: it lands on the wrapping
+		     `.action-item` element rather than the trigger button, which is still
+		     what the browser resolves the tooltip from when the button itself has
+		     none. `menuName` is deliberately NOT used — it nulls the trigger's
+		     aria-label and widens the control. The data-driven menus bind their
+		     hint through menuHint() so it disappears along with the menu; see
+		     that helper for why. -->
+
 		<!-- Move to stack -->
 		<NcActions
+			v-bind="menuHint(stacks, t('kanso', 'Move to…'))"
 			:disabled="applying || count === 0"
 			:aria-label="t('kanso', 'Move to…')">
 			<template #icon>
@@ -26,6 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 		<!-- Add label -->
 		<NcActions
+			v-bind="menuHint(labels, t('kanso', 'Add label…'))"
 			:disabled="applying || count === 0"
 			:aria-label="t('kanso', 'Add label…')">
 			<template #icon>
@@ -47,6 +59,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 		<!-- Remove label -->
 		<NcActions
+			v-bind="menuHint(labels, t('kanso', 'Remove label…'))"
 			:disabled="applying || count === 0"
 			:aria-label="t('kanso', 'Remove label…')">
 			<template #icon>
@@ -68,6 +81,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 		<!-- Assign user -->
 		<NcActions
+			v-bind="menuHint(participants, t('kanso', 'Assign…'))"
 			:disabled="applying || count === 0"
 			:aria-label="t('kanso', 'Assign…')">
 			<template #icon>
@@ -82,9 +96,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			</NcActionButton>
 		</NcActions>
 
-		<!-- Set due date -->
+		<!-- Set due date — a fixed two-entry menu, so it never collapses and can
+		     carry its hint directly. -->
 		<NcActions
 			:disabled="applying || count === 0"
+			:title="t('kanso', 'Set due date…')"
 			:aria-label="t('kanso', 'Set due date…')">
 			<template #icon>
 				<CalendarClockIcon :size="20" />
@@ -203,6 +219,26 @@ defineProps({
 		default: false,
 	},
 })
+
+/**
+ * Hover hint for one of the data-driven menu triggers, bound with `v-bind` so
+ * the attribute is ABSENT rather than empty when it must not apply.
+ *
+ * NcActions renders nothing at all for an empty menu, and collapses to a single
+ * button that acts immediately when it holds exactly one entry. In that
+ * collapsed form the library already sets a better `title` — the entry's own
+ * name ("Bug", "Alice") — and a menu label ending in "…" would promise a picker
+ * that never opens. Passing `title: null` would not help: a fall-through
+ * attribute is merged unconditionally, so it would wipe the library's title
+ * instead of leaving it alone. Hence an object with or without the key.
+ *
+ * @param {Array} items entries the menu will render
+ * @param {string} label hint to show while it really is a menu
+ * @return {object} `{ title }` for a real menu, `{}` otherwise
+ */
+function menuHint(items, label) {
+	return items.length > 1 ? { title: label } : {}
+}
 
 const emit = defineEmits(['move', 'add-label', 'remove-label', 'assign', 'set-due', 'set-status', 'archive', 'delete', 'close'])
 

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1265,12 +1265,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									:class="{ 'card-modal__checklist-item--done': item.done }"
 									:data-item-id="item.id"
 									:data-drag-over="dragOverItemId === item.id ? 'true' : 'false'"
+									:aria-busy="isUnsavedItem(item) ? 'true' : undefined"
 									@dragover.prevent="onItemDragOver($event, item)"
 									@dragleave="onItemDragLeave($event, item)"
 									@drop.prevent="onItemDrop($event, item)">
 									<span
 										class="card-modal__checklist-drag"
-										:draggable="true"
+										:draggable="!isUnsavedItem(item)"
 										:title="t('kanso', 'Drag to reorder')"
 										@dragstart="onItemDragStart($event, item)"
 										@dragend="onItemDragEnd">
@@ -1299,6 +1300,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 										:class="{ 'card-modal__checklist-item-title--done': item.done }"
 										role="button"
 										tabindex="0"
+										:aria-disabled="isUnsavedItem(item) ? 'true' : undefined"
 										:aria-label="t('kanso', 'Edit item')"
 										@click="startItemEdit(item)"
 										@keydown.enter.prevent="startItemEdit(item)"
@@ -1358,7 +1360,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									<button
 										class="card-modal__checklist-item-delete"
 										:title="t('kanso', 'Delete item')"
-										:disabled="deleteItem.isPending.value"
+										:disabled="deleteItem.isPending.value || isUnsavedItem(item)"
 										@click="handleDeleteItem(item)">
 										<CloseIcon :size="14" />
 									</button>
@@ -3792,11 +3794,16 @@ async function handleAddItem() {
 
 // A checklist row rendered from the optimistic create still carries the negative
 // placeholder id `useChecklist` assigns it, and is not addressable on the server
-// yet. Its checkbox and its step pickers (assign / due date) are disabled until
-// the create resolves and swaps in the real row, so a click in that window waits
-// instead of firing `PATCH|POST /api/checklist/-1788…` — which can never match
-// and used to drop the toggle, or the assignment, silently after rolling the
-// optimistic change back with a bare "Not found".
+// yet. Every ENTRY POINT into a row — the checkbox, the step pickers (assign /
+// due date), delete, inline rename and drag-reorder — is guarded here, so an
+// action in that window waits instead of firing
+// `PATCH|POST|DELETE /api/checklist/-1788…`, which can never match a row and used
+// to roll the change back with a bare "Not found": the toggle and the assignment
+// were dropped silently, and a delete was worse still — the row vanished and then
+// came BACK when the in-flight create landed. The mutation helpers behind the step
+// popover (assign / unassign / due / clear-due) carry no guard of their own: they
+// are reachable only through a popover that `toggleStepMenu` refuses to open on an
+// unsaved row.
 function isUnsavedItem(item) {
 	return Number(item?.id) < 0
 }
@@ -3812,6 +3819,11 @@ async function handleToggleItem(item) {
 }
 
 async function handleDeleteItem(item) {
+	// Backs up the `:disabled` on the delete button. Deleting an unsaved row sent
+	// `DELETE /api/checklist/-1788…` → 404, which rolled the optimistic removal
+	// back WHILE the create was still in flight, so the step the user just deleted
+	// reappeared a moment later.
+	if (isUnsavedItem(item)) return
 	checklistError.value = ''
 	try {
 		await deleteItem.mutateAsync({ item })
@@ -3834,6 +3846,13 @@ function setItemInputRef(id, el) {
 }
 
 async function startItemEdit(item) {
+	// The editor is keyed by the row id (`editingItemId === item.id`, and the row
+	// itself by `:key="item.id"`), so opening it on an unsaved row was doubly
+	// broken: saving sent `PATCH /api/checklist/-1788…` → 404 "Failed to rename
+	// item.", and if the create resolved mid-edit the id swap tore the input down
+	// without a blur and threw the typed title away. Editing waits for the real id
+	// instead — the same window the row's other controls already wait out.
+	if (isUnsavedItem(item)) return
 	editingItemId.value = item.id
 	editingItemTitle.value = item.title
 	await nextTick()
@@ -3963,6 +3982,15 @@ const draggingItem = ref(null)
 const dragOverItemId = ref(null)
 
 function onItemDragStart(event, item) {
+	// Backs up `:draggable="!isUnsavedItem(item)"` on the handle: a row still on its
+	// placeholder id cannot be reordered, in either role. Dragging it sent
+	// `POST /api/checklist/-1788…/move` → 404; dropping onto it sent a real row's
+	// move with `afterItemId: -1788…` → 400 "afterItemId is not an item of this
+	// card" (see onItemDragOver / onItemDrop for the drop-target half).
+	if (isUnsavedItem(item)) {
+		event.preventDefault()
+		return
+	}
 	draggingItem.value = item
 	event.dataTransfer.effectAllowed = 'move'
 	event.dataTransfer.setData('text/plain', String(item.id))
@@ -3974,7 +4002,8 @@ function onItemDragEnd() {
 }
 
 function onItemDragOver(event, item) {
-	if (!draggingItem.value || draggingItem.value.id === item.id) return
+	// No drop indicator on an unsaved row — the drop it advertises can't be sent.
+	if (!draggingItem.value || draggingItem.value.id === item.id || isUnsavedItem(item)) return
 	event.dataTransfer.dropEffect = 'move'
 	dragOverItemId.value = item.id
 }
@@ -3986,7 +4015,10 @@ function onItemDragLeave(_event, item) {
 }
 
 async function onItemDrop(event, targetItem) {
-	if (!draggingItem.value || draggingItem.value.id === targetItem.id) {
+	// `isUnsavedItem(targetItem)`: the drop-target half of the guard in
+	// onItemDragStart — the move would carry `afterItemId: -1788…`, which is not a
+	// row of this card, so the server rejects it with a 400.
+	if (!draggingItem.value || draggingItem.value.id === targetItem.id || isUnsavedItem(targetItem)) {
 		dragOverItemId.value = null
 		return
 	}
@@ -4006,6 +4038,13 @@ async function onItemDrop(event, targetItem) {
 		// Insert before the target → sit after the target's predecessor,
 		// skipping the item being moved (so dragging item #2 onto item #1's top
 		// half lands it at the top, not back where it was).
+		//
+		// The predecessor cannot be an unsaved row, so `afterItemId` cannot carry a
+		// placeholder id: an optimistic row is appended LAST (useChecklist.addItem),
+		// and there is only ever one of them, because the add input is disabled
+		// while `addItem.isPending`. If concurrent creates ever become possible, a
+		// placeholder could sit ahead of a real row and this scan would need the
+		// same isUnsavedItem check the drop target above gets.
 		const ordered = checklistItems.value
 		const targetIdx = ordered.findIndex((i) => i.id === targetItem.id)
 		let predecessor = null
@@ -7648,10 +7687,21 @@ body.theme--dark .card-modal,
 .card-modal__checklist-item[data-drag-over='true'] {
 	box-shadow: inset 0 2px 0 var(--color-primary-element);
 }
+/* Still on its optimistic placeholder id: every control that addresses the row
+   by id is inert for this window, so the row reads as pending rather than
+   leaving the user clicking a title that silently does nothing. */
+.card-modal__checklist-item[aria-busy='true'] {
+	opacity: 0.65;
+}
 .card-modal__checklist-drag {
 	display: inline-flex;
 	color: var(--color-border-dark);
 	cursor: grab;
+}
+/* A row still on its optimistic placeholder id can't be reordered yet. */
+.card-modal__checklist-drag[draggable='false'] {
+	cursor: default;
+	opacity: 0.5;
 }
 .card-modal__checklist-checkbox {
 	width: 16px;
@@ -7666,6 +7716,9 @@ body.theme--dark .card-modal,
 	color: var(--color-main-text);
 	cursor: text;
 	word-break: break-word;
+}
+.card-modal__checklist-item-title[aria-disabled='true'] {
+	cursor: default;
 }
 .card-modal__checklist-item-title--done {
 	color: var(--color-text-maxcontrast);
@@ -7762,9 +7815,13 @@ body.theme--dark .card-modal,
 	color: var(--color-text-maxcontrast);
 	cursor: pointer;
 }
-.card-modal__checklist-item-delete:hover {
+.card-modal__checklist-item-delete:hover:not(:disabled) {
 	background: var(--color-error);
 	color: #fff;
+}
+.card-modal__checklist-item-delete:disabled {
+	cursor: default;
+	opacity: 0.5;
 }
 .card-modal__checklist-add {
 	display: flex;

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -4618,6 +4618,19 @@ async function handleToggleResolved(topComment) {
 // isn't in the loaded thread (deleted / not yet loaded) - never throws.
 const highlightedCommentId = ref(null)
 let highlightTimer = null
+// The thread pane is still settling when we scroll, and the deferral below can
+// only ever guess at how long that takes. The composer under the thread renders
+// its MarkdownEditor as a LAZY chunk (defineAsyncComponent) behind a much shorter
+// placeholder, so on a slow connection - or a slow machine - the real editor
+// mounts AFTER the scroll and grows, and `.card-modal__thread-scroll` (flex: 1)
+// shrinks by exactly that much. `scrollTop` survives the shrink; the comment we
+// centred does not, and since `scrollHandled` is already latched nothing scrolls
+// again. A reminder or mention link then lands the reader on a nearby comment
+// with no sign that it missed. So the scroll is not a one-shot: the target is
+// re-pinned on every resize of the pane, for exactly as long as the highlight is
+// up (4s) - the window in which the app is still telling the reader "this is the
+// one you came for".
+let threadResizeObserver = null
 
 function parseTargetCommentId() {
 	// Prefer the query the boot handoff set; fall back to a raw location hash so
@@ -4677,12 +4690,44 @@ async function scrollToTargetComment() {
 	await new Promise((r) => requestAnimationFrame(r))
 	await new Promise((r) => requestAnimationFrame(r))
 	el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+	pinTargetWhileThreadSettles(el)
 	highlightedCommentId.value = id
 	if (highlightTimer) clearTimeout(highlightTimer)
 	highlightTimer = setTimeout(() => {
 		highlightedCommentId.value = null
 		highlightTimer = null
+		stopPinningTarget()
 	}, 4000)
+}
+
+/**
+ * Keep `el` centred while the thread pane is still resizing under it.
+ *
+ * Only a RESIZE re-scrolls, so this does not fight the reader: scrolling the
+ * thread by hand does not resize it, and once the composer has settled the
+ * observer stops firing on its own. It is torn down with the highlight either
+ * way, so the correction window is bounded by the same 4s the highlight is.
+ *
+ * @param {HTMLElement} el the deep-linked comment node
+ */
+function pinTargetWhileThreadSettles(el) {
+	if (typeof ResizeObserver === 'undefined') return
+	const scroller = el.closest('.card-modal__thread-scroll')
+	if (!scroller) return
+	stopPinningTarget()
+	threadResizeObserver = new ResizeObserver(() => {
+		// Instant, not smooth: this corrects a scroll that already ran, and a
+		// second animation would be interrupted by the next resize anyway.
+		el.scrollIntoView({ block: 'center' })
+	})
+	threadResizeObserver.observe(scroller)
+}
+
+function stopPinningTarget() {
+	if (threadResizeObserver) {
+		threadResizeObserver.disconnect()
+		threadResizeObserver = null
+	}
 }
 
 // The thread loads async, so wait until comments actually arrive, then scroll.
@@ -5320,6 +5365,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
 	document.removeEventListener('mousedown', onDocumentMousedown, true)
 	if (highlightTimer) clearTimeout(highlightTimer)
+	stopPinningTarget()
 })
 
 // The modal shell funnels its X button here, and the backdrop handler above does

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1340,6 +1340,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											v-if="!item.assignedUser"
 											class="card-modal__step-btn"
 											:title="t('kanso', 'Assign step')"
+											:disabled="isUnsavedItem(item)"
 											:aria-expanded="isStepMenuOpen(item, 'assign')"
 											@click="toggleStepMenu(item, 'assign')">
 											<AccountPlusIcon :size="14" />
@@ -1348,6 +1349,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											v-if="!item.dueDate"
 											class="card-modal__step-btn"
 											:title="t('kanso', 'Set step due date')"
+											:disabled="isUnsavedItem(item)"
 											:aria-expanded="isStepMenuOpen(item, 'due')"
 											@click="toggleStepMenu(item, 'due')">
 											<CalendarIcon :size="14" />
@@ -3790,10 +3792,11 @@ async function handleAddItem() {
 
 // A checklist row rendered from the optimistic create still carries the negative
 // placeholder id `useChecklist` assigns it, and is not addressable on the server
-// yet. Its checkbox is disabled until the create resolves and swaps in the real
-// row, so a click in that window waits instead of firing
-// `PATCH /api/checklist/-1788…` — which can never match and used to drop the
-// toggle silently after rolling the optimistic tick back.
+// yet. Its checkbox and its step pickers (assign / due date) are disabled until
+// the create resolves and swaps in the real row, so a click in that window waits
+// instead of firing `PATCH|POST /api/checklist/-1788…` — which can never match
+// and used to drop the toggle, or the assignment, silently after rolling the
+// optimistic change back with a bare "Not found".
 function isUnsavedItem(item) {
 	return Number(item?.id) < 0
 }
@@ -3868,6 +3871,11 @@ function isStepMenuOpen(item, type) {
 	return openStepMenu.value === `${type}:${item.id}`
 }
 function toggleStepMenu(item, type) {
+	// Belt and braces with the `:disabled` on the two picker buttons, exactly as
+	// `handleToggleItem` backs up the checkbox: an unsaved row has no server id to
+	// address, and the popover key is `${type}:${item.id}`, so a menu opened on the
+	// placeholder id would also vanish the moment the create swaps the real one in.
+	if (isUnsavedItem(item)) return
 	const key = `${type}:${item.id}`
 	openStepMenu.value = openStepMenu.value === key ? null : key
 }
@@ -7728,9 +7736,13 @@ body.theme--dark .card-modal,
 	color: var(--color-text-maxcontrast);
 	cursor: pointer;
 }
-.card-modal__step-btn:hover {
+.card-modal__step-btn:hover:not(:disabled) {
 	background: var(--color-background-dark);
 	color: var(--color-main-text);
+}
+.card-modal__step-btn:disabled {
+	cursor: default;
+	opacity: 0.5;
 }
 .card-modal__step-popover {
 	top: calc(100% - 4px);

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1241,8 +1241,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</template>
 						</section>
 
-						<!-- Checklist - promoted next to the description -->
-						<section v-if="checklistTotal > 0 || canEdit" class="card-modal__checklist">
+						<!-- Checklist - promoted next to the description. Hidden entirely
+						     when the board switched checklists off (#5894); the items stay
+						     in the database and come back on re-enable. -->
+						<section v-if="cardFeatures.checklist && (checklistTotal > 0 || canEdit)" class="card-modal__checklist">
 							<div class="card-modal__checklist-head">
 								<CheckboxMarkedOutlineIcon :size="16" class="card-modal__checklist-head-icon" />
 								<span class="card-modal__checklist-title">{{ t('kanso', 'Checklist') }}</span>

--- a/src/components/CardPreview.vue
+++ b/src/components/CardPreview.vue
@@ -60,9 +60,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				{{ dueLabel }}
 			</span>
 
-			<!-- Checklist progress -->
+			<!-- Checklist progress - hidden when the board switched checklists off (#5894) -->
 			<span
-				v-if="card.checklist && card.checklist.total > 0"
+				v-if="cardFeatures.checklist && card.checklist && card.checklist.total > 0"
 				class="card-preview__checklist"
 				:class="{ 'card-preview__checklist--complete': card.checklist.done === card.checklist.total }">
 				<CheckboxMarkedOutlineIcon :size="12" />
@@ -122,6 +122,7 @@ import { cssColor, readableColor } from '../services/color.js'
 import { humanId } from '../services/humanId.js'
 import { PRIORITY_LEVELS } from '../composables/usePriority.js'
 import { formatCardDate } from '../utils/dateDisplay.js'
+import { useCardFeatures } from '../services/cardFeatures.js'
 
 const props = defineProps({
 	/** Board summary card (title, boardSeq, labelIds, assigneeIds, priority, duedate, checklist). */
@@ -167,6 +168,10 @@ const renderedDescription = computed(() =>
 )
 
 // ── Cache-first meta (all from the board summary card) ────────────────────────
+// Built-in card sections the board switched off (#5894). Provided by BoardView,
+// which is where the preview is rendered from.
+const cardFeatures = useCardFeatures()
+
 const cardHumanId = computed(() => humanId(props.boardPrefix, props.card.boardSeq))
 
 const cardLabels = computed(() => {
@@ -182,7 +187,7 @@ const hasMeta = computed(() =>
 	cardLabels.value.length > 0
 		|| props.card.priority > 0
 		|| !!props.card.duedate
-		|| (props.card.checklist && props.card.checklist.total > 0)
+		|| (cardFeatures.value.checklist && props.card.checklist && props.card.checklist.total > 0)
 		|| assigneeIds.value.length > 0,
 )
 

--- a/src/components/CardTile.vue
+++ b/src/components/CardTile.vue
@@ -49,7 +49,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<span class="card-tile__title" :class="{ 'card-tile__title--done': isDone }">{{ card.title }}</span>
 			<!-- Single meta row: all badges inline, assignees pushed to the right -->
 			<div
-				v-if="card.parentCardId || isInProgress || card.blocked || card.waitingOnExternal || card.recurring || (card.timerRunning && cardFeatures.timeTracking) || card.duedate || (card.checklist && card.checklist.total > 0) || (card.childProgress && card.childProgress.total > 0) || card.commentCount > 0 || card.priority > 0 || cardType || (card.assigneeIds && card.assigneeIds.length) || card.reviewState || card.estimate || isRestricted"
+				v-if="card.parentCardId || isInProgress || card.blocked || card.waitingOnExternal || card.recurring || (card.timerRunning && cardFeatures.timeTracking) || card.duedate || (cardFeatures.checklist && card.checklist && card.checklist.total > 0) || (card.childProgress && card.childProgress.total > 0) || card.commentCount > 0 || card.priority > 0 || cardType || (card.assigneeIds && card.assigneeIds.length) || card.reviewState || card.estimate || isRestricted"
 				class="card-tile__meta">
 				<!-- Sub-card marker: this card hangs under another one. The board draws
 				     no indent (columns are flat), so without this a sub-card is
@@ -160,9 +160,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					:title="t('kanso', 'Timer running')">
 					<TimerOutlineIcon :size="14" />
 				</span>
-				<!-- Checklist progress badge - only when the card has checklist items -->
+				<!-- Checklist progress badge - only when the card has checklist items
+				     and the board still shows checklists (#5894). -->
 				<span
-					v-if="card.checklist && card.checklist.total > 0"
+					v-if="cardFeatures.checklist && card.checklist && card.checklist.total > 0"
 					class="card-tile__checklist"
 					:class="{ 'card-tile__checklist--complete': card.checklist.done === card.checklist.total }"
 					:aria-label="t('kanso', 'Checklist progress')">

--- a/src/components/CsvImportModal.vue
+++ b/src/components/CsvImportModal.vue
@@ -46,6 +46,36 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				</div>
 			</template>
 
+			<!-- Step 3: report what landed. Navigating straight to the board hid
+			     the skipped rows and the labels that were never created — a
+			     partial import must not look like a complete one. -->
+			<template v-else-if="step === 'summary'">
+				<ul class="csv-import__summary" role="status" data-test="csv-import-summary">
+					<li>{{ n('kanso', '%n card created', '%n cards created', summary.cards) }}</li>
+					<li v-if="summary.labelsCreated > 0">
+						{{ n('kanso', '%n label created', '%n labels created', summary.labelsCreated) }}
+					</li>
+				</ul>
+				<p v-if="summary.skipped > 0" class="csv-import__warning" role="status" data-test="csv-import-skipped-rows">
+					{{ n('kanso',
+						'%n row was skipped because it had no title.',
+						'%n rows were skipped because they had no title.',
+						summary.skipped) }}
+				</p>
+				<p v-if="summary.labelsSkipped > 0" class="csv-import__warning" role="status" data-test="csv-import-labels-skipped">
+					{{ n('kanso',
+						'%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards.',
+						'%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards.',
+						summary.labelsSkipped) }}
+				</p>
+				<div class="csv-import__actions">
+					<NcButton type="primary" data-test="csv-import-open" @click="$emit('open-board', summary)">
+						{{ t('kanso', 'Open board') }}
+					</NcButton>
+					<NcButton @click="$emit('close')">{{ t('kanso', 'Close') }}</NcButton>
+				</div>
+			</template>
+
 			<!-- Step 2: choose board + stack, map columns, confirm. -->
 			<template v-else>
 				<div class="csv-import__grid">
@@ -104,9 +134,12 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import UploadIcon from 'vue-material-design-icons/Upload.vue'
 import { fetchBoards, fetchBoard, importCsvCards } from '../services/api.js'
 
-const emit = defineEmits(['close', 'imported'])
+const emit = defineEmits(['close', 'imported', 'open-board'])
 
+// 'source' → 'mapping' → 'summary'.
 const step = ref('source')
+// The import result, rendered on the summary step.
+const summary = ref(null)
 const rawText = ref('')
 const parseError = ref('')
 const fileInput = ref(null)
@@ -257,7 +290,11 @@ async function doImport() {
 	}
 	try {
 		const res = await importCsvCards(targetBoardId.value, targetStackId.value, rawText.value, sent, true)
-		emit('imported', { boardId: targetBoardId.value, ...res })
+		summary.value = { boardId: targetBoardId.value, ...res }
+		// The parent refreshes the board list; the modal stays open and reports
+		// the counts (including anything skipped) before the user moves on.
+		emit('imported', summary.value)
+		step.value = 'summary'
 	} catch (err) {
 		parseError.value = err?.response?.data?.error || t('kanso', 'Could not import that CSV.')
 	} finally {
@@ -349,6 +386,19 @@ async function doImport() {
 .csv-import__error {
 	color: var(--color-error);
 	font-size: 0.85rem;
+	margin: 0;
+}
+
+.csv-import__summary {
+	list-style: disc;
+	padding-left: 20px;
+	margin: 0;
+	color: var(--color-main-text);
+}
+
+.csv-import__warning {
+	color: var(--color-warning-text, var(--color-error));
+	font-weight: 600;
 	margin: 0;
 }
 

--- a/src/composables/useBoard.js
+++ b/src/composables/useBoard.js
@@ -75,16 +75,35 @@ export function useBoard(id) {
 	// captures its delay once at setup and would pin the board to whatever push
 	// looked like the instant the view mounted - the flag flipping later would
 	// change nothing.
+	//
+	// Hidden tabs don't poll (#10278). Every sibling feed gets this for free from
+	// TanStack's refetchIntervalInBackground=false default (queryKeys.js,
+	// useMyReviews.js, useInbox.js); this loop is hand-rolled, so it has to
+	// implement the same policy itself - a board left open in a background tab
+	// otherwise hits /changes forever, and that tick is NOT free: the endpoint
+	// has no ETag/304 path (BoardController::changes), so every empty poll still
+	// costs a request, an ACL check and a findSince.
+	// Read as `visibilityState`, the same bit main.js:invalidateMyWorkThrottled and
+	// TanStack's own focusManager test, so the whole app agrees on one definition
+	// of "hidden". `typeof document` because the unit rig stubs `window` without a
+	// DOM.
+	const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden'
+	// The one condition that makes a tick worth doing. Mid-drag is skipped for
+	// the reason syncBoardDelta documents: a patch would clobber the optimistic
+	// placement.
+	const shouldSync = () => !isHidden() && !isBoardMovePending(id)
 	let deltaTimer = null
 	const scheduleDelta = () => {
 		deltaTimer = setTimeout(() => {
 			// The re-arm is in a `finally` because this loop IS the poll: unlike
 			// setInterval - which fires again regardless of what its callback did -
 			// a single throw here would end the chain for the lifetime of the page
-			// and leave only the 60s refetch. Same reason the mid-drag skip below
-			// is a condition and not an early return.
+			// and leave only the 60s refetch. Same reason the skips above are
+			// conditions and not an early return: an early `return` past this
+			// finally would stop the poll for the rest of the session, silently,
+			// for VISIBLE tabs too.
 			try {
-				if (!isBoardMovePending(id)) {
+				if (shouldSync()) {
 					syncBoardDelta(queryClient, id)
 				}
 			} finally {
@@ -93,7 +112,36 @@ export function useBoard(id) {
 		}, pushActive() ? 30_000 : 5_000)
 	}
 	scheduleDelta()
-	onScopeDispose(() => clearTimeout(deltaTimer))
+
+	// Catch the tab up on the way back in, for the window nothing else covers.
+	// TanStack's focusManager listens to this same event, so a return already
+	// triggers the query's own refetchOnWindowFocus - but only once the data is
+	// stale, and staleTime is 30s globally (main.js). Hide for 10s and come back
+	// and no refetch fires; without this handler the board would then wait out the
+	// rest of the poll interval. This covers exactly that sub-staleTime gap, and it
+	// covers it as a delta (O(changes)) rather than a full board read.
+	//
+	// visibilitychange fires on hide as well as show, hence the guard inside: only
+	// the transition TO visible does work. And, like the loop above, this is per
+	// useBoard instance - CardDetail's is alive on top of BoardView's while a card
+	// modal is open - so a return costs one delta read per live consumer, all in
+	// one event dispatch with the same cursor. That is the fan-out #10279 measures:
+	// the loop already has it (staggered by mount time instead), it is not made
+	// worse here, and it is not fixed here either.
+	const onVisibilityChange = () => {
+		if (shouldSync()) {
+			syncBoardDelta(queryClient, id)
+		}
+	}
+	if (typeof document !== 'undefined') {
+		document.addEventListener('visibilitychange', onVisibilityChange)
+	}
+	onScopeDispose(() => {
+		clearTimeout(deltaTimer)
+		if (typeof document !== 'undefined') {
+			document.removeEventListener('visibilitychange', onVisibilityChange)
+		}
+	})
 
 	const createStack = useMutation({
 		mutationFn: (data) => apiCreateStack(data),

--- a/src/composables/useBoard.js
+++ b/src/composables/useBoard.js
@@ -88,11 +88,33 @@ export function useBoard(id) {
 	// of "hidden". `typeof document` because the unit rig stubs `window` without a
 	// DOM.
 	const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden'
-	// The one condition that makes a tick worth doing. Mid-drag is skipped for
-	// the reason syncBoardDelta documents: a patch would clobber the optimistic
-	// placement.
-	const shouldSync = () => !isHidden() && !isBoardMovePending(id)
+	// The one condition this loop owns: a tab nobody is looking at does no work.
+	//
+	// Mid-drag suppression is deliberately NOT duplicated here. syncBoardDelta
+	// refuses at its own entry, which covers this loop and the visibilitychange
+	// handler below alike. A second copy lived here until #10292, and the pair was
+	// worse than either alone: with both in place, deleting EITHER left the whole
+	// realtime suite green, because the other still refused - so neither guard was
+	// pinned by any test. Now the entry check is the one this loop relies on, and
+	// pushLiveness.test.mjs ('the poll survives ticks it skips') reddens if it goes.
+	//
+	// Two further copies of the check exist and are NOT pinned by anything
+	// (measured, not assumed): syncBoardDelta's post-fetch re-check, which covers a
+	// move that starts while the delta is in flight and so is genuinely load-bearing,
+	// and main.js's pre-check on the push path. Neither is touched here - they are
+	// their own follow-up, not a licence to add a third copy back into this file.
+	const shouldSync = () => !isHidden()
 	let deltaTimer = null
+	// The dispose below clears `deltaTimer`, but clearTimeout can only cancel a
+	// timer that is still PENDING. A dispose landing after this callback entered its
+	// `try` and before the `finally` would find nothing to cancel, and the finally
+	// would then arm a fresh timer nothing holds a handle to: an immortal 5s
+	// /changes loop for a board that no longer exists, one per occurrence. No such
+	// path is known today (Vue defers unmount to its scheduler, and the only
+	// synchronous work in the try is an invalidation), but CardDetail and
+	// BoardSettingsModal each compose useBoard per open, so the blast radius if one
+	// ever appears is per-interaction - and the latch is one line (#10292).
+	let stopped = false
 	const scheduleDelta = () => {
 		deltaTimer = setTimeout(() => {
 			// The re-arm is in a `finally` because this loop IS the poll: unlike
@@ -107,7 +129,9 @@ export function useBoard(id) {
 					syncBoardDelta(queryClient, id)
 				}
 			} finally {
-				scheduleDelta()
+				if (!stopped) {
+					scheduleDelta()
+				}
 			}
 		}, pushActive() ? 30_000 : 5_000)
 	}
@@ -137,6 +161,9 @@ export function useBoard(id) {
 		document.addEventListener('visibilitychange', onVisibilityChange)
 	}
 	onScopeDispose(() => {
+		// Both are needed: the latch stops a re-arm from inside a tick already in
+		// flight, clearTimeout stops the one sitting in the queue.
+		stopped = true
 		clearTimeout(deltaTimer)
 		if (typeof document !== 'undefined') {
 			document.removeEventListener('visibilitychange', onVisibilityChange)

--- a/src/composables/useBoard.js
+++ b/src/composables/useBoard.js
@@ -68,13 +68,32 @@ export function useBoard(id) {
 	// (5s), a slow secondary safety net when push covers realtime (30s, since the
 	// push handler in main.js already delta-syncs on each mutation). Guarded to
 	// never run mid-drag inside syncBoardDelta.
-	const deltaTimer = setInterval(() => {
-		if (isBoardMovePending(id)) {
-			return
-		}
-		syncBoardDelta(queryClient, id)
-	}, pushActive() ? 30_000 : 5_000)
-	onScopeDispose(() => clearInterval(deltaTimer))
+	//
+	// A self-rescheduling timeout, not setInterval, on purpose (#10225):
+	// pushActive() is false until the first push frame proves the socket is
+	// really live, so the cadence has to be re-read on every tick. setInterval
+	// captures its delay once at setup and would pin the board to whatever push
+	// looked like the instant the view mounted - the flag flipping later would
+	// change nothing.
+	let deltaTimer = null
+	const scheduleDelta = () => {
+		deltaTimer = setTimeout(() => {
+			// The re-arm is in a `finally` because this loop IS the poll: unlike
+			// setInterval - which fires again regardless of what its callback did -
+			// a single throw here would end the chain for the lifetime of the page
+			// and leave only the 60s refetch. Same reason the mid-drag skip below
+			// is a condition and not an early return.
+			try {
+				if (!isBoardMovePending(id)) {
+					syncBoardDelta(queryClient, id)
+				}
+			} finally {
+				scheduleDelta()
+			}
+		}, pushActive() ? 30_000 : 5_000)
+	}
+	scheduleDelta()
+	onScopeDispose(() => clearTimeout(deltaTimer))
 
 	const createStack = useMutation({
 		mutationFn: (data) => apiCreateStack(data),

--- a/src/services/cardFeatures.js
+++ b/src/services/cardFeatures.js
@@ -11,15 +11,15 @@ import { computed, inject } from 'vue'
  * board that predates the feature reads as all-enabled.
  *
  * Switching a feature off HIDES its UI and nothing else. Attachments, contact
- * links, GitHub links, time entries and cover colours are never deleted, a
- * running timer is not stopped, and old activity entries stay readable — so
- * re-enabling brings everything back exactly as it was.
+ * links, GitHub links, time entries, cover colours and checklist items are
+ * never deleted, a running timer is not stopped, and old activity entries stay
+ * readable — so re-enabling brings everything back exactly as it was.
  *
  * Enforcement is CLIENT-SIDE ONLY and deliberately so: the API still accepts an
  * upload or a timer start on a board whose switch is off. See the class
  * docblock on `lib/Db/CardFeatures.php` for why.
  */
-export const CARD_FEATURE_KEYS = ['contacts', 'attachments', 'github', 'timeTracking', 'coverColor']
+export const CARD_FEATURE_KEYS = ['contacts', 'attachments', 'github', 'timeTracking', 'coverColor', 'checklist']
 
 /** Every feature on — the shape used whenever a board hasn't said otherwise. */
 export const ALL_CARD_FEATURES_ENABLED = Object.freeze(

--- a/src/services/realtime.js
+++ b/src/services/realtime.js
@@ -7,41 +7,76 @@ import { listen } from '@nextcloud/notify_push'
  * notify_push bridge. The backend broadcasts a `kanso_board_changed` custom
  * event (body: {boardId}) to every board participant on each mutation.
  *
- * `listen()` returns synchronously whether push is available on this server
- * (the notify_push capability is present); the websocket itself connects,
- * authenticates and reconnects in the background. When push is unavailable
- * the listener is simply never called and polling (see useBoard) carries
- * realtime alone.
+ * `listen()` returns synchronously whether push is ADVERTISED by this server -
+ * that is only the notify_push capability, never connectivity: the flag it
+ * returns (`window._notify_push_available`) is set from the capability object
+ * before the library has even constructed the WebSocket, so it cannot reflect
+ * whether the daemon is up or the reverse proxy forwards /push. The socket
+ * connects, authenticates and reconnects in the background. When push is
+ * unavailable the listener is simply never called and polling (see useBoard)
+ * carries realtime alone.
  */
 
 const EVENT_NAME = 'kanso_board_changed'
 
 // initRealtime is called once from main.js module top-level; if it ever
 // moves into a component's setup it needs an idempotency guard.
-let active = false
+let available = false
+
+// Push liveness latch (#10225). `available` above is the server's ADVERTISEMENT
+// and stays true on an instance whose notify_push daemon is dead or whose proxy
+// never forwards the websocket - a common self-hosted state, and one the
+// capability never retracts once `notify_push:setup` has succeeded once.
+// Trusting it there stretched every board's delta poll 5s -> 30s while no frame
+// could ever arrive, so a change took up to 30s to show. So we are pessimistic:
+// a RECEIVED frame is the only unambiguous evidence the whole path works, and
+// nothing short of one flips this.
+//
+// Deliberately one-way, and deliberately module-global:
+//  - One-way: if the socket dies AFTER a frame arrived, this stays true and
+//    that session keeps the 30s cadence. Closing that hole needs a liveness
+//    timer, and there is no correct timeout - a HEALTHY socket on an idle board
+//    emits nothing Kanso can observe (the library swallows its only
+//    heartbeat-ish message, `authenticated`, before listeners see it, and WS
+//    pings are protocol-level), so silence is indistinguishable from "nobody
+//    changed the board" and any finite timeout would degrade every healthy
+//    deployment. Reconnection is already the library's job (onerror = onclose,
+//    linear backoff). The case guarded here is the one that is decidable:
+//    startup, where push was never working at all.
+//  - Module-global rather than per-board: one working socket proves push works,
+//    for every board. Frames for board A are proof for board B too.
+let confirmed = false
 
 /**
  * Register the push listener. Call once at app startup.
  *
  * @param {(boardId: number) => void} onBoardChanged called with the changed board's id
- * @return {boolean} whether push is available
+ * @return {boolean} whether push is advertised by the server (not yet proven live)
  */
 export function initRealtime(onBoardChanged) {
-	active = listen(EVENT_NAME, (name, body) => {
+	available = listen(EVENT_NAME, (name, body) => {
+		// Any `kanso_board_changed` frame - even one whose body we can't use -
+		// proves the capability, the daemon, the proxy and the auth handshake all
+		// work. (Only frames for THIS event reach here: the library dispatches by
+		// event name, so another app's traffic on the shared socket is equally
+		// good evidence but cannot be observed from in here.)
+		confirmed = true
 		const boardId = body?.boardId
 		if (boardId !== undefined && boardId !== null) {
 			onBoardChanged(boardId)
 		}
 	})
-	return active
+	return available
 }
 
 /**
- * Whether push is available - polling consumers use this to stretch their
- * interval from fallback (5s) to safety-net (60s).
+ * Whether push has been PROVEN live - polling consumers use this to stretch
+ * their interval from fallback (5s) to safety-net (30s). False until the first
+ * frame lands, so a dead daemon degrades to the fast fallback instead of to a
+ * cadence nothing can ever wake.
  *
  * @return {boolean}
  */
 export function pushActive() {
-	return active
+	return available && confirmed
 }

--- a/src/views/BoardList.vue
+++ b/src/views/BoardList.vue
@@ -161,7 +161,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<CsvImportModal
 			v-if="showCsvImport"
 			@close="showCsvImport = false"
-			@imported="onCsvImported" />
+			@imported="onCsvImported"
+			@open-board="onCsvOpenBoard" />
 
 		<!-- Delete-board confirm (#3750). Same pattern as BoardSettingsModal's
 		     danger zone: an explicit confirm dialog, no undo toast (board delete
@@ -190,38 +191,79 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		</NcDialog>
 
 		<!-- Import-from-Deck modal -->
-		<NcModal v-if="showImport" size="normal" @close="showImport = false">
+		<NcModal v-if="showImport" size="normal" @close="closeImport">
 			<div class="deck-import">
 				<h2 class="deck-import__title">{{ t('kanso', 'Import from Deck') }}</h2>
-				<p class="deck-import__hint">
-					{{ t('kanso', 'Each Deck board is copied into a new Kanso board you own: stacks, cards, labels and assignees. Your Deck boards are left untouched.') }}
-				</p>
 
-				<p v-if="importLoading" class="deck-import__state">{{ t('kanso', 'Loading your Deck boards…') }}</p>
-				<p v-else-if="importLoadError" class="deck-import__error">{{ importLoadError }}</p>
-				<p v-else-if="!deckAvailable" class="deck-import__state">
-					{{ t('kanso', 'The Deck app is not installed on this server, so there is nothing to import.') }}
-				</p>
-				<p v-else-if="deckBoards.length === 0" class="deck-import__state">
-					{{ t('kanso', 'No Deck boards found to import.') }}
-				</p>
-
-				<ul v-else class="deck-import__list">
-					<li v-for="db in deckBoards" :key="db.id" class="deck-import__row">
-						<span
-							class="deck-import__dot"
-							:style="{ background: db.color ? '#' + db.color : 'var(--color-primary-element)' }" />
-						<span class="deck-import__name">{{ db.title }}</span>
-						<span class="deck-import__count">{{ n('kanso', '%n card', '%n cards', db.cardCount) }}</span>
-						<NcButton
-							type="primary"
-							:disabled="importingId !== null"
-							@click="doImport(db)">
-							{{ importingId === db.id ? t('kanso', 'Importing…') : t('kanso', 'Import') }}
+				<!-- Result step: the import finished, so report what actually landed
+				     instead of navigating away. A summary the user never sees is how
+				     a partial import gets mistaken for a complete one. -->
+				<template v-if="importSummary">
+					<!-- The board title is rendered by Vue, NOT interpolated through
+					     t(): t() escapes + sanitizes its placeholders and the mustache
+					     escapes again, which would show a board called "R&D" as
+					     "R&amp;D" on the one line the user reads to confirm the right
+					     board landed. -->
+					<p class="deck-import__hint">
+						{{ t('kanso', 'Imported into a new Kanso board:') }}
+						<strong>{{ importSummary.title }}</strong>
+					</p>
+					<ul class="deck-import__summary" role="status" data-test="deck-import-summary">
+						<li>{{ n('kanso', '%n column', '%n columns', importSummary.stacks) }}</li>
+						<li>{{ n('kanso', '%n card', '%n cards', importSummary.cards) }}</li>
+						<li>{{ n('kanso', '%n label', '%n labels', importSummary.labels) }}</li>
+						<li>{{ n('kanso', '%n comment', '%n comments', importSummary.comments) }}</li>
+						<li>{{ n('kanso', '%n attachment', '%n attachments', importSummary.attachments) }}</li>
+					</ul>
+					<p
+						v-if="importSummary.skippedAttachments > 0"
+						class="deck-import__warning"
+						role="status"
+						data-test="deck-import-skipped">
+						{{ n('kanso',
+							'%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it.',
+							'%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them.',
+							importSummary.skippedAttachments) }}
+					</p>
+					<div class="deck-import__actions">
+						<NcButton type="primary" data-test="deck-import-open" @click="openImportedBoard">
+							{{ t('kanso', 'Open board') }}
 						</NcButton>
-					</li>
-				</ul>
-				<p v-if="importError" class="deck-import__error">{{ importError }}</p>
+						<NcButton @click="closeImport">{{ t('kanso', 'Close') }}</NcButton>
+					</div>
+				</template>
+
+				<template v-else>
+					<p class="deck-import__hint">
+						{{ t('kanso', 'Each Deck board is copied into a new Kanso board you own: stacks, cards, labels and assignees. Your Deck boards are left untouched.') }}
+					</p>
+
+					<p v-if="importLoading" class="deck-import__state">{{ t('kanso', 'Loading your Deck boards…') }}</p>
+					<p v-else-if="importLoadError" class="deck-import__error">{{ importLoadError }}</p>
+					<p v-else-if="!deckAvailable" class="deck-import__state">
+						{{ t('kanso', 'The Deck app is not installed on this server, so there is nothing to import.') }}
+					</p>
+					<p v-else-if="deckBoards.length === 0" class="deck-import__state">
+						{{ t('kanso', 'No Deck boards found to import.') }}
+					</p>
+
+					<ul v-else class="deck-import__list">
+						<li v-for="db in deckBoards" :key="db.id" class="deck-import__row">
+							<span
+								class="deck-import__dot"
+								:style="{ background: db.color ? '#' + db.color : 'var(--color-primary-element)' }" />
+							<span class="deck-import__name">{{ db.title }}</span>
+							<span class="deck-import__count">{{ n('kanso', '%n card', '%n cards', db.cardCount) }}</span>
+							<NcButton
+								type="primary"
+								:disabled="importingId !== null"
+								@click="doImport(db)">
+								{{ importingId === db.id ? t('kanso', 'Importing…') : t('kanso', 'Import') }}
+							</NcButton>
+						</li>
+					</ul>
+					<p v-if="importError" class="deck-import__error">{{ importError }}</p>
+				</template>
 			</div>
 		</NcModal>
 
@@ -794,11 +836,16 @@ const deckAvailable = ref(false)
 const deckBoards = ref([])
 const importingId = ref(null)
 const importError = ref('')
+// The result payload of a finished import — rendered in place of the board list
+// so the counts (and any skipped attachments) reach the user before they act on
+// "the migration worked".
+const importSummary = ref(null)
 
 async function openImport() {
 	showImport.value = true
 	importError.value = ''
 	importLoadError.value = ''
+	importSummary.value = null
 	importLoading.value = true
 	try {
 		const res = await fetchDeckImportBoards()
@@ -817,13 +864,27 @@ async function doImport(db) {
 	try {
 		const res = await importDeckBoard(db.id)
 		await queryClient.invalidateQueries({ queryKey: ['boards'] })
-		showImport.value = false
-		router.push({ name: 'board', params: { id: res.boardId } })
+		// Stay on the modal and show what was imported. Navigating straight to a
+		// board full of cards reads as "the migration worked" even when
+		// attachments were dropped — the one moment a user then deletes the
+		// source board in Deck.
+		importSummary.value = res
 	} catch (err) {
 		importError.value = err?.response?.data?.error || t('kanso', 'Failed to import that board.')
 	} finally {
 		importingId.value = null
 	}
+}
+
+function openImportedBoard() {
+	const id = importSummary.value?.boardId
+	closeImport()
+	if (id) router.push({ name: 'board', params: { id } })
+}
+
+function closeImport() {
+	showImport.value = false
+	importSummary.value = null
 }
 
 // ── Import from a Kanso export (.zip archive, or an older bare .json) ─────────
@@ -882,11 +943,15 @@ async function onTrelloImportChange(event) {
 // ── Import cards from CSV into an existing board/stack (#3678) ─────────────────
 const showCsvImport = ref(false)
 
-async function onCsvImported({ boardId }) {
-	showCsvImport.value = false
-	// The imported cards land on an existing board; refresh the list stats and
-	// jump the user to the board they just populated.
+// The import finished: refresh the board stats behind the modal, but leave the
+// modal mounted — it now renders its own summary (rows skipped, labels not
+// created) and the user clicks through from there.
+async function onCsvImported() {
 	await queryClient.invalidateQueries({ queryKey: ['boards'] })
+}
+
+function onCsvOpenBoard({ boardId }) {
+	showCsvImport.value = false
 	if (boardId) router.push({ name: 'board', params: { id: boardId } })
 }
 </script>
@@ -1238,6 +1303,26 @@ button.board-tile:hover,
 .deck-import__hint {
 	color: var(--color-text-maxcontrast);
 	margin-bottom: 16px;
+}
+
+/* Post-import summary: the counts that actually landed, plus a skip warning. */
+.deck-import__summary {
+	list-style: disc;
+	padding-left: 20px;
+	margin: 0 0 12px;
+	color: var(--color-main-text);
+}
+
+.deck-import__warning {
+	color: var(--color-warning-text, var(--color-error));
+	font-weight: 600;
+	margin: 0 0 16px;
+}
+
+.deck-import__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
 }
 
 .deck-import__state {

--- a/src/views/PublicBoard.vue
+++ b/src/views/PublicBoard.vue
@@ -52,7 +52,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						<div class="public-card__meta">
 							<span v-if="card.priority >= 4" class="public-card__prio">{{ t('kanso', 'Urgent') }}</span>
 							<span v-if="card.duedate" class="public-card__due">{{ formatDate(card.duedate) }}</span>
-							<span v-if="card.checklist.total > 0" class="public-card__check">
+							<span v-if="checklistEnabled && card.checklist.total > 0" class="public-card__check">
 								{{ card.checklist.done }}/{{ card.checklist.total }}
 							</span>
 						</div>
@@ -115,7 +115,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<span v-if="selectedCard.estimate" class="public-detail__field">
 						{{ t('kanso', 'Estimate') }}: {{ selectedCard.estimate }}
 					</span>
-					<span v-if="selectedCard.checklist.total > 0" class="public-detail__field">
+					<span v-if="checklistEnabled && selectedCard.checklist.total > 0" class="public-detail__field">
 						{{ selectedCard.checklist.done }}/{{ selectedCard.checklist.total }}
 					</span>
 				</div>
@@ -184,9 +184,10 @@ export default {
 			cards: [],
 			selectedCard: null,
 			commentsEnabled: false,
-			// Built-in card sections (#5894); defaults to ON so a payload without the
-			// flag (or an older server) looks exactly as it did before.
+			// Built-in card sections (#5894); default to ON so a payload without the
+			// flags (or an older server) looks exactly as it did before.
 			coverColorEnabled: true,
+			checklistEnabled: true,
 		}
 	},
 	computed: {
@@ -208,7 +209,8 @@ export default {
 		hasMeta() {
 			const c = this.selectedCard
 			if (!c) return false
-			return c.priority >= 4 || !!c.startDate || !!c.duedate || !!c.estimate || c.checklist.total > 0
+			return c.priority >= 4 || !!c.startDate || !!c.duedate || !!c.estimate
+				|| (this.checklistEnabled && c.checklist.total > 0)
 		},
 		// The open card's flat comment list nested one level by parentCommentId:
 		// top-level comments in order, each with its direct replies (also in order).
@@ -240,6 +242,7 @@ export default {
 			this.cards = data.cards
 			this.commentsEnabled = !!(data.board && data.board.commentsEnabled)
 			this.coverColorEnabled = data.board?.cardFeatures?.coverColor !== false
+			this.checklistEnabled = data.board?.cardFeatures?.checklist !== false
 		} catch (e) {
 			this.error = true
 		} finally {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,7 +15,7 @@ npx playwright test labels       # a single spec
 
 ## Optional Nextcloud apps some specs need
 
-Two specs exercise integrations with other Nextcloud apps, and fail with a
+A few specs exercise integrations with other Nextcloud apps, and fail with a
 confusing "button is missing" / "board not found" error if that app isn't
 installed rather than saying so:
 
@@ -23,6 +23,7 @@ installed rather than saying so:
 | --- | --- |
 | [`card-contacts.spec.js`](./card-contacts.spec.js) | `contacts` — `ContactService::isAvailable()` is false without the app, so the picker's search returns an empty list and the spec times out waiting for its option |
 | [`deck-import.spec.js`](./deck-import.spec.js) | `deck` — its `beforeAll` seeds a source board through the real Deck API, so the whole describe errors out |
+| [`deck-import-ui.spec.js`](./deck-import-ui.spec.js) | `deck` — same reason: it seeds a source board, then drives the import modal to assert the result summary |
 
 `dev/setup.sh` side-loads both (pinned release tarballs) through
 [`dev/install-optional-apps.sh`](../../dev/install-optional-apps.sh), and the CI

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -34,11 +34,14 @@ afterwards. The pins support Nextcloud **34** only, so on a stack booted with
 that's expected, not a regression.
 
 One more spec depends on an optional app: [`realtime.spec.js`](./realtime.spec.js)'s
-push test needs `notify_push`, which `dev/setup.sh` installs from the appstore.
-That install is best-effort — if it printed a `WARNING: could not install
-notify_push`, push is unavailable and the test **fails rather than skips**. Run
-the suite with `KANSO_SKIP_NOTIFY_PUSH=1` to skip it and exercise only the
-delta-poll fallback.
+push test needs `notify_push`, which `dev/setup.sh` side-loads from a pinned
+release tarball (falling back to the appstore only when that download fails).
+The pin has to match the `icewind1991/notify_push` image tag in
+`dev/docker-compose.yml` — `notify_push:self-test` compares the two versions and
+fails on a skew. The install is best-effort — if the boot printed a
+`WARNING: could not set up notify_push`, push is unavailable and the test **fails
+rather than skips**. Run the suite with `KANSO_SKIP_NOTIFY_PUSH=1` to skip it and
+exercise only the delta-poll fallback.
 
 ## Shared helpers — use these, don't re-roll them
 

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -30,6 +30,14 @@ test.describe('Accessibility smoke', () => {
 		// The single polite aria-live region for own-action announcements exists.
 		await expect(page.locator('.board-view [aria-live="polite"]')).toHaveCount(1)
 
+		// `.board-view` is the SHELL: it renders (with skeleton columns) before the
+		// board read resolves, so snapshotting here races the data exactly as the
+		// modal half below does. On a slow runner the tree held nothing but the back
+		// button and this live region. Wait for the card to actually be on the board
+		// first — the snapshot assertion below is then about the ARIA tree (is the
+		// card exposed under an accessible name?), not about the fetch.
+		await expect(page.locator('.board-view')).toContainText('Accessible card', { timeout: 20_000 })
+
 		// Playwright's native accessibility snapshot (aria tree) must be
 		// non-trivial and surface the card by its accessible name.
 		const boardSnapshot = await page.locator('.board-view').ariaSnapshot()

--- a/tests/e2e/activity.spec.js
+++ b/tests/e2e/activity.spec.js
@@ -158,9 +158,19 @@ test.describe('Card Activity feed', () => {
 		// One card with MANY activity rows, all authored by the same actor (admin).
 		const stack = await api.send('POST', '/stacks', { boardId: state.boardId, title: 'Storm' })
 		const card = await api.send('POST', '/cards', { stackId: stack.id, title: 'Storm card' })
+		// 30 seeding round-trips, and they were all awaited one at a time: measured
+		// 43s healthy / 72s on a saturated CI runner, most of it here rather than in
+		// the browser. The comment POST and the priority PATCH within one iteration
+		// touch different rows and neither depends on the other's result, so they go
+		// out together — halving the serial round-trips to 15 without changing what
+		// is seeded. Iterations stay sequential so the priority sequence (and so the
+		// activity rows it generates) is exactly as before; only the comment/patch
+		// interleaving inside an iteration changes, and nothing asserts on that.
 		for (let i = 0; i < 15; i++) {
-			await api.send('POST', `/cards/${card.id}/comments`, { body: `note ${i}` })
-			await api.send('PATCH', `/cards/${card.id}`, { priority: i % 3 })
+			await Promise.all([
+				api.send('POST', `/cards/${card.id}/comments`, { body: `note ${i}` }),
+				api.send('PATCH', `/cards/${card.id}`, { priority: i % 3 }),
+			])
 		}
 		const cardUrl = `${BASE}/index.php/apps/kanso#/board/${state.boardId}/card/${card.id}`
 

--- a/tests/e2e/board-pins.spec.js
+++ b/tests/e2e/board-pins.spec.js
@@ -42,7 +42,7 @@ test.describe('Board pinning (#3632)', () => {
 		// Open the tile's options (⋯) menu and click Pin — must NOT navigate.
 		await tile.locator(`[data-test="board-options-menu-${state.boardId}"] button`).first().click()
 		await page.locator(`[data-test="toggle-pin-${state.boardId}"]`).first().click()
-		await expect(page).toHaveURL(/#\/$|apps\/kanso#\/$|apps\/kanso#\//, { timeout: 3_000 })
+		await expect(page).toHaveURL(/#\/$|apps\/kanso#\/$|apps\/kanso#\//)
 
 		// The board now appears in the Pinned section.
 		await expect(page.locator('.board-section', { hasText: 'Pinned' })

--- a/tests/e2e/bulk-edit.spec.js
+++ b/tests/e2e/bulk-edit.spec.js
@@ -16,11 +16,23 @@ async function stackTitles(boardId, stackId) {
 test.describe('Bulk edit cards (multi-select)', () => {
 	const state = { boardId: 0, todoId: 0, doneId: 0, boardUrl: '' }
 
-	test.beforeAll(async () => {
+	test.beforeAll(async ({ peer }) => {
 		const board = await api.post('/boards', { title: 'Bulk-Edit E2E' })
 		state.boardId = board.id
 		state.todoId = (await api.post('/stacks', { boardId: board.id, title: 'To Do' })).id
 		state.doneId = (await api.post('/stacks', { boardId: board.id, title: 'Done' })).id
+		// The bulk bar's menus must each hold MORE than one entry to render as
+		// menus at all: NcActions renders nothing for an empty menu and collapses
+		// to a single immediate-action button for a one-entry one. Two labels and
+		// a second board member (the browser stays the owner — the peer is only
+		// there to be assignable) give every menu in the bar its real shape.
+		await api.post('/labels', { boardId: board.id, title: 'Bug', color: 'e07b00' })
+		await api.post('/labels', { boardId: board.id, title: 'Chore', color: '2ecc71' })
+		await api.post(`/boards/${board.id}/acl`, {
+			participant: peer.user,
+			participantType: 'user',
+			permission: 3,
+		})
 		await api.post('/cards', { stackId: state.todoId, title: 'Alpha' })
 		await api.post('/cards', { stackId: state.todoId, title: 'Bravo' })
 		await api.post('/cards', { stackId: state.todoId, title: 'Charlie' })
@@ -50,6 +62,31 @@ test.describe('Bulk edit cards (multi-select)', () => {
 
 		// The bulk action bar reports the selection count.
 		await expect(page.locator('.bulk-action-bar')).toContainText('2')
+
+		// #10275 — every control in the bar shows a hover hint, so a sighted mouse
+		// user can tell the icon-only buttons apart. The plain buttons carry `title`
+		// themselves; the menu triggers get it from the wrapping `.action-item`
+		// (NcActions forwards fall-through attributes to its root element, not to
+		// the trigger button) — which is exactly what the browser resolves a
+		// tooltip from when the button itself has none. Polled: the assignee list
+		// is a separate request, so the "Assign…" menu appears a beat after the
+		// rest of the bar.
+		await expect.poll(
+			() => page.locator('.bulk-action-bar button').evaluateAll(
+				(els) => els.map((el) => el.closest('[title]')?.getAttribute('title') ?? null),
+			),
+			{ timeout: 10_000 },
+		).toEqual([
+			'Move to…',
+			'Add label…',
+			'Remove label…',
+			'Assign…',
+			'Set due date…',
+			'Mark done',
+			'Archive selected',
+			'Delete selected',
+			'Exit selection mode',
+		])
 
 		// Open the "Move to…" menu and pick the Done stack.
 		await page.getByRole('button', { name: 'Move to…' }).click()

--- a/tests/e2e/card-features.spec.js
+++ b/tests/e2e/card-features.spec.js
@@ -4,13 +4,14 @@
 // #5894 — per-board switches for the BUILT-IN card sections.
 //
 // Every card used to show every section whether the team used it or not. A
-// board manager can now switch five of them off (contacts, attachments, GitHub
-// links, time tracking, cover colour) from board settings → Card fields.
+// board manager can now switch six of them off (contacts, attachments, GitHub
+// links, time tracking, cover colour, checklist) from board settings → Card
+// fields.
 //
 // The guarantee this suite exists to protect: **hiding is not deleting.** A
 // disabled section vanishes from the card modal AND from the tiles/list rows,
-// but the attachment, time entry and cover colour behind it stay in the
-// database and come back intact the moment the switch goes on again.
+// but the attachment, time entry, cover colour and checklist items behind it
+// stay in the database and come back intact the moment the switch goes on again.
 
 import { test, expect, api, ncLogin, BASE, currentAuth } from './helpers.js'
 
@@ -49,6 +50,9 @@ async function openCardFieldsPane(page, boardId) {
 }
 
 const FILE_NAME = 'kept-on-purpose.txt'
+// Two checklist steps, one ticked, so every surface shows a 1/2 progress badge.
+const STEP_DONE = 'Draft the brief'
+const STEP_OPEN = 'Sign it off'
 
 test.describe('Built-in card sections (#5894)', () => {
 	const state = { boardId: 0, otherBoardId: 0, todoStackId: 0, progStackId: 0, cardId: 0 }
@@ -66,13 +70,16 @@ test.describe('Built-in card sections (#5894)', () => {
 		const otherStack = await api.post('/stacks', { boardId: state.otherBoardId, title: 'To do' })
 		await api.post('/cards', { stackId: otherStack.id, title: 'Untouched card' })
 
-		// The card carries real data behind three of the five features, so a
+		// The card carries real data behind four of the six features, so a
 		// later re-enable has something to restore.
 		const card = await api.post('/cards', { stackId: state.todoStackId, title: 'Loaded card' })
 		state.cardId = card.id
 		await uploadFile(card.id, FILE_NAME, 'do not delete me')
 		await api.post(`/cards/${card.id}/time-entries`, { seconds: 3600, note: 'Manual entry' })
 		await api.patch(`/cards/${card.id}`, { coverColor: '0082c9' })
+		const step = await api.post(`/cards/${card.id}/checklist`, { title: STEP_DONE })
+		await api.patch(`/checklist/${step.id}`, { done: true })
+		await api.post(`/cards/${card.id}/checklist`, { title: STEP_OPEN })
 
 		// A running timer, so the tile badge has something to show. Started the
 		// only way the app starts one: an automation rule on column entry.
@@ -95,10 +102,73 @@ test.describe('Built-in card sections (#5894)', () => {
 			github: true,
 			timeTracking: true,
 			coverColor: true,
+			checklist: true,
 		})
 		// Sanity: the fixture data really is there.
 		expect(board.cards.find((c) => c.id === state.cardId).timerRunning).toBe(true)
+		expect(board.cards.find((c) => c.id === state.cardId).checklist).toEqual({ done: 1, total: 2 })
 		expect(await api.get(`/cards/${state.cardId}/attachments`)).toHaveLength(1)
+	})
+
+	test('switching the checklist off hides the section and the tile badge, and back on restores the items', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		const tile = page.locator('.card-tile', { hasText: 'Loaded card' })
+		const modal = page.locator('.card-modal')
+		const checklistSection = modal.locator('.card-modal__checklist')
+
+		// --- Baseline: the tile badge and the modal section both show 1/2 ---
+		await expect(tile).toBeVisible({ timeout: 10_000 })
+		await expect(tile.locator('.card-tile__checklist')).toHaveText('1/2')
+
+		await tile.click()
+		await expect(modal).toBeVisible({ timeout: 10_000 })
+		await expect(checklistSection).toBeVisible()
+		await expect(checklistSection.locator('.card-modal__checklist-count')).toHaveText('1 / 2')
+		await expect(checklistSection.getByText(STEP_DONE)).toBeVisible()
+		await expect(checklistSection.getByText(STEP_OPEN)).toBeVisible()
+		await page.keyboard.press('Escape')
+		await expect(modal).toBeHidden({ timeout: 8_000 })
+
+		// --- Switch it off ---
+		await openCardFieldsPane(page, state.boardId)
+		await expect(featureInput(page, 'checklist')).toBeChecked()
+		await featureLabel(page, 'Checklist').click()
+		await expect(featureInput(page, 'checklist')).not.toBeChecked({ timeout: 8_000 })
+		await page.keyboard.press('Escape')
+
+		// Gone from the tile - and the badge is gone, not merely emptied.
+		await expect(tile.locator('.card-tile__checklist')).toHaveCount(0, { timeout: 10_000 })
+		// Gone from the card modal, including its add-an-item row.
+		await tile.click()
+		await expect(modal).toBeVisible({ timeout: 10_000 })
+		await expect(checklistSection).toHaveCount(0)
+		await expect(modal.getByText(STEP_OPEN)).toHaveCount(0)
+		await page.keyboard.press('Escape')
+		await expect(modal).toBeHidden({ timeout: 8_000 })
+
+		// Hiding is not deleting: both items are still on the server, one still ticked.
+		const stored = await api.get(`/cards/${state.cardId}/checklist`)
+		expect(stored).toHaveLength(2)
+		expect(stored.filter((i) => i.done)).toHaveLength(1)
+
+		// --- Switch it back on: the same items, the same done/total ---
+		await openCardFieldsPane(page, state.boardId)
+		await featureLabel(page, 'Checklist').click()
+		await expect(featureInput(page, 'checklist')).toBeChecked({ timeout: 8_000 })
+		await page.keyboard.press('Escape')
+
+		await expect(tile.locator('.card-tile__checklist')).toHaveText('1/2', { timeout: 10_000 })
+		await tile.click()
+		await expect(modal).toBeVisible({ timeout: 10_000 })
+		await expect(checklistSection).toBeVisible({ timeout: 8_000 })
+		await expect(checklistSection.locator('.card-modal__checklist-count')).toHaveText('1 / 2')
+		await expect(checklistSection.getByText(STEP_DONE)).toBeVisible()
+		await expect(checklistSection.getByText(STEP_OPEN)).toBeVisible()
+		await page.keyboard.press('Escape')
+		await expect(modal).toBeHidden({ timeout: 8_000 })
 	})
 
 	test('switching attachments and time tracking off hides them everywhere, and back on restores the data', async ({ page }) => {
@@ -154,7 +224,8 @@ test.describe('Built-in card sections (#5894)', () => {
 		expect(await api.get(`/cards/${state.cardId}/attachments`)).toHaveLength(1)
 		expect(await api.get(`/cards/${state.cardId}/time-entries`)).toHaveLength(1)
 
-		// --- Now the other three, so all five switches have a UI-level guard ---
+		// --- Now the other three, so every switch bar checklist (covered by its
+		//     own test above) has a UI-level guard ---
 		await openCardFieldsPane(page, state.boardId)
 		await featureLabel(page, 'Cover colour').click()
 		await expect(featureInput(page, 'coverColor')).not.toBeChecked({ timeout: 8_000 })
@@ -210,7 +281,7 @@ test.describe('Built-in card sections (#5894)', () => {
 		const boardB = await api.get(`/boards/${state.otherBoardId}`)
 		expect(boardA.board.cardFeatures.github).toBe(false)
 		expect(boardB.board.cardFeatures.github).toBe(true)
-		// And the other four on board A are still on.
+		// And the other five on board A are still on.
 		expect(boardA.board.cardFeatures.attachments).toBe(true)
 		expect(boardA.board.cardFeatures.timeTracking).toBe(true)
 		await api.patch(`/boards/${state.boardId}`, { cardFeatures: { github: true } })

--- a/tests/e2e/card-fields.spec.js
+++ b/tests/e2e/card-fields.spec.js
@@ -110,7 +110,11 @@ test.describe('Custom fields', () => {
 			const cardPayload = await api.get(`/cards/${state.cardId}`)
 			const byField = Object.fromEntries(cardPayload.fieldValues.map((v) => [v.fieldId, v.value]))
 			return byField[state.fields.text]
-		}, { timeout: 8_000 }).toBe('done and dusted')
+		// 30s, not 8s: this covers a debounced write plus the PATCH round-trip plus
+		// the read-back, and the debounce is a FIXED cost that eats most of an 8s
+		// budget before the network is even reached. On a saturated CI runner
+		// (#10332) the poll expired still seeing the old value, failing the run.
+		}, { timeout: 30_000 }).toBe('done and dusted')
 	})
 
 	// ── Board settings: create a new field via the UI form ───────────────────
@@ -134,6 +138,8 @@ test.describe('Custom fields', () => {
 		await expect.poll(async () => {
 			const boardPayload = await api.get(`/boards/${state.boardId}`)
 			return boardPayload.cardFields.some((f) => f.name === 'Team')
-		}, { timeout: 8_000 }).toBe(true)
+		// 30s for the same reason as the poll above: a form submit round-trip has
+		// no business sharing a budget sized for a local DOM update.
+		}, { timeout: 30_000 }).toBe(true)
 	})
 })

--- a/tests/e2e/card-full-page.spec.js
+++ b/tests/e2e/card-full-page.spec.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, BASE, api, ncLogin } from './helpers.js'
+import { test, expect, BASE, api, ncLogin, collectConsoleErrors } from './helpers.js'
 
 // The standalone full-page card view (#3817): the modal and the full page share
 // one CardDetail component, so both render identical card content. These specs
@@ -49,13 +49,20 @@ test.describe('Full-page card view (#3817)', () => {
 	})
 
 	test('navigating to /card/:cardId renders the card full-page (not as an overlay)', async ({ page }) => {
-		const consoleErrors = []
-		page.on('console', (msg) => {
-			if (msg.type() === 'error') consoleErrors.push(msg.text())
-		})
-
 		await page.setViewportSize({ width: 1280, height: 800 })
 		await ncLogin(page)
+
+		// Collect AFTER logging in, and filter by the message's source bundle. This
+		// assertion used to catch every console error on every page the test ever
+		// touched: ncLogin goes via /index.php/login, which with a live session
+		// redirects through the Nextcloud DASHBOARD, where every other installed
+		// app mounts a widget. CI failed here on "could not load recommendation
+		// preview Event" + a 404 from /apps/recommendations/js/ — another app's
+		// code, on a page this test does not even assert about. See
+		// collectConsoleErrors() for why the filter keys on the source URL rather
+		// than on an allowlist of message strings.
+		const consoleErrors = collectConsoleErrors(page)
+
 		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}`)
 
 		// The shared CardDetail content renders...
@@ -73,7 +80,7 @@ test.describe('Full-page card view (#3817)', () => {
 		// A back-to-board affordance exists on the page shell.
 		await expect(page.locator('.card-page__back')).toBeVisible()
 
-		// No new console errors while rendering the full page.
+		// No console errors from Kanso's own code while rendering the full page.
 		expect(consoleErrors, consoleErrors.join('\n')).toEqual([])
 	})
 

--- a/tests/e2e/card-picker-click-outside.spec.js
+++ b/tests/e2e/card-picker-click-outside.spec.js
@@ -57,13 +57,13 @@ test.describe('Card picker click-outside dismiss (#3665)', () => {
 
 		// Popover is open.
 		const popover = page.locator('.card-modal__popover')
-		await expect(popover.first()).toBeVisible({ timeout: 3000 })
+		await expect(popover.first()).toBeVisible()
 
 		// Click a neutral area of the modal (the header) — outside popover + trigger.
 		await page.locator('.card-modal__header').click()
 
 		// Popover closes; the card modal stays open.
-		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0)
 		await expect(page.locator('.card-modal')).toBeVisible()
 	})
 
@@ -79,7 +79,7 @@ test.describe('Card picker click-outside dismiss (#3665)', () => {
 		// Selection applied…
 		await expect(attrbar.locator('.card-modal__pill--priority-3')).toBeVisible({ timeout: 5000 })
 		// …and the popover closed as part of the same click.
-		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0)
 	})
 
 	test('open due → click inside the date input → stays open', async ({ page }) => {
@@ -91,7 +91,7 @@ test.describe('Card picker click-outside dismiss (#3665)', () => {
 		await duePill.click()
 
 		const dateInput = page.locator('.card-modal__popover .card-modal__date-input').first()
-		await expect(dateInput).toBeVisible({ timeout: 3000 })
+		await expect(dateInput).toBeVisible()
 
 		// Clicking inside the popover's own input must NOT dismiss it.
 		await dateInput.click()
@@ -105,12 +105,12 @@ test.describe('Card picker click-outside dismiss (#3665)', () => {
 
 		const priorityPill = page.locator('.card-modal__attrbar button.card-modal__pill').first()
 		await priorityPill.click()
-		await expect(page.locator('.card-modal__popover').first()).toBeVisible({ timeout: 3000 })
+		await expect(page.locator('.card-modal__popover').first()).toBeVisible()
 
 		await page.keyboard.press('Escape')
 
 		// Picker-first precedence: picker gone, card still open.
-		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0)
 		await expect(page.locator('.card-modal')).toBeVisible()
 
 		// A second Escape now closes the card.
@@ -125,7 +125,7 @@ test.describe('Card picker click-outside dismiss (#3665)', () => {
 
 		const priorityPill = page.locator('.card-modal__attrbar button.card-modal__pill').first()
 		await priorityPill.click()
-		await expect(page.locator('.card-modal__popover').first()).toBeVisible({ timeout: 3000 })
+		await expect(page.locator('.card-modal__popover').first()).toBeVisible()
 
 		// The dismiss handler is a document-level mousedown (capture) that keys on
 		// event.target being the dark backdrop (.modal-wrapper). Dispatch that exact
@@ -139,7 +139,7 @@ test.describe('Card picker click-outside dismiss (#3665)', () => {
 
 		// Picker-first precedence: the backdrop mousedown clears the picker only.
 		await fireWrapperMousedown()
-		await expect(page.locator('.card-modal__popover')).toHaveCount(0, { timeout: 3000 })
+		await expect(page.locator('.card-modal__popover')).toHaveCount(0)
 		await expect(page.locator('.card-modal')).toBeVisible()
 
 		// With no picker open, a second backdrop mousedown now closes the card.

--- a/tests/e2e/checklist.spec.js
+++ b/tests/e2e/checklist.spec.js
@@ -326,22 +326,32 @@ test.describe('Checklist steps', () => {
 	})
 
 	// A just-added step renders from the optimistic create carrying a NEGATIVE
-	// placeholder id and is not addressable on the server yet. Assigning it in that
-	// window used to fire `POST /api/checklist/-1788…/assign` → 404 → a bare
-	// "Not found" under the checklist, and the assignment was silently dropped —
-	// on a slow connection the window is wide enough for a real user to hit. The
+	// placeholder id and is not addressable on the server yet. Acting on it in that
+	// window used to fire requests at that placeholder — `POST /api/checklist/
+	// -1788…/assign` → 404 → a bare "Not found" under the checklist and a silently
+	// dropped assignment; `DELETE /api/checklist/-1788…` → 404 → the optimistic
+	// removal rolled back WHILE the create was still in flight, so the step the user
+	// just deleted CAME BACK; `PATCH /api/checklist/-1788…` → 404 "Failed to rename
+	// item.", and an id swap landing mid-edit tore the input down without a blur and
+	// threw the typed title away; `POST /api/checklist/-1788…/move` → 404 dragging
+	// the row, or 400 "afterItemId is not an item of this card" dropping onto it.
+	// On a slow connection the window is wide enough for a real user to hit. The
 	// create POST is delayed here so the window is a deterministic 3s to act in.
-	test('the step pickers stay inert until the just-added step has its server id', async ({ page }) => {
-		await page.route('**/api/cards/*/checklist', async (route) => {
-			if (route.request().method() === 'POST') {
-				await new Promise((resolve) => setTimeout(resolve, 3000))
-			}
-			await route.continue()
-		})
+	//
+	// EVERY assertion below is on the control's DISABLED STATE, never on "driving
+	// the UI works out". Playwright's actionability wait absorbs the latency: a
+	// spec that simply clicks passes whether or not the guard exists, because the
+	// click lands after the real id arrives. Removing any one guard must turn this
+	// test red — the forced clicks and the dispatched drag are what prove that.
+	test('the step controls stay inert until the just-added step has its server id', async ({ page }) => {
 		// Anything addressed to a negative id can only 404 — nothing may be sent.
+		// A move addressed to a real id may still carry a placeholder `afterItemId`,
+		// which the server rejects with a 400, so reorders are tracked too.
 		const placeholderCalls = []
+		const moveCalls = []
 		page.on('request', (req) => {
 			if (/\/api\/checklist\/-\d+/.test(req.url())) placeholderCalls.push(`${req.method()} ${req.url()}`)
+			if (/\/api\/checklist\/-?\d+\/move/.test(req.url())) moveCalls.push(`${req.method()} ${req.url()}`)
 		})
 
 		await ncLogin(page)
@@ -350,28 +360,140 @@ test.describe('Checklist steps', () => {
 		await page.locator('.card-tile').filter({ hasText: 'Card With Steps' }).click()
 		await page.waitForSelector('.card-modal', { timeout: 10_000 })
 
+		// A settled row to drag against — added BEFORE the latency is injected.
 		const addInput = page.locator('.card-modal__checklist-add-input')
+		await addInput.fill('Anchor step')
+		await addInput.press('Enter')
+		// `.last()`: a retry re-adds the row on the same card, and the newest row is
+		// always appended last, so the locator still resolves to exactly one row.
+		const anchor = page.locator('.card-modal__checklist-item').filter({ hasText: 'Anchor step' }).last()
+		await expect(anchor).toHaveAttribute('data-item-id', /^\d+$/, { timeout: 15_000 })
+		const anchorId = await anchor.getAttribute('data-item-id')
+
+		// The create is held on a GATE, not a timer: the window has to stay open
+		// across every control below, and a fixed delay races the CI runner (~4-5×
+		// slower than a dev box, see playwright.config.js) — a control exercised
+		// after the id landed proves nothing. The test decides when it closes.
+		let releaseCreate
+		const createGate = new Promise((resolve) => { releaseCreate = resolve })
+		await page.route('**/api/cards/*/checklist', async (route) => {
+			if (route.request().method() === 'POST') await createGate
+			await route.continue()
+		})
+
 		await addInput.fill('Deferred step')
 		await addInput.press('Enter')
 
-		const item = page.locator('.card-modal__checklist-item').filter({ hasText: 'Deferred step' })
+		const item = page.locator('.card-modal__checklist-item').filter({ hasText: 'Deferred step' }).last()
 		await expect(item).toBeVisible({ timeout: 10_000 })
 		await expect(item).toHaveAttribute('data-item-id', /^-\d+$/)
+		const placeholderId = await item.getAttribute('data-item-id')
 
 		const assignBtn = item.locator('.card-modal__step-btn[title="Assign step"]')
 		const dueBtn = item.locator('.card-modal__step-btn[title="Set step due date"]')
+		const deleteBtn = item.locator('.card-modal__checklist-item-delete')
+		const itemTitle = item.locator('.card-modal__checklist-item-title')
+		const dragHandle = item.locator('.card-modal__checklist-drag')
+
 		await expect(assignBtn).toBeDisabled()
 		await expect(dueBtn).toBeDisabled()
+		await expect(deleteBtn).toBeDisabled()
+		// The title is a role=button span, so it carries aria-disabled rather than
+		// the disabled property — toBeDisabled() honours both.
+		await expect(itemTitle).toBeDisabled()
+		await expect(dragHandle).toHaveAttribute('draggable', 'false')
+		// …and the row says so, rather than just going quietly dead under the cursor.
+		await expect(item).toHaveAttribute('aria-busy', 'true')
+
+		// Every forced interaction below is followed by this. It is the assertion
+		// that actually bites: the *symptoms* are unreliable detectors here — a
+		// local server 404s the placeholder in milliseconds, so the rolled-back
+		// optimistic delete puts the row back before any DOM assertion can see it
+		// gone. What is deterministic is that the request was sent at all.
+		const assertNoPlaceholderTraffic = async (label) => {
+			await page.waitForTimeout(300)
+			const sent = [...placeholderCalls, ...moveCalls]
+			if (sent.length > 0) {
+				throw new Error(`${label}: request(s) addressed the optimistic placeholder id: ${sent.join(', ')}`)
+			}
+		}
+
+		// Chromium never delivers a click to a NATIVELY disabled button, so
+		// `click({ force: true })` on one exercises nothing — it would leave the
+		// handler-side guard (and this assertion) unfalsifiable. A programmatically
+		// dispatched click IS delivered to the listener, so both are used: the
+		// forced click for the elements that carry aria-disabled (where the click
+		// does land), the dispatch for the ones with the disabled property.
+		const dispatchClick = (selector) => page.evaluate(([rowId, sel]) => {
+			const el = document.querySelector(`li[data-item-id="${rowId}"] ${sel}`)
+			if (!el) throw new Error(`no element for ${sel}`)
+			el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+		}, [placeholderId, selector])
 
 		// Forced past the disabled state, the picker still must not open — no
 		// popover means no request can be addressed to the placeholder id.
 		await assignBtn.click({ force: true })
+		await dispatchClick('.card-modal__step-btn[title="Assign step"]')
+		await assertNoPlaceholderTraffic('assign')
 		await expect(item.locator('.card-modal__step-popover')).toHaveCount(0)
 
-		// Once the create resolves and the real row swaps in, both pickers work.
+		// Forced past it, delete must not fire — a 404'd delete rolls its optimistic
+		// removal back while the create is still in flight, so the step the user
+		// deleted comes back. The row-still-present check backs the traffic check up
+		// for a slow server, where the gap is actually visible.
+		await deleteBtn.click({ force: true })
+		await dispatchClick('.card-modal__checklist-item-delete')
+		await assertNoPlaceholderTraffic('delete')
+		await expect(item).toHaveCount(1, { timeout: 1500 })
+
+		// Forced past it, the inline title editor must not open — an editor here
+		// both PATCHes the placeholder id and loses the typed draft when the id
+		// swaps out from under it. Scoped to the page, not to `item`: an open editor
+		// replaces the row's title text, so the hasText filter would stop matching
+		// and a row-scoped locator would be vacuously empty.
+		await itemTitle.click({ force: true })
+		await assertNoPlaceholderTraffic('rename')
+		await expect(page.locator('.card-modal__checklist-item-input')).toHaveCount(0)
+
+		// Reorder, both roles. Playwright's dragTo drives mouse events, which native
+		// HTML5 DnD ignores, so the drag events are dispatched directly — that also
+		// forces the handle's draggable=false, exactly like the forced clicks above.
+		const dispatchDrag = (fromId, toId) => page.evaluate(([from, to]) => {
+			const dt = new DataTransfer()
+			const fromRow = document.querySelector(`li[data-item-id="${from}"]`)
+			const toRow = document.querySelector(`li[data-item-id="${to}"]`)
+			if (!fromRow || !toRow) throw new Error(`drag rows missing: ${from} → ${to}`)
+			fromRow.querySelector('.card-modal__checklist-drag')
+				.dispatchEvent(new DragEvent('dragstart', { dataTransfer: dt, bubbles: true, cancelable: true }))
+			const rect = toRow.getBoundingClientRect()
+			const opts = {
+				dataTransfer: dt,
+				bubbles: true,
+				cancelable: true,
+				clientX: rect.left + 5,
+				// Bottom half → "insert after the target", i.e. afterItemId = target id.
+				clientY: rect.top + rect.height * 0.75,
+			}
+			toRow.dispatchEvent(new DragEvent('dragover', opts))
+			toRow.dispatchEvent(new DragEvent('drop', opts))
+		}, [fromId, toId])
+
+		await dispatchDrag(placeholderId, anchorId) // unsaved row dragged
+		await assertNoPlaceholderTraffic('reorder (unsaved row dragged)')
+		await dispatchDrag(anchorId, placeholderId) // unsaved row as the drop target
+		await assertNoPlaceholderTraffic('reorder (unsaved row as drop target)')
+		// …and it never advertised a drop it could not send.
+		await expect(item).toHaveAttribute('data-drag-over', 'false')
+
+		// Once the create resolves and the real row swaps in, every control works.
+		releaseCreate()
 		await expect(item).toHaveAttribute('data-item-id', /^\d+$/, { timeout: 15_000 })
 		await expect(assignBtn).toBeEnabled()
 		await expect(dueBtn).toBeEnabled()
+		await expect(deleteBtn).toBeEnabled()
+		await expect(itemTitle).toBeEnabled()
+		await expect(dragHandle).toHaveAttribute('draggable', 'true')
+		await expect(item).not.toHaveAttribute('aria-busy', 'true')
 		await assignBtn.click()
 		await expect(item.locator('.card-modal__step-popover')).toBeVisible({ timeout: 5000 })
 

--- a/tests/e2e/checklist.spec.js
+++ b/tests/e2e/checklist.spec.js
@@ -458,7 +458,15 @@ test.describe('Checklist steps', () => {
 		// Reorder, both roles. Playwright's dragTo drives mouse events, which native
 		// HTML5 DnD ignores, so the drag events are dispatched directly — that also
 		// forces the handle's draggable=false, exactly like the forced clicks above.
-		const dispatchDrag = (fromId, toId) => page.evaluate(([from, to]) => {
+		//
+		// `dragover` and `drop` are TWO calls on purpose (#10292). onItemDrop clears
+		// `dragOverItemId` on its early-return branch as well as its success branch,
+		// so a `data-drag-over` assertion taken after the drop reads 'false' whether
+		// onItemDragOver's guard exists or not — the previous single-shot helper made
+		// that assertion unfalsifiable. The drop indicator is only observable in the
+		// window BETWEEN the two events, so the DataTransfer (and the pointer offsets
+		// derived from the target row) are parked on `window` to survive the gap.
+		const dispatchDragOver = (fromId, toId) => page.evaluate(([from, to]) => {
 			const dt = new DataTransfer()
 			const fromRow = document.querySelector(`li[data-item-id="${from}"]`)
 			const toRow = document.querySelector(`li[data-item-id="${to}"]`)
@@ -474,16 +482,43 @@ test.describe('Checklist steps', () => {
 				// Bottom half → "insert after the target", i.e. afterItemId = target id.
 				clientY: rect.top + rect.height * 0.75,
 			}
+			// `opts` already carries the DataTransfer, so the drop below needs nothing
+			// but this object — see the note there about why it has to be reused.
+			window.__kansoDrag = opts
 			toRow.dispatchEvent(new DragEvent('dragover', opts))
-			toRow.dispatchEvent(new DragEvent('drop', opts))
 		}, [fromId, toId])
 
-		await dispatchDrag(placeholderId, anchorId) // unsaved row dragged
+		// No wait between the two halves on purpose. Nothing clears the indicator in
+		// the gap, so the assertion there has all of its own timeout to observe a
+		// missing guard — Playwright's toHaveAttribute retries. A requestAnimationFrame
+		// await here would buy nothing and could hang the evaluate if the renderer is
+		// ever throttled.
+		const dispatchDrop = (toId) => page.evaluate((to) => {
+			const toRow = document.querySelector(`li[data-item-id="${to}"]`)
+			if (!toRow) throw new Error(`drop row missing: ${to}`)
+			// The SAME DragEvent init as the dragover, DataTransfer included: a drop
+			// carrying a fresh DataTransfer is a different drag as far as the handler is
+			// concerned, and the clientY is what selects the closest-edge branch.
+			const opts = window.__kansoDrag
+			if (!opts) throw new Error('dispatchDrop called without a preceding dispatchDragOver')
+			toRow.dispatchEvent(new DragEvent('drop', opts))
+		}, toId)
+
+		// The unsaved row DRAGGED: dragstart is preventDefault()ed, so nothing is ever
+		// dragging — asserted, not just claimed, in the same gap: with no drag in
+		// progress the ANCHOR must not light up as a drop target either.
+		await dispatchDragOver(placeholderId, anchorId)
+		await expect(anchor).toHaveAttribute('data-drag-over', 'false')
+		await dispatchDrop(anchorId)
 		await assertNoPlaceholderTraffic('reorder (unsaved row dragged)')
-		await dispatchDrag(anchorId, placeholderId) // unsaved row as the drop target
-		await assertNoPlaceholderTraffic('reorder (unsaved row as drop target)')
-		// …and it never advertised a drop it could not send.
+
+		// The unsaved row as the DROP TARGET — a real row is dragging, so this is the
+		// case where onItemDragOver actually has to refuse. Asserted in the gap: it
+		// must never advertise a drop it could not send.
+		await dispatchDragOver(anchorId, placeholderId)
 		await expect(item).toHaveAttribute('data-drag-over', 'false')
+		await dispatchDrop(placeholderId)
+		await assertNoPlaceholderTraffic('reorder (unsaved row as drop target)')
 
 		// Once the create resolves and the real row swaps in, every control works.
 		releaseCreate()

--- a/tests/e2e/checklist.spec.js
+++ b/tests/e2e/checklist.spec.js
@@ -106,7 +106,7 @@ test.describe('Checklist', () => {
 
 		// Assert progress shows 0/2 initially
 		await expect(page.locator('.card-modal__checklist-count'))
-			.toHaveText('0 / 2', { timeout: 3000 })
+			.toHaveText('0 / 2')
 
 		// Toggle "Buy groceries" done by clicking its checkbox. This waits for the
 		// item + checkbox to be visible/enabled and awaits the PATCH response so

--- a/tests/e2e/checklist.spec.js
+++ b/tests/e2e/checklist.spec.js
@@ -254,6 +254,13 @@ test.describe('Checklist steps', () => {
 		await addInput.press('Enter')
 		const item = page.locator('.card-modal__checklist-item').filter({ hasText: 'Send contract' })
 		await expect(item).toBeVisible({ timeout: 10_000 })
+		// The row renders from the optimistic create with a NEGATIVE placeholder id
+		// and is not addressable on the server until the POST resolves — the app
+		// keeps the step pickers disabled for that window (asserted by the test
+		// below). Wait for the real id so a slow create surfaces here as a legible
+		// failure instead of a 30s actionability timeout on the click at :270 —
+		// same precondition toggleChecklistItem() uses.
+		await expect(item).toHaveAttribute('data-item-id', /^\d+$/, { timeout: 15_000 })
 
 		// Assign it to the current user via the row's assign picker.
 		await item.hover()
@@ -316,5 +323,61 @@ test.describe('Checklist steps', () => {
 		const reopened = (await api.get(`/cards/${state.cardId}/checklist`)).find((i) => i.title === 'Send contract')
 		if (reopened.doneAt !== null) throw new Error('un-done did not clear done_at')
 		if (reopened.assignedUser !== me) throw new Error('un-done must not touch the assignee')
+	})
+
+	// A just-added step renders from the optimistic create carrying a NEGATIVE
+	// placeholder id and is not addressable on the server yet. Assigning it in that
+	// window used to fire `POST /api/checklist/-1788…/assign` → 404 → a bare
+	// "Not found" under the checklist, and the assignment was silently dropped —
+	// on a slow connection the window is wide enough for a real user to hit. The
+	// create POST is delayed here so the window is a deterministic 3s to act in.
+	test('the step pickers stay inert until the just-added step has its server id', async ({ page }) => {
+		await page.route('**/api/cards/*/checklist', async (route) => {
+			if (route.request().method() === 'POST') {
+				await new Promise((resolve) => setTimeout(resolve, 3000))
+			}
+			await route.continue()
+		})
+		// Anything addressed to a negative id can only 404 — nothing may be sent.
+		const placeholderCalls = []
+		page.on('request', (req) => {
+			if (/\/api\/checklist\/-\d+/.test(req.url())) placeholderCalls.push(`${req.method()} ${req.url()}`)
+		})
+
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await page.waitForSelector('.card-tile', { timeout: 10_000 })
+		await page.locator('.card-tile').filter({ hasText: 'Card With Steps' }).click()
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const addInput = page.locator('.card-modal__checklist-add-input')
+		await addInput.fill('Deferred step')
+		await addInput.press('Enter')
+
+		const item = page.locator('.card-modal__checklist-item').filter({ hasText: 'Deferred step' })
+		await expect(item).toBeVisible({ timeout: 10_000 })
+		await expect(item).toHaveAttribute('data-item-id', /^-\d+$/)
+
+		const assignBtn = item.locator('.card-modal__step-btn[title="Assign step"]')
+		const dueBtn = item.locator('.card-modal__step-btn[title="Set step due date"]')
+		await expect(assignBtn).toBeDisabled()
+		await expect(dueBtn).toBeDisabled()
+
+		// Forced past the disabled state, the picker still must not open — no
+		// popover means no request can be addressed to the placeholder id.
+		await assignBtn.click({ force: true })
+		await expect(item.locator('.card-modal__step-popover')).toHaveCount(0)
+
+		// Once the create resolves and the real row swaps in, both pickers work.
+		await expect(item).toHaveAttribute('data-item-id', /^\d+$/, { timeout: 15_000 })
+		await expect(assignBtn).toBeEnabled()
+		await expect(dueBtn).toBeEnabled()
+		await assignBtn.click()
+		await expect(item.locator('.card-modal__step-popover')).toBeVisible({ timeout: 5000 })
+
+		await expect(page.locator('.card-modal__save-error')).toHaveCount(0)
+		if (placeholderCalls.length > 0) {
+			throw new Error(`request(s) sent against the optimistic placeholder id: ${placeholderCalls.join(', ')}`)
+		}
 	})
 })

--- a/tests/e2e/command-palette.spec.js
+++ b/tests/e2e/command-palette.spec.js
@@ -60,7 +60,7 @@ test.describe('Command Palette', () => {
 
 		// Input should be auto-focused
 		const input = palette.locator('.command-palette__input')
-		await expect(input).toBeFocused({ timeout: 3000 })
+		await expect(input).toBeFocused()
 	})
 
 	test('empty query shows recent boards section', async ({ page }) => {
@@ -157,7 +157,7 @@ test.describe('Command Palette', () => {
 
 		await page.keyboard.press('Escape')
 
-		await expect(palette).not.toBeVisible({ timeout: 3000 })
+		await expect(palette).not.toBeVisible()
 	})
 
 	test('Ctrl+K does NOT open palette when typing in a text input', async ({ page }) => {

--- a/tests/e2e/comment-deeplink.spec.js
+++ b/tests/e2e/comment-deeplink.spec.js
@@ -93,6 +93,48 @@ test.describe('Scroll-to-comment deep links (#3870)', () => {
 		await expect(target).toBeInViewport({ timeout: 5000 })
 	})
 
+	test('the target stays in view when the composer lands after the scroll', async ({ page }) => {
+		// The thread pane is still settling when the deep-link scroll runs. The
+		// comment composer only renders once the BOARD read has resolved (it is
+		// gated on the viewer's edit permission), and its MarkdownEditor is a lazy
+		// chunk on top of that - while the comments themselves come from their own,
+		// independent query. On a slow connection the composer therefore appears
+		// AFTER the scroll, and `.card-modal__thread-scroll` (`flex: 1`) shrinks by
+		// its full height. `scrollTop` survives that; the comment we centred does
+		// not. Nothing used to scroll again, so the reader silently landed on a
+		// different comment than the one the link pointed at.
+		//
+		// The board read is gated on the test rather than on a sleep, so the
+		// ordering is fixed rather than raced: it is held back until the highlight
+		// proves the scroll has happened, and only then allowed through.
+		let releaseBoardRead
+		const boardReadGate = new Promise((resolve) => { releaseBoardRead = resolve })
+		await page.route('**/apps/kanso/api/boards/*', async (route) => {
+			await boardReadGate
+			await route.continue()
+		})
+
+		const targetId = state.comments[6]
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}?comment=${targetId}`)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		const target = page.locator(`#comment-${targetId}`)
+		await expect(target).toBeVisible({ timeout: 10_000 })
+		// The scroll has run by the time the highlight is on, and the composer is
+		// provably not on screen yet - so the reflow below really is after it.
+		await expect(target).toHaveClass(/card-modal__comment-group--highlight/, { timeout: 5000 })
+		await expect(page.locator('.card-modal__composer')).toHaveCount(0)
+		await expect(target).toBeInViewport({ timeout: 5000 })
+
+		// Now let the composer in and shrink the thread pane under the target.
+		releaseBoardRead()
+		await expect(page.locator('.card-modal__composer .kanso-md-editor')).toBeVisible({ timeout: 10_000 })
+
+		// The deep link's target must survive that reflow, not be left below it.
+		await expect(target).toBeInViewport({ timeout: 5000 })
+	})
+
 	test('a reply is deep-linkable and gets highlighted', async ({ page }) => {
 		await ncLogin(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}?comment=${state.replyId}`)

--- a/tests/e2e/comment-deeplink.spec.js
+++ b/tests/e2e/comment-deeplink.spec.js
@@ -12,7 +12,7 @@
  * the targeted comment is scrolled into view and carries the highlight class.
  */
 
-import { test, expect, api, ncLogin, BASE } from './helpers.js'
+import { test, expect, api, ncLogin, BASE, collectConsoleErrors } from './helpers.js'
 
 test.describe('Scroll-to-comment deep links (#3870)', () => {
 	const state = { boardId: 0, cardId: 0, comments: [], replyId: 0 }
@@ -49,14 +49,19 @@ test.describe('Scroll-to-comment deep links (#3870)', () => {
 	})
 
 	test('full-page card route with ?comment=<id> scrolls to + highlights the target', async ({ page }) => {
-		const errors = []
-		page.on('console', (msg) => {
-			if (msg.type() === 'error') errors.push(msg.text())
-		})
-
 		// The 6th comment - far enough down the thread to require a scroll.
 		const targetId = state.comments[5]
 		await ncLogin(page)
+
+		// Collect AFTER logging in, and filter by the message's source bundle. The
+		// old `favicon|manifest|ResizeObserver` allowlist was a string allowlist,
+		// and it rotted exactly as one does: CI failed here on "could not load
+		// recommendation preview Event" + a 404, both from
+		// /apps/recommendations/js/ — another app's code, logged on the Nextcloud
+		// DASHBOARD that ncLogin redirects through, not on the card page this test
+		// asserts about. collectConsoleErrors() keys on the source URL instead, so
+		// it does not need a new entry every time an unrelated app changes wording.
+		const errors = collectConsoleErrors(page)
 		await page.goto(`${BASE}/index.php/apps/kanso#/card/${state.cardId}?comment=${targetId}`)
 
 		await page.waitForSelector('.card-modal', { timeout: 10_000 })
@@ -73,9 +78,8 @@ test.describe('Scroll-to-comment deep links (#3870)', () => {
 		// The highlight is transient: it clears after the fade (~4s).
 		await expect(target).not.toHaveClass(/card-modal__comment-group--highlight/, { timeout: 8000 })
 
-		// No console errors from the scroll-to-comment path.
-		const relevant = errors.filter((e) => !/favicon|manifest|ResizeObserver/i.test(e))
-		expect(relevant, `console errors: ${relevant.join('\n')}`).toEqual([])
+		// No console errors from Kanso's own code on the scroll-to-comment path.
+		expect(errors, `console errors: ${errors.join('\n')}`).toEqual([])
 	})
 
 	test('raw #comment-<id> fragment on the full-page route also scrolls + highlights', async ({ page }) => {

--- a/tests/e2e/csv-import.spec.js
+++ b/tests/e2e/csv-import.spec.js
@@ -47,7 +47,16 @@ test.describe('Import cards from CSV', () => {
 
 		await page.locator('[data-test="csv-import-submit"]').click()
 
-		// The FE navigates to the populated board once the import returns.
+		// The modal reports what landed instead of navigating away silently
+		// (#10297): three cards created, and nothing skipped for this CSV.
+		const summary = page.locator('[data-test="csv-import-summary"]')
+		await expect(summary).toBeVisible({ timeout: 20_000 })
+		await expect(summary).toContainText('3 cards created')
+		await expect(page.locator('[data-test="csv-import-skipped-rows"]')).toHaveCount(0)
+		await expect(page.locator('[data-test="csv-import-labels-skipped"]')).toHaveCount(0)
+
+		// Clicking through from the summary is what navigates to the board.
+		await page.locator('[data-test="csv-import-open"]').click()
 		await page.waitForURL(new RegExp(`#/board/${state.boardId}\\b`), { timeout: 20_000 })
 
 		// Assert the three cards landed on the Inbox stack, in file order, with the
@@ -71,5 +80,77 @@ test.describe('Import cards from CSV', () => {
 		const detail = await api.get(`/cards/${byTitle['Design login'].id}`)
 		expect(detail.description).toBe('Wireframe the flow')
 		expect(byTitle['Design login'].duedate).toBeTruthy()
+	})
+})
+
+// #10297 — an EDIT-only member's unknown label names are dropped (minting a
+// label definition needs MANAGE). That was computed and thrown away, so the
+// member saw a plain success and never learned their labels were missing.
+test.describe('CSV import reports labels an editor could not create', () => {
+	// A second identity logs in explicitly, so this describe must NOT inherit the
+	// shared admin storageState — admin HAS manage, so it would false-pass. What
+	// actually guarantees that is the explicit `browser.newContext()` below (a
+	// fresh context with no stored session); under E2E_ISOLATE the storageState
+	// FIXTURE in helpers.js outranks a describe-level `test.use`, so this line is
+	// belt-and-braces for the `page` fixture, not the load-bearing part.
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	const stamp = Math.floor(Date.now() / 1000)
+	const state = {}
+
+	test.beforeAll(async ({ peer }) => {
+		const board = await api.post('/boards', { title: 'CSV Editor ' + stamp })
+		state.boardId = board.id
+		state.boardTitle = board.title
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Inbox' })
+		state.stackId = stack.id
+		// READ | EDIT (3) — the import is allowed, creating a label is not.
+		await api.post(`/boards/${board.id}/acl`, {
+			participant: peer.user,
+			participantType: 'user',
+			permission: 3,
+		})
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	test('an editor is told the labels were not created', async ({ browser, peer }) => {
+		const ctx = await browser.newContext()
+		try {
+			const page = await ctx.newPage()
+			await ncLogin(page, { user: peer.user, pass: peer.pass })
+			await page.goto(`${BASE}/index.php/apps/kanso#/`)
+			await page.waitForSelector('.board-list-view', { timeout: 15_000 })
+
+			await page.getByRole('button', { name: 'Import' }).click()
+			await page.getByText('CSV file', { exact: true }).click()
+
+			await page.locator('[data-test="csv-import-paste"]').fill([
+				'title,labels',
+				'Editor row one,brand-new-label',
+				'Editor row two,brand-new-label',
+			].join('\n'))
+			await page.locator('[data-test="csv-import-next"]').click()
+
+			await page.locator('[data-test="csv-import-board"]').selectOption({ label: state.boardTitle })
+			await page.locator('[data-test="csv-import-stack"]').selectOption({ label: 'Inbox' })
+			await page.locator('[data-test="csv-import-submit"]').click()
+
+			// The cards land, but the modal says the label was NOT created.
+			await expect(page.locator('[data-test="csv-import-summary"]'))
+				.toContainText('2 cards created', { timeout: 20_000 })
+			await expect(page.locator('[data-test="csv-import-labels-skipped"]'))
+				.toContainText('only board managers can add new labels')
+		} finally {
+			await ctx.close()
+		}
+
+		// …and the board really has no such label, so the warning is not cosmetic.
+		const payload = await api.get(`/boards/${state.boardId}`)
+		expect(payload.labels.map((l) => l.title)).not.toContain('brand-new-label')
+		expect(payload.cards.map((c) => c.title).sort())
+			.toEqual(['Editor row one', 'Editor row two'])
 	})
 })

--- a/tests/e2e/deck-import-ui.spec.js
+++ b/tests/e2e/deck-import-ui.spec.js
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, currentAuth, ncLogin, BASE } from './helpers.js'
+
+// #10297 — the Deck import used to navigate straight to the new board, throwing
+// its result summary away. A user then saw a board full of cards, concluded the
+// migration was complete, and deleted the Deck board — never learning that
+// attachments had been dropped. The modal must now REPORT what landed and let
+// the user click through.
+//
+// The source board is created with `currentAuth` (not a hardcoded admin) so the
+// Deck board belongs to whoever the browser session is under E2E_ISOLATE.
+const DECK = BASE + '/index.php/apps/deck/api/v1.0'
+
+async function deck(method, path, body) {
+	const r = await fetch(DECK + path, {
+		method,
+		headers: {
+			'OCS-APIRequest': 'true',
+			'Content-Type': 'application/json',
+			Authorization: currentAuth,
+		},
+		body: body === undefined ? undefined : JSON.stringify(body),
+	})
+	if (!r.ok) throw new Error(`${method} ${path} → ${r.status}: ${await r.text()}`)
+	const text = await r.text()
+	return text ? JSON.parse(text) : null
+}
+
+test.describe('Import from Deck — result summary', () => {
+	const title = 'E2E Deck Summary ' + Math.floor(Date.now() / 1000)
+	const state = { deckBoardId: 0, kansoBoardId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await deck('POST', '/boards', { title, color: '0082c9' })
+		state.deckBoardId = board.id
+		const stack = await deck('POST', `/boards/${board.id}/stacks`, { title: 'To do', order: 1 })
+		await deck('POST', `/boards/${board.id}/stacks/${stack.id}/cards`,
+			{ title: 'Alpha', type: 'plain', order: 1 })
+		await deck('POST', `/boards/${board.id}/stacks/${stack.id}/cards`,
+			{ title: 'Beta', type: 'plain', order: 2 })
+	})
+
+	test.afterAll(async () => {
+		if (state.kansoBoardId) await api.delete(`/boards/${state.kansoBoardId}`).catch(() => {})
+		if (state.deckBoardId) await deck('DELETE', `/boards/${state.deckBoardId}`).catch(() => {})
+	})
+
+	test('shows what was imported instead of navigating away silently', async ({ page }) => {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/`)
+		await page.waitForSelector('.board-list-view', { timeout: 15_000 })
+
+		// Import ▸ Nextcloud Deck, then import the board seeded above.
+		await page.getByRole('button', { name: 'Import' }).click()
+		await page.getByText('Nextcloud Deck', { exact: true }).click()
+		const row = page.locator('.deck-import__row', { hasText: title })
+		await expect(row).toBeVisible({ timeout: 20_000 })
+		await row.getByRole('button', { name: 'Import', exact: true }).click()
+
+		// The modal stays open and reports the counts that actually landed.
+		const summary = page.locator('[data-test="deck-import-summary"]')
+		await expect(summary).toBeVisible({ timeout: 30_000 })
+		await expect(summary).toContainText('1 column')
+		await expect(summary).toContainText('2 cards')
+		await expect(summary).toContainText('0 attachments')
+		// Nothing was dropped for this board, so no loss warning is shown.
+		await expect(page.locator('[data-test="deck-import-skipped"]')).toHaveCount(0)
+
+		// Clicking through from the summary is what navigates to the new board.
+		await page.locator('[data-test="deck-import-open"]').click()
+		await page.waitForURL(/#\/board\/\d+/, { timeout: 20_000 })
+		state.kansoBoardId = Number(page.url().match(/#\/board\/(\d+)/)[1])
+
+		const payload = await api.get(`/boards/${state.kansoBoardId}`)
+		expect(payload.board.title).toBe(title)
+		expect(payload.cards.map((c) => c.title).sort()).toEqual(['Alpha', 'Beta'])
+	})
+})

--- a/tests/e2e/estimations.spec.js
+++ b/tests/e2e/estimations.spec.js
@@ -158,6 +158,16 @@ test.describe('Estimate sorting & filtering', () => {
 		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
 		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
 
+		// `.board-view__header` is part of the SHELL: it renders (alongside skeleton
+		// columns) before the board read resolves. `allTextContents()` below is a
+		// one-shot read with no auto-retry, so taking it at that moment returns an
+		// EMPTY list on a slow runner and both indexOf() calls come back -1 — which
+		// is exactly how this failed in CI (`Expected: < -1 / Received: -1`). Wait
+		// for all three fixture tiles to actually be on the board first; the
+		// ordering assertions below are then about the ORDER, which is the claim
+		// this test makes, and not about whether the fetch had landed.
+		await expect(page.locator('.card-tile__title')).toHaveCount(3, { timeout: 20_000 })
+
 		// Manual (persisted) order first: None, Small, Big.
 		const titlesManual = (await page.locator('.card-tile__title').allTextContents()).map((s) => s.trim())
 		expect(titlesManual.indexOf('EstNone')).toBeLessThan(titlesManual.indexOf('EstSmall'))

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -139,6 +139,61 @@ export async function ncLogin(page, { user = ADMIN.user, pass = ADMIN.pass } = {
 	}
 }
 
+/** Kanso's own front-end assets. The dev + CI stack bind-mounts the app at
+ * /custom_apps/kanso, an app-store install lands at /apps/kanso; both match. */
+const KANSO_SOURCE = /\/(?:custom_)?apps\/kanso\//
+
+/** Another Nextcloud app's front-end bundle, or the server's own (`/dist/`,
+ * `/core/`). Kanso is excluded from the apps arm by the negative lookahead, so
+ * a Kanso URL can never be classified as foreign here. `/index.php/` is
+ * optional because NC serves the same routes with and without it. */
+const FOREIGN_SOURCE = new RegExp(
+	'^https?://[^/]+/(?:index\\.php/)?(?:(?:custom_)?apps/(?!kanso/)[^/]+/|dist/|core/)',
+)
+
+/**
+ * Collect this page's console errors, keeping only the ones Kanso is answerable
+ * for. Returns a live array — read it at the end of the test.
+ *
+ * Two specs assert "rendering this page logs no console errors", and CI failed
+ * both on errors that were not Kanso's and not even on Kanso's page:
+ *
+ *     Failed to load resource: the server responded with a status of 404
+ *     could not load recommendation preview Event
+ *
+ * That pair comes from /apps/recommendations/js/recommendations-dashboard.js.
+ * It reaches the assertion because the collector is attached before `ncLogin`,
+ * and `ncLogin` goes through /index.php/login — which, with a live session,
+ * redirects through the Nextcloud DASHBOARD, where every other installed app
+ * mounts a widget (photos, circles, notifications, deck, recommendations…).
+ *
+ * The discriminator is the message's SOURCE URL, not its text. An allowlist of
+ * message strings rots the moment another app rewords its own logging (and it
+ * grows by one entry per unrelated app), whereas "which bundle logged this"
+ * stays true. Callers should also attach AFTER ncLogin so the login detour is
+ * out of scope by construction; the URL filter then covers the foreign bundles
+ * that Kanso's own page really does load (theming, user_status, notifications,
+ * files_sharing, unified-search, core).
+ *
+ * Anything NOT positively attributable to a foreign origin is KEPT. That is the
+ * important direction: Kanso's own console errors still fail the assertion, and
+ * so do uncaught exceptions with no location and failed requests for Kanso's
+ * own URLs. A filter that passed everything would be worse than no assertion.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @return {string[]} live array of `<message>  [<source url>]`
+ */
+export function collectConsoleErrors(page) {
+	const errors = []
+	page.on('console', (msg) => {
+		if (msg.type() !== 'error') return
+		const url = msg.location()?.url ?? ''
+		if (!KANSO_SOURCE.test(url) && FOREIGN_SOURCE.test(url)) return
+		errors.push(`${msg.text()}  [${url || 'no source url'}]`)
+	})
+	return errors
+}
+
 /**
  * A ~40-line zip reader, so the board export archive (#10060) can be verified
  * with no new dependency: walk the central directory and inflate each entry

--- a/tests/e2e/keyboard.spec.js
+++ b/tests/e2e/keyboard.spec.js
@@ -3,6 +3,30 @@
 
 import { test, expect, api, ncLogin, BASE } from './helpers.js'
 
+// Every wait in this file used to be a fixed `waitForTimeout`, and that is a
+// fragile way to drive a keyboard: BoardView's window keydown handler DROPS a
+// keypress it cannot act on, and a dropped keypress is not something an
+// auto-retrying assertion can recover from. It bails when
+// `route.name === 'card-modal'` (src/views/BoardView.vue), and ArrowDown with no
+// `focusedCardId` seeds to the first card of the first NON-EMPTY stack — so a
+// key sent before the modal route has actually unwound, or before the card
+// summaries have arrived, is simply swallowed. The assertion that follows then
+// starts from a state that will never arrive and burns its whole budget.
+//
+// So each sleep is replaced by a wait on the condition it stood in for: the
+// tiles being present, the route having changed, the modal being gone, or the
+// focus ring having landed.
+
+// Focus lands on the nextTick+rAF after the keypress — sub-frame work locally,
+// but a saturated CI runner (measured 1.8-3x degradation, see
+// playwright.config.js) can starve that rAF for far longer than the 3s these
+// assertions used to allow. 15s is ~100x the healthy cost and still fails fast
+// when a keypress was genuinely dropped rather than merely delayed.
+const FOCUS_TIMEOUT = 15_000
+
+/** The board-scoped card modal route, e.g. `#/board/12/card/34`. */
+const CARD_ROUTE = /#\/board\/\d+\/card\/\d+/
+
 test.describe('Keyboard navigation', () => {
 	const state = {
 		boardId: 0,
@@ -13,6 +37,28 @@ test.describe('Keyboard navigation', () => {
 		card3Id: 0,
 		card4Id: 0,
 		boardUrl: '',
+	}
+
+	/**
+	 * Open the board and wait until it is actually keyboard-navigable.
+	 *
+	 * `waitForSelector('.stack-column')` was not enough: the columns render from
+	 * the board read while the card summaries are still in flight, and on that
+	 * board `nonEmptyStacks` is empty, so the seeding ArrowDown/j returns without
+	 * doing anything. Waiting for all four seeded tiles makes the precondition
+	 * explicit instead of hoping a 200ms sleep covered the fetch.
+	 */
+	async function openBoard(page) {
+		await ncLogin(page)
+		await page.goto(state.boardUrl)
+		await expect(page.locator('.stack-column')).toHaveCount(2, { timeout: 30_000 })
+		await expect(page.locator('.card-tile')).toHaveCount(4, { timeout: 30_000 })
+	}
+
+	/** Wait until the card modal route is fully unwound — route AND DOM. */
+	async function waitForModalClosed(page) {
+		await page.waitForURL((url) => !url.hash.includes('/card/'), { timeout: FOCUS_TIMEOUT })
+		await expect(page.locator('.card-modal')).toHaveCount(0, { timeout: FOCUS_TIMEOUT })
 	}
 
 	test.beforeAll(async () => {
@@ -46,68 +92,70 @@ test.describe('Keyboard navigation', () => {
 	})
 
 	test('ArrowDown seeds to first card, navigates down and right', async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
 		// ArrowDown with no focus should seed to first card of first stack
 		await page.keyboard.press('ArrowDown')
-		await page.waitForTimeout(200)
 
-		// First card in S1 should be focused
+		// First card in S1 should be focused. No sleep first: toBeFocused already
+		// polls, and openBoard has established the precondition the sleep guessed at.
 		const s1 = page.locator('.stack-column').nth(0)
 		const firstCard = s1.locator('.card-tile').first()
-		await expect(firstCard).toBeFocused({ timeout: 3000 })
+		await expect(firstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// ArrowDown → second card in S1
 		await page.keyboard.press('ArrowDown')
-		await page.waitForTimeout(200)
 		const secondCard = s1.locator('.card-tile').nth(1)
-		await expect(secondCard).toBeFocused({ timeout: 3000 })
+		await expect(secondCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// ArrowDown at bottom clamps - still second card
 		await page.keyboard.press('ArrowDown')
-		await expect(secondCard).toBeFocused({ timeout: 3000 })
+		await expect(secondCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// ArrowRight → move to S2, card index clamped to 1
 		await page.keyboard.press('ArrowRight')
-		await page.waitForTimeout(200)
 		const s2 = page.locator('.stack-column').nth(1)
 		const s2SecondCard = s2.locator('.card-tile').nth(1)
-		await expect(s2SecondCard).toBeFocused({ timeout: 3000 })
+		await expect(s2SecondCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// ArrowUp → first card of S2
 		await page.keyboard.press('ArrowUp')
-		await page.waitForTimeout(200)
 		const s2FirstCard = s2.locator('.card-tile').first()
-		await expect(s2FirstCard).toBeFocused({ timeout: 3000 })
+		await expect(s2FirstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 	})
 
 	test("'e' opens card modal for the focused card (URL check), Esc closes", async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
-		// Seed focus
+		const s1 = page.locator('.stack-column').nth(0)
+		const s2 = page.locator('.stack-column').nth(1)
+
+		// Seed focus, then navigate right to S2 and down to its second card. Each
+		// step waits for the focus ring it should have moved rather than sleeping:
+		// asserting the intermediate state is also what makes the final 'e' target
+		// unambiguous, since a swallowed keypress would leave focus behind.
 		await page.keyboard.press('ArrowDown')
-		await page.waitForTimeout(200)
+		await expect(s1.locator('.card-tile').first()).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
-		// Navigate right to S2, then ArrowDown to second card
 		await page.keyboard.press('ArrowRight')
-		await page.waitForTimeout(200)
-		await page.keyboard.press('ArrowDown')
-		await page.waitForTimeout(200)
+		await expect(s2.locator('.card-tile').first()).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
-		// 'e' should open the card modal - URL should include /card/<id>
+		await page.keyboard.press('ArrowDown')
+		await expect(s2.locator('.card-tile').nth(1)).toBeFocused({ timeout: FOCUS_TIMEOUT })
+
+		// 'e' should open the card modal - URL should include /card/<id>.
+		// `page.url()` is a single-shot read with no retry of its own, so the route
+		// push is waited for explicitly; a fixed sleep here read the pre-push URL
+		// on a loaded runner and failed outright rather than flakily.
 		await page.keyboard.press('e')
-		await page.waitForTimeout(500)
+		await page.waitForURL(CARD_ROUTE, { timeout: FOCUS_TIMEOUT })
 
 		const url = page.url()
 		expect(url).toContain('/card/')
 
 		// Esc closes the modal (NcModal native close)
 		await page.keyboard.press('Escape')
-		await page.waitForTimeout(500)
+		await waitForModalClosed(page)
 
 		// URL should no longer have /card/
 		const urlAfter = page.url()
@@ -115,52 +163,50 @@ test.describe('Keyboard navigation', () => {
 	})
 
 	test("'d' toggles done styling on the focused tile", async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
 		// Seed focus to first card S1
 		await page.keyboard.press('ArrowDown')
-		await page.waitForTimeout(200)
 
 		const s1 = page.locator('.stack-column').nth(0)
 		const firstTile = s1.locator('.card-tile').first()
-		await expect(firstTile).toBeFocused({ timeout: 3000 })
+		await expect(firstTile).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// Toggle done
 		await page.keyboard.press('d')
 
-		// Wait for done styling to appear (poll - the update is async)
-		await expect(firstTile).toHaveClass(/card-tile--done/, { timeout: 8000 })
+		// Wait for done styling to appear (poll - the update is a server round-trip)
+		await expect(firstTile).toHaveClass(/card-tile--done/, { timeout: 30_000 })
 
 		// Toggle done back
 		await page.keyboard.press('d')
-		await expect(firstTile).not.toHaveClass(/card-tile--done/, { timeout: 8000 })
+		await expect(firstTile).not.toHaveClass(/card-tile--done/, { timeout: 30_000 })
 	})
 
 	test("'n' focuses the composer of the focused card's stack", async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
-		// Seed focus to S1
+		const s1 = page.locator('.stack-column').nth(0)
+
+		// Seed focus to S1 — asserted, so 'n' below is known to be aimed at S1
+		// rather than landing there by the no-focus fallback.
 		await page.keyboard.press('ArrowDown')
-		await page.waitForTimeout(200)
+		await expect(s1.locator('.card-tile').first()).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// 'n' should focus the composer input of S1
 		await page.keyboard.press('n')
-		await page.waitForTimeout(200)
 
-		const s1 = page.locator('.stack-column').nth(0)
 		const composer = s1.locator('.card-composer__input')
-		await expect(composer).toBeFocused({ timeout: 3000 })
+		await expect(composer).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// IMPORTANT: typing in the composer should NOT trigger shortcuts
 		// Type a title containing 'n', 'e', 'd'
 		await page.keyboard.type('ned')
-		await page.waitForTimeout(200)
 
-		// Composer value should be 'ned', no modal opened, no done toggled
+		// Composer value should be 'ned', no modal opened, no done toggled.
+		// toHaveValue polls, so it also establishes that all three keys landed —
+		// which is what makes the single-shot url read below sound: a shortcut
+		// would have pushed the route synchronously with its own keydown.
 		await expect(composer).toHaveValue('ned')
 		// Card modal should not be open
 		const url = page.url()
@@ -168,71 +214,61 @@ test.describe('Keyboard navigation', () => {
 	})
 
 	test("'?' opens the shortcuts overlay and Esc closes it", async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
 		// '?' should open the shortcuts overlay
 		await page.keyboard.press('?')
-		await page.waitForTimeout(300)
 
 		// NcModal should be visible - look for the modal with keyboard shortcuts heading
 		const modal = page.locator('.modal-container, [role="dialog"]').filter({ hasText: 'Keyboard shortcuts' })
-		await expect(modal).toBeVisible({ timeout: 3000 })
+		await expect(modal).toBeVisible({ timeout: FOCUS_TIMEOUT })
 
 		// Esc should close it (NcModal native close)
 		await page.keyboard.press('Escape')
-		await expect(modal).not.toBeVisible({ timeout: 3000 })
+		await expect(modal).not.toBeVisible({ timeout: FOCUS_TIMEOUT })
 	})
 
 	test('hjkl alias the arrow-key navigation (j/k cards, l/h stacks)', async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
 		// 'j' with no focus should seed to first card of first stack (like ArrowDown)
 		await page.keyboard.press('j')
-		await page.waitForTimeout(200)
 		const s1 = page.locator('.stack-column').nth(0)
 		const firstCard = s1.locator('.card-tile').first()
-		await expect(firstCard).toBeFocused({ timeout: 3000 })
+		await expect(firstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// 'j' → second card in S1 (ArrowDown)
 		await page.keyboard.press('j')
-		await page.waitForTimeout(200)
 		const secondCard = s1.locator('.card-tile').nth(1)
-		await expect(secondCard).toBeFocused({ timeout: 3000 })
+		await expect(secondCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// 'k' → back to first card in S1 (ArrowUp)
 		await page.keyboard.press('k')
-		await expect(firstCard).toBeFocused({ timeout: 3000 })
+		await expect(firstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// 'l' → move to S2 (ArrowRight)
 		await page.keyboard.press('l')
-		await page.waitForTimeout(200)
 		const s2 = page.locator('.stack-column').nth(1)
 		const s2FirstCard = s2.locator('.card-tile').first()
-		await expect(s2FirstCard).toBeFocused({ timeout: 3000 })
+		await expect(s2FirstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// 'h' → back to S1 (ArrowLeft)
 		await page.keyboard.press('h')
-		await expect(firstCard).toBeFocused({ timeout: 3000 })
+		await expect(firstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 	})
 
 	test('typing h/j/k/l in the composer inserts the letters (guard holds)', async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
+
+		const s1 = page.locator('.stack-column').nth(0)
 
 		// Seed focus to S1, then open its composer with 'n'
 		await page.keyboard.press('j')
-		await page.waitForTimeout(200)
-		await page.keyboard.press('n')
-		await page.waitForTimeout(200)
+		await expect(s1.locator('.card-tile').first()).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
-		const s1 = page.locator('.stack-column').nth(0)
+		await page.keyboard.press('n')
 		const composer = s1.locator('.card-composer__input')
-		await expect(composer).toBeFocused({ timeout: 3000 })
+		await expect(composer).toBeFocused({ timeout: FOCUS_TIMEOUT })
 
 		// Typing the vim nav letters must insert them, not navigate
 		await page.keyboard.type('hjkl')
@@ -240,28 +276,35 @@ test.describe('Keyboard navigation', () => {
 	})
 
 	test('mouse click on tile keeps focusedCardId in sync (tile click syncs keyboard state)', async ({ page }) => {
-		await ncLogin(page)
-		await page.goto(state.boardUrl)
-		await page.waitForSelector('.stack-column', { timeout: 10_000 })
+		await openBoard(page)
 
 		// Click on the second card in S2 to open the modal
 		const s2 = page.locator('.stack-column').nth(1)
 		const s2SecondCard = s2.locator('.card-tile').nth(1)
 		await s2SecondCard.click()
-		await page.waitForTimeout(300)
+
+		// The click opens the modal through a route push. Wait for the route: the
+		// url read below cannot retry, so a fixed sleep that came up short here
+		// failed the test outright.
+		await page.waitForURL(CARD_ROUTE, { timeout: FOCUS_TIMEOUT })
 
 		// Modal should be open
 		const url = page.url()
 		expect(url).toContain('/card/')
 
-		// Close modal with Esc
+		// Close modal with Esc.
 		await page.keyboard.press('Escape')
-		await page.waitForTimeout(300)
+		// THIS is what the old 300ms sleep stood in for, and why this test failed
+		// three attempts in a row on a saturated runner: BoardView's keydown
+		// handler returns immediately for as long as `route.name === 'card-modal'`,
+		// so the ArrowUp below is SWALLOWED if it arrives before the route has
+		// unwound — and no assertion budget can recover a keypress that was never
+		// handled. Wait for the route and the modal DOM to be gone instead.
+		await waitForModalClosed(page)
 
 		// After close, ArrowUp from the second card position should go to first card of S2
 		await page.keyboard.press('ArrowUp')
-		await page.waitForTimeout(200)
 		const s2FirstCard = s2.locator('.card-tile').first()
-		await expect(s2FirstCard).toBeFocused({ timeout: 3000 })
+		await expect(s2FirstCard).toBeFocused({ timeout: FOCUS_TIMEOUT })
 	})
 })

--- a/tests/e2e/list-view.spec.js
+++ b/tests/e2e/list-view.spec.js
@@ -568,6 +568,22 @@ test.describe('List view — column composer (#9853)', () => {
 	})
 
 	test('the composer keeps its focus and half-typed draft while the list recycles rows', async ({ page }) => {
+		// Explicit budget, measured rather than guessed. This is the thinnest margin
+		// in the whole suite: 60s on two healthy CI runs and 108s on two saturated
+		// ones, against what used to be a 120s cap — 1.11x headroom, i.e. it passed
+		// twice with 12 seconds to spare and a slightly worse runner turns it into a
+		// deterministic timeout (the failure mode that took out timeline-view at the
+		// same 1.67x margin, #10332).
+		//
+		// The cost is the 50 sequential card creates below, and they CANNOT be
+		// overlapped: CardService::create derives each sort key from the stack tail
+		// under the (stack_id, sort_key) and (board_id, board_seq) unique indexes and
+		// re-derives only MAX_CREATE_ATTEMPTS=5 times, so firing them concurrently
+		// into one stack trades a slow test for a flaky one. Nor can the fixture
+		// shrink: 50 rows is what makes the list actually recycle, which is the whole
+		// regression under test. So the honest fix is to state the budget.
+		test.setTimeout(360_000)
+
 		// This is the whole reason the composer is rendered OUTSIDE the virtualizer:
 		// as a virtual row it would be unmounted and recycled onto another card the
 		// moment the list scrolled, taking the focus and the draft with it. Needs

--- a/tests/e2e/my-work-live.spec.js
+++ b/tests/e2e/my-work-live.spec.js
@@ -69,7 +69,11 @@ test.describe('My Work live updates (#3768)', () => {
 
 	test('a review requested by another user appears in the open My Reviews view by itself', async ({ browser, peer }) => {
 		// Polling budget (60s interval + slow-CI headroom) on top of the default.
-		test.setTimeout(180_000)
+		// 240s: measured 66s healthy / 90s saturated. Most of that is the FIXED 60s
+		// poll interval rather than runner speed, but 180s was only 2x the worst
+		// observed, and an explicit setTimeout overrides the config default in both
+		// directions — at 180s this would now cap below the suite-wide 240s.
+		test.setTimeout(240_000)
 		const ctx = await browser.newContext()
 		try {
 			const page = await ctx.newPage()
@@ -96,7 +100,8 @@ test.describe('My Work live updates (#3768)', () => {
 	})
 
 	test('a card assigned by another user appears in the open My Tasks view by itself', async ({ browser, peer }) => {
-		test.setTimeout(180_000)
+		// 240s — see the sibling test above (measured 72s healthy / 72s saturated).
+		test.setTimeout(240_000)
 		const ctx = await browser.newContext()
 		try {
 			const page = await ctx.newPage()

--- a/tests/e2e/parent-child.spec.js
+++ b/tests/e2e/parent-child.spec.js
@@ -3,6 +3,12 @@
 
 import { test, expect, api, ncLogin, BASE } from './helpers.js'
 
+// Every 20s budget below covers a server round-trip: creating a sub-card, then
+// the parent's progress recomputing from it. They were 8s, which is inside the
+// range a saturated CI runner reaches for a create (#10332 saw this test fail on
+// the create at :41 with the board already loaded — a budget problem, not a
+// missing wait), and 8s buys nothing that 20s does not: an auto-retrying
+// assertion only spends its budget when it is already failing.
 test.describe('Parent / Child cards', () => {
 	// Unique board title to avoid collisions with parallel test runs
 	const BOARD_TITLE = 'Parent Child Test Board ' + Date.now()
@@ -60,14 +66,14 @@ test.describe('Parent / Child cards', () => {
 
 		// Wait for the child to appear in the list
 		await expect(page.locator('.card-modal__child').filter({ hasText: 'Sub-task Alpha' }))
-			.toBeVisible({ timeout: 8000 })
+			.toBeVisible({ timeout: 20_000 })
 
 		// Add second sub-card "Sub-task Beta"
 		await addChildInput.fill('Sub-task Beta')
 		await addChildInput.press('Enter')
 
 		await expect(page.locator('.card-modal__child').filter({ hasText: 'Sub-task Beta' }))
-			.toBeVisible({ timeout: 8000 })
+			.toBeVisible({ timeout: 20_000 })
 
 		// Assert Children section shows 2 items
 		await expect(page.locator('.card-modal__child')).toHaveCount(2, { timeout: 5000 })
@@ -100,7 +106,7 @@ test.describe('Parent / Child cards', () => {
 
 		// Progress should now show 1 / 2
 		await expect(page.locator('.card-modal__section-count'))
-			.toHaveText('1 / 2', { timeout: 8000 })
+			.toHaveText('1 / 2', { timeout: 20_000 })
 
 		// The done child should have its done indicator active
 		const doneChildItem = page.locator('.card-modal__child').filter({ hasText: firstChild.title })
@@ -115,7 +121,7 @@ test.describe('Parent / Child cards', () => {
 		await expect(
 			page.locator('.card-tile').filter({ hasText: 'Parent Card' })
 				.locator('.card-tile__children'),
-		).toHaveText(/1\/2/, { timeout: 8000 })
+		).toHaveText(/1\/2/, { timeout: 20_000 })
 	})
 
 	test('reload board and assert parent tile persists child badge 1/2', async ({ page }) => {
@@ -126,13 +132,13 @@ test.describe('Parent / Child cards', () => {
 		// Tile badge should show 1/2 after fresh load
 		const parentTile = page.locator('.card-tile').filter({ hasText: 'Parent Card' })
 		await expect(parentTile.locator('.card-tile__children'))
-			.toHaveText(/1\/2/, { timeout: 8000 })
+			.toHaveText(/1\/2/, { timeout: 20_000 })
 
 		// Open and re-verify modal progress
 		await parentTile.click()
 		await page.waitForSelector('.card-modal', { timeout: 10_000 })
 		await expect(page.locator('.card-modal__section-count'))
-			.toHaveText('1 / 2', { timeout: 8000 })
+			.toHaveText('1 / 2', { timeout: 20_000 })
 		await expect(page.locator('.card-modal__child')).toHaveCount(2, { timeout: 5000 })
 	})
 
@@ -154,14 +160,14 @@ test.describe('Parent / Child cards', () => {
 		// Wait for the child card modal to open (URL changes to child cardId)
 		await page.waitForFunction(
 			() => window.location.hash.includes('/card/'),
-			{ timeout: 8000 },
+			{ timeout: 20_000 },
 		)
 
 		await page.waitForSelector('.card-modal', { timeout: 10_000 })
 
 		// The child card modal should show the "Parent card" section (not Sub-cards)
 		const parentSection = page.locator('.card-modal__parent-link')
-		await expect(parentSection).toBeVisible({ timeout: 8000 })
+		await expect(parentSection).toBeVisible({ timeout: 20_000 })
 		await expect(parentSection).toHaveText('Parent Card', { timeout: 5000 })
 
 		// The "Add sub-card" input should NOT be present (one-level rule: a card
@@ -191,13 +197,13 @@ test.describe('Parent / Child cards', () => {
 		const undoneChildItem = page.locator('.card-modal__child').filter({ hasText: undoneChild.title })
 		await undoneChildItem.hover()
 		const removeBtn = undoneChildItem.locator('.card-modal__child-remove')
-		await expect(removeBtn).toBeVisible({ timeout: 3000 })
+		await expect(removeBtn).toBeVisible()
 		await removeBtn.click()
 
 		// Progress should now be 1 / 1 (only the done child remains). Since we
 		// detached the undone one, 1 done out of 1 total → progress text "1 / 1".
 		await expect(page.locator('.card-modal__section-count'))
-			.toHaveText('1 / 1', { timeout: 8000 })
+			.toHaveText('1 / 1', { timeout: 20_000 })
 
 		// The list should now have 1 item
 		await expect(page.locator('.card-modal__child')).toHaveCount(1, { timeout: 5000 })

--- a/tests/e2e/priority.spec.js
+++ b/tests/e2e/priority.spec.js
@@ -78,7 +78,7 @@ test.describe('Card priorities', () => {
 			.locator('.card-tile__priority')
 		await expect(priorityBadge).toBeVisible({ timeout: 5000 })
 		// High is priority level 3 - badge should carry the --3 class
-		await expect(priorityBadge).toHaveClass(/card-tile__priority--3/, { timeout: 3000 })
+		await expect(priorityBadge).toHaveClass(/card-tile__priority--3/)
 	})
 
 	test('set Urgent card priority via UI; assert its tile shows urgent indicator', async ({ page }) => {

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -71,6 +71,14 @@ const PUBLIC_CARD_KEYS = [
 // and never the internal board id.
 const PUBLIC_STACK_KEYS = ['color', 'id', 'title'].sort()
 
+// And likewise for one entry of the card's nested `labels` array, built at
+// PublicShareService.php:242. The card/stack/comment key sets above are pinned
+// but this one was not (#10292), and it is the other nested object on the public
+// payload — so the same drift a flat key set catches (a label gaining a
+// createdBy, an owner, a lastEditedBy) would have slipped through here. Note the
+// internal label `id` is deliberately NOT exposed.
+const PUBLIC_LABEL_KEYS = ['color', 'name'].sort()
+
 // Public / read-only board share links (#3531). A MANAGE user mints a token; an
 // unauthenticated reader gets a STRIPPED read-only board; disabling 404s it.
 test.describe('Public read-only board share', () => {
@@ -99,6 +107,11 @@ test.describe('Public read-only board share', () => {
 		const comment = await api('POST', `/cards/${cardId}/comments`, { body: 'internal comment SHOULD NOT LEAK' })
 		expect(comment.status).toBe(200)
 		expect(comment.body.body).toContain('SHOULD NOT LEAK')
+		// A label on the public card, so the nested-labels key assertion below runs
+		// against a real entry instead of passing vacuously over an empty array.
+		const label = await api('POST', '/labels', { boardId, title: 'Public label', color: '31CC7C' })
+		expect(label.status).toBe(200)
+		expect((await api('PUT', `/cards/${cardId}/labels/${label.body.id}`)).status).toBe(200)
 	})
 
 	// The token is minted by the 'MANAGE enables a link' test below, so every
@@ -159,6 +172,13 @@ test.describe('Public read-only board share', () => {
 		expect(res.body.stacks.length).toBe(1) // so the loop below can't pass by being empty
 		for (const stack of res.body.stacks) {
 			expect(Object.keys(stack).sort()).toEqual(PUBLIC_STACK_KEYS)
+		}
+		// The nested `labels` entries get the same exhaustive treatment. The length
+		// check is what stops it passing over an empty array — beforeAll assigns
+		// exactly one label to this card.
+		expect(card.labels.length).toBe(1)
+		for (const label of card.labels) {
+			expect(Object.keys(label).sort()).toEqual(PUBLIC_LABEL_KEYS)
 		}
 
 		// Raw-string SUPPLEMENTS to the key-set assertions above — deliberately not

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -3,7 +3,7 @@
 
 // BASE/API come from helpers.js so this spec honours E2E_BASE_URL like every
 // other spec; it used to hardcode http://localhost:8891 and silently ignore it.
-import { test, expect, currentAuth, me, BASE, API } from './helpers.js'
+import { test, expect, currentAuth, me, BASE, API, OCS, adminAuth, provisionUser, deleteUser } from './helpers.js'
 
 const HEADERS = { 'OCS-APIREQUEST': 'true', 'Content-Type': 'application/json' }
 
@@ -664,5 +664,140 @@ test.describe('Public board honours the hidden card sections', () => {
 		expect(payloadCard.coverColor).toBe(COVER)
 		expect(res.body.board.cardFeatures.checklist).toBe(false)
 		expect(res.body.board.cardFeatures.coverColor).toBe(false)
+	})
+})
+
+// A `@mention` is the one way a real LOGIN uid rides the anonymous payload as
+// "board content": mentions have no entity table, so they are stored as the
+// literal string `@uid` inside a card description and a comment body, and the
+// public page renders them as chips. The key-set assertions above cannot catch
+// this — the uid arrives inside the VALUE of a permitted key — so it needs its
+// own board and its own fixture.
+//
+// This is the DEFAULT configuration, not an opt-in: the description case holds
+// with the comments toggle off, which is why the first test does not touch it.
+//
+// Why a dedicated provisioned account instead of `me`: helpers.js:269 provisions
+// the worker's own user with displayName === username, so substituting a display
+// name for that uid changes nothing and every assertion here would pass
+// vacuously. This account's display name deliberately differs from its uid, and
+// beforeAll asserts that it really does.
+test.describe('Public payload redacts @mention uids', () => {
+	// Nothing here drives a browser, but keep the shared admin storageState out of
+	// it like every sibling describe — fetchPublic must stay cookieless.
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	// SCOPE, so the whole-payload assertion below is not over-trusted: only the two
+	// FREE-TEXT fields are redacted. A `@name` typed into a card/stack/board title or
+	// a label name still ships verbatim by design — those are not mention surfaces
+	// and the sibling 'substring-immune' describe pins them as byte-exact. The
+	// `not.toContain(mentioned)` checks hold here because this board's titles are
+	// mention-free, not because the payload redacts everything.
+	//
+	// The three tests share one fixture and run in declaration order (the config is
+	// serial per file: workers default to 1 and fullyParallel is off), which the
+	// second one relies on — it flips the comments toggle the first asserts is off.
+
+	const DISPLAY_NAME = 'Mona Mentioned'
+	const PASS = 'Public#Mention2026'
+	const CARD_TITLE = 'Card that mentions a board member'
+	// `@`-shaped text that is NOT an account and must survive byte-identical: an
+	// email address, a social handle, a time, an unknown uid. Over-eager
+	// substitution here would corrupt real board content, so these are asserted as
+	// explicitly as the redaction itself.
+	const DECOYS = ['foo@bar.com', '@nextcloud', '@9.30', '@nosuchuser-42']
+
+	let mentioned = ''
+	let description = ''
+	let boardId = 0
+	let cardId = 0
+	let token = ''
+
+	test.beforeAll(async ({}, workerInfo) => {
+		// Per-worker unique, so parallel workers never fight over the account.
+		mentioned = `kanso_pubmention_w${workerInfo.workerIndex}`
+		// Delete-then-create: the shared provisionUser is idempotent, so a leftover
+		// account from an earlier run would keep its OLD display name and the
+		// assertions below would be comparing against the wrong string.
+		await deleteUser(mentioned)
+		await provisionUser(mentioned, PASS, { displayName: DISPLAY_NAME })
+		// Assert the display name actually landed AND that it differs from the uid.
+		// Without this the whole describe can pass vacuously: if the display name
+		// were the uid (Nextcloud's fallback when none is set), substituting one for
+		// the other is a no-op and "the uid is gone" could never fail.
+		const info = await fetch(`${OCS}/users/${encodeURIComponent(mentioned)}`, {
+			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json', Authorization: adminAuth },
+		})
+		const stored = (await info.json()).ocs.data.displayname
+		expect(stored).toBe(DISPLAY_NAME)
+		expect(stored).not.toContain(mentioned)
+
+		boardId = (await api('POST', '/boards', { title: 'Public Mention E2E' })).body.id
+		// A real board member — this is a member's login uid, not a stranger's.
+		expect((await api('POST', `/boards/${boardId}/acl`, {
+			participant: mentioned, participantType: 'user', permission: 3,
+		})).status).toBe(200)
+		const stackId = (await api('POST', '/stacks', { boardId, title: 'To do' })).body.id
+		cardId = (await api('POST', '/cards', { stackId, title: CARD_TITLE })).body.id
+		// Two shapes of the same mention: one followed by a space, and one ENDING a
+		// sentence — `.` is a legal uid character, so the second token is `<uid>.` and
+		// only resolves after the trailing punctuation is trimmed. Writing an ordinary
+		// English sentence was the bypass.
+		description = `Assigned to @${mentioned} for review. Also ping @${mentioned}. Decoys: ${DECOYS.join(' ')}`
+		expect((await api('PATCH', `/cards/${cardId}`, { description })).status).toBe(200)
+		expect((await api('POST', `/cards/${cardId}/comments`, {
+			body: `cc @${mentioned} — please look`,
+		})).status).toBe(200)
+		token = (await api('POST', `/boards/${boardId}/public-share`)).body.token
+		expect(token).toBeTruthy()
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await api('DELETE', `/boards/${boardId}`)
+		await deleteUser(mentioned)
+	})
+
+	test('the default payload serves the description with display names, never uids', async () => {
+		const res = await fetchPublic(token)
+		expect(res.status).toBe(200)
+		// Comments opt-in untouched: this is the out-of-the-box configuration.
+		expect(res.body.board.commentsEnabled).toBe(false)
+
+		const card = res.body.cards.find((c) => c.title === CARD_TITLE)
+		expect(card).toBeTruthy()
+		expect(card.description).toContain(DISPLAY_NAME)
+		// THE assertion: no board member's uid anywhere in what the token serves.
+		expect(card.description).not.toContain(mentioned)
+		expect(JSON.stringify(res.body)).not.toContain(mentioned)
+		// …and nothing else was mangled on the way.
+		for (const decoy of DECOYS) {
+			expect(card.description).toContain(decoy)
+		}
+		// Redaction is a VALUE change, so the field list must be untouched.
+		expect(Object.keys(card).sort()).toEqual(PUBLIC_CARD_KEYS)
+	})
+
+	test('the opted-in comment body is redacted too', async () => {
+		expect((await api('PUT', `/boards/${boardId}/public-share/comments`, { enabled: true })).body.commentsEnabled).toBe(true)
+
+		const res = await fetchPublic(token)
+		const card = res.body.cards.find((c) => c.title === CARD_TITLE)
+		expect(card.comments.length).toBe(1)
+		expect(card.comments[0].body).toContain(DISPLAY_NAME)
+		expect(card.comments[0].body).not.toContain(mentioned)
+		// Widening the link with comments must not widen it to uids: the whole
+		// payload — description, comment body and author byline together — is uid-free.
+		expect(JSON.stringify(res.body)).not.toContain(mentioned)
+	})
+
+	test('the stored row keeps its raw @mention for authenticated viewers', async () => {
+		// Redaction is payload-only. If it ever became a write-back, the mention would
+		// stop notifying and stop rendering as a chip for members — and no migration
+		// may rewrite user content.
+		const stored = (await api('GET', `/cards/${cardId}`)).body
+		expect(stored.description).toBe(description)
+		expect(stored.description).toContain(`@${mentioned}`)
+		const comments = (await api('GET', `/cards/${cardId}/comments`)).body
+		expect(JSON.stringify(comments)).toContain(`@${mentioned}`)
 	})
 })

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -143,8 +143,9 @@ test.describe('Public read-only board share', () => {
 
 		// The board object carries no owner / acl / token / webhook - only the
 		// presentational fields, the comments opt-in flag (#3949) and the
-		// built-in-section switches (#5894, five booleans about the BOARD, never
-		// about a person) so the public link honours what the manager hid.
+		// built-in-section switches (#5894, six booleans about the BOARD, never
+		// about a person — CardFeatures::ALL) so the public link honours what the
+		// manager hid.
 		expect(Object.keys(res.body.board).sort()).toEqual(['cardFeatures', 'color', 'commentsEnabled', 'prefix', 'title'])
 
 		const card = res.body.cards.find((c) => c.title === 'Public visible card')
@@ -470,5 +471,178 @@ test.describe('Public payload key sets are substring-immune', () => {
 		// And no false red from the structural guard: keys are value-blind, so the
 		// key set is still exactly the public field list.
 		expect(Object.keys(card).sort()).toEqual(PUBLIC_CARD_KEYS)
+	})
+})
+
+// The built-in card sections a manager can switch off (#5894) are a BOARD-level
+// setting, and the public link is the same board — so the anonymous view follows
+// the same switches. tests/e2e/card-features.spec.js asserts the checklist switch
+// on the authenticated tile and card modal, plus attachments and time tracking;
+// the public share was uncovered, and it is the only surface whose audience is
+// anonymous. (For `coverColor`, this is the only place in the suite that asserts
+// the switch changes anything ON SCREEN at all — card-features.spec.js checks its
+// settings checkbox and its payload flag, never a rendered cover band.)
+//
+// Two keys are exercised, because it is one test shape used twice: `checklist`
+// (src/views/PublicBoard.vue:55, :118 and the `hasMeta` computed at :213) and
+// `coverColor` (:84). Deleting any of those guards must turn this test red.
+//
+// SCOPE, stated so nobody later reads this as more than it is: hiding a section
+// is PRESENTATION-ONLY by design (lib/Db/CardFeatures.php:28-38 — "Enforcement:
+// CLIENT-SIDE ONLY (deliberate)"). The payload assertions at the end pin exactly
+// that: the anonymous JSON still carries the checklist counts and the cover
+// colour while both sections are hidden. This is a RENDERING contract, not a
+// confidentiality one; making it one would be a server change, not a test change.
+test.describe('Public board honours the hidden card sections', () => {
+	// True anonymous reader (opt out of the shared admin storageState). This is
+	// load-bearing here, not decoration: under the admin session the page would
+	// still render and every "…is hidden" assertion would pass for the wrong
+	// reason. The test asserts its own anonymity below rather than trusting this.
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	const CARD_TITLE = 'Card with a cover and a checklist'
+	const DATED_TITLE = 'Card with a due date and a checklist'
+	const COVER = 'cc3311'
+
+	let boardId = 0
+	let token = ''
+
+	test.beforeAll(async () => {
+		boardId = (await api('POST', '/boards', { title: 'Public Card Features E2E' })).body.id
+		const stackId = (await api('POST', '/stacks', { boardId, title: 'To do' })).body.id
+		const cardId = (await api('POST', '/cards', { stackId, title: CARD_TITLE })).body.id
+		await api('PATCH', `/cards/${cardId}`, { coverColor: COVER })
+		// One step of two ticked, so every surface has a 1/2 to show. This card
+		// deliberately carries NO other meta (no priority, due/start date or
+		// estimate): that makes the checklist the only thing keeping the detail's
+		// meta ROW alive, which is what pins the `hasMeta` guard.
+		const step = (await api('POST', `/cards/${cardId}/checklist`, { title: 'Step one' })).body
+		await api('PATCH', `/checklist/${step.id}`, { done: true })
+		await api('POST', `/cards/${cardId}/checklist`, { title: 'Step two' })
+
+		// A SECOND card whose meta row survives the checklist being hidden, because
+		// it also has a due date. Without it the FIELD guard inside the meta row is
+		// untestable: `hasMeta` already removes the whole row for the card above, so
+		// the two guards could only ever be proven together. Here the row stays and
+		// only the 0/1 must go.
+		const datedId = (await api('POST', '/cards', { stackId, title: DATED_TITLE })).body.id
+		await api('PATCH', `/cards/${datedId}`, { duedate: '2026-05-06T12:00:00+00:00' })
+		await api('POST', `/cards/${datedId}/checklist`, { title: 'Only step' })
+
+		token = (await api('POST', `/boards/${boardId}/public-share`)).body.token
+		expect(token).toBeTruthy()
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await api('DELETE', `/boards/${boardId}`)
+	})
+
+	test('both sections render while they are on, and vanish once the board hides them', async ({ page }) => {
+		await page.goto(`${BASE}/index.php/apps/kanso/p/${token}`)
+		await expect(page.locator('.public-board__title')).toHaveText('Public Card Features E2E')
+
+		// This browser context really is anonymous — asserted, not assumed. An
+		// authenticated Kanso call from the page's own origin is refused, which it
+		// would not be if the shared admin storageState had leaked in: a live session
+		// answers 200, or 412 (CSRF, no requesttoken on a bare fetch). Neither is in
+		// the accepted set, so the guard catches a leak either way. Without it the
+		// "hidden" assertions below could all be vacuous.
+		//
+		// `Accept: application/json` is load-bearing, not decoration: NC's
+		// SecurityMiddleware answers an unauthenticated request with a JSON 401 only
+		// for a JSON-ish Accept, and with a 303 to the login page for `text/html`
+		// (which fetch would follow into a 200). The path comes from `API` rather
+		// than a literal so this honours E2E_BASE_URL under a webroot subdirectory,
+		// the same reason the header of this file gives for not hardcoding a host.
+		const apiPath = new URL(API).pathname
+		const authedStatus = await page.evaluate(async (p) => {
+			const r = await fetch(p + '/boards', {
+				headers: { Accept: 'application/json', 'OCS-APIREQUEST': 'true' },
+			})
+			return r.status
+		}, apiPath)
+		expect([401, 403]).toContain(authedStatus)
+
+		const tile = page.locator('.public-card').filter({ hasText: CARD_TITLE })
+		const datedTile = page.locator('.public-card').filter({ hasText: DATED_TITLE })
+		const detail = page.locator('.public-detail')
+		const meta = detail.locator('.public-detail__meta')
+
+		// --- Both features ON (the default): the badge, the cover band and the
+		//     checklist meta field are all there.
+		await expect(tile.locator('.public-card__check')).toHaveText('1/2')
+		await tile.click()
+		await expect(detail).toBeVisible()
+		await expect(detail.locator('.public-detail__cover')).toBeVisible()
+		// The checklist is this card's ONLY meta, so the whole row reads '1/2'.
+		await expect(meta).toHaveText('1/2')
+		await detail.locator('.public-detail__close').click()
+		await expect(detail).toHaveCount(0)
+
+		// The dated card shows its progress alongside the due date.
+		await expect(datedTile.locator('.public-card__check')).toHaveText('0/1')
+		await datedTile.click()
+		await expect(detail).toBeVisible()
+		await expect(meta).toContainText('Due')
+		await expect(meta).toContainText('0/1')
+		await detail.locator('.public-detail__close').click()
+		await expect(detail).toHaveCount(0)
+
+		// --- The manager hides both sections on the board.
+		const patched = await api('PATCH', `/boards/${boardId}`, {
+			cardFeatures: { checklist: false, coverColor: false },
+		})
+		expect(patched.status).toBe(200)
+		// Read it back before touching the page, so a switch that never landed fails
+		// here with a clear cause instead of as a confusing "still visible" below.
+		const stored = (await api('GET', `/boards/${boardId}`)).body.board.cardFeatures
+		expect(stored.checklist).toBe(false)
+		expect(stored.coverColor).toBe(false)
+
+		// --- Both features OFF: the anonymous view drops them. The card itself is
+		//     still listed — hiding a section is not hiding the card.
+		await page.reload()
+		await expect(page.locator('.public-board__title')).toHaveText('Public Card Features E2E')
+		await expect(tile).toBeVisible()
+		// The badge is GONE, not merely emptied.
+		await expect(tile.locator('.public-card__check')).toHaveCount(0)
+		await expect(tile).not.toContainText('1/2')
+
+		await tile.click()
+		await expect(detail).toBeVisible()
+		await expect(detail.locator('.public-detail__cover')).toHaveCount(0)
+		// The checklist was this card's only meta, so the row goes with it — the
+		// `hasMeta` guard.
+		await expect(meta).toHaveCount(0)
+		await expect(detail).not.toContainText('1/2')
+		// Still the same read-only detail otherwise.
+		await expect(detail.locator('.public-detail__title')).toHaveText(CARD_TITLE)
+		await detail.locator('.public-detail__close').click()
+		await expect(detail).toHaveCount(0)
+
+		// The dated card's meta row SURVIVES (it still has a due date) — and the
+		// progress is gone from inside it. This is the field guard on its own, the
+		// one `hasMeta` would otherwise mask.
+		// Assert the tile is there BEFORE counting what it must not contain, so the
+		// count-0 can't pass by the tile itself having gone missing.
+		await expect(datedTile).toBeVisible()
+		await expect(datedTile.locator('.public-card__check')).toHaveCount(0)
+		await datedTile.click()
+		await expect(detail).toBeVisible()
+		await expect(meta).toBeVisible()
+		await expect(meta).toContainText('Due')
+		await expect(meta).not.toContainText('0/1')
+
+		// --- Presentation-only, exactly as documented: the anonymous PAYLOAD is
+		//     unchanged by the switches. The counts and the colour are still served;
+		//     only the rendering above respects the flags.
+		const res = await fetchPublic(token)
+		expect(res.status).toBe(200)
+		const payloadCard = res.body.cards.find((c) => c.title === CARD_TITLE)
+		expect(payloadCard).toBeTruthy()
+		expect(payloadCard.checklist).toEqual({ total: 2, done: 1 })
+		expect(payloadCard.coverColor).toBe(COVER)
+		expect(res.body.board.cardFeatures.checklist).toBe(false)
+		expect(res.body.board.cardFeatures.coverColor).toBe(false)
 	})
 })

--- a/tests/e2e/public-share.spec.js
+++ b/tests/e2e/public-share.spec.js
@@ -51,6 +51,26 @@ async function fetchPublic(token) {
 	return { status: r.status, body: text ? JSON.parse(text) : null }
 }
 
+// The EXHAUSTIVE key set of one anonymous card object, mirrored from the closed
+// literal at lib/Service/PublicShareService.php:247-274. `comments` is the ONE
+// conditional addition, and only when a MANAGE user opts in (:276-278).
+//
+// Asserting the whole KEY SET — not just the absence of a few known-bad VALUES —
+// is what makes the leak guard hold. A raw-string check over the payload can only
+// catch a leak whose text happens to match a fixture string, so a future
+// person-bearing field on $cardPayload (an owner uid, an author, an email) slips
+// past it whenever its value doesn't collide with one. An exact key set fails on
+// the drift itself, whatever the value turns out to be.
+const PUBLIC_CARD_KEYS = [
+	'allDay', 'checklist', 'coverColor', 'description', 'duedate', 'estimate',
+	'humanId', 'id', 'labels', 'priority', 'stackId', 'startDate', 'status',
+	'title', 'type',
+].sort()
+
+// Likewise for one stack (PublicShareService.php:218-222): presentational only,
+// and never the internal board id.
+const PUBLIC_STACK_KEYS = ['color', 'id', 'title'].sort()
+
 // Public / read-only board share links (#3531). A MANAGE user mints a token; an
 // unauthenticated reader gets a STRIPPED read-only board; disabling 404s it.
 test.describe('Public read-only board share', () => {
@@ -130,10 +150,26 @@ test.describe('Public read-only board share', () => {
 		const card = res.body.cards.find((c) => c.title === 'Public visible card')
 		expect(card).toBeTruthy()
 
-		// No people, no comments, no internal metadata anywhere in the payload.
+		// The card and stack objects carry EXACTLY the public field lists — the same
+		// exhaustive treatment the board envelope gets above. This is the assertion
+		// that catches drift: a person-bearing field added to the payload fails here
+		// on its KEY, whatever its value happens to be.
+		expect(Object.keys(card).sort()).toEqual(PUBLIC_CARD_KEYS)
+		expect(res.body.stacks.length).toBe(1) // so the loop below can't pass by being empty
+		for (const stack of res.body.stacks) {
+			expect(Object.keys(stack).sort()).toEqual(PUBLIC_STACK_KEYS)
+		}
+
+		// Raw-string SUPPLEMENTS to the key-set assertions above — deliberately not
+		// identity checks. `me` is both the acting uid AND its display name in the
+		// e2e env (helpers.js:269 provisions displayName === username), so a trip on
+		// the line below cannot tell a leaked uid from a leaked display name; it is a
+		// substring match over the whole serialized payload for two exact fixture
+		// strings, nothing more. Their value is coverage BREADTH (board and stack
+		// envelopes too, not just the card keys), not precision.
 		const json = JSON.stringify(res.body)
-		expect(json).not.toContain(me) // no assignee / owner uid
-		expect(json).not.toContain('SHOULD NOT LEAK') // no comments
+		expect(json).not.toContain(me)
+		expect(json).not.toContain('SHOULD NOT LEAK') // no comment bodies while the opt-in is off
 		expect(card.assignees).toBeUndefined()
 		expect(card.assigneeIds).toBeUndefined()
 		expect(card.comments).toBeUndefined()
@@ -345,6 +381,12 @@ test.describe('Public board comments opt-in', () => {
 		const card = res.body.cards.find((c) => c.title === 'Card with a discussion')
 		expect(Array.isArray(card.comments)).toBe(true)
 		expect(card.comments.length).toBe(2)
+		// Opting in adds EXACTLY one key to the card — `comments` — and the comment
+		// object carries exactly {id, parentCommentId, author, body, timestamps}.
+		// This is the one place a person-data regression can actually land (an
+		// `authorUid` alongside the display name), so pin both key sets here too.
+		expect(Object.keys(card).sort()).toEqual([...PUBLIC_CARD_KEYS, 'comments'].sort())
+		expect(Object.keys(card.comments[0]).sort()).toEqual(['author', 'body', 'createdAt', 'editedAt', 'id', 'parentCommentId'])
 		// The comment carries the author's DISPLAY NAME (resolved from the uid, like
 		// the authenticated endpoint) - a non-empty string - and its markdown body,
 		// timestamps and one-level parent link. (In this dev instance the admin's
@@ -382,5 +424,51 @@ test.describe('Public board comments opt-in', () => {
 		const card = res.body.cards.find((c) => c.title === 'Card with a discussion')
 		expect(card.comments).toBeUndefined()
 		expect(JSON.stringify(res.body)).not.toContain('PUBLIC_TOP')
+	})
+})
+
+// A card title may legitimately CONTAIN the acting user's uid inside a longer word
+// ("administrator notes" contains "admin"), and such a card must still be served
+// VERBATIM on the public link — the fix for a person-data leak is a narrower
+// payload, never scrubbing uid-shaped text out of board content. Nothing else in
+// the suite covers that: every other fixture title is uid-free, so an over-eager
+// redaction would pass unnoticed. The board is its own because the raw-string
+// supplement in the leak test above would read this title as a leak — the two
+// cannot share a payload, which is itself the point.
+test.describe('Public payload key sets are substring-immune', () => {
+	// Match the sibling describes and keep the shared admin storageState out of it.
+	// (Nothing here drives a browser — fetchPublic is cookieless and the local api()
+	// carries its own Authorization — so this is consistency, not load-bearing.)
+	test.use({ storageState: { cookies: [], origins: [] } })
+
+	let boardId = 0
+	let token = ''
+	let title = ''
+
+	test.beforeAll(async () => {
+		// Built here, not at module scope: `me` is rebound by the worker fixture
+		// (helpers.js:269), and a describe body runs at collection time — before the
+		// rebind — so a top-level snapshot would embed 'admin' instead of the worker.
+		title = `${me}istrator notes`
+		boardId = (await api('POST', '/boards', { title: 'Public Substring E2E' })).body.id
+		const stackId = (await api('POST', '/stacks', { boardId, title: 'To do' })).body.id
+		await api('POST', '/cards', { stackId, title })
+		token = (await api('POST', `/boards/${boardId}/public-share`)).body.token
+	})
+
+	test.afterAll(async () => {
+		if (boardId) await api('DELETE', `/boards/${boardId}`)
+	})
+
+	test('a card title that embeds the uid in a longer word is not a leak', async () => {
+		const res = await fetchPublic(token)
+		expect(res.status).toBe(200)
+		// The title is served verbatim, uid substring and all — no redaction of
+		// legitimate board content. This is the assertion that can fail here.
+		const card = res.body.cards.find((c) => c.title === title)
+		expect(card).toBeTruthy()
+		// And no false red from the structural guard: keys are value-blind, so the
+		// key set is still exactly the public field list.
+		expect(Object.keys(card).sort()).toEqual(PUBLIC_CARD_KEYS)
 	})
 })

--- a/tests/e2e/quick-preview.spec.js
+++ b/tests/e2e/quick-preview.spec.js
@@ -51,14 +51,14 @@ test.describe('Quick-look preview (Space)', () => {
 		await page.keyboard.press('Space')
 
 		const preview = page.locator('.card-preview')
-		await expect(preview).toBeVisible({ timeout: 3000 })
+		await expect(preview).toBeVisible()
 		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha')
 		// Description is lazily fetched via useCard - poll until it renders.
 		await expect(preview.locator('.card-preview__desc-rendered')).toContainText(DESC, { timeout: 5000 })
 
 		// Space again closes it.
 		await page.keyboard.press('Space')
-		await expect(preview).not.toBeVisible({ timeout: 3000 })
+		await expect(preview).not.toBeVisible()
 
 		// The board must not have scrolled from the Space presses (preventDefault).
 		const scrolled = await page.evaluate(() => window.scrollY)
@@ -74,16 +74,16 @@ test.describe('Quick-look preview (Space)', () => {
 		await page.keyboard.press('ArrowDown')
 		await page.waitForTimeout(200)
 		const firstTile = page.locator('.card-tile').first()
-		await expect(firstTile).toBeFocused({ timeout: 3000 })
+		await expect(firstTile).toBeFocused()
 
 		await page.keyboard.press('Space')
 		const preview = page.locator('.card-preview')
-		await expect(preview).toBeVisible({ timeout: 3000 })
+		await expect(preview).toBeVisible()
 		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha')
 
 		// Escape closes it.
 		await page.keyboard.press('Escape')
-		await expect(preview).not.toBeVisible({ timeout: 3000 })
+		await expect(preview).not.toBeVisible()
 	})
 
 	test('Enter from an open preview opens the full card modal', async ({ page }) => {
@@ -94,13 +94,13 @@ test.describe('Quick-look preview (Space)', () => {
 		await page.keyboard.press('ArrowDown')
 		await page.waitForTimeout(200)
 		await page.keyboard.press('Space')
-		await expect(page.locator('.card-preview')).toBeVisible({ timeout: 3000 })
+		await expect(page.locator('.card-preview')).toBeVisible()
 
 		await page.keyboard.press('Enter')
 		// Wait for the route to actually change (auto-waiting; replaces a fixed sleep).
 		await page.waitForURL(/\/card\//, { timeout: 5_000 })
 		// Preview is dismissed when the modal opens.
-		await expect(page.locator('.card-preview')).not.toBeVisible({ timeout: 3000 })
+		await expect(page.locator('.card-preview')).not.toBeVisible()
 	})
 
 	test('click-away on the backdrop dismisses the preview', async ({ page }) => {
@@ -112,13 +112,13 @@ test.describe('Quick-look preview (Space)', () => {
 		await page.waitForTimeout(200)
 		await page.keyboard.press('Space')
 		const preview = page.locator('.card-preview')
-		await expect(preview).toBeVisible({ timeout: 3000 })
+		await expect(preview).toBeVisible()
 
 		// Click empty board whitespace (viewport coords) - covered only by the
 		// transparent full-screen backdrop, clear of the floating panel (anchored
 		// near the top-left card) and the fixed Nextcloud header at the very top.
 		await page.mouse.click(900, 500)
-		await expect(preview).not.toBeVisible({ timeout: 3000 })
+		await expect(preview).not.toBeVisible()
 		// Click-away must not have opened the card modal.
 		expect(page.url()).not.toContain('/card/')
 	})
@@ -138,11 +138,11 @@ test.describe('Quick-look preview (Space)', () => {
 		await page.waitForTimeout(200)
 		const alphaTile = page.locator(`[data-card-id="${state.card1Id}"]`)
 		const betaTile = page.locator(`[data-card-id="${state.card2Id}"]`)
-		await expect(alphaTile).toBeFocused({ timeout: 3000 })
+		await expect(alphaTile).toBeFocused()
 
 		await page.keyboard.press('Space')
 		const preview = page.locator('.card-preview')
-		await expect(preview).toBeVisible({ timeout: 3000 })
+		await expect(preview).toBeVisible()
 		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha')
 		await expect(preview.locator('.card-preview__desc-rendered')).toContainText(DESC, { timeout: 5000 })
 
@@ -152,8 +152,8 @@ test.describe('Quick-look preview (Space)', () => {
 
 		// Move the keyboard selection down: the OPEN preview must switch to Beta.
 		await page.keyboard.press('ArrowDown')
-		await expect(betaTile).toBeFocused({ timeout: 3000 })
-		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Beta', { timeout: 3000 })
+		await expect(betaTile).toBeFocused()
+		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Beta')
 		// No stale content: it must now show Beta's body, not Alpha's.
 		await expect(preview.locator('.card-preview__desc-rendered')).toContainText(DESC_B, { timeout: 5000 })
 
@@ -166,8 +166,8 @@ test.describe('Quick-look preview (Space)', () => {
 
 		// Move back up: preview follows to Alpha again and re-anchors.
 		await page.keyboard.press('ArrowUp')
-		await expect(alphaTile).toBeFocused({ timeout: 3000 })
-		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha', { timeout: 3000 })
+		await expect(alphaTile).toBeFocused()
+		await expect(preview.locator('.card-preview__title')).toHaveText('Preview Alpha')
 		const alphaLeft2 = await preview.evaluate((el) => el.getBoundingClientRect().left)
 		const alphaPanelTop2 = await preview.evaluate((el) => el.getBoundingClientRect().top)
 		// Same column → same horizontal anchor, and the panel returned up to Alpha.
@@ -176,7 +176,7 @@ test.describe('Quick-look preview (Space)', () => {
 
 		// Escape still dismisses.
 		await page.keyboard.press('Escape')
-		await expect(preview).not.toBeVisible({ timeout: 3000 })
+		await expect(preview).not.toBeVisible()
 
 		expect(errors, `console errors: ${errors.join('\n')}`).toEqual([])
 	})
@@ -189,7 +189,7 @@ test.describe('Quick-look preview (Space)', () => {
 		const s1 = page.locator('.stack-column').nth(0)
 		const composer = s1.locator('.card-composer__input')
 		await composer.click()
-		await expect(composer).toBeFocused({ timeout: 3000 })
+		await expect(composer).toBeFocused()
 
 		// A title with an embedded space must insert the space, not open a preview.
 		await page.keyboard.type('hello world')

--- a/tests/e2e/recur-rule-custom-offset.spec.js
+++ b/tests/e2e/recur-rule-custom-offset.spec.js
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10130 — the same failure mode as #10045, one field down. The Automation
+// recurrence editor models the due-date offset in whole DAYS, but the API and
+// MCP accept an arbitrary offset in seconds (e.g. a 1-hour lead time). Opening
+// such a rule loaded the offset through `Math.round(seconds / 86400)` and, since
+// `duedatePolicy === 1` always re-sent `duedateOffsetSeconds`, saving the rule
+// for an unrelated reason wrote the rounded value back — silently zeroing (or
+// changing) the user's lead time.
+//
+// As with #10045 the assertion that matters is the API read-back, not the UI:
+// the panel never renders the lost precision, so "the form still looks right"
+// passes against the broken build. Only the stored seconds tell the two apart.
+
+import { test, expect, BASE, api, ncLogin } from './helpers.js'
+
+const SUB_DAY_OFFSET = 3600 // one hour — not a whole number of days
+
+async function openRuleEditor(page, boardId, cardTitle) {
+	await ncLogin(page)
+	await page.goto(`${BASE}/index.php/apps/kanso#/board/${boardId}`)
+	await page.getByRole('button', { name: 'More' }).click()
+	await page.getByRole('menuitem', { name: /board settings/i }).click()
+	await page.getByRole('tab', { name: /automation/i }).click()
+	await page.getByRole('button', { name: /Recurring cards/ }).click()
+	const recurring = page.locator('#bs-automation-recurring')
+	const item = recurring.locator('.automation__rule-item').filter({ hasText: cardTitle })
+	await expect(item).toBeVisible({ timeout: 8_000 })
+	await item.getByRole('button', { name: /^Edit$/ }).click()
+	return recurring
+}
+
+test.describe('Editing a rule with a sub-day due-date offset (#10130)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Offset RRULE ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Prep' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Ready' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'Warm up the oven' })).id
+
+		// The kind of rule only the API / MCP can author today: a one-hour lead time.
+		const rule = await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY',
+			duedatePolicy: 1,
+			duedateOffsetSeconds: SUB_DAY_OFFSET,
+		})
+		state.ruleId = rule.id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	const storedRule = async () => {
+		const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+		return rules.find((r) => Number(r.id) === Number(state.ruleId)) ?? null
+	}
+
+	test('changing only the target column leaves the sub-day offset intact', async ({ page }) => {
+		const before = await storedRule()
+		expect(Number(before.duedateOffsetSeconds)).toBe(SUB_DAY_OFFSET)
+
+		const recurring = await openRuleEditor(page, state.boardId, 'Warm up the oven')
+
+		// The offset is shown read-only: the raw duration with a note, and the
+		// whole-day number input is not rendered at all.
+		await expect(recurring.locator('.automation__custom-note')).toBeVisible()
+		await expect(recurring.locator('.automation__custom-rrule')).toHaveText('1h')
+		await expect(page.locator(`#recur-due-offset-${state.boardId}`)).toHaveCount(0)
+
+		// Change an unrelated field — the target column — and save.
+		await page.locator(`#recur-stack-${state.boardId}`).selectOption(String(state.otherStackId))
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		// Read the rule back: the column moved, the offset survived byte for byte.
+		await expect.poll(
+			async () => Number((await storedRule())?.targetStackId),
+			{ timeout: 8_000 },
+		).toBe(Number(state.otherStackId))
+
+		const after = await storedRule()
+		expect(Number(after.duedateOffsetSeconds)).toBe(SUB_DAY_OFFSET)
+		expect(Number(after.duedatePolicy)).toBe(1)
+	})
+})
+
+test.describe('Editing a rule with a whole-day due-date offset (#10130)', () => {
+	const state = { boardId: 0, stackId: 0, otherStackId: 0, cardId: 0, ruleId: 0 }
+	const TWO_DAYS = 2 * 86400
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Day offset ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		state.stackId = (await api.post('/stacks', { boardId: board.id, title: 'Todo' })).id
+		state.otherStackId = (await api.post('/stacks', { boardId: board.id, title: 'Filed' })).id
+		state.cardId = (await api.post('/cards', { stackId: state.stackId, title: 'File the report' })).id
+		state.ruleId = (await api.post(`/boards/${state.boardId}/recur-rules`, {
+			templateCardId: state.cardId,
+			targetStackId: state.stackId,
+			mode: 0,
+			rrule: 'FREQ=WEEKLY',
+			duedatePolicy: 1,
+			duedateOffsetSeconds: TWO_DAYS,
+		})).id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	// A whole-day offset stays fully editable through the days control, exactly
+	// as before: the custom read-only branch must not swallow the ordinary case.
+	test('the days control still edits a whole-day offset', async ({ page }) => {
+		const recurring = await openRuleEditor(page, state.boardId, 'File the report')
+
+		// The editable number input, populated from the stored offset — no note.
+		await expect(recurring.locator('.automation__custom-note')).toHaveCount(0)
+		const input = page.locator(`#recur-due-offset-${state.boardId}`)
+		await expect(input).toHaveValue('2')
+
+		// Bump it to three days and save.
+		await input.fill('3')
+		await page.getByRole('button', { name: /^Save rule$/ }).click()
+
+		await expect.poll(async () => {
+			const rules = await api.get(`/boards/${state.boardId}/recur-rules`)
+			return Number(rules.find((r) => Number(r.id) === Number(state.ruleId))?.duedateOffsetSeconds ?? 0)
+		}, { timeout: 8_000 }).toBe(3 * 86400)
+	})
+})

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -195,7 +195,7 @@ test.describe('Search', () => {
 		// Input should be cleared
 		await expect(searchInput).toHaveValue('')
 		// Dropdown should be gone
-		await expect(page.locator('.search-box__dropdown')).not.toBeVisible({ timeout: 3000 })
+		await expect(page.locator('.search-box__dropdown')).not.toBeVisible()
 	})
 
 	test('pressing "/" keyboard shortcut focuses the search box', async ({ page }) => {
@@ -208,6 +208,6 @@ test.describe('Search', () => {
 		await page.keyboard.press('/')
 
 		const searchInput = page.locator('.search-box__input')
-		await expect(searchInput).toBeFocused({ timeout: 3000 })
+		await expect(searchInput).toBeFocused()
 	})
 })

--- a/tests/e2e/settings-panel.spec.js
+++ b/tests/e2e/settings-panel.spec.js
@@ -66,7 +66,7 @@ test.describe('Settings panel (right-docked drawer)', () => {
 
 		// ── Escape key closes the panel ───────────────────────────────────────
 		await page.keyboard.press('Escape')
-		await expect(panel).not.toBeVisible({ timeout: 3_000 })
+		await expect(panel).not.toBeVisible()
 	})
 
 	test('close button (×) inside panel header dismisses the panel', async ({ page }) => {
@@ -83,7 +83,7 @@ test.describe('Settings panel (right-docked drawer)', () => {
 
 		// Click the close (×) button inside the settings modal header
 		await page.locator('.bs-modal__close').click()
-		await expect(panel).not.toBeVisible({ timeout: 3_000 })
+		await expect(panel).not.toBeVisible()
 	})
 
 	test('Board settings menu item toggles the panel (second invocation closes)', async ({ page }) => {
@@ -106,6 +106,6 @@ test.describe('Settings panel (right-docked drawer)', () => {
 		// menu — its item is hidden while the menu is dismissed — then invoke again.
 		await moreBtn.click()
 		await settingsItem.click()
-		await expect(panel).not.toBeVisible({ timeout: 3_000 })
+		await expect(panel).not.toBeVisible()
 	})
 })

--- a/tests/e2e/subscription.spec.js
+++ b/tests/e2e/subscription.spec.js
@@ -86,14 +86,14 @@ test.describe('Card Subscriptions / Watchers', () => {
 		await expect(watchBtn).toBeVisible({ timeout: 5000 })
 
 		// Should NOT have the active class (not watching)
-		await expect(watchBtn).not.toHaveClass(/card-modal__watch-btn--active/, { timeout: 3000 })
+		await expect(watchBtn).not.toHaveClass(/card-modal__watch-btn--active/)
 
 		// aria-pressed should be false
-		await expect(watchBtn).toHaveAttribute('aria-pressed', 'false', { timeout: 3000 })
+		await expect(watchBtn).toHaveAttribute('aria-pressed', 'false')
 
 		// Label should say "Watch" (not "Watching")
 		const label = watchBtn.locator('.card-modal__watch-label')
-		await expect(label).toHaveText('Watch', { timeout: 3000 })
+		await expect(label).toHaveText('Watch')
 	})
 
 	test('clicking Watch subscribes the user and shows count 1', async ({ page }) => {
@@ -110,7 +110,7 @@ test.describe('Card Subscriptions / Watchers', () => {
 		// Should become active. The compact button swaps the "Watch" label for a
 		// count badge once there is at least one watcher (no "Watching" text).
 		await expect(watchBtn).toHaveClass(/card-modal__watch-btn--active/, { timeout: 6000 })
-		await expect(watchBtn).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 })
+		await expect(watchBtn).toHaveAttribute('aria-pressed', 'true')
 
 		// Count badge should show 1
 		const countBadge = watchBtn.locator('.card-modal__watch-count')
@@ -130,7 +130,7 @@ test.describe('Card Subscriptions / Watchers', () => {
 		// After prior test subscribed, this should still be active on fresh load,
 		// with the count badge (not the "Watch" label) shown.
 		await expect(watchBtn).toHaveClass(/card-modal__watch-btn--active/, { timeout: 6000 })
-		await expect(watchBtn).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 })
+		await expect(watchBtn).toHaveAttribute('aria-pressed', 'true')
 		await expect(watchBtn.locator('.card-modal__watch-count')).toBeVisible({ timeout: 4000 })
 	})
 
@@ -150,10 +150,10 @@ test.describe('Card Subscriptions / Watchers', () => {
 
 		// Should revert to "Watch" (unsubscribed)
 		await expect(watchBtn).not.toHaveClass(/card-modal__watch-btn--active/, { timeout: 6000 })
-		await expect(watchBtn).toHaveAttribute('aria-pressed', 'false', { timeout: 3000 })
+		await expect(watchBtn).toHaveAttribute('aria-pressed', 'false')
 
 		const label = watchBtn.locator('.card-modal__watch-label')
-		await expect(label).toHaveText('Watch', { timeout: 3000 })
+		await expect(label).toHaveText('Watch')
 
 		// Count badge should be gone or show 0
 		const countBadge = watchBtn.locator('.card-modal__watch-count')
@@ -183,7 +183,7 @@ test.describe('Card Subscriptions / Watchers', () => {
 
 		// Admin should now be auto-subscribed - Watching state expected
 		await expect(watchBtn).toHaveClass(/card-modal__watch-btn--active/, { timeout: 8000 })
-		await expect(watchBtn).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 })
+		await expect(watchBtn).toHaveAttribute('aria-pressed', 'true')
 
 		// Count should be ≥ 1 (at least admin is watching)
 		const countBadge = watchBtn.locator('.card-modal__watch-count')
@@ -228,7 +228,7 @@ test.describe('Watchers dropdown UI (caret panel)', () => {
 		await page.waitForSelector('.card-modal', { timeout: 10_000 })
 
 		// The old "Add watcher" pill lived in the attribute bar; it must be gone.
-		await expect(page.locator('.card-modal__attrbar')).not.toContainText('Add watcher', { timeout: 3000 })
+		await expect(page.locator('.card-modal__attrbar')).not.toContainText('Add watcher')
 		// The dropdown panel is closed until the caret is clicked.
 		await expect(page.locator('.card-modal__watch-panel')).toHaveCount(0)
 	})
@@ -240,13 +240,13 @@ test.describe('Watchers dropdown UI (caret panel)', () => {
 
 		const caret = page.locator('.card-modal__watch-caret')
 		await expect(caret).toBeVisible({ timeout: 5000 })
-		await expect(caret).toHaveAttribute('aria-expanded', 'false', { timeout: 3000 })
+		await expect(caret).toHaveAttribute('aria-expanded', 'false')
 
 		// Open the dropdown.
 		await caret.click()
 		const panel = page.locator('.card-modal__watch-panel')
 		await expect(panel).toBeVisible({ timeout: 4000 })
-		await expect(caret).toHaveAttribute('aria-expanded', 'true', { timeout: 3000 })
+		await expect(caret).toHaveAttribute('aria-expanded', 'true')
 
 		// Add BOB via the "Add watcher" picker inside the panel.
 		const addOption = panel.locator('.card-modal__assign-option', { hasText: BOB })
@@ -278,8 +278,8 @@ test.describe('Watchers dropdown UI (caret panel)', () => {
 
 		// First Escape dismisses the panel but keeps the card open.
 		await page.keyboard.press('Escape')
-		await expect(page.locator('.card-modal__watch-panel')).toHaveCount(0, { timeout: 3000 })
-		await expect(page.locator('.card-modal')).toBeVisible({ timeout: 3000 })
+		await expect(page.locator('.card-modal__watch-panel')).toHaveCount(0)
+		await expect(page.locator('.card-modal')).toBeVisible()
 	})
 })
 

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -334,16 +334,43 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 	// GEOMETRY and HIT-TESTING at the bottom of a board that overflows the
 	// viewport: the bar for the last row must actually be painted there.
 	test('a board taller than the viewport paints track, grid and bars down to the last row (#9858)', async ({ page }) => {
+		// Explicit budget, measured rather than guessed. The 30-row fixture below
+		// makes this the slowest test in the suite: 72s in two healthy CI runs
+		// against the plain 120s default, i.e. only 1.67x headroom — so a runner
+		// merely 1.8x slower than usual times it out deterministically, which is
+		// what happened (all three attempts) in the run investigated in #10332.
+		// Seeding the fixture is the cost (see below), not the browser work, and
+		// halving it is not enough margin on its own, so state the budget too —
+		// same idiom as my-work-live.spec.js. The 30 rows ARE the regression
+		// (#9858), so the fixture is never the thing to shrink here.
+		test.setTimeout(180_000)
+
 		// A dedicated board: the shared 3-card fixture is far too short to overflow.
 		const board = await api.post('/boards', { title: 'Timeline tall ' + Math.floor(Date.now() / 1000) })
 		try {
 			const stack = await api.post('/stacks', { boardId: board.id, title: 'To do' })
 			const day = (offset) => new Date(Date.now() + offset * 86_400_000).toISOString()
 			// 30 dated rows ≈ 1080px of lanes — comfortably past the ~500px body at 720p.
+			//
+			// The creates stay SEQUENTIAL on purpose: concurrent creates into one
+			// stack contend on the (stack_id, sort_key) and (board_id, board_seq)
+			// unique indexes and re-derive only MAX_CREATE_ATTEMPTS=5 times before
+			// surfacing a retryable 409 (CardService::create, lib/Service/CardService.php),
+			// so firing 30 at once would trade a slow test for a flaky one.
+			// The date PATCHes have no such contention — separate rows, no shared
+			// unique key — so each one is dispatched WITHOUT awaiting it and the
+			// whole set is settled below. That overlaps every PATCH round-trip with
+			// the following creates and roughly halves the seeding wall-clock.
+			// Nothing about the fixture changes: the same 30 cards are created in
+			// the same order with the same dates, and no assertion depends on the
+			// order the dates land in (only on all of them being set before the
+			// board is opened, which the await below guarantees).
+			const dated = []
 			for (let i = 0; i < 30; i++) {
 				const c = await api.post('/cards', { stackId: stack.id, title: `Row ${String(i).padStart(2, '0')}` })
-				await api.patch(`/cards/${c.id}`, { startDate: day(i % 20), duedate: day((i % 20) + 4) })
+				dated.push(api.patch(`/cards/${c.id}`, { startDate: day(i % 20), duedate: day((i % 20) + 4) }))
 			}
+			await Promise.all(dated)
 
 			await ncLogin(page)
 			await page.setViewportSize({ width: 1280, height: 720 })

--- a/tests/e2e/timeline-view.spec.js
+++ b/tests/e2e/timeline-view.spec.js
@@ -343,7 +343,11 @@ test.describe('Timeline (Gantt) view (#3471)', () => {
 		// halving it is not enough margin on its own, so state the budget too —
 		// same idiom as my-work-live.spec.js. The 30 rows ARE the regression
 		// (#9858), so the fixture is never the thing to shrink here.
-		test.setTimeout(180_000)
+		// 240s: measured 72s on two healthy CI runs and 78s on a saturated one, so
+		// this is ~3x the worst observed. (Also: an explicit setTimeout OVERRIDES the
+		// config default in both directions, so leaving this at 180s would now cap
+		// this test BELOW the suite-wide 240s.)
+		test.setTimeout(240_000)
 
 		// A dedicated board: the shared 3-card fixture is far too short to overflow.
 		const board = await api.post('/boards', { title: 'Timeline tall ' + Math.floor(Date.now() / 1000) })

--- a/tests/e2e/trash.spec.js
+++ b/tests/e2e/trash.spec.js
@@ -149,11 +149,11 @@ test.describe('Trash', () => {
 
 		// The confirm row should appear.
 		const confirmText = cardItem.locator('.trash-view__confirm-text')
-		await expect(confirmText).toBeVisible({ timeout: 3000 })
+		await expect(confirmText).toBeVisible()
 
 		// Click "Yes, delete" to confirm purge.
 		const confirmBtn = cardItem.locator('button', { hasText: 'Yes, delete' })
-		await expect(confirmBtn).toBeVisible({ timeout: 3000 })
+		await expect(confirmBtn).toBeVisible()
 		await confirmBtn.click()
 
 		// The item should disappear from the trash list.

--- a/tests/e2e/visibility-leak-matrix.spec.js
+++ b/tests/e2e/visibility-leak-matrix.spec.js
@@ -1,25 +1,33 @@
 // SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { test, expect, makeApi, currentAuth, API, BASE, exportArchive } from './helpers.js'
+import { test, expect, makeApi, currentAuth, API, BASE, exportArchive, provisionUser, deleteUser } from './helpers.js'
 
-// Sentinels for the two viewers. They are NOT auth strings themselves — the
+// Sentinels for the three viewers. They are NOT auth strings themselves — the
 // client dispatch below resolves them at CALL time: ADMIN → the current user
 // (board owner, `currentAuth`), TESTER → the worker-scoped `peer` (captured in
-// beforeAll). This keeps every `api(ADMIN|TESTER, …)` call site byte-for-byte
+// beforeAll), OUTSIDER → an account with NO membership on the board at all.
+// This keeps every `api(ADMIN|TESTER|OUTSIDER, …)` call site byte-for-byte
 // identical while staying parallel-safe under E2E_ISOLATE.
 const ADMIN = Symbol('owner')
 const TESTER = Symbol('peer')
+const OUTSIDER = Symbol('non-member')
 
 // The worker-scoped peer, captured once in beforeAll so the module-level client
 // dispatch and the `peer.user` participant/assignee literals can reach it.
 let peerRef = null
 
-// #3743 — the endpoint-level leak matrix: two viewers (admin = internal board
-// owner, tester = EXTERNAL member) plus the anonymous token surfaces, asserted
-// against every HTTP read path AND the write gates. The unit-level truth table
-// lives in tests/unit/Service/LeakMatrixTest.php; this spec proves the same
-// rule holds through real SQL on a real server.
+// A logged-in account that is NOT on the board's ACL — the third viewer the
+// matrix needs, because "member who may not see this card" (TESTER) and
+// "not a member" (OUTSIDER) fail through different guards and so leak
+// differently. Provisioned per run in beforeAll, removed in afterAll.
+let outsiderRef = null
+
+// #3743 — the endpoint-level leak matrix: three viewers (admin = internal board
+// owner, tester = EXTERNAL member, outsider = NON-member) plus the anonymous
+// token surfaces, asserted against every HTTP read path AND the write gates.
+// The unit-level truth table lives in tests/unit/Service/LeakMatrixTest.php;
+// this spec proves the same rule holds through real SQL on a real server.
 //
 // Fixture (one board, one stack, unique title token per run):
 //   PUB        public,   created by admin
@@ -31,9 +39,13 @@ let peerRef = null
 //   admin  → PUB, PROV, PRIV   (never CLI — no owner/manager backdoor)
 //   tester → PUB, CLI      (never PROV, never PRIV)
 //   anon   → PUB              (public share + ICS feed)
+//
+// The outsider holds no ACL row, so every board-scoped route 403s for them
+// before visibility is ever consulted; they exist here to pin the ORDER of
+// those two checks on the routes that read a child row by id (#10296).
 
-// Per-viewer API clients (owner + external peer), cached so the (auth, method,
-// path, body) call sites below stay byte-for-byte identical. The ADMIN/TESTER
+// Per-viewer API clients (owner + external peer + non-member), cached so the
+// (auth, method, path, body) call sites below stay byte-for-byte identical. The
 // sentinels resolve lazily (after the worker-isolation rebind + peer capture).
 const clients = new Map()
 function clientFor(auth) {
@@ -44,6 +56,7 @@ function clientFor(auth) {
 		return clients.get(currentAuth)
 	}
 	if (auth === TESTER) return peerRef.api
+	if (auth === OUTSIDER) return outsiderRef.api
 	if (!clients.has(auth)) clients.set(auth, makeApi(auth))
 	return clients.get(auth)
 }
@@ -70,6 +83,8 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 
 	test.beforeAll(async ({ peer }) => {
 		peerRef = peer
+		// Named off the worker's peer so two parallel workers never share it.
+		outsiderRef = await provisionUser(`${peer.user}_out`, peer.pass, { displayName: `${peer.user}_out` })
 		const board = await api(ADMIN, 'POST', '/boards', { title: 'Leak Matrix ' + token })
 		state.boardId = board.id
 		const stack = await api(ADMIN, 'POST', '/stacks', { boardId: board.id, title: 'Lane' })
@@ -104,6 +119,7 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 
 	test.afterAll(async () => {
 		if (state.boardId) await api(ADMIN, 'DELETE', `/boards/${state.boardId}`).catch(() => {})
+		if (outsiderRef) await deleteUser(outsiderRef.user)
 	})
 
 	const expectTitles = (payloadCards, expectedNames) => {
@@ -173,6 +189,43 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 		expect(titles).toEqual([title('PUB')])
 	})
 
+	test('reviews: a non-member cannot tell an existing review from a ghost id (#10296)', async () => {
+		// This one needs the OUTSIDER, not the tester: the card-id probes below
+		// pin "hidden card ⇒ 404", but a board MEMBER 404s at the visibility guard
+		// for every review id, so they can never observe the review lookup. The
+		// oracle lives one step out — a NON-member on a card whose `public`
+		// visibility passes that guard for everyone. Only the ORDER of the
+		// board-READ assert then decides whether the row lookup runs at all and
+		// answers 404 (no such review) vs 403 (exists, not yours).
+		const card = state.cards.PUB.id
+		const detail = await api(ADMIN, 'GET', `/cards/${card}`)
+		expect(detail.visibility, 'the probe needs a card the guard lets anyone past').toBe('public')
+		const real = detail.reviews.find((r) => r.reviewer === peerRef.user)
+		expect(real, 'PUB carries the review requested in the previous test').toBeTruthy()
+
+		const onReal = await call(OUTSIDER, 'PATCH', `/cards/${card}/reviews/${real.id}`, { state: 'approved' })
+		const onGhost = await call(OUTSIDER, 'PATCH', `/cards/${card}/reviews/99999999`, { state: 'approved' })
+		expect(onReal.status, 'verdict on a review that DOES exist').toBe(403)
+		expect(onGhost.status, 'verdict on a review id that does not exist').toBe(403)
+		// The property, stated directly: the two answers must be identical, or the
+		// difference itself enumerates the reviews on the card.
+		expect(onGhost.status, 'the two responses must be indistinguishable').toBe(onReal.status)
+
+		// …and nothing was written on the way to that 403.
+		const after = await api(ADMIN, 'GET', `/cards/${card}`)
+		expect(after.reviews.find((r) => r.id === real.id).state).toBe('pending')
+
+		// The siblings gate on board permission before the row lookup by
+		// construction; assert it, so a reordering there is caught too. Withdraw
+		// is the sharper one: past the gate it would answer 200 for a ghost id
+		// (and DELETE the real review).
+		expect((await call(OUTSIDER, 'PUT', `/cards/${card}/reviews/${peerRef.user}`)).status).toBe(403)
+		expect((await call(OUTSIDER, 'DELETE', `/cards/${card}/reviews/${real.id}`)).status).toBe(403)
+		expect((await call(OUTSIDER, 'DELETE', `/cards/${card}/reviews/99999999`)).status).toBe(403)
+		const survived = await api(ADMIN, 'GET', `/cards/${card}`)
+		expect(survived.reviews.some((r) => r.id === real.id)).toBe(true)
+	})
+
 	test('board stats + boards-list counts: hidden cards are not counted', async () => {
 		const adminStats = await api(ADMIN, 'GET', `/boards/${state.boardId}/stats`)
 		const adminByStack = adminStats.byStack.reduce((n, r) => n + r.count, 0)
@@ -221,6 +274,13 @@ test.describe.serial('Card visibility leak matrix (#3743)', () => {
 			['POST', `/cards/${hidden}/move`, { targetStackId: state.stackId }],
 			['PUT', `/cards/${hidden}/labels/1`],
 			['PUT', `/cards/${hidden}/assignees/${peerRef.user}`],
+			// The review routes belong in this list like any other card-addressed
+			// route: hidden card ⇒ 404, whatever review id is named. (What they do
+			// NOT cover is the check ORDER inside a verdict — a member 404s here
+			// either way; that oracle is asserted against the OUTSIDER above.)
+			['PATCH', `/cards/${hidden}/reviews/1`, { state: 'approved' }],
+			['DELETE', `/cards/${hidden}/reviews/1`],
+			['PUT', `/cards/${hidden}/reviews/${peerRef.user}`],
 		]
 		for (const [method, path, body] of probes) {
 			const r = await call(TESTER, method, path, body)

--- a/tests/unit/Db/CardFeaturesTest.php
+++ b/tests/unit/Db/CardFeaturesTest.php
@@ -25,6 +25,7 @@ class CardFeaturesTest extends TestCase {
 		'github' => true,
 		'timeTracking' => true,
 		'coverColor' => true,
+		'checklist' => true,
 	];
 
 	public function testNullColumnMeansEveryFeatureIsEnabled(): void {
@@ -48,9 +49,39 @@ class CardFeaturesTest extends TestCase {
 
 	public function testDecodeMarksOnlyTheStoredKeysDisabled(): void {
 		self::assertSame(
-			['contacts' => true, 'attachments' => false, 'github' => false, 'timeTracking' => true, 'coverColor' => true],
+			['contacts' => true, 'attachments' => false, 'github' => false, 'timeTracking' => true, 'coverColor' => true, 'checklist' => true],
 			CardFeatures::decode('["attachments","github"]')
 		);
+	}
+
+	/**
+	 * Checklists are switchable like the five sections that shipped with the
+	 * column, and they cost no migration: `disabled_card_features` stores only the
+	 * DISABLED keys, so an existing board simply reads back `checklist => true`.
+	 */
+	public function testChecklistRoundTripsThroughStorage(): void {
+		// A board that predates the key reads back as "checklist shown".
+		self::assertTrue(CardFeatures::decode(null)['checklist']);
+
+		$disabled = self::ALL_ENABLED;
+		$disabled['checklist'] = false;
+		self::assertSame('["checklist"]', CardFeatures::encode($disabled));
+		self::assertSame($disabled, CardFeatures::decode('["checklist"]'));
+	}
+
+	/**
+	 * The one assertion that pins the SERVER allowlist rather than the client
+	 * mirror: applyPatch() throws InvalidInputException for any key missing from
+	 * CardFeatures::ALL, so a checklist-only patch being ACCEPTED is what proves
+	 * the settings switch won't 400. Deliberately its own test with nothing before
+	 * it, so dropping the key from ::ALL surfaces as that exception and not as an
+	 * earlier assertion failure.
+	 */
+	public function testApplyPatchAcceptsTheChecklistKey(): void {
+		$disabled = self::ALL_ENABLED;
+		$disabled['checklist'] = false;
+		self::assertSame($disabled, CardFeatures::applyPatch(self::ALL_ENABLED, ['checklist' => false]));
+		self::assertSame(self::ALL_ENABLED, CardFeatures::applyPatch($disabled, ['checklist' => true]));
 	}
 
 	/** A key from a newer version (after a downgrade) is simply ignored. */

--- a/tests/unit/Service/BoardServiceTest.php
+++ b/tests/unit/Service/BoardServiceTest.php
@@ -415,6 +415,7 @@ class BoardServiceTest extends TestCase {
 			CardFeatures::GITHUB => true,
 			CardFeatures::TIME_TRACKING => false,
 			CardFeatures::COVER_COLOR => true,
+			CardFeatures::CHECKLIST => true,
 		], $payload['cardFeatures']);
 	}
 

--- a/tests/unit/Service/CsvImportServiceTest.php
+++ b/tests/unit/Service/CsvImportServiceTest.php
@@ -7,26 +7,35 @@ declare(strict_types=1);
 
 namespace OCA\Kanso\Tests\Unit\Service;
 
+use OCA\Kanso\Access\ViewerContext;
+use OCA\Kanso\Db\Acl;
+use OCA\Kanso\Db\AclMapper;
 use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAssignee;
 use OCA\Kanso\Db\CardAssigneeMapper;
 use OCA\Kanso\Db\CardLabel;
 use OCA\Kanso\Db\CardLabelMapper;
 use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Db\ChangeDetailMapper;
 use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCA\Kanso\Service\BoardService;
 use OCA\Kanso\Service\CardService;
+use OCA\Kanso\Service\CardVisibilityGuard;
 use OCA\Kanso\Service\ChangeNotifier;
 use OCA\Kanso\Service\CsvImportService;
 use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\LabelService;
 use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\PermissionService;
 use OCA\Kanso\Service\SortKeyService;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -40,6 +49,7 @@ class CsvImportServiceTest extends TestCase {
 	private CardAssigneeMapper&MockObject $cardAssigneeMapper;
 	private ChangeNotifier&MockObject $changeNotifier;
 	private PermissionService&MockObject $permissionService;
+	private BoardMapper&MockObject $boardMapper;
 	private CardService&MockObject $cardService;
 	private IUserManager&MockObject $userManager;
 	private IDBConnection&MockObject $db;
@@ -58,11 +68,35 @@ class CsvImportServiceTest extends TestCase {
 		$this->cardAssigneeMapper = $this->createMock(CardAssigneeMapper::class);
 		$this->changeNotifier = $this->createMock(ChangeNotifier::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->cardService = $this->createMock(CardService::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->db = $this->createMock(IDBConnection::class);
 
-		$this->service = new CsvImportService(
+		$this->service = $this->serviceWith($this->permissionService);
+	}
+
+	/**
+	 * The importer wired against $permissions, with a REAL {@see LabelService}
+	 * behind it. Real, not mocked, deliberately: label creation is the privileged
+	 * write this suite has to pin, so the MANAGE assert and the ENTITY_LABEL
+	 * change row must be the production ones - a LabelService mock would let the
+	 * importer "create" a label without either and the tests would still pass.
+	 */
+	private function serviceWith(PermissionService $permissions): CsvImportService {
+		$labelService = new LabelService(
+			$this->labelMapper,
+			$this->cardLabelMapper,
+			$this->cardMapper,
+			$this->boardMapper,
+			$this->changeNotifier,
+			$permissions,
+			$this->db,
+			$this->createMock(CardVisibilityGuard::class),
+			$this->createMock(ChangeDetailMapper::class),
+		);
+
+		return new CsvImportService(
 			$this->boardService,
 			$this->stackMapper,
 			$this->cardMapper,
@@ -71,11 +105,41 @@ class CsvImportServiceTest extends TestCase {
 			$this->cardAssigneeMapper,
 			new SortKeyService(),
 			$this->changeNotifier,
-			$this->permissionService,
+			$permissions,
+			$labelService,
 			$this->cardService,
 			$this->userManager,
 			$this->db,
 		);
+	}
+
+	/**
+	 * An importer whose permission checks run through the REAL
+	 * {@see PermissionService} over $rows, so a test can pin what the effective
+	 * mask actually folds to (notably the external-role strip) instead of
+	 * asserting against a mock that was told the answer.
+	 */
+	private function serviceWithRealPermissions(Acl ...$rows): CsvImportService {
+		$aclMapper = $this->createMock(AclMapper::class);
+		$aclMapper->method('findByBoard')->willReturn($rows);
+		// Group rows would need $this->userManager->get() stubbed as well:
+		// PermissionService::getUserGroupIds() short-circuits to [] for an unknown
+		// uid, so a group-ACL test written against this helper without that stub
+		// would silently resolve to no groups. Only TYPE_USER rows are used here.
+		$groupManager = $this->createMock(IGroupManager::class);
+
+		return $this->serviceWith(new PermissionService($aclMapper, $groupManager, $this->userManager));
+	}
+
+	/** One board ACL row for $uid, on the given board side, carrying $permission. */
+	private function acl(string $uid, int $permission, string $role): Acl {
+		$acl = new Acl();
+		$acl->setBoardId(self::BOARD_ID);
+		$acl->setParticipantType(Acl::TYPE_USER);
+		$acl->setParticipant($uid);
+		$acl->setPermission($permission);
+		$acl->setRole($role);
+		return $acl;
 	}
 
 	private function board(): Board {
@@ -94,11 +158,25 @@ class CsvImportServiceTest extends TestCase {
 		return $s;
 	}
 
-	/** Wires up the common happy-path expectations (board/stack found + EDIT ok). */
-	private function primeTarget(): void {
-		$this->boardService->method('find')->with(self::BOARD_ID, 'alice')->willReturn($this->board());
+	/**
+	 * Wires up the common happy-path expectations (board/stack found + the actor's
+	 * rights). $mask drives assertPermission() the way the real PermissionService
+	 * does - throwing when the mask lacks a required bit - so a test cannot grant
+	 * EDIT to the import while silently granting MANAGE to label creation too.
+	 *
+	 * getPermissions() is deliberately left to the individual test: the label tests
+	 * pin one mask for the actor, the assignee test drives it per uid.
+	 */
+	private function primeTarget(int $mask = PermissionService::PERMISSION_ALL, string $actorUid = 'alice'): void {
+		$this->boardService->method('find')->with(self::BOARD_ID, $actorUid)->willReturn($this->board());
 		$this->stackMapper->method('find')->with(self::STACK_ID)->willReturn($this->stack());
-		$this->permissionService->method('assertPermission');
+		$this->permissionService->method('assertPermission')->willReturnCallback(
+			static function (Board $board, string $uid, int $permission) use ($mask): void {
+				if (($mask & $permission) !== $permission) {
+					throw new NotPermittedException('Operation not allowed on this board');
+				}
+			},
+		);
 		$this->cardMapper->method('nextBoardSeq')->willReturnCallback(function (): int {
 			static $n = 0;
 			return ++$n;
@@ -222,25 +300,53 @@ class CsvImportServiceTest extends TestCase {
 		self::assertSame(100, mb_strlen($captured->getTitle()));
 	}
 
-	// ── labels: match-or-create ─────────────────────────────────────────────────
+	// ── labels: match-or-create, and creating is MANAGE-gated ───────────────────
 
-	public function testLabelsMatchExistingOrAreCreated(): void {
-		$this->primeTarget();
-		$this->db->method('beginTransaction');
-		$this->db->method('commit');
+	/**
+	 * The CSV every label test imports. Row 1 names the existing "bug" (in a
+	 * different case) plus an unknown "urgent"; row 2 names "urgent" again, so a
+	 * name is created - or counted as skipped - exactly ONCE either way.
+	 */
+	private const LABEL_CSV = "title,labels\n"
+		. "A,\"bug, urgent\"\n"
+		. "B,urgent\n";
 
-		// An existing "Bug" label on the board (matched case-insensitively).
+	/** The board already carries a "Bug" label, matched case-insensitively. */
+	private function primeExistingBugLabel(): void {
 		$existing = new Label();
 		$existing->setId(7);
 		$existing->setTitle('Bug');
 		$existing->setColor('eb5a46');
 		$this->labelMapper->method('findByBoard')->willReturn([$existing]);
-
 		$this->cardMapper->method('insert')->willReturnCallback(function (Card $c): Card {
 			static $id = 100;
 			$c->setId($id++);
 			return $c;
 		});
+	}
+
+	/**
+	 * Records every card↔label assignment the import writes into $assignments.
+	 *
+	 * @param list<array{int, int}> $assignments
+	 */
+	private function captureAssignments(array &$assignments): void {
+		$this->cardLabelMapper->method('insertAssignment')->willReturnCallback(
+			function (int $cardId, int $labelId) use (&$assignments): CardLabel {
+				$assignments[] = [$cardId, $labelId];
+				return new CardLabel();
+			},
+		);
+	}
+
+	public function testAManagerImportCreatesUnknownLabelsWithTheirChangeRow(): void {
+		$this->primeTarget();
+		$this->db->method('beginTransaction');
+		$this->db->method('commit');
+		$this->primeExistingBugLabel();
+		// alice manages the board, so her import may still define labels.
+		$this->permissionService->method('getPermissions')->willReturn(PermissionService::PERMISSION_ALL);
+		$this->boardMapper->method('find')->with(self::BOARD_ID)->willReturn($this->board());
 
 		$createdLabels = [];
 		$this->labelMapper->method('insert')->willReturnCallback(function (Label $l) use (&$createdLabels): Label {
@@ -250,31 +356,136 @@ class CsvImportServiceTest extends TestCase {
 		});
 
 		$assignments = [];
-		$this->cardLabelMapper->method('insertAssignment')->willReturnCallback(function (int $cardId, int $labelId) use (&$assignments): CardLabel {
-			$assignments[] = [$cardId, $labelId];
-			return new CardLabel();
-		});
+		$this->captureAssignments($assignments);
 
-		// Row 1 references the existing "bug" (different case) + a new "urgent";
-		// row 2 references "urgent" again → it must be created ONCE and reused.
-		$csv = "title,labels\n"
-			. "A,\"bug, urgent\"\n"
-			. "B,urgent\n";
-		$result = $this->service->import($csv, self::BOARD_ID, self::STACK_ID, ['title' => 0, 'labels' => 1], true, 'alice');
+		// Every created label carries its OWN ENTITY_LABEL / ACTION_CREATE change
+		// row. Without it a delta client patches in cards naming a label id that is
+		// absent from its cached `labels` array, instead of the resync an
+		// ENTITY_LABEL row forces. push MUST be false: the row is written inside
+		// the import transaction, and import() fires ONE board push after commit.
+		$labelChanges = [];
+		$this->changeNotifier->method('notify')->willReturnCallback(
+			function (int $boardId, int $entity, int $entityId, int $action, ?string $actor, bool $push = true, ?int $verb = null) use (&$labelChanges): Change {
+				$labelChanges[] = [$boardId, $entity, $entityId, $action, $actor, $push];
+				return new Change();
+			},
+		);
+
+		$result = $this->service->import(
+			self::LABEL_CSV,
+			self::BOARD_ID,
+			self::STACK_ID,
+			['title' => 0, 'labels' => 1],
+			true,
+			'alice',
+		);
 
 		self::assertSame(1, $result['labelsCreated']);
+		self::assertSame(0, $result['labelsSkipped']);
 		self::assertCount(1, $createdLabels);
 		self::assertSame('urgent', $createdLabels[0]->getTitle());
 
+		$newLabelId = $createdLabels[0]->getId();
+		self::assertSame(
+			[[self::BOARD_ID, Change::ENTITY_LABEL, $newLabelId, Change::ACTION_CREATE, 'alice', false]],
+			$labelChanges,
+		);
+
 		// Card A got both the existing (7) and the new label; card B reused the new
 		// label id (never a second create).
-		$newLabelId = $createdLabels[0]->getId();
 		$forA = array_values(array_filter($assignments, fn ($a) => $a[0] === 100));
 		$forB = array_values(array_filter($assignments, fn ($a) => $a[0] === 101));
 		$aIds = array_map(fn ($a) => $a[1], $forA);
 		sort($aIds);
 		self::assertSame([7, $newLabelId], $aIds);
 		self::assertSame([[101, $newLabelId]], $forB);
+	}
+
+	public function testAnEditOnlyImportReusesExistingLabelsButNeverMintsNewOnes(): void {
+		// bob holds READ|EDIT and not MANAGE - exactly what the share dialog's "can
+		// edit" grants. The import is EDIT-gated and must still run; defining a
+		// board-level label is a MANAGE concern, so "urgent" is dropped and counted
+		// rather than minted through the importer's back door.
+		$editOnly = PermissionService::PERMISSION_READ | PermissionService::PERMISSION_EDIT;
+		$this->primeTarget($editOnly, 'bob');
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+		$this->primeExistingBugLabel();
+		$this->permissionService->method('getPermissions')->willReturn($editOnly);
+
+		// The escalation, pinned: not one board-level label definition is written.
+		$this->labelMapper->expects(self::never())->method('insert');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$assignments = [];
+		$this->captureAssignments($assignments);
+
+		$result = $this->service->import(
+			self::LABEL_CSV,
+			self::BOARD_ID,
+			self::STACK_ID,
+			['title' => 0, 'labels' => 1],
+			true,
+			'bob',
+		);
+
+		// Skipped, NOT rejected: the rows are the point of the import, so both cards
+		// land and the response reports the shortfall instead of refusing outright.
+		self::assertSame(2, $result['cards']);
+		self::assertSame(0, $result['labelsCreated']);
+		// "urgent" appears on both rows and is reported ONCE - distinct names, the
+		// same unit labelsCreated counts.
+		self::assertSame(1, $result['labelsSkipped']);
+
+		// The existing "bug" still attaches (case-insensitively) to card A; card B
+		// referenced only the un-creatable name, so it gets no labels at all.
+		self::assertSame([[100, 7]], $assignments);
+	}
+
+	public function testAnExternalSideMemberCannotMintLabelsEvenHoldingTheManageBit(): void {
+		// The role cap, end to end through the REAL PermissionService: 'ext' holds
+		// an ACL row that literally stores MANAGE, but every matching row is
+		// external, so getPermissions() strips SHARE|MANAGE from the effective mask
+		// (PermissionService::INTERNAL_ONLY_PERMISSIONS). EDIT survives that strip -
+		// which is why the import itself still runs - and MANAGE does not, so no
+		// separate internal-side assert is needed to stop the label creation here.
+		$service = $this->serviceWithRealPermissions($this->acl(
+			'ext',
+			PermissionService::PERMISSION_ALL,
+			ViewerContext::ROLE_EXTERNAL,
+		));
+		$this->boardService->method('find')->with(self::BOARD_ID, 'ext')->willReturn($this->board());
+		$this->stackMapper->method('find')->with(self::STACK_ID)->willReturn($this->stack());
+		$this->cardMapper->method('nextBoardSeq')->willReturn(1);
+		$this->cardMapper->method('findLastInStack')->willReturn(null);
+		// Resolvable for LabelService too, so removing the importer's own MANAGE
+		// pre-check surfaces the role cap refusing the create - not a mock TypeError.
+		$this->boardMapper->method('find')->with(self::BOARD_ID)->willReturn($this->board());
+		$this->db->expects(self::once())->method('beginTransaction');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+		$this->primeExistingBugLabel();
+
+		$this->labelMapper->expects(self::never())->method('insert');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$assignments = [];
+		$this->captureAssignments($assignments);
+
+		$result = $service->import(
+			self::LABEL_CSV,
+			self::BOARD_ID,
+			self::STACK_ID,
+			['title' => 0, 'labels' => 1],
+			true,
+			'ext',
+		);
+
+		self::assertSame(2, $result['cards']);
+		self::assertSame(0, $result['labelsCreated']);
+		self::assertSame(1, $result['labelsSkipped']);
+		self::assertSame([[100, 7]], $assignments);
 	}
 
 	// ── assignees: match-or-drop, READ-filtered ─────────────────────────────────

--- a/tests/unit/Service/DeckImportServiceTest.php
+++ b/tests/unit/Service/DeckImportServiceTest.php
@@ -34,6 +34,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IUserManager;
@@ -188,7 +189,7 @@ class DeckImportServiceTest extends TestCase {
 			'labels' => 1,
 			'comments' => 0,
 			'attachments' => 0,
-			'skippedFileAttachments' => 0,
+			'skippedAttachments' => 0,
 		], $result);
 
 		// Card field mapping: archived + done + duedate carried across.
@@ -801,6 +802,40 @@ class DeckImportServiceTest extends TestCase {
 		self::assertSame('appdata.json', $captured->getFilename());
 	}
 
+	public function testImportSkipsDeckFileWithMissingSourceObjectButFinishesImport(): void {
+		// A deck_file row whose source object is GONE from Deck's app-data (the
+		// "row present, object missing" case that object-storage/relocated-appdata
+		// instances hit) is logged + skipped, never fatal - and, critically, it is
+		// COUNTED in skippedAttachments so the summary cannot claim a clean import.
+		$this->stubOneCardBoard();
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([
+			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'gone.pdf', 'createdBy' => 'bob', 'createdAt' => 333],
+		]);
+		$this->userManager->method('userExists')->willReturn(true);
+
+		$deckFolder = $this->createMock(ISimpleFolder::class);
+		$deckFolder->method('getFile')->with('gone.pdf')
+			->willThrowException(new NotFoundException('no such object'));
+		$deckAppData = $this->createMock(IAppData::class);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
+		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
+
+		// Nothing written/linked; the miss is logged, not fatal.
+		$this->appData->expects(self::never())->method('getFolder');
+		$this->cardAttachmentMapper->expects(self::never())->method('insert');
+		$this->logger->expects(self::atLeastOnce())->method('warning');
+		$this->db->expects(self::once())->method('commit');
+		$this->db->expects(self::never())->method('rollBack');
+
+		$result = $this->service->importBoard(2, 'alice');
+
+		self::assertSame(0, $result['attachments']);
+		self::assertSame(1, $result['skippedAttachments']);
+		self::assertSame(1, $result['cards']);
+	}
+
 	public function testImportSkipsOversizedAttachmentButFinishesImport(): void {
 		// An oversized source (getSize() > MAX_SIZE) is skipped-and-not-counted,
 		// never read, and never fatal - the rest of the import still succeeds.
@@ -831,8 +866,10 @@ class DeckImportServiceTest extends TestCase {
 
 		$result = $this->service->importBoard(2, 'alice');
 
-		// The whole import still succeeds; the oversized attachment is not counted.
+		// The whole import still succeeds; the oversized attachment is not counted
+		// as imported - and IS counted as skipped, so the summary reports the loss.
 		self::assertSame(0, $result['attachments']);
+		self::assertSame(1, $result['skippedAttachments']);
 		self::assertSame(1, $result['cards']);
 	}
 
@@ -865,13 +902,14 @@ class DeckImportServiceTest extends TestCase {
 		$result = $this->service->importBoard(2, 'alice');
 
 		self::assertSame(0, $result['attachments']);
+		self::assertSame(1, $result['skippedAttachments']);
 		self::assertSame(1, $result['cards']);
 	}
 
 	public function testImportSkipsUnresolvableFileReferenceAttachment(): void {
 		// Two `file`-kind references (Deck shares) whose source nodes can no longer
 		// be resolved (owner has no matching file id) are LOGGED and skipped -
-		// counted as skippedFileAttachments, never fatal, nothing written/linked.
+		// counted in skippedAttachments, never fatal, nothing written/linked.
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
@@ -892,7 +930,7 @@ class DeckImportServiceTest extends TestCase {
 		$result = $this->service->importBoard(2, 'alice');
 
 		self::assertSame(0, $result['attachments']);
-		self::assertSame(2, $result['skippedFileAttachments']);
+		self::assertSame(2, $result['skippedAttachments']);
 		self::assertSame(1, $result['cards']);
 	}
 
@@ -900,7 +938,7 @@ class DeckImportServiceTest extends TestCase {
 		// A `file`-kind reference (a Deck share) is resolved from the owner's Files
 		// by file id and its bytes are COPIED into Kanso via the same sanitized
 		// store path as an upload - so it lands as a normal Kanso attachment and
-		// counts toward `attachments`, not `skippedFileAttachments`.
+		// counts toward `attachments`, not `skippedAttachments`.
 		$this->stubOneCardBoard();
 		$this->deckReader->method('readComments')->willReturn([]);
 		$this->deckReader->method('readAttachments')->willReturn([]);
@@ -934,7 +972,7 @@ class DeckImportServiceTest extends TestCase {
 		$result = $this->service->importBoard(2, 'alice');
 
 		self::assertSame(1, $result['attachments']);
-		self::assertSame(0, $result['skippedFileAttachments']);
+		self::assertSame(0, $result['skippedAttachments']);
 		self::assertNotNull($captured);
 		self::assertSame(500, $captured->getCardId());
 		self::assertSame(100, $captured->getBoardId());
@@ -944,6 +982,43 @@ class DeckImportServiceTest extends TestCase {
 		self::assertSame('reffkey1', $captured->getStorageKey());
 		self::assertSame('carol', $captured->getUploadedBy());
 		self::assertSame(444, $captured->getCreatedAt());
+	}
+
+	public function testImportSumsSkippedAttachmentsAcrossBothPaths(): void {
+		// The summary reports ONE honest skipped total: a dropped deck_file upload
+		// and a dropped file reference both land in the same number, so neither
+		// path can hide a loss behind the other's clean count.
+		$this->stubOneCardBoard();
+		$this->deckReader->method('readComments')->willReturn([]);
+		$this->deckReader->method('readAttachments')->willReturn([
+			['id' => 31, 'cardId' => 21, 'type' => 'deck_file', 'data' => 'huge.bin', 'createdBy' => 'bob', 'createdAt' => 333],
+		]);
+		$this->deckReader->method('readFileReferenceAttachments')->willReturn([
+			['cardId' => 21, 'fileId' => 900, 'filename' => 'a.pdf', 'owner' => 'carol', 'createdBy' => 'carol', 'createdAt' => 10],
+		]);
+		$this->userManager->method('userExists')->willReturn(true);
+
+		// deck_file: oversized → skipped.
+		$sourceFile = $this->createMock(ISimpleFile::class);
+		$sourceFile->method('getSize')->willReturn(AttachmentSanitizer::MAX_SIZE + 1);
+		$deckFolder = $this->createMock(ISimpleFolder::class);
+		$deckFolder->method('getFile')->with('huge.bin')->willReturn($sourceFile);
+		$deckAppData = $this->createMock(IAppData::class);
+		$deckAppData->method('getFolder')->with('file-card-21')->willReturn($deckFolder);
+		$this->appDataFactory->method('get')->with('deck')->willReturn($deckAppData);
+
+		// file reference: unresolvable → skipped.
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->willReturn([]);
+		$this->rootFolder->method('getUserFolder')->with('carol')->willReturn($userFolder);
+
+		$this->cardAttachmentMapper->expects(self::never())->method('insert');
+		$this->db->expects(self::once())->method('commit');
+
+		$result = $this->service->importBoard(2, 'alice');
+
+		self::assertSame(0, $result['attachments']);
+		self::assertSame(2, $result['skippedAttachments']);
 	}
 
 	public function testImportImportsBothAttachmentKindsTogether(): void {
@@ -996,7 +1071,7 @@ class DeckImportServiceTest extends TestCase {
 		$result = $this->service->importBoard(2, 'alice');
 
 		self::assertSame(2, $result['attachments']);
-		self::assertSame(0, $result['skippedFileAttachments']);
+		self::assertSame(0, $result['skippedAttachments']);
 		self::assertCount(2, $captured);
 		$filenames = array_map(static fn (CardAttachment $a): string => $a->getFilename(), $captured);
 		self::assertContains('upload.pdf', $filenames);

--- a/tests/unit/Service/LabelServiceTest.php
+++ b/tests/unit/Service/LabelServiceTest.php
@@ -116,7 +116,13 @@ class LabelServiceTest extends TestCase {
 				Change::ENTITY_LABEL,
 				7,
 				Change::ACTION_CREATE,
-				'alice'
+				'alice',
+				// The endpoint pushes immediately - it is NOT inside a caller-managed
+				// transaction. Pinned explicitly because PHPUnit ignores actual
+				// arguments beyond the constraints given, so without this the $push
+				// default could flip to false and silence the realtime broadcast for
+				// POST /labels with the whole suite still green.
+				true,
 			)
 			->willReturn(new Change());
 

--- a/tests/unit/Service/PublicShareServiceTest.php
+++ b/tests/unit/Service/PublicShareServiceTest.php
@@ -19,6 +19,7 @@ use OCA\Kanso\Db\Label;
 use OCA\Kanso\Db\LabelMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
+use OCA\Kanso\Service\MentionService;
 use OCA\Kanso\Service\NotPermittedException;
 use OCA\Kanso\Service\PermissionService;
 use OCA\Kanso\Service\PublicShareService;
@@ -456,6 +457,329 @@ class PublicShareServiceTest extends TestCase {
 		// The raw uid must appear NOWHERE in the serialized public payload.
 		$json = json_encode($payload);
 		self::assertStringNotContainsString('ghostuid', $json, 'deleted author uid leaked into the public payload');
+	}
+
+	// ── @mention redaction in free text ───────────────────────────────────
+	//
+	// A mention has NO entity table: it is the literal string `@uid` inside a card
+	// description or a comment body, and those two fields are the only place a real
+	// LOGIN uid can ride the anonymous payload as "board content". The description
+	// case holds in the DEFAULT configuration (comments opt-in off), so these pin
+	// the same "uid never leaves" invariant the author byline already has.
+
+	/**
+	 * One public card with the given description, and optionally an opted-in
+	 * comment thread. Deliberately separate from primePublicBoard() so each test
+	 * owns its fixture text.
+	 *
+	 * @param Comment[] $comments
+	 */
+	private function primeCardWithText(string $description, array $comments = []): void {
+		$this->boardMapper->method('findByPublicToken')->with(self::TOKEN)
+			->willReturn($this->board(1, self::TOKEN, null, $comments !== []));
+		$this->stackMapper->method('findByBoard')->with(1)->willReturn([$this->stack(10, 'To do')]);
+		$card = $this->card(100, 10, 'Live card');
+		$card->setDescription($description);
+		$this->cardMapper->method('findPublicByBoard')->with(1)->willReturn([$card]);
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardLabelMapper->method('findLabelIdsByBoardPublicOnly')->willReturn([]);
+		$this->checklistItemMapper->method('progressByBoardPublicOnly')->willReturn([]);
+		if ($comments !== []) {
+			$this->commentMapper->method('findByBoardPublicOnly')->with(1)->willReturn([100 => $comments]);
+		}
+	}
+
+	private function liveUser(string $displayName): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn($displayName);
+		return $user;
+	}
+
+	public function testDescriptionMentionShipsDisplayNameNotUid(): void {
+		// The default configuration: comments opt-in OFF, description still public.
+		$this->primeCardWithText('@jsmith please review before Friday');
+		$this->userManager->method('get')->willReturnMap([['jsmith', $this->liveUser('Jane Smith')]]);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertFalse($payload['board']['commentsEnabled']);
+		self::assertSame('Jane Smith please review before Friday', $payload['cards'][0]['description']);
+		// The uid must appear NOWHERE in the serialized anonymous payload.
+		self::assertStringNotContainsString('jsmith', json_encode($payload), 'mentioned uid leaked into the public payload');
+	}
+
+	public function testCommentBodyMentionShipsDisplayNameNotUid(): void {
+		$this->primeCardWithText('no mentions here', [
+			$this->comment(1, 100, 'bob', 'cc @jsmith on this one'),
+		]);
+		$this->userManager->method('get')->willReturnMap([
+			['bob', $this->liveUser('Bob Builder')],
+			['jsmith', $this->liveUser('Jane Smith')],
+		]);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		$comments = $payload['cards'][0]['comments'];
+		self::assertSame('Bob Builder', $comments[0]['author']);
+		self::assertSame('cc Jane Smith on this one', $comments[0]['body']);
+		// Neither the author's uid nor the MENTIONED uid survives.
+		$json = json_encode($payload);
+		self::assertStringNotContainsString('jsmith', $json, 'mentioned uid leaked out of a public comment body');
+		self::assertStringNotContainsString('"bob"', $json);
+	}
+
+	public function testNonResolvableAtStringsAreLeftByteIdentical(): void {
+		// `@`-shaped text that is NOT an account: an email address (which the shared
+		// MENTION_PATTERN never matches at all), a plain handle, a time, a hyphenated
+		// token. Over-eager substitution here would corrupt real board content, so
+		// this is as load-bearing as the redaction itself.
+		$text = 'mail foo@bar.com, follow @nextcloud, standup @9.30, ping @nosuchuser-42 later';
+		$this->primeCardWithText($text);
+		// Every lookup misses: none of these tokens is an account.
+		$this->userManager->method('get')->willReturn(null);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame($text, $payload['cards'][0]['description']);
+	}
+
+	public function testMentionThatSwallowsTrailingPunctuationIsStillRedacted(): void {
+		// `.`, `-` and `_` are legal uid characters, so a mention ending a sentence
+		// captures the punctuation: the token is `jsmith.`, not `jsmith`. Without the
+		// trailing-punctuation retry the lookup misses and the uid ships verbatim -
+		// a bypass reachable by writing an ordinary English sentence.
+		// (`_@jsmith_` is deliberately absent: the shared pattern's negative
+		// lookbehind treats a `@` preceded by a word char as not-a-mention at all, so
+		// the server would not notify for it and the client would not chip it either.
+		// Widening that is a change to MentionService's semantics, not to this
+		// redaction.)
+		$this->primeCardWithText('ping @jsmith. dash @jsmith- under @jsmith_ done');
+		$this->userManager->method('get')->willReturnMap([['jsmith', $this->liveUser('Jane Smith')]]);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame(
+			'ping Jane Smith. dash Jane Smith- under Jane Smith_ done',
+			$payload['cards'][0]['description']
+		);
+		self::assertStringNotContainsString('jsmith', json_encode($payload));
+	}
+
+	public function testATokenNotEndingInPunctuationIsNeverSplit(): void {
+		// The other side of that retry: `@bob.smith` is NOT a mention of `bob` (the
+		// server would not notify bob either), so it must be looked up whole and left
+		// alone - never rewritten to "Bob Builder.smith".
+		$this->primeCardWithText('ask @bob.smith about it');
+		$this->userManager->method('get')->willReturnMap([
+			['bob.smith', null],
+			['bob', $this->liveUser('Bob Builder')],
+		]);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame('ask @bob.smith about it', $payload['cards'][0]['description']);
+	}
+
+	public function testMentionOfDeletedAccountKeepsItsLiteralTextWhileTheBylineDoesNot(): void {
+		// A DELETED account: the comment AUTHOR field is known to be a uid, so it
+		// still becomes the generic label. A bare `@token` in free text is NOT known
+		// to be a uid - it is indistinguishable from prose - so it is left alone
+		// rather than rewritten, which is the deliberate asymmetry between the two.
+		$this->primeCardWithText('@ghostuid used to own this', [
+			$this->comment(1, 100, 'ghostuid', 'and @ghostuid said so'),
+		]);
+		$this->userManager->method('get')->with('ghostuid')->willReturn(null);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame('Former user', $payload['cards'][0]['comments'][0]['author']);
+		self::assertSame('@ghostuid used to own this', $payload['cards'][0]['description']);
+		self::assertSame('and @ghostuid said so', $payload['cards'][0]['comments'][0]['body']);
+	}
+
+	public function testOrdinaryNamesAreSubstitutedWithoutEscapeNoise(): void {
+		// The description is served BOTH as markdown (the card detail renders it with
+		// v-html) and as raw source printed verbatim (the board tile interpolates it as
+		// text - src/views/PublicBoard.vue:51). So escaping punctuation unconditionally
+		// would show "Anne\-Marie Dubois" to every anonymous visitor, and hyphens,
+		// apostrophes, parentheses and sentence dots are what real names are made of.
+		// None of them can open a markdown construct, so none of them is escaped.
+		$this->primeCardWithText('@a and @b and @c and @d');
+		$this->userManager->method('get')->willReturnMap([
+			['a', $this->liveUser('Anne-Marie Dubois')],
+			['b', $this->liveUser("Sinead O'Brien")],
+			['c', $this->liveUser('Dana Smith (Acme)')],
+			['d', $this->liveUser('Zoe Ünicode Jr.')],
+		]);
+
+		self::assertSame(
+			"Anne-Marie Dubois and Sinead O'Brien and Dana Smith (Acme) and Zoe Ünicode Jr.",
+			$this->service->getPublicBoard(self::TOKEN)['cards'][0]['description']
+		);
+	}
+
+	public function testADisplayNameCannotInjectMarkdownIntoSomebodyElsesText(): void {
+		// The name is spliced into ANOTHER author's text, so a mentioned user who
+		// renames themselves must not thereby inject a link or formatting into it. The
+		// escaped form renders as the literal characters (CommonMark), and the
+		// domain-shaped name must not survive `linkify: true` as a live link either.
+		$this->primeCardWithText('ask @trickster or @domainy about it');
+		$this->userManager->method('get')->willReturnMap([
+			['trickster', $this->liveUser('[click](https://evil.example)')],
+			['domainy', $this->liveUser('www.evil.example')],
+		]);
+
+		self::assertSame(
+			'ask \[click\]\(https\:\/\/evil\.example\) or www\.evil\.example about it',
+			$this->service->getPublicBoard(self::TOKEN)['cards'][0]['description']
+		);
+	}
+
+	public function testAnAccountWithNothingToShowFallsBackToTheGenericLabel(): void {
+		// The account EXISTS (so the token really is a uid) but has no displayable
+		// name. The one thing that must not happen is answering with the raw uid.
+		$this->primeCardWithText('ping @blankname now');
+		$this->userManager->method('get')->willReturnMap([['blankname', $this->liveUser('   ')]]);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame('ping Former user now', $payload['cards'][0]['description']);
+		self::assertStringNotContainsString('blankname', json_encode($payload));
+	}
+
+	public function testAResolvingUidIsRedactedInEveryContextItAppearsIn(): void {
+		// Pins the deliberate decision, so nobody has to re-derive it: a token that IS
+		// a real uid is substituted even inside a URL path or a code span, because the
+		// uid is what must not leave - the link breaking is the lesser cost, and the
+		// authenticated renderer already chips the URL case. The non-account tokens in
+		// the same fixture make this a MIXED case: greedy over-substitution fails here
+		// just as a missed substitution does.
+		$this->primeCardWithText('see https://forge.example/@jsmith and `@jsmith` but not @nobody or foo@bar.com');
+		$this->userManager->method('get')->willReturnCallback(
+			fn (string $uid): ?IUser => $uid === 'jsmith' ? $this->liveUser('Jane Smith') : null
+		);
+
+		self::assertSame(
+			'see https://forge.example/Jane Smith and `Jane Smith` but not @nobody or foo@bar.com',
+			$this->service->getPublicBoard(self::TOKEN)['cards'][0]['description']
+		);
+	}
+
+	public function testOneUserLookupPerDistinctUidAcrossTheWholeBoard(): void {
+		// The board-read hot path: a uid named by many cards (and by a comment
+		// author) must cost ONE IUserManager::get(), not one per mention. The cache
+		// is shared across cards and across both free-text fields.
+		$this->boardMapper->method('findByPublicToken')->with(self::TOKEN)
+			->willReturn($this->board(1, self::TOKEN, null, true));
+		$this->stackMapper->method('findByBoard')->with(1)->willReturn([$this->stack(10, 'To do')]);
+		$cards = [];
+		foreach ([100, 101, 102] as $id) {
+			$card = $this->card($id, 10, 'Card ' . $id);
+			$card->setDescription('@jsmith and @jsmith again');
+			$cards[] = $card;
+		}
+		$this->cardMapper->method('findPublicByBoard')->with(1)->willReturn($cards);
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardLabelMapper->method('findLabelIdsByBoardPublicOnly')->willReturn([]);
+		$this->checklistItemMapper->method('progressByBoardPublicOnly')->willReturn([]);
+		$this->commentMapper->method('findByBoardPublicOnly')->with(1)->willReturn([
+			100 => [$this->comment(1, 100, 'jsmith', 'mine, and @jsmith again')],
+		]);
+		// SIX mentions plus one author byline, all naming the same uid: exactly one
+		// lookup.
+		$this->userManager->expects(self::once())->method('get')->with('jsmith')
+			->willReturn($this->liveUser('Jane Smith'));
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame('Jane Smith and Jane Smith again', $payload['cards'][0]['description']);
+		self::assertSame('Jane Smith', $payload['cards'][0]['comments'][0]['author']);
+	}
+
+	public function testDistinctMentionLookupsAreBoundedPerField(): void {
+		// The bound exists so the amount of TEXT in a field cannot set the number of
+		// user-backend lookups one anonymous request makes. 250 DISTINCT tokens, all
+		// of them real accounts: only MentionService::MAX_MENTIONS are resolved, which
+		// is exactly the set the WRITE path acts on - a mention past that count never
+		// notified anybody either. The rest are left verbatim rather than mangled.
+		$tokens = [];
+		for ($i = 1; $i <= 250; $i++) {
+			$tokens[] = '@user' . $i;
+		}
+		$this->primeCardWithText(implode(' ', $tokens));
+		$this->userManager->expects(self::exactly(MentionService::MAX_MENTIONS))->method('get')
+			->willReturnCallback(fn (string $uid): IUser => $this->liveUser('Name of ' . $uid));
+
+		$description = (string)$this->service->getPublicBoard(self::TOKEN)['cards'][0]['description'];
+
+		self::assertStringContainsString('Name of user1', $description);
+		self::assertStringContainsString('Name of user' . MentionService::MAX_MENTIONS, $description);
+		// Past the bound the raw token survives - documented, and only reachable by
+		// content an EDIT user deliberately stuffed with hundreds of distinct tokens.
+		self::assertStringContainsString('@user250', $description);
+	}
+
+	public function testOneCardsJunkTokensCannotDeRedactAnotherCard(): void {
+		// The bound is per FIELD for this reason: a shared, board-wide budget would
+		// let ONE card padded with non-account `@tokens` (a pasted log, a CSV, an
+		// address dump - no attacker needed) spend it, and every LATER card's real
+		// mention would then ship its uid verbatim.
+		$this->boardMapper->method('findByPublicToken')->with(self::TOKEN)
+			->willReturn($this->board(1, self::TOKEN));
+		$this->stackMapper->method('findByBoard')->with(1)->willReturn([$this->stack(10, 'To do')]);
+		$junk = [];
+		for ($i = 1; $i <= MentionService::MAX_MENTIONS * 2; $i++) {
+			$junk[] = '@notauser' . $i;
+		}
+		$padded = $this->card(100, 10, 'Pasted log');
+		$padded->setDescription(implode(' ', $junk));
+		$real = $this->card(101, 10, 'Real work');
+		$real->setDescription('@jsmith please review');
+		$this->cardMapper->method('findPublicByBoard')->with(1)->willReturn([$padded, $real]);
+		$this->labelMapper->method('findByBoard')->willReturn([]);
+		$this->cardLabelMapper->method('findLabelIdsByBoardPublicOnly')->willReturn([]);
+		$this->checklistItemMapper->method('progressByBoardPublicOnly')->willReturn([]);
+		$this->userManager->method('get')->willReturnCallback(
+			fn (string $uid): ?IUser => $uid === 'jsmith' ? $this->liveUser('Jane Smith') : null
+		);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertSame('Jane Smith please review', $payload['cards'][1]['description']);
+		self::assertStringNotContainsString('jsmith', json_encode($payload));
+	}
+
+	public function testCommentAuthorLookupsDoNotSpendTheMentionBudget(): void {
+		// The bound counts only the lookups the REDACTION starts, and it is local to
+		// one field. Author bylines have to resolve either way, so a busy board - 250
+		// distinct commenters, far past the bound - must not leave the description's
+		// own mention unredacted.
+		$comments = [];
+		for ($i = 1; $i <= 250; $i++) {
+			$comments[] = $this->comment($i, 100, 'commenter' . $i, 'nothing to redact here');
+		}
+		$this->primeCardWithText('@jsmith please review', $comments);
+		$this->userManager->method('get')->willReturnCallback(
+			fn (string $uid): IUser => $this->liveUser($uid === 'jsmith' ? 'Jane Smith' : 'Commenter ' . $uid)
+		);
+
+		$payload = $this->service->getPublicBoard(self::TOKEN);
+
+		self::assertCount(250, $payload['cards'][0]['comments']);
+		self::assertSame('Jane Smith please review', $payload['cards'][0]['description']);
+	}
+
+	public function testStoredRowsAreNeverRewritten(): void {
+		// Payload-only: the mention must keep working for authenticated viewers, so
+		// nothing in the public read may write back through a mapper.
+		$this->primeCardWithText('@jsmith please review');
+		$this->userManager->method('get')->willReturnMap([['jsmith', $this->liveUser('Jane Smith')]]);
+		$this->cardMapper->expects(self::never())->method('update');
+		$this->commentMapper->expects(self::never())->method('update');
+		$this->boardMapper->expects(self::never())->method('update');
+
+		$this->service->getPublicBoard(self::TOKEN);
+		$this->addToAssertionCount(1);
 	}
 
 	public function testSetCommentsRequiresManageAndPersists(): void {

--- a/tests/unit/Service/PublicShareServiceTest.php
+++ b/tests/unit/Service/PublicShareServiceTest.php
@@ -273,7 +273,7 @@ class PublicShareServiceTest extends TestCase {
 		// `commentsEnabled` flag is a public-safe boolean gate (#3949) - it says
 		// WHETHER comments are shown, never who; with the opt-in OFF here it is
 		// false and no comment data is present. `cardFeatures` (#5894) is the same
-		// shape: five booleans saying which built-in card sections this board
+		// shape: one boolean per built-in card section saying which ones this board
 		// renders, so the public link honours the manager's switches. No PII, no
 		// internal identifier, nothing about a person.
 		$boardKeys = array_keys($payload['board']);
@@ -283,7 +283,7 @@ class PublicShareServiceTest extends TestCase {
 		// A board that never touched the switches reads as all-enabled - the public
 		// link looks exactly as it did before the feature landed.
 		self::assertSame(
-			['contacts' => true, 'attachments' => true, 'github' => true, 'timeTracking' => true, 'coverColor' => true],
+			['contacts' => true, 'attachments' => true, 'github' => true, 'timeTracking' => true, 'coverColor' => true, 'checklist' => true],
 			$payload['board']['cardFeatures']
 		);
 

--- a/tests/unit/Service/ReviewServiceTest.php
+++ b/tests/unit/Service/ReviewServiceTest.php
@@ -60,11 +60,20 @@ class ReviewServiceTest extends TestCase {
 		$this->boardService = $this->createMock(BoardService::class);
 		$this->commentService = $this->createMock(CommentService::class);
 		$this->boardAccess = $this->createMock(BoardAccess::class);
-		// Default: everyone sees every card (assertVisible passes as a no-op);
-		// a test hides the card from specific uids via $this->hiddenFrom.
+		// Default: everyone sees every card; a test hides it from specific uids via
+		// $this->hiddenFrom. assertVisible mirrors the real guard - "hidden" is
+		// raised as the SAME DoesNotExistException a missing id raises - so a test
+		// can tell apart "rejected for membership (403)" from "hidden (404)".
 		$this->visibilityGuard = $this->createMock(CardVisibilityGuard::class);
 		$this->visibilityGuard->method('isVisible')->willReturnCallback(
 			fn (Board $board, Card $card, string $uid): bool => !in_array($uid, $this->hiddenFrom, true),
+		);
+		$this->visibilityGuard->method('assertVisible')->willReturnCallback(
+			function (Board $board, Card $card, string $uid): void {
+				if (in_array($uid, $this->hiddenFrom, true)) {
+					throw new DoesNotExistException('Card ' . $card->getId() . ' does not exist');
+				}
+			},
 		);
 		$this->service = new ReviewService(
 			$this->cardReviewMapper,
@@ -298,6 +307,23 @@ class ReviewServiceTest extends TestCase {
 		$this->service->requestReview(9, 'bob', 'alice');
 	}
 
+	public function testRequestRejectsActorWhoCannotSeeTheCard(): void {
+		// The ACTOR's own visibility guard, distinct from the reviewer check above:
+		// a board member with EDIT who sits outside this card's visibility must not
+		// be able to route a review at a card that reads as missing to them.
+		// Deleting that guard leaves the reviewer check untouched, so it needs its
+		// own test - the reviewer-side test only exercises isVisible().
+		$this->loadCardAndBoard();
+		$this->hiddenFrom = ['mallory'];
+		$this->cardReviewMapper->expects(self::never())->method('existsForType');
+		$this->cardReviewMapper->expects(self::never())->method('insertRequest');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->expectExceptionMessage('Card 9 does not exist');
+		$this->service->requestReview(9, 'bob', 'mallory');
+	}
+
 	public function testRequestRejectsDeletedCard(): void {
 		$card = $this->card();
 		$card->setDeletedAt(1234);
@@ -391,6 +417,21 @@ class ReviewServiceTest extends TestCase {
 		$this->cardReviewMapper->expects(self::never())->method('delete');
 
 		$this->service->withdrawReview(9, 1, 'alice');
+	}
+
+	public function testWithdrawRejectsActorWhoCannotSeeTheCard(): void {
+		// Same guard as testRequestRejectsActorWhoCannotSeeTheCard, on the other
+		// EDIT-gated mutation: a hidden card must read as missing before the review
+		// row is even looked up, or withdraw becomes an existence oracle.
+		$this->loadCardAndBoard();
+		$this->hiddenFrom = ['mallory'];
+		$this->cardReviewMapper->expects(self::never())->method('findById');
+		$this->cardReviewMapper->expects(self::never())->method('delete');
+		$this->changeNotifier->expects(self::never())->method('notify');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->expectExceptionMessage('Card 9 does not exist');
+		$this->service->withdrawReview(9, 1, 'mallory');
 	}
 
 	// ---- setState (by review id) ------------------------------------------
@@ -516,11 +557,20 @@ class ReviewServiceTest extends TestCase {
 	}
 
 	public function testSetStateRejectsActorWhoIsNotTheReviewer(): void {
-		$this->loadCardAndBoard();
+		// mallory is a full board member (READ granted) so she sails past the
+		// board-access guard - the ONLY thing that may stop her is the
+		// reviewer-identity check. Asserting the MESSAGE, not just the class, is
+		// what keeps the two NotPermittedException guards apart: without it,
+		// deleting this guard passes the test on the next guard's throw.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'mallory')
+			->willReturn(PermissionService::PERMISSION_READ);
 		$this->cardReviewMapper->method('findById')->with(1)->willReturn($this->review('bob'));
 		$this->cardReviewMapper->expects(self::never())->method('update');
 
 		$this->expectException(NotPermittedException::class);
+		$this->expectExceptionMessage('Only the reviewer may set their review state');
 		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'mallory');
 	}
 
@@ -532,11 +582,15 @@ class ReviewServiceTest extends TestCase {
 	}
 
 	public function testSetStateThrowsWhenReviewMissing(): void {
-		$this->loadCardAndBoard();
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')
+			->willReturn(PermissionService::PERMISSION_READ);
 		$this->cardReviewMapper->method('findById')->with(1)->willReturn(null);
 		$this->cardReviewMapper->expects(self::never())->method('update');
 
 		$this->expectException(DoesNotExistException::class);
+		$this->expectExceptionMessage('Review 1 does not exist on card 9');
 		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
 	}
 
@@ -554,6 +608,10 @@ class ReviewServiceTest extends TestCase {
 	}
 
 	public function testSetStateRejectsReviewerWhoLostBoardAccess(): void {
+		// The actor IS the reviewer, so the identity guard is a no-op here and only
+		// the board-access guard can reject - the mirror image of
+		// testSetStateRejectsActorWhoIsNotTheReviewer. Message asserted for the
+		// same reason: the two guards must stay individually falsifiable.
 		$board = $this->loadCardAndBoard();
 		$this->permissionService->method('getPermissions')
 			->with($board, 'bob')
@@ -562,6 +620,79 @@ class ReviewServiceTest extends TestCase {
 		$this->cardReviewMapper->expects(self::never())->method('update');
 
 		$this->expectException(NotPermittedException::class);
+		$this->expectExceptionMessage('User has no access to this board');
+		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
+	}
+
+	public function testSetStateRejectsNonMemberWithoutProbingWhetherTheReviewExists(): void {
+		// Existence oracle: with the board-access guard behind the review lookup, a
+		// non-member got a 404 for an unknown review id and a 403 for a real one -
+		// enough to enumerate which reviews sit on a card. Membership is now
+		// asserted BEFORE the lookup, so the row is never read at all.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'mallory')
+			->willReturn(0);
+		$this->cardReviewMapper->expects(self::never())->method('findById');
+		$this->cardReviewMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->expectExceptionMessage('User has no access to this board');
+		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'mallory');
+	}
+
+	public function testSetStateChecksMembershipBeforeCardVisibility(): void {
+		// Ordering pinned by CardVisibilityGuard's own contract (membership first -
+		// 403 for non-members - then visibility, 404 for members who may not see
+		// this card). A non-member who ALSO cannot see the card must still get the
+		// membership 403; if the visibility guard ran first they would get the
+		// DoesNotExistException instead, diverging from every sibling mutation.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'mallory')
+			->willReturn(0);
+		$this->hiddenFrom = ['mallory'];
+		$this->cardReviewMapper->expects(self::never())->method('findById');
+		$this->cardReviewMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->expectExceptionMessage('User has no access to this board');
+		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'mallory');
+	}
+
+	public function testSetStateRejectsMemberHoldingEditButNotRead(): void {
+		// The guard is a BITMASK test, not a truthiness test: a row granting EDIT
+		// without READ is storable, and such a member must still be turned away.
+		// Without this, weakening the guard to `getPermissions(...) === 0` passes
+		// every other setState test (they all stub exactly 0 or exactly READ).
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')
+			->willReturn(PermissionService::PERMISSION_EDIT);
+		$this->cardReviewMapper->method('findById')->with(1)->willReturn($this->review('bob'));
+		$this->cardReviewMapper->expects(self::never())->method('update');
+
+		$this->expectException(NotPermittedException::class);
+		$this->expectExceptionMessage('User has no access to this board');
+		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
+	}
+
+	public function testSetStateRejectsReviewerWhoCanNoLongerSeeTheCard(): void {
+		// The card narrowed past its own reviewer (#3743): a member who still holds
+		// READ but is outside the card's visibility gets the missing-card 404, and
+		// no verdict is written. setState raises DoesNotExistException from TWO
+		// places (this guard and the review lookup below), so the message is
+		// asserted to keep them apart.
+		$board = $this->loadCardAndBoard();
+		$this->permissionService->method('getPermissions')
+			->with($board, 'bob')
+			->willReturn(PermissionService::PERMISSION_READ);
+		$this->hiddenFrom = ['bob'];
+		$this->cardReviewMapper->method('findById')->with(1)->willReturn($this->review('bob'));
+		$this->cardReviewMapper->expects(self::never())->method('update');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->expectExceptionMessage('Card 9 does not exist');
 		$this->service->setState(9, 1, CardReview::STATE_APPROVED, 'bob');
 	}
 

--- a/tests/unit/boardPollVisibility.test.mjs
+++ b/tests/unit/boardPollVisibility.test.mjs
@@ -23,6 +23,11 @@
 // the hidden→visible resume assertion below is the one that fails if the skip
 // ever regresses into a `return`.
 //
+// The file also owns the loop's TEARDOWN, because both halves of useBoard's
+// `onScopeDispose` are the same claim as the skip above - "a board nobody is
+// looking at makes no requests" - just for a board that is gone rather than
+// hidden. The listener half and the timer half get one test each.
+//
 // Rig is pushLiveness.test.mjs's: a `window` stub before any @nextcloud import,
 // dynamic imports in that order, the real composable under app.runWithContext,
 // transport stubbed at the axios ADAPTER, so the real timer loop, the real
@@ -130,7 +135,7 @@ async function flush() {
  *
  * @param {import('node:test').TestContext} t
  * @param {number} boardId - distinct per test; the cursor registry is module-scoped
- * @return {{deltaReads: () => number}}
+ * @return {{deltaReads: () => number, scope: import('vue').EffectScope}}
  */
 function harness(t, boardId) {
 	const app = createApp({})
@@ -163,7 +168,11 @@ function harness(t, boardId) {
 	t.after(() => scope.stop())
 	app.runWithContext(() => scope.run(() => useBoard(boardId)))
 
-	return { deltaReads: () => changes }
+	// The scope is handed back so a test can dispose the board MID-TEST. Timer
+	// leaks are only observable that way: MockTimers is per-test and drops every
+	// pending timer when it restores, so a timer leaked by a test that disposes in
+	// its `after` hook can never fire anywhere. See the two teardown tests below.
+	return { deltaReads: () => changes, scope }
 }
 
 test('a hidden tab makes no delta requests, and the poll resumes when the tab comes back', async (t) => {
@@ -268,4 +277,46 @@ test('the visibility listener is removed when the board scope is disposed', asyn
 		+ 'and BoardSettingsModal each compose useBoard per open: without this, '
 		+ 'opening and closing fifty cards leaves fifty listeners, every one of '
 		+ 'them firing a /changes read on every single tab focus')
+})
+
+test('the delta poll timer is cleared when the board scope is disposed', async (t) => {
+	// The other half of the same dispose callback, and the half with no coverage
+	// until #10292: deleting `clearTimeout(deltaTimer)` left the whole
+	// realtime suite green. Same lifecycle as the listener above, same
+	// fifty-open-cards argument, and a worse failure mode - a leaked LISTENER
+	// costs one read per tab focus, a leaked POLL costs one read every 5s forever,
+	// on an endpoint with no 304 path.
+	//
+	// It has to be asserted INSIDE one test. MockTimers is per-test and discards
+	// pending timers on restore, so a timer leaked by a board disposed in a
+	// `t.after` hook is thrown away before the next test could ever observe it -
+	// which is exactly why the existing tests could not catch this.
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	const tick = (ms) => t.mock.timers.tick(ms)
+	setVisibility(false)
+
+	const { deltaReads, scope } = harness(t, 204)
+
+	// Anchor, same as everywhere else in this file: the loop really is running, so
+	// the silence asserted after the dispose means "stopped", not "never started".
+	tick(CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 1, 'the poll must be live before the dispose is meaningful')
+
+	scope.stop()
+
+	// The chain re-arms from inside its own callback, so at this moment exactly one
+	// timeout is outstanding - the one the tick above scheduled. If dispose does
+	// not clear it, it fires here, does a full /changes read for a board nobody is
+	// looking at, and re-arms itself again: an immortal loop, one per closed card
+	// modal.
+	for (let window = 0; window < 3; window++) {
+		tick(CADENCE)
+		await flush()
+		assert.equal(deltaReads(), 1,
+			'a disposed board must stop polling: CardDetail and BoardSettingsModal '
+			+ 'compose useBoard per open, so a poll that outlives its scope means '
+			+ 'fifty opened-and-closed cards leave fifty 5s /changes loops running '
+			+ 'for the rest of the session')
+	}
 })

--- a/tests/unit/boardPollVisibility.test.mjs
+++ b/tests/unit/boardPollVisibility.test.mjs
@@ -320,3 +320,69 @@ test('the delta poll timer is cleared when the board scope is disposed', async (
 			+ 'for the rest of the session')
 	}
 })
+
+test('a dispose landing inside a tick does not let the re-arm outlive it', async (t) => {
+	// The `stopped` latch (#10292). clearTimeout above only cancels a PENDING timer,
+	// so it cannot help once a tick is already running: a dispose that lands after
+	// the callback entered its `try` and before the `finally` leaves the finally free
+	// to arm a fresh timer that NOTHING holds a handle to. That one is unkillable -
+	// no clearTimeout can reach it and no later dispose knows about it - so it polls
+	// /changes for a dead board until the page is closed.
+	//
+	// The interleaving is INJECTED, and deliberately so: no real path to it is known
+	// (Vue defers unmount to its scheduler), which is exactly why the latch needs a
+	// test to be worth having. The injection point is honest rather than arbitrary -
+	// `isHidden()` reads document.visibilityState from inside the try, so a getter
+	// that disposes on read reproduces "disposed mid-tick" at the precise moment the
+	// hypothesis is about, deterministically and with no timing race.
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	const tick = (ms) => t.mock.timers.tick(ms)
+	setVisibility(false)
+
+	const { deltaReads, scope } = harness(t, 205)
+
+	let disposedInsideTick = false
+	Object.defineProperty(document, 'visibilityState', {
+		configurable: true,
+		get() {
+			if (!disposedInsideTick) {
+				disposedInsideTick = true
+				scope.stop()
+			}
+			return 'visible'
+		},
+	})
+	tick(CADENCE)
+	await flush()
+	// Back to a plain property immediately: setVisibility() assigns to it, and this
+	// module is ESM (strict), so a getter-only property left behind would throw in
+	// any test added after this one.
+	Object.defineProperty(document, 'visibilityState', {
+		configurable: true, writable: true, enumerable: true, value: 'visible',
+	})
+	assert.ok(disposedInsideTick,
+		'the rig must actually have disposed from inside the tick, or this test '
+		+ 'proves nothing - if shouldSync() stops reading visibilityState, move the '
+		+ 'injection to whatever it does read inside the try')
+
+	// The anchor, and it is doing more work than the usual one. The getter above is
+	// first-read-wins, so `disposedInsideTick` only proves SOMETHING read
+	// visibilityState - if a future reader (TanStack's focusManager reads the same
+	// property) got there first, the dispose would have landed BEFORE the tick, which
+	// plain clearTimeout already handles, and this test would quietly stop exercising
+	// the latch at all. This read count separates the two cases: a dispose before the
+	// tick cancels the pending timer, so the tick does nothing and this is 0. Exactly
+	// 1 means the tick ran, did its work, and THEN hit the dispose - the interleaving
+	// the latch is for.
+	const readsAtDispose = deltaReads()
+	assert.equal(readsAtDispose, 1,
+		'the dispose must have landed inside a tick that actually ran: 0 here means '
+		+ 'it landed before the tick instead, and the latch is no longer under test')
+	for (let window = 0; window < 3; window++) {
+		tick(CADENCE)
+		await flush()
+		assert.equal(deltaReads(), readsAtDispose,
+			'the finally must not re-arm after a dispose: that timer is untracked, so '
+			+ 'no clearTimeout can ever reach it and the board polls /changes forever')
+	}
+})

--- a/tests/unit/boardPollVisibility.test.mjs
+++ b/tests/unit/boardPollVisibility.test.mjs
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10278 — a board parked in a background tab must stop polling /changes.
+//
+// Every OTHER feed in the app already does: the My Work queries are TanStack
+// `refetchInterval` queries, and TanStack's refetchIntervalInBackground default
+// of false skips interval ticks while the tab is hidden (documented at
+// queryKeys.js MY_WORK_POLL_INTERVAL, useMyReviews.js, useInbox.js). The board
+// delta poll is the one hand-rolled loop - it has to be a timeout, not
+// `refetchInterval`, because #10225 requires the cadence to be re-read on every
+// tick - so it inherits none of that and used to hit /changes forever in a tab
+// nobody was looking at. That tick is not free either: GET
+// /api/boards/{id}/changes has no ETag/304 path (BoardController::changes says
+// so in as many words), so an empty delta still costs a request, an ACL lookup
+// and a findSince.
+//
+// The trap this file exists to nail down is the SHAPE of the skip, not the skip.
+// The loop owns its own continuation, so implementing "hidden ⇒ don't fetch" as
+// an early `return` past the re-arm would kill the poll permanently - and for
+// every VISIBLE tab too, since the chain never restarts. pushLiveness.test.mjs
+// already pins that for the mid-drag skip; this pins it for the hidden skip, and
+// the hidden→visible resume assertion below is the one that fails if the skip
+// ever regresses into a `return`.
+//
+// Rig is pushLiveness.test.mjs's: a `window` stub before any @nextcloud import,
+// dynamic imports in that order, the real composable under app.runWithContext,
+// transport stubbed at the axios ADAPTER, so the real timer loop, the real
+// services/api.js call and the real syncBoardDelta run.
+
+import test, { after } from 'node:test'
+import assert from 'node:assert/strict'
+
+globalThis.window = {
+	_oc_webroot: '',
+	location: { href: 'http://localhost/' },
+	addEventListener() {},
+	removeEventListener() {},
+}
+
+const { createApp, effectScope } = await import('vue')
+const { QueryClient, VueQueryPlugin } = await import('@tanstack/vue-query')
+const axios = (await import('@nextcloud/axios')).default
+const { useBoard } = await import('../../src/composables/useBoard.js')
+const { seedCursor } = await import('../../src/composables/useBoardDelta.js')
+const { boardQueryKey } = await import('../../src/composables/queryKeys.js')
+
+// Deliberately defined AFTER the imports above, and deliberately not a DOM: a
+// `document` global present while `vue` initialises makes it pick up this object
+// as its document (see the note in cardMoveQueue.test.mjs). useBoard reads
+// `document` lazily, per tick and per listener call, so a late stub is enough -
+// and everything else stays on the no-DOM path it already takes today.
+const visibilityListeners = new Set()
+globalThis.document = {
+	hidden: false,
+	visibilityState: 'visible',
+	addEventListener(type, cb) {
+		if (type === 'visibilitychange') visibilityListeners.add(cb)
+	},
+	removeEventListener(type, cb) {
+		if (type === 'visibilitychange') visibilityListeners.delete(cb)
+	},
+}
+
+/**
+ * Set the visibility state WITHOUT dispatching the event.
+ *
+ * Both properties, because a real browser sets both and they are the same bit:
+ * the app reads `visibilityState` (useBoard, main.js, TanStack's focusManager),
+ * but a rig that stubs only the property today's code happens to read pins the
+ * property name instead of the behaviour, and turns a harmless swap between the
+ * two into a red suite with a misleading message.
+ *
+ * @param {boolean} hidden
+ */
+function setVisibility(hidden) {
+	document.hidden = hidden
+	document.visibilityState = hidden ? 'hidden' : 'visible'
+}
+
+/** Hide or reveal the tab exactly as the browser does: state first, then event. */
+function setHidden(hidden) {
+	setVisibility(hidden)
+	for (const cb of [...visibilityListeners]) {
+		cb()
+	}
+}
+
+// No initRealtime() and no push frame, so pushActive() is false and the loop is
+// on the 5s push-less fallback - the cadence a background tab is most expensive
+// on, and the one this card is about.
+const CADENCE = 5_000
+
+// Scopes are stopped per test (see harness); only the query clients need a
+// process-wide teardown, so their gcTime timers don't hold the run open.
+const clients = []
+after(() => {
+	for (const client of clients) {
+		client.unmount()
+		client.clear()
+	}
+})
+
+/**
+ * Let every already-resolved promise chain run. `tick()` only fires timers; the
+ * delta request they start settles in microtasks/immediates. setImmediate is
+ * deliberately NOT among the mocked apis so this still works.
+ *
+ * @return {Promise<void>}
+ */
+async function flush() {
+	for (let i = 0; i < 20; i++) {
+		await new Promise((resolve) => setImmediate(resolve))
+	}
+}
+
+/**
+ * A real useBoard for `boardId`, with its own QueryClient, a seeded delta cursor
+ * (what the query's own queryFn does after a full board read) and an axios
+ * adapter that counts `/changes` reads.
+ *
+ * Must be called with mock timers already enabled: the poll loop arms its first
+ * timeout during setup.
+ *
+ * Torn down at the end of the test that created it, and that is not tidiness:
+ * a board left mounted keeps its visibilitychange listener registered, so the
+ * NEXT test's setHidden() would sync that board too - through this test's axios
+ * adapter, inflating this test's count. (Which is how the shared-listener nature
+ * of the real thing showed up here first.)
+ *
+ * @param {import('node:test').TestContext} t
+ * @param {number} boardId - distinct per test; the cursor registry is module-scoped
+ * @return {{deltaReads: () => number}}
+ */
+function harness(t, boardId) {
+	const app = createApp({})
+	const queryClient = new QueryClient()
+	app.use(VueQueryPlugin, { queryClient })
+	clients.push(queryClient)
+
+	queryClient.setQueryData(boardQueryKey(boardId), {
+		cards: [{ id: 1, stackId: 10, sortKey: 'a' }],
+		stacks: [],
+	})
+	seedCursor(boardId, 1)
+
+	let changes = 0
+	axios.defaults.adapter = async (config) => {
+		const isDelta = config.url.includes('/changes')
+		if (isDelta) changes++
+		return {
+			status: 200,
+			statusText: 'OK',
+			data: isDelta
+				? { cursor: 1, cards: { upsert: [], remove: [] }, stacks: { upsert: [], remove: [] } }
+				: { id: boardId, cards: [], stacks: [], cursor: 1, lastModified: 1 },
+			headers: {},
+			config,
+		}
+	}
+
+	const scope = effectScope()
+	t.after(() => scope.stop())
+	app.runWithContext(() => scope.run(() => useBoard(boardId)))
+
+	return { deltaReads: () => changes }
+}
+
+test('a hidden tab makes no delta requests, and the poll resumes when the tab comes back', async (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	// t.mock.timers is this test's own tracker — the module-level `mock` export is
+	// a different one and would refuse to tick.
+	const tick = (ms) => t.mock.timers.tick(ms)
+
+	const { deltaReads } = harness(t, 201)
+
+	// Anchor: the rig really does observe a poll when the tab is visible. Without
+	// this the "no requests while hidden" assertion below could pass because
+	// nothing polls at all.
+	tick(CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 1, 'a visible tab must poll at the 5s fallback')
+
+	setHidden(true)
+
+	// (a) Backgrounded: several full cadences must produce nothing. /changes has
+	// no 304 path, so each of these ticks would be a full request + ACL +
+	// findSince on the server, forever, for a tab nobody is looking at.
+	for (let window = 0; window < 3; window++) {
+		tick(CADENCE)
+		await flush()
+		assert.equal(deltaReads(), 1,
+			'a hidden tab must not read /changes: every sibling feed pauses in the '
+			+ 'background (refetchIntervalInBackground=false) and this loop must too')
+	}
+
+	// (b) THE important half. The loop owns its own continuation, so a skip
+	// implemented as an early `return` past the re-arm would have killed the
+	// chain during the three hidden windows above - permanently, for visible tabs
+	// as well. Coming back must find the poll still alive.
+	//
+	// setVisibility, NOT setHidden: dispatching the event here would let the
+	// visibilitychange handler produce the read, and the assertion below would
+	// pass with a dead loop. This is the one place in the file that must reveal
+	// the tab silently - do not "tidy" it into setHidden().
+	setVisibility(false)
+	tick(CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 2,
+		'the poll must survive the ticks it skips: a hidden tick that forgets to '
+		+ 're-arm kills realtime for this board for the rest of the session')
+
+	tick(CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 3, 'and keep going at the normal cadence')
+})
+
+test('becoming visible syncs immediately instead of waiting out the interval', async (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	const tick = (ms) => t.mock.timers.tick(ms)
+
+	const { deltaReads } = harness(t, 202)
+
+	setHidden(true)
+	tick(CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 0, 'nothing polls while hidden')
+
+	// (c) No timers are advanced across this transition on purpose: the fetch has
+	// to come from the visibilitychange handler, not from the loop. Otherwise a
+	// user returning to a parked board would stare at stale cards for a whole
+	// interval - up to 30s once push is proven.
+	setHidden(false)
+	await flush()
+	assert.equal(deltaReads(), 1,
+		'the transition to visible must sync at once, without waiting for the next '
+		+ 'poll tick')
+
+	// And the loop is still the loop - the immediate sync does not double up or
+	// replace it.
+	tick(CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 2)
+})
+
+test('the visibility listener is removed when the board scope is disposed', async (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+
+	const before = visibilityListeners.size
+	const app = createApp({})
+	const queryClient = new QueryClient()
+	app.use(VueQueryPlugin, { queryClient })
+	clients.push(queryClient)
+	const scope = effectScope()
+	// Registered before the assertions, not after: a throw in between would
+	// otherwise leak the listener into every test added after this one. (No cursor
+	// is seeded for 203 and the adapter is whatever the last harness left, so
+	// nothing here asserts on requests - only on the listener registry.)
+	t.after(() => scope.stop())
+	app.runWithContext(() => scope.run(() => useBoard(203)))
+	assert.equal(visibilityListeners.size, before + 1,
+		'useBoard must register exactly one visibilitychange listener')
+
+	scope.stop()
+	assert.equal(visibilityListeners.size, before,
+		'and drop it on scope dispose. BoardView itself is reused across board '
+		+ 'switches (see useBoard\'s own note on the board key), but CardDetail '
+		+ 'and BoardSettingsModal each compose useBoard per open: without this, '
+		+ 'opening and closing fifty cards leaves fifty listeners, every one of '
+		+ 'them firing a /changes read on every single tab focus')
+})

--- a/tests/unit/pushLiveness.test.mjs
+++ b/tests/unit/pushLiveness.test.mjs
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// #10225 — a dead notify_push daemon must not slow every board down.
+//
+// `listen()` reports only that the server ADVERTISES notify_push: it returns
+// `window._notify_push_available`, which the library sets from the capability
+// object before it has even constructed the WebSocket. So on an instance where
+// the daemon is stopped or the proxy never forwards /push, the advertisement
+// still says "push is available" — and the client used to trust it, stretching
+// its delta poll from 5s to 30s while no frame could ever arrive. Every change
+// then took up to 30s to appear, which is WORSE than the push-less fallback.
+//
+// The fix inverts the default: push is not live until a frame proves it. That is
+// two coupled pieces, and neither works alone —
+//   1. realtime.js latches `confirmed` on the first received frame, and
+//      pushActive() is `available && confirmed`.
+//   2. useBoard re-reads pushActive() on every poll tick. setInterval captured
+//      its delay once at setup, so the flag flipping later changed nothing.
+// This file pins the OBSERVABLE cadence, so it fails if either half regresses.
+//
+// Asserted here rather than in Playwright deliberately, for the same reason
+// spelled out in queryKeys.test.mjs: the trigger is a notify_push frame, and
+// push is unavailable in the dev stack and explicitly disabled in CI
+// (KANSO_SKIP_NOTIFY_PUSH=1) — a browser test would pass vacuously, with
+// pushActive() false for the wrong reason (nothing advertised at all).
+//
+// Rig follows cardMoveQueue.test.mjs: a `window` stub before any @nextcloud
+// import, dynamic imports in that order, the real composable under
+// app.runWithContext, and the transport stubbed at the axios ADAPTER, so the
+// real timer loop, the real services/api.js call and the real syncBoardDelta run.
+
+import test, { after } from 'node:test'
+import assert from 'node:assert/strict'
+
+const EVENT_NAME = 'kanso_board_changed'
+
+// The notify_push globals are pre-seeded so the REAL `listen()` from the
+// dependency takes its "socket already up" branch: it registers our handler in
+// `_notify_push_listeners`, sends `listen <name>` down the stub socket and
+// returns `_notify_push_available`. No capabilities lookup, no pre_auth POST, no
+// WebSocket — but the registration path, and therefore the handler we later
+// invoke, is the library's own.
+globalThis.window = {
+	_oc_webroot: '',
+	location: { href: 'http://localhost/' },
+	addEventListener() {},
+	removeEventListener() {},
+	_notify_push_listeners: {},
+	_notify_push_ws: { send() {} },
+	_notify_push_ready: true,
+	// The server advertises push. Whether it WORKS is what this file is about.
+	_notify_push_available: true,
+	_notify_push_online: true,
+	_notify_push_error_count: 0,
+}
+
+const { createApp, effectScope } = await import('vue')
+const { QueryClient, VueQueryPlugin } = await import('@tanstack/vue-query')
+const axios = (await import('@nextcloud/axios')).default
+const { initRealtime, pushActive } = await import('../../src/services/realtime.js')
+const { useBoard } = await import('../../src/composables/useBoard.js')
+const { useCardMove } = await import('../../src/composables/useCardMove.js')
+const { seedCursor } = await import('../../src/composables/useBoardDelta.js')
+const { boardQueryKey } = await import('../../src/composables/queryKeys.js')
+
+const FALLBACK_CADENCE = 5_000
+const PROVEN_CADENCE = 30_000
+
+const scopes = []
+const clients = []
+after(() => {
+	for (const scope of scopes) scope.stop()
+	for (const client of clients) {
+		client.unmount()
+		client.clear()
+	}
+})
+
+/**
+ * Let every already-resolved promise chain run. `tick()` only fires
+ * timers; the delta request they start settles in microtasks/immediates.
+ * setImmediate is deliberately NOT among the mocked apis so this still works.
+ *
+ * @return {Promise<void>}
+ */
+async function flush() {
+	for (let i = 0; i < 20; i++) {
+		await new Promise((resolve) => setImmediate(resolve))
+	}
+}
+
+/**
+ * A real useBoard for `boardId`, with its own QueryClient, a seeded delta cursor
+ * (exactly what the query's own queryFn does after a full board read) and an
+ * axios adapter that counts `/changes` reads.
+ *
+ * Must be called with mock timers already enabled: the poll loop arms its first
+ * timeout during setup.
+ *
+ * Also returns the board's real move queue, so a test can put the board into the
+ * mid-drag state the poll has to skip (and survive).
+ *
+ * @param {number} boardId - distinct per test; the cursor registry is module-scoped
+ * @return {{deltaReads: () => number, enqueueMove: Function, releaseMove: () => void}}
+ */
+function harness(boardId) {
+	const app = createApp({})
+	const queryClient = new QueryClient()
+	app.use(VueQueryPlugin, { queryClient })
+	clients.push(queryClient)
+
+	queryClient.setQueryData(boardQueryKey(boardId), {
+		cards: [{ id: 1, stackId: 10, sortKey: 'a' }],
+		stacks: [],
+	})
+	seedCursor(boardId, 1)
+
+	let changes = 0
+	// A move request parks here until releaseMove() is called, which is what keeps
+	// isBoardMovePending(boardId) true for as many poll ticks as a test needs.
+	let unpark = null
+	axios.defaults.adapter = async (config) => {
+		const isDelta = config.url.includes('/changes')
+		if (isDelta) changes++
+		if (config.url.includes('/move')) {
+			await new Promise((resolve) => { unpark = resolve })
+		}
+		return {
+			status: 200,
+			statusText: 'OK',
+			data: isDelta
+				? { cursor: 1, cards: { upsert: [], remove: [] }, stacks: { upsert: [], remove: [] } }
+				: { id: boardId, cards: [], stacks: [], cursor: 1, stackId: 20, sortKey: 'm', lastModified: 1 },
+			headers: {},
+			config,
+		}
+	}
+
+	const scope = effectScope()
+	scopes.push(scope)
+	const board = app.runWithContext(() => scope.run(() => {
+		// Same app context, so the move queue shares this board's QueryClient.
+		const move = useCardMove(boardId)
+		useBoard(boardId)
+		return move
+	}))
+
+	return {
+		deltaReads: () => changes,
+		enqueueMove: board.enqueueMove,
+		releaseMove: () => unpark?.(),
+	}
+}
+
+/** Deliver a push frame exactly the way the library's onmessage handler does. */
+function pushFrame(boardId) {
+	for (const cb of window._notify_push_listeners[EVENT_NAME]) {
+		cb(EVENT_NAME, { boardId })
+	}
+}
+
+test('an advertised-but-unproven push channel polls at the 5s fallback, then stretches to 30s once a frame lands', async (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	// t.mock.timers is this test's own tracker — the module-level `mock` export is
+	// a different one and would refuse to tick.
+	const tick = (ms) => t.mock.timers.tick(ms)
+
+	// The advertisement is true — this is the dead-daemon instance, indistinguishable
+	// from a healthy one at this point — and it must NOT count as live.
+	assert.equal(initRealtime(() => {}), true,
+		'the rig must reproduce a server that advertises notify_push')
+	assert.equal(pushActive(), false,
+		'the capability alone is not evidence the daemon or the proxy work; '
+		+ 'pushActive() must not be satisfied by the advertisement')
+
+	const { deltaReads } = harness(101)
+
+	// While no frame has arrived we are on the fast fallback, tick by tick.
+	tick(FALLBACK_CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 1,
+		'with push unproven the delta poll must run at the 5s fallback — a dead '
+		+ 'daemon on the 30s cadence means changes take up to 30s to appear')
+
+	tick(FALLBACK_CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 2, 'the 5s cadence must repeat, not fire once')
+
+	// A frame arrives: the whole path (capability, daemon, proxy, auth) is proven.
+	pushFrame(101)
+	assert.equal(pushActive(), true, 'a received frame is what proves push is live')
+
+	// The timeout already armed keeps its 5s delay; the stretch takes effect when
+	// the loop re-arms, which is the tick after the frame.
+	tick(FALLBACK_CADENCE)
+	await flush()
+	assert.equal(deltaReads(), 3)
+
+	// From here the cadence is 30s — and nothing before 30s.
+	tick(PROVEN_CADENCE - 1)
+	await flush()
+	assert.equal(deltaReads(), 3,
+		'once push is proven the delta poll must back off to 30s; still polling at '
+		+ '5s means useBoard is not re-reading pushActive() per tick')
+
+	tick(1)
+	await flush()
+	assert.equal(deltaReads(), 4, 'the 30s safety-net poll must still fire')
+})
+
+test('the confirmation latch is one-way and board-independent', async (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	// t.mock.timers is this test's own tracker — the module-level `mock` export is
+	// a different one and would refuse to tick.
+	const tick = (ms) => t.mock.timers.tick(ms)
+
+	// Deliberately self-sufficient rather than inheriting test 1's latch: running
+	// one test alone (--test-name-pattern while debugging, a shard, a .only) must
+	// fail only for real reasons, and `confirmed` is module-global process state.
+	// The cross-board claim is carried by harness(102) below — a board opened for
+	// the FIRST time here, on a socket whose only frame named a different board —
+	// not by the process state.
+	initRealtime(() => {})
+	pushFrame(999)
+	assert.equal(pushActive(), true, 'the latch must survive across boards')
+
+	const { deltaReads } = harness(102)
+
+	tick(PROVEN_CADENCE - 1)
+	await flush()
+	assert.equal(deltaReads(), 0,
+		'a board opened after push was proven must arm at 30s from the start')
+
+	tick(1)
+	await flush()
+	assert.equal(deltaReads(), 1)
+
+	// No further frames arrive — a healthy socket on an idle board sends nothing
+	// Kanso can observe, so silence must never be read as "push died". Without
+	// this, a future liveness timer would make the cadence flap between 5s and
+	// 30s and no test would notice. (One window per tick: MockTimers does not run
+	// a timer the callback of an already-fired timer scheduled during the same
+	// tick, and the loop re-arms itself from inside its own callback.)
+	for (let window = 0; window < 3; window++) {
+		tick(PROVEN_CADENCE - 1)
+		await flush()
+		assert.equal(deltaReads(), window + 1,
+			'silence is not evidence of death: the cadence must stay at 30s and never '
+			+ 'fall back to 5s')
+		tick(1)
+		await flush()
+		assert.equal(deltaReads(), window + 2)
+	}
+	assert.equal(pushActive(), true, 'the latch must not clear itself')
+})
+
+test('the poll survives ticks it skips: a mid-drag board still polls afterwards', async (t) => {
+	// The cost of turning setInterval into a self-rescheduling timeout: the loop
+	// now owns its own continuation. setInterval fired again no matter what its
+	// callback did; this one stops FOREVER — leaving only the 60s refetch — if any
+	// tick fails to re-arm. The mid-drag skip is the one branch that deliberately
+	// does no work, so it is where that mistake is easiest to make.
+	t.mock.timers.enable({ apis: ['setTimeout', 'setInterval'] })
+	const tick = (ms) => t.mock.timers.tick(ms)
+
+	initRealtime(() => {})
+	pushFrame(999)
+	const cadence = PROVEN_CADENCE
+
+	const { deltaReads, enqueueMove, releaseMove } = harness(103)
+
+	// A drag whose server call is parked: the board stays move-pending across as
+	// many ticks as we like, and syncBoardDelta must not patch over the optimistic
+	// placement while it is.
+	enqueueMove({ cardId: 1, targetStackId: 20, afterCardId: null, optimisticKey: 'z' })
+	await flush()
+
+	for (let skipped = 0; skipped < 2; skipped++) {
+		tick(cadence)
+		await flush()
+		assert.equal(deltaReads(), 0,
+			'the delta poll must not read while a move is pending — that patch would '
+			+ 'clobber the optimistic placement mid-drag')
+	}
+
+	// The move lands, the queue drains, the board is no longer pending.
+	releaseMove()
+	await flush()
+
+	tick(cadence)
+	await flush()
+	assert.equal(deltaReads(), 1,
+		'the poll must resume after the drag: a skipped tick that forgets to '
+		+ 're-arm kills realtime for this board for the rest of the session')
+
+	tick(cadence)
+	await flush()
+	assert.equal(deltaReads(), 2, 'and keep going')
+})

--- a/tests/unit/pushLiveness.test.mjs
+++ b/tests/unit/pushLiveness.test.mjs
@@ -278,12 +278,23 @@ test('the poll survives ticks it skips: a mid-drag board still polls afterwards'
 	enqueueMove({ cardId: 1, targetStackId: 20, afterCardId: null, optimisticKey: 'z' })
 	await flush()
 
+	// Which guard this pins, named on purpose: syncBoardDelta's ENTRY check. useBoard's
+	// shouldSync used to carry a duplicate of it, and the pair made this assertion
+	// unfalsifiable (#10292) — removing either one left the whole realtime suite
+	// green, because the other still refused, so neither was pinned by anything. The
+	// duplicate is gone; if the entry check ever leaves syncBoardDelta, this reddens.
+	//
+	// Its post-fetch sibling (a move that STARTS while the delta is in flight) is a
+	// different guard and is still unpinned — deleting it leaves this green, because
+	// the entry check already refused. Not this card's scope; noted so the next
+	// reader does not mistake this assertion for cover.
 	for (let skipped = 0; skipped < 2; skipped++) {
 		tick(cadence)
 		await flush()
 		assert.equal(deltaReads(), 0,
-			'the delta poll must not read while a move is pending — that patch would '
-			+ 'clobber the optimistic placement mid-drag')
+			'no /changes read may go out while a move is pending — a delta patch '
+			+ 'would clobber the optimistic placement mid-drag (the one guard for '
+			+ 'this is syncBoardDelta\'s entry check in useBoardDelta.js)')
 	}
 
 	// The move lands, the queue drains, the board is no longer pending.

--- a/tests/unit/pushLiveness.test.mjs
+++ b/tests/unit/pushLiveness.test.mjs
@@ -21,9 +21,11 @@
 //
 // Asserted here rather than in Playwright deliberately, for the same reason
 // spelled out in queryKeys.test.mjs: the trigger is a notify_push frame, and
-// push is unavailable in the dev stack and explicitly disabled in CI
-// (KANSO_SKIP_NOTIFY_PUSH=1) — a browser test would pass vacuously, with
-// pushActive() false for the wrong reason (nothing advertised at all).
+// push is explicitly disabled in CI (KANSO_SKIP_NOTIFY_PUSH=1 — the runner has
+// no egress to install the app) — so a browser test would pass vacuously there,
+// with pushActive() false for the wrong reason (nothing advertised at all). The
+// dev stack does run a real push daemon, but a guard that only holds on one
+// developer's machine is not a guard.
 //
 // Rig follows cardMoveQueue.test.mjs: a `window` stub before any @nextcloud
 // import, dynamic imports in that order, the real composable under

--- a/tests/unit/queryKeys.test.mjs
+++ b/tests/unit/queryKeys.test.mjs
@@ -18,11 +18,13 @@
 // only by ViewPage and invalidateQueries refetches ACTIVE queries.
 //
 // This is asserted here rather than in Playwright on purpose: the trigger is a
-// notify_push event, and push is unavailable in the dev stack and explicitly
-// disabled in CI (KANSO_SKIP_NOTIFY_PUSH=1), so a browser test of it would pass
-// vacuously and guard nothing. queryKeys.js imports nothing, so the real module
-// can be exercised directly here — no bundler, no DOM, no mocks beyond a
-// recording stub.
+// notify_push event, and push is explicitly disabled in CI
+// (KANSO_SKIP_NOTIFY_PUSH=1 — the runner has no egress to install the app), so
+// a browser test of it would pass vacuously there and guard nothing. (The dev
+// stack does wire up a real push daemon, so a local run would exercise it — but
+// a guard that only holds on one developer's machine is not a guard.)
+// queryKeys.js imports nothing, so the real module can be exercised directly
+// here — no bundler, no DOM, no mocks beyond a recording stub.
 
 import test from 'node:test'
 import assert from 'node:assert/strict'

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s hat dich um ein Review von %2$s gebeten"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s hat %2$s mit dir geteilt"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n Karte"
 msgstr[1] "%n Karten"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n Projekte"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "Schließen"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Schließen"
@@ -2874,6 +2931,10 @@ msgstr "Karten aus CSV importieren"
 msgid "Import from Deck"
 msgstr "Aus Deck importieren"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Öffnen"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Als ganze Seite öffnen"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
 msgstr[1] "%n Projekte"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4528,7 +4528,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
 msgstr[1] "%n Projekte"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4528,7 +4528,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— keine —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n-mal"
@@ -1539,6 +1539,10 @@ msgstr "Strg+Eingabe zum Senden"
 msgid "Custom fields"
 msgstr "Benutzerdefinierte Felder"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Eigener Zeitplan – bearbeite ihn unter Board-Einstellungen → Automatisierung."
@@ -2046,25 +2050,25 @@ msgstr "alle"
 msgid "Every"
 msgstr "Alle"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Täglich"
 msgstr[1] "Alle %n Tage"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Monatlich"
 msgstr[1] "Alle %n Monate"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Wöchentlich"
 msgstr[1] "Alle %n Wochen"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Jährlich"
@@ -3680,6 +3684,10 @@ msgstr "Zahl"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Aus — keine Karten erstellen"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— keine —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n-mal"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
 msgstr[1] "vor %n Stunden"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
 msgstr[1] "%n Projekte"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Änderungen angefordert"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Checkliste"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -2050,25 +2051,25 @@ msgstr "alle"
 msgid "Every"
 msgstr "Alle"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Täglich"
 msgstr[1] "Alle %n Tage"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Monatlich"
 msgstr[1] "Alle %n Monate"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Wöchentlich"
 msgstr[1] "Alle %n Wochen"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Jährlich"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4527,7 +4528,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
 msgstr[1] "%n proyectos"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4528,7 +4528,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— ninguno —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
 msgstr[1] "%n proyectos"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Cambios solicitados"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Lista de tareas"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -2050,25 +2051,25 @@ msgstr "cada"
 msgid "Every"
 msgstr "Cada"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Cada día"
 msgstr[1] "Cada %n días"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Cada mes"
 msgstr[1] "Cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Cada semana"
 msgstr[1] "Cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Cada año"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4527,7 +4528,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s ha solicitado tu revisión en %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s ha compartido %2$s contigo"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n tarjeta"
 msgstr[1] "%n tarjetas"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n proyectos"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "cerrar"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Cerrar"
@@ -2874,6 +2931,10 @@ msgstr "Importar tarjetas desde un CSV"
 msgid "Import from Deck"
 msgstr "Importar desde Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Abrir"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Abrir a página completa"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— ninguno —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Intro para publicar"
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Periodicidad personalizada: edítala en Ajustes del tablero → Automatización."
@@ -2046,25 +2050,25 @@ msgstr "cada"
 msgid "Every"
 msgstr "Cada"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Cada día"
 msgstr[1] "Cada %n días"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Cada mes"
 msgstr[1] "Cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Cada semana"
 msgstr[1] "Cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Cada año"
@@ -3680,6 +3684,10 @@ msgstr "Número"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Desactivada: no crear tarjetas"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
 msgstr[1] "hace %n horas"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
 msgstr[1] "%n proyectos"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4528,7 +4528,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— aucun —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n fois"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projet"
 msgstr[1] "%n projets"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Modifications demandées"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Liste de contrôle"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -2050,25 +2051,25 @@ msgstr "tous les"
 msgid "Every"
 msgstr "Tous les"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Tous les jours"
 msgstr[1] "Tous les %n jours"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Tous les mois"
 msgstr[1] "Tous les %n mois"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toutes les semaines"
 msgstr[1] "Toutes les %n semaines"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Tous les ans"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4527,7 +4528,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projet"
 msgstr[1] "%n projets"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4528,7 +4528,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projet"
 msgstr[1] "%n projets"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4528,7 +4528,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— aucun —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n fois"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Entrée pour publier"
 msgid "Custom fields"
 msgstr "Champs personnalisés"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Rythme personnalisé — modifiable dans Paramètres du tableau → Automatisation."
@@ -2046,25 +2050,25 @@ msgstr "tous les"
 msgid "Every"
 msgstr "Tous les"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Tous les jours"
 msgstr[1] "Tous les %n jours"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Tous les mois"
 msgstr[1] "Tous les %n mois"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toutes les semaines"
 msgstr[1] "Toutes les %n semaines"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Tous les ans"
@@ -3680,6 +3684,10 @@ msgstr "Nombre"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Désactivé — ne pas créer de cartes"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s a demandé votre revue sur %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s a partagé %2$s avec vous"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n carte"
 msgstr[1] "%n cartes"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
 msgstr[1] "il y a %n heures"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n projets"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "fermer"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Fermer"
@@ -2874,6 +2931,10 @@ msgstr "Importer des cartes depuis un CSV"
 msgid "Import from Deck"
 msgstr "Importer depuis Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Ouvrir"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Ouvrir en pleine page"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s ha richiesto la tua revisione su %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s ha condiviso %2$s con te"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n scheda"
 msgstr[1] "%n schede"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n progetti"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "chiudi"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Chiudi"
@@ -2874,6 +2931,10 @@ msgstr "Importa schede da CSV"
 msgid "Import from Deck"
 msgstr "Importa da Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Apri"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Apri a pagina intera"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nessuno —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n volta"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n progetto"
 msgstr[1] "%n progetti"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Modifiche richieste"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Lista di controllo"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -2050,25 +2051,25 @@ msgstr "ogni"
 msgid "Every"
 msgstr "Ogni"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Ogni giorno"
 msgstr[1] "Ogni %n giorni"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Ogni mese"
 msgstr[1] "Ogni %n mesi"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Ogni settimana"
 msgstr[1] "Ogni %n settimane"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Ogni anno"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4527,7 +4528,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n progetto"
 msgstr[1] "%n progetti"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4528,7 +4528,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
 msgstr[1] "%n ore fa"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n progetto"
 msgstr[1] "%n progetti"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4528,7 +4528,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nessuno —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n volta"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Invio per pubblicare"
 msgid "Custom fields"
 msgstr "Campi personalizzati"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Pianificazione personalizzata — modificala in Impostazioni della bacheca → Automazione."
@@ -2046,25 +2050,25 @@ msgstr "ogni"
 msgid "Every"
 msgstr "Ogni"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Ogni giorno"
 msgstr[1] "Ogni %n giorni"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Ogni mese"
 msgstr[1] "Ogni %n mesi"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Ogni settimana"
 msgstr[1] "Ogni %n settimane"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Ogni anno"
@@ -3680,6 +3684,10 @@ msgstr "Numero"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Disattivato — non creare schede"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s heeft jouw review gevraagd op %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s heeft %2$s met je gedeeld"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n kaart"
 msgstr[1] "%n kaarten"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n projecten"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "sluiten"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Sluiten"
@@ -2874,6 +2931,10 @@ msgstr "Kaarten importeren uit CSV"
 msgid "Import from Deck"
 msgstr "Importeren uit Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Openen"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Openen als volledige pagina"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n project"
 msgstr[1] "%n projecten"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4528,7 +4528,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n project"
 msgstr[1] "%n projecten"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4528,7 +4528,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— geen —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n keer"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
 msgstr[1] "%n uur geleden"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n project"
 msgstr[1] "%n projecten"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Wijzigingen gevraagd"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Checklist"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -2050,25 +2051,25 @@ msgstr "elke"
 msgid "Every"
 msgstr "Elke"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Elke dag"
 msgstr[1] "Elke %n dagen"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Elke maand"
 msgstr[1] "Elke %n maanden"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Elke week"
 msgstr[1] "Elke %n weken"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Elk jaar"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4527,7 +4528,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— geen —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n keer"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Enter om te plaatsen"
 msgid "Custom fields"
 msgstr "Aangepaste velden"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Aangepast schema — bewerk het bij Bordinstellingen → Automatisering."
@@ -2046,25 +2050,25 @@ msgstr "elke"
 msgid "Every"
 msgstr "Elke"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Elke dag"
 msgstr[1] "Elke %n dagen"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Elke maand"
 msgstr[1] "Elke %n maanden"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Elke week"
 msgstr[1] "Elke %n weken"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Elk jaar"
@@ -3680,6 +3684,10 @@ msgstr "Getal"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Uit — geen kaarten aanmaken"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -248,8 +248,23 @@ msgstr "%1$s poprosił Cię o recenzję %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s udostępnił Ci %2$s"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -258,7 +273,28 @@ msgstr[0] "%n karta"
 msgstr[1] "%n karty"
 msgstr[2] "%n kart"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "Wykryto %n wiersz danych"
@@ -278,6 +314,27 @@ msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -317,6 +374,13 @@ msgstr[2] "%n projektów"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -1206,6 +1270,8 @@ msgid "close"
 msgstr "zamknij"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Zamknij"
@@ -2892,6 +2958,10 @@ msgstr "Importuj karty z pliku CSV"
 msgid "Import from Deck"
 msgstr "Importuj z Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3749,6 +3819,11 @@ msgstr "Otwórz"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Otwórz jako pełną stronę"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— brak —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n raz"
@@ -1552,6 +1552,10 @@ msgstr "Ctrl+Enter, aby opublikować"
 msgid "Custom fields"
 msgstr "Pola niestandardowe"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Harmonogram niestandardowy — edytuj go w Ustawieniach tablicy → Automatyzacja."
@@ -2060,28 +2064,28 @@ msgstr "co"
 msgid "Every"
 msgstr "Co"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Codziennie"
 msgstr[1] "Co %n dni"
 msgstr[2] "Co %n dni"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Co miesiąc"
 msgstr[1] "Co %n miesiące"
 msgstr[2] "Co %n miesięcy"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Co tydzień"
 msgstr[1] "Co %n tygodnie"
 msgstr[2] "Co %n tygodni"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Co rok"
@@ -3699,6 +3703,10 @@ msgstr "Liczba"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Wyłączone — nie twórz kart"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -314,7 +314,7 @@ msgstr[0] "%n projekt"
 msgstr[1] "%n projekty"
 msgstr[2] "%n projektów"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1583,7 +1583,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -3218,7 +3218,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4547,7 +4547,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5190,7 +5190,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5272,7 +5272,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— brak —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n raz"
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -314,7 +314,7 @@ msgstr[0] "%n projekt"
 msgstr[1] "%n projekty"
 msgstr[2] "%n projektów"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1105,6 +1105,7 @@ msgid "Changes requested"
 msgstr "Poproszono o zmiany"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Lista kontrolna"
@@ -1582,7 +1583,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -2064,28 +2065,28 @@ msgstr "co"
 msgid "Every"
 msgstr "Co"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Codziennie"
 msgstr[1] "Co %n dni"
 msgstr[2] "Co %n dni"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Co miesiąc"
 msgstr[1] "Co %n miesiące"
 msgstr[2] "Co %n miesięcy"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Co tydzień"
 msgstr[1] "Co %n tygodnie"
 msgstr[2] "Co %n tygodni"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Co rok"
@@ -3217,7 +3218,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4546,7 +4547,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5189,7 +5190,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5271,7 +5272,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -4622,7 +4622,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
 msgstr[1] "%n godziny temu"
 msgstr[2] "%n godzin temu"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -314,7 +314,7 @@ msgstr[0] "%n projekt"
 msgstr[1] "%n projekty"
 msgstr[2] "%n projektów"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1583,7 +1583,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -3218,7 +3218,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4547,7 +4547,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5190,7 +5190,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5272,7 +5272,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s solicitou sua revisão em %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s compartilhou %2$s com você"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n cartão"
 msgstr[1] "%n cartões"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n projetos"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "fechar"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Fechar"
@@ -2874,6 +2931,10 @@ msgstr "Importar cartões de um CSV"
 msgid "Import from Deck"
 msgstr "Importar do Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Abrir"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Abrir em página inteira"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projeto"
 msgstr[1] "%n projetos"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4528,7 +4528,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nenhum —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projeto"
 msgstr[1] "%n projetos"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Alterações solicitadas"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Checklist"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -2050,25 +2051,25 @@ msgstr "a cada"
 msgid "Every"
 msgstr "A cada"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Todo dia"
 msgstr[1] "A cada %n dias"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Todo mês"
 msgstr[1] "A cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toda semana"
 msgstr[1] "A cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Todo ano"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4527,7 +4528,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
 msgstr[1] "há %n horas"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projeto"
 msgstr[1] "%n projetos"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4528,7 +4528,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nenhum —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -1539,6 +1539,10 @@ msgstr "Ctrl+Enter para publicar"
 msgid "Custom fields"
 msgstr "Campos personalizados"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Programação personalizada — edite em Configurações do quadro → Automação."
@@ -2046,25 +2050,25 @@ msgstr "a cada"
 msgid "Every"
 msgstr "A cada"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Todo dia"
 msgstr[1] "A cada %n dias"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Todo mês"
 msgstr[1] "A cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toda semana"
 msgstr[1] "A cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Todo ano"
@@ -3680,6 +3684,10 @@ msgstr "Número"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Desligado — não criar cartões"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— нет —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· повторов: %n"
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -314,7 +314,7 @@ msgstr[0] "%n проект"
 msgstr[1] "%n проекта"
 msgstr[2] "%n проектов"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1105,6 +1105,7 @@ msgid "Changes requested"
 msgstr "Запрошены изменения"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Чек-лист"
@@ -1582,7 +1583,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -2064,28 +2065,28 @@ msgstr "каждые"
 msgid "Every"
 msgstr "Каждые"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Каждый %n день"
 msgstr[1] "Каждые %n дня"
 msgstr[2] "Каждые %n дней"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Каждый %n месяц"
 msgstr[1] "Каждые %n месяца"
 msgstr[2] "Каждые %n месяцев"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Каждую %n неделю"
 msgstr[1] "Каждые %n недели"
 msgstr[2] "Каждые %n недель"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Каждый %n год"
@@ -3217,7 +3218,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4546,7 +4547,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5189,7 +5190,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5271,7 +5272,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -4622,7 +4622,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— нет —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· повторов: %n"
@@ -1552,6 +1552,10 @@ msgstr "Ctrl+Enter — отправить"
 msgid "Custom fields"
 msgstr "Пользовательские поля"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Особое расписание — измените его в настройках доски → Автоматизация."
@@ -2060,28 +2064,28 @@ msgstr "каждые"
 msgid "Every"
 msgstr "Каждые"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Каждый %n день"
 msgstr[1] "Каждые %n дня"
 msgstr[2] "Каждые %n дней"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Каждый %n месяц"
 msgstr[1] "Каждые %n месяца"
 msgstr[2] "Каждые %n месяцев"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Каждую %n неделю"
 msgstr[1] "Каждые %n недели"
 msgstr[2] "Каждые %n недель"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Каждый %n год"
@@ -3699,6 +3703,10 @@ msgstr "Число"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Выключено — не создавать карточки"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -314,7 +314,7 @@ msgstr[0] "%n проект"
 msgstr[1] "%n проекта"
 msgstr[2] "%n проектов"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1583,7 +1583,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -3218,7 +3218,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4547,7 +4547,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5190,7 +5190,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5272,7 +5272,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -248,8 +248,23 @@ msgstr "%1$s запросил вашу проверку %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s поделился с вами %2$s"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -258,7 +273,28 @@ msgstr[0] "%n карточка"
 msgstr[1] "%n карточки"
 msgstr[2] "%n карточек"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "Обнаружена %n строка данных"
@@ -278,6 +314,27 @@ msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -317,6 +374,13 @@ msgstr[2] "%n проектов"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -1206,6 +1270,8 @@ msgid "close"
 msgstr "закрыть"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Закрыть"
@@ -2892,6 +2958,10 @@ msgstr "Импорт карточек из CSV"
 msgid "Import from Deck"
 msgstr "Импорт из Deck"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3749,6 +3819,11 @@ msgstr "Открыть"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Открыть на всю страницу"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -265,21 +265,21 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
 msgstr[1] "%n часа назад"
 msgstr[2] "%n часов назад"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -314,7 +314,7 @@ msgstr[0] "%n проект"
 msgstr[1] "%n проекта"
 msgstr[2] "%n проектов"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1583,7 +1583,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -3218,7 +3218,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4547,7 +4547,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5190,7 +5190,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5272,7 +5272,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "— none —"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] ""
@@ -1538,6 +1538,10 @@ msgstr ""
 msgid "Custom fields"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr ""
@@ -2045,25 +2049,25 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] ""
@@ -3678,6 +3682,10 @@ msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -246,8 +246,21 @@ msgstr ""
 msgid "%1$s shared %2$s with you"
 msgstr ""
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -255,7 +268,25 @@ msgid_plural "%n cards"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] ""
@@ -270,6 +301,24 @@ msgstr[1] ""
 #: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -306,6 +355,12 @@ msgstr[1] ""
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1192,6 +1247,8 @@ msgid "close"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr ""
@@ -2873,6 +2930,10 @@ msgstr ""
 msgid "Import from Deck"
 msgstr ""
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3728,6 +3789,11 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Open as full page"
+msgstr ""
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "— none —"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] ""
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -303,7 +303,7 @@ msgid_plural "%n projects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1091,6 +1091,7 @@ msgid "Changes requested"
 msgstr ""
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr ""
@@ -1568,7 +1569,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -2049,25 +2050,25 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] ""
@@ -3198,7 +3199,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4526,7 +4527,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5168,7 +5169,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5249,7 +5250,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -303,7 +303,7 @@ msgid_plural "%n projects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1569,7 +1569,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -3199,7 +3199,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5169,7 +5169,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5250,7 +5250,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -261,19 +261,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -303,7 +303,7 @@ msgid_plural "%n projects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1569,7 +1569,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -3199,7 +3199,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5169,7 +5169,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5250,7 +5250,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -4593,7 +4593,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -4594,7 +4594,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -247,8 +247,21 @@ msgstr "%1$s, %2$s kartı için incelemeni istedi"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s, %2$s öğesini seninle paylaştı"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+msgstr[1] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
@@ -256,7 +269,25 @@ msgid_plural "%n cards"
 msgstr[0] "%n kart"
 msgstr[1] "%n kart"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
@@ -273,6 +304,24 @@ msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -307,6 +356,12 @@ msgstr[1] "%n proje"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1193,6 +1248,8 @@ msgid "close"
 msgstr "kapat"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "Kapat"
@@ -2874,6 +2931,10 @@ msgstr "CSV'den kart içe aktar"
 msgid "Import from Deck"
 msgstr "Deck'ten içe aktar"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3730,6 +3791,11 @@ msgstr "Aç"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "Tam sayfa olarak aç"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— yok —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n kez"
@@ -1539,6 +1539,10 @@ msgstr "Göndermek için Ctrl+Enter"
 msgid "Custom fields"
 msgstr "Özel alanlar"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "Özel zamanlama — Pano ayarları → Otomasyon bölümünden düzenle."
@@ -2046,25 +2050,25 @@ msgstr "her"
 msgid "Every"
 msgstr "Her"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Her gün"
 msgstr[1] "Her %n günde bir"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Her ay"
 msgstr[1] "Her %n ayda bir"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Her hafta"
 msgstr[1] "Her %n haftada bir"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Her yıl"
@@ -3680,6 +3684,10 @@ msgstr "Sayı"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "Kapalı — kart oluşturma"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— yok —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n kez"
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proje"
 msgstr[1] "%n proje"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1092,6 +1092,7 @@ msgid "Changes requested"
 msgstr "Değişiklik istendi"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "Kontrol listesi"
@@ -1569,7 +1570,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -2050,25 +2051,25 @@ msgstr "her"
 msgid "Every"
 msgstr "Her"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Her gün"
 msgstr[1] "Her %n günde bir"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Her ay"
 msgstr[1] "Her %n ayda bir"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Her hafta"
 msgstr[1] "Her %n haftada bir"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Her yıl"
@@ -3199,7 +3200,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4527,7 +4528,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5169,7 +5170,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5250,7 +5251,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proje"
 msgstr[1] "%n proje"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4528,7 +4528,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -262,19 +262,19 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
 msgstr[1] "%n saat önce"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -304,7 +304,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proje"
 msgstr[1] "%n proje"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1570,7 +1570,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -3200,7 +3200,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4528,7 +4528,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5170,7 +5170,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5251,7 +5251,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4256
+#: src/components/CardDetail.vue:4295
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4254
+#: src/components/CardDetail.vue:4293
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4252
+#: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -294,7 +294,7 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
 
-#: src/components/CardDetail.vue:1973
+#: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1557,7 +1557,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4445
+#: src/components/CardDetail.vue:4484
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -3182,7 +3182,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4447
+#: src/components/CardDetail.vue:4486
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4509,7 +4509,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:6069
+#: src/components/CardDetail.vue:6108
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5150,7 +5150,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4446
+#: src/components/CardDetail.vue:4485
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5230,7 +5230,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4448
+#: src/components/CardDetail.vue:4487
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4248
+#: src/components/CardDetail.vue:4256
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4254
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4252
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -294,7 +294,7 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
 
-#: src/components/CardDetail.vue:1971
+#: src/components/CardDetail.vue:1973
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1557,7 +1557,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4445
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -3182,7 +3182,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4439
+#: src/components/CardDetail.vue:4447
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4509,7 +4509,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:6061
+#: src/components/CardDetail.vue:6069
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5150,7 +5150,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4446
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5230,7 +5230,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4440
+#: src/components/CardDetail.vue:4448
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -4566,7 +4566,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:6108
+#: src/components/CardDetail.vue:6154
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— 无 —"
 
-#: src/components/BoardSettingsModal.vue:4062
+#: src/components/BoardSettingsModal.vue:4063
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n 次"
@@ -259,17 +259,17 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4246
+#: src/components/CardDetail.vue:4248
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4244
+#: src/components/CardDetail.vue:4246
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
 
-#: src/components/CardDetail.vue:4242
+#: src/components/CardDetail.vue:4244
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -294,7 +294,7 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
 
-#: src/components/CardDetail.vue:1969
+#: src/components/CardDetail.vue:1971
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1079,6 +1079,7 @@ msgid "Changes requested"
 msgstr "已请求修改"
 
 #: src/components/BoardFilterBar.vue
+#: src/components/BoardSettingsModal.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
 msgstr "清单"
@@ -1556,7 +1557,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:1949
-#: src/components/CardDetail.vue:4435
+#: src/components/CardDetail.vue:4437
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -2036,22 +2037,22 @@ msgstr "每"
 msgid "Every"
 msgstr "每"
 
-#: src/components/BoardSettingsModal.vue:4042
+#: src/components/BoardSettingsModal.vue:4043
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "每 %n 天"
 
-#: src/components/BoardSettingsModal.vue:4052
+#: src/components/BoardSettingsModal.vue:4053
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "每 %n 个月"
 
-#: src/components/BoardSettingsModal.vue:4044
+#: src/components/BoardSettingsModal.vue:4045
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "每 %n 周"
 
-#: src/components/BoardSettingsModal.vue:4054
+#: src/components/BoardSettingsModal.vue:4055
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "每 %n 年"
@@ -3181,7 +3182,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:1951
-#: src/components/CardDetail.vue:4437
+#: src/components/CardDetail.vue:4439
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4508,7 +4509,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:6059
+#: src/components/CardDetail.vue:6061
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5149,7 +5150,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:1950
-#: src/components/CardDetail.vue:4436
+#: src/components/CardDetail.vue:4438
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5229,7 +5230,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:1952
-#: src/components/CardDetail.vue:4438
+#: src/components/CardDetail.vue:4440
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— 无 —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4062
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n 次"
@@ -1526,6 +1526,10 @@ msgstr "Ctrl+Enter 发布"
 msgid "Custom fields"
 msgstr "自定义字段"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Custom offset — it is kept exactly as it is."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Custom schedule — edit it in Board settings → Automation."
 msgstr "自定义计划 — 请在“看板设置 → 自动化”中编辑。"
@@ -2032,22 +2036,22 @@ msgstr "每"
 msgid "Every"
 msgstr "每"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4042
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "每 %n 天"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4052
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "每 %n 个月"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4044
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "每 %n 周"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4054
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "每 %n 年"
@@ -3661,6 +3665,10 @@ msgstr "数字"
 #: src/components/BoardSettingsModal.vue
 msgid "Off — do not create cards"
 msgstr "关闭 — 不创建卡片"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Offset"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Offset (days)"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -246,15 +246,41 @@ msgstr "%1$s 请求你评审 %2$s"
 msgid "%1$s shared %2$s with you"
 msgstr "%1$s 与你共享了 %2$s"
 
+#: src/views/BoardList.vue:216
+msgid "%n attachment"
+msgid_plural "%n attachments"
+msgstr[0] ""
+
+#: src/views/BoardList.vue:223
+msgid "%n attachment could not be copied and is missing from the new board. Keep your Deck board until you have checked it."
+msgid_plural "%n attachments could not be copied and are missing from the new board. Keep your Deck board until you have checked them."
+msgstr[0] ""
+
 #: src/components/BoardTileContent.vue:18
-#: src/views/BoardList.vue:215
+#: src/views/BoardList.vue:213
+#: src/views/BoardList.vue:256
 #: src/views/BoardStats.vue:420
 #: src/views/ProjectStats.vue:340
 msgid "%n card"
 msgid_plural "%n cards"
 msgstr[0] "%n 张卡片"
 
-#: src/components/CsvImportModal.vue:80
+#: src/components/CsvImportModal.vue:54
+msgid "%n card created"
+msgid_plural "%n cards created"
+msgstr[0] ""
+
+#: src/views/BoardList.vue:212
+msgid "%n column"
+msgid_plural "%n columns"
+msgstr[0] ""
+
+#: src/views/BoardList.vue:215
+msgid "%n comment"
+msgid_plural "%n comments"
+msgstr[0] ""
+
+#: src/components/CsvImportModal.vue:110
 msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
@@ -268,6 +294,21 @@ msgstr[0] "%n 天前"
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
+
+#: src/views/BoardList.vue:214
+msgid "%n label"
+msgid_plural "%n labels"
+msgstr[0] ""
+
+#: src/components/CsvImportModal.vue:56
+msgid "%n label created"
+msgid_plural "%n labels created"
+msgstr[0] ""
+
+#: src/components/CsvImportModal.vue:66
+msgid "%n label was not created and is missing from the imported cards: only board managers can add new labels. Ask a manager to add it, then set it on the cards."
+msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
+msgstr[0] ""
 
 #: src/components/CardDetail.vue:4291
 msgid "%n minute ago"
@@ -297,6 +338,11 @@ msgstr[0] "%n 个项目"
 #: src/components/CardDetail.vue:1975
 msgid "%n reply"
 msgid_plural "%n replies"
+msgstr[0] ""
+
+#: src/components/CsvImportModal.vue:60
+msgid "%n row was skipped because it had no title."
+msgid_plural "%n rows were skipped because they had no title."
 msgstr[0] ""
 
 #: src/components/BoardTimelineView.vue:306
@@ -1180,6 +1226,8 @@ msgid "close"
 msgstr "关闭"
 
 #: src/components/BoardSettingsModal.vue
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
 #: src/views/PublicBoard.vue
 msgid "Close"
 msgstr "关闭"
@@ -2856,6 +2904,10 @@ msgstr "从 CSV 导入卡片"
 msgid "Import from Deck"
 msgstr "从 Deck 导入"
 
+#: src/views/BoardList.vue
+msgid "Imported into a new Kanso board:"
+msgstr ""
+
 #: src/components/CsvImportModal.vue
 #: src/views/BoardList.vue
 msgid "Importing…"
@@ -3711,6 +3763,11 @@ msgstr "打开"
 #: src/components/CardDetail.vue
 msgid "Open as full page"
 msgstr "以整页方式打开"
+
+#: src/components/CsvImportModal.vue
+#: src/views/BoardList.vue
+msgid "Open board"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 #: src/views/ArchivedView.vue


### PR DESCRIPTION
Autonomous /pm session on the Kanso board (board 19). One branch, one PR, **18 cards, 22 commits**.

> ### ⚠️ Contains three security fixes — please prioritise review
> - **`36523c7`** — anonymous share links were leaking real Nextcloud **login uids** through `@mentions` in card descriptions, in the **default** config (comments off). Reproduced live before the fix.
> - **`b46136f`** — CSV import minted board-level labels at **EDIT**, bypassing `LabelService`'s **MANAGE** gate; EDIT also survives the external-role strip.
> - **`87264bd`** — `ReviewService::setState` let any READ member record a verdict on **someone else's** review, and let a non-member distinguish 403/404 to probe review existence.
>
> If you would rather these went out as their own small PR, say so on the board and I will split them.

> ### Also: PR #109 is superseded — please CLOSE it rather than merge
> `5e86d08` is its commit, byte-identical. #109 had been open since 2026-09-04 with every required check green, blocked only by a `.po`/`.pot` line-ref conflict. Merging both would land the same fix twice.

## Theme, which emerged rather than being planned

**Guards and assertions that could not fail.** It started with one flaky test and ended up recursive — the session found this defect class in shipped code, in the tests written to prove the fixes, and in its own tooling.

## What landed

| commit | card | what |
|---|---|---|
| `5e86d08` | 10276 | `fix(recurrence)` sub-day due-date lead time survives editing a repeat rule |
| `672336e` | 10225 | `fix(realtime)` boards stay on the fast 5s refresh until push proves it works |
| `8eba10b` | 10222 | `test(e2e)` pin the exact public-share payload key sets |
| `b63826a` | 10278 | `fix(realtime)` stop polling a board while its tab is backgrounded |
| `5f490d8` | 10226 | `chore(dev)` verify notify_push on boot instead of assuming it |
| `e54af07` | 10255 | `feat(boards)` a board can hide the checklist section like the others |
| `e779f3a` | 10284 | `fix(checklist)` a just-added step no longer loses its assignee on a slow connection |
| `327e2ba` | 10285 | `fix(checklist)` a just-added step no longer reappears when you delete it |
| `a50b67c` | 10275 | `fix(ui)` hover hint on every button in the multi-select action bar |
| `59feaf3` | 10281 | `chore(dev)` pin both halves of notify_push so the boot check can't cry wolf |
| `59b7309` `98095dd` | 10292 | `test` + `fix(realtime)` make three shipped guards fail when removed; no orphaned poll loop |
| `36523c7` | 10294 | **`fix(share)` display names, not login names, in public board text** |
| `b46136f` | 10295 | **`fix` CSV import label creation now needs MANAGE** |
| `87264bd` `e13d400` | 10296 | **`fix(security)` + `test` review verdicts are the reviewer's alone; no existence oracle** |
| `9871ce0` | 10297 | `fix(import)` show what an import copied, and warn about anything it skipped |
| `c4df0ca` | 10305 | `test(e2e)` probe the review routes in the visibility leak matrix |
| `d7bb6c0` `36b77ad` | 10310 | `fix(comments)` + `test(e2e)` a deep-linked comment stays in view while the card loads |

## Review notes

- **No `<version>` bump** anywhere — versioning is release-only here.
- **Please merge with a merge commit.** Commit types are deliberate (`fix:` ×11, `feat:` ×1, `test:` ×3, `chore(dev):` ×2); a squash under one title would collapse them and lose release entries.
- **Every behavioural change is mutation-proven** — break the fix, confirm red, restore. `327e2ba` carries nine such proofs, `87264bd` nine, one per guard.
- Three of my own specs were **wrong and the workers said so** rather than building them: an `apache2ctl` root cause that did not exist (and whose "fix" broke the boot), a mutation proof that was impossible once the fix landed, and a leak-matrix probe that **could not have failed** because its viewer was a board member. Those corrections are recorded on the cards.
- **The earlier e2e failure was attributed and is not from this branch**: branch and `main` bundles fail and pass at identical latency thresholds across six injection points. Investigating it is what surfaced the two `fix(checklist)` bugs.
- **23 follow-up cards** were filed rather than scope-crept into these commits, including two that correct /pm's own earlier reasoning.

## On the one CI failure, and what it found

Run `34358052981` on `c4df0ca` was **14/15 green** — full install matrix (NC 32/33/34 × sqlite/postgres/mysql), upgrade-with-data, psalm, cs-check, both PHP versions, build-frontend, unit-mcp — with `e2e` failing 2 of 599.

Both failures were attributed by bundle-swap A/B (identical backend and fixtures, only the built JS swapped) as **pre-existing, not from this branch**:

- `accessibility.spec.js` — a test race. `src/views/BoardView.vue` is **not in this branch's diff at all**; `.board-view` renders skeleton columns before the board read resolves, and a 4s API delay reproduces the CI output character-for-character. Fixed by waiting for content before snapshotting; **the assertion is unchanged**.
- `comment-deeplink.spec.js` — **a real product bug, now fixed.** Under CPU throttling it fails **0/3 on `origin/main`** and 3/3 passes only after the fix. Measured cause: the thread pane *shrinks after* the scroll (the composer and its lazy `MarkdownEditor` mount once the board read resolves), `scrollTop` survives but the centred comment does not, and `scrollHandled` is already latched. **User impact: a reminder or mention link silently lands the reader on a neighbouring comment.** Fixed with a `ResizeObserver` that re-centres on resize only, so hand-scrolling isn't fought.

Neither assertion was weakened. Both fixes are mutation-proven, and the specs were run 3× at workers=1 and 2× at workers=2 (CI's setting).
