### PR TITLE
feat(mail): create cards by sending email to a board

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -326,6 +326,7 @@ Kanso 是一款为速度而生的 Nextcloud 看板应用。看板、列和卡片
 		<job>OCA\Kanso\Cron\SendDueReminders</job>
 		<job>OCA\Kanso\Cron\SendPersonalReminders</job>
 		<job>OCA\Kanso\Cron\BackupBoards</job>
+		<job>OCA\Kanso\Cron\PollMailIntake</job>
 	</background-jobs>
 	<commands>
 		<command>OCA\Kanso\Command\Rebalance</command>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -247,6 +247,13 @@ return [
 		['name' => 'webhook#forgejoIntake', 'url' => '/api/boards/{id}/forgejo/intake', 'verb' => 'PUT'],
 		['name' => 'webhook#forgejoDisable', 'url' => '/api/boards/{id}/forgejo', 'verb' => 'DELETE'],
 
+		// Email intake (#117). No ingest route: unlike the webhooks above, mail is
+		// PULLED from IMAP by cron, so these are config-only and all MANAGE-gated.
+		['name' => 'mailIntake#show', 'url' => '/api/boards/{id}/mail-intake', 'verb' => 'GET'],
+		['name' => 'mailIntake#save', 'url' => '/api/boards/{id}/mail-intake', 'verb' => 'PUT'],
+		['name' => 'mailIntake#test', 'url' => '/api/boards/{id}/mail-intake/test', 'verb' => 'POST'],
+		['name' => 'mailIntake#destroy', 'url' => '/api/boards/{id}/mail-intake', 'verb' => 'DELETE'],
+
 		['name' => 'cardLink#index', 'url' => '/api/cards/{cardId}/links', 'verb' => 'GET'],
 		['name' => 'cardLink#create', 'url' => '/api/cards/{cardId}/links', 'verb' => 'POST'],
 		['name' => 'cardLink#destroy', 'url' => '/api/cards/{cardId}/links/{linkId}', 'verb' => 'DELETE'],

--- a/docs/email-intake-security.md
+++ b/docs/email-intake-security.md
@@ -62,6 +62,7 @@ one card.
 |---|---|
 | Credential readable at rest | `ICrypto`-encrypted (NC's server-secret cipher). |
 | Credential leaking outward | Absent from `jsonSerialize` (`hasPassword` instead); login-failure text replaced wholesale, since servers echo the command back; the configured username is scrubbed out of any stored error. |
+| **Credential theft by repointing the mailbox** — a manager who never knew the password could edit an existing config to a host they control, leave the password field blank (which means "keep the stored one") and have the next connection hand them the credential. MANAGE on the board was the only thing needed. | A stored password is only ever carried over to the **same host and account**. Changing either requires typing it again. Changing just the folder does not — same server, same account, nothing to steal. |
 | Credential outliving its mailbox | Deleting the config removes the row and its dedupe keys. |
 | Undecryptable credential after a server-secret change | Reported as "re-enter it" rather than a generic failure. |
 
@@ -113,7 +114,14 @@ These are accepted, not solved. They are properties of the feature as specified.
   detect this, so the option is off by default and the admin doc states the
   requirement.
 - **A board manager still chooses the mail server.** The SSRF guard restricts
-  *where*, not *whether*. A manager can still point intake at any public host.
+  *where*, not *whether*. A manager can still point intake at any public host —
+  with a password they supply themselves, since a stored one cannot be carried
+  to a different server.
+- **A Nextcloud server administrator can recover the password.** `ICrypto` keys
+  off the instance secret in `config.php`, so anyone holding both the database
+  and that file can decrypt it. This is the same guarantee Nextcloud gives its
+  own external-storage credentials, and it is why the docs say to use a
+  dedicated mailbox rather than a personal account.
 - **Content is unverified text.** A phishing mail that clears the filters still
   becomes a card with a clickable link. The provenance line is the mitigation;
   it is not a content filter.

--- a/docs/email-intake-security.md
+++ b/docs/email-intake-security.md
@@ -27,6 +27,15 @@ people read. Two facts drive everything below:
 Every row has at least one test; the ones marked ▲ were additionally verified by
 mutation (break the code, watch the named test fail).
 
+The unit tests drive a scripted IMAP server, so the client was additionally
+checked against a **real Dovecot 2.3** instance with a CA-signed certificate:
+TLS handshake, `LOGIN`, `EXAMINE`, `UID SEARCH` and a literal `UID FETCH` all
+behaved, an RFC 2047 subject and a quoted-printable UTF-8 body came through
+intact, and of three seeded messages only the genuine one became a card — the
+auto-reply and the spam-flagged message were declined. Polling four times, and
+then again with the watermark forcibly rewound to zero, still produced exactly
+one card.
+
 ### Content and privilege
 
 | Threat | Defence |

--- a/docs/email-intake-security.md
+++ b/docs/email-intake-security.md
@@ -3,142 +3,118 @@ SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Email intake: threat model and abuse plan
+# Email intake: threat model
 
-Working document for #117 (create cards by email). It records what the current
-implementation already defends against, what it does **not**, and the order the
-gaps should be closed in.
+Companion to [email-intake.md](email-intake.md) (how to set it up). This one
+records what the feature defends against and why each defence is shaped the way
+it is. Written for #117.
 
 ## The trust change this feature makes
 
 Every other way a card gets created requires a Nextcloud session or a per-board
 HMAC secret. Email intake is the first path where **an unauthenticated stranger
 causes a write**, and the content they supply lands in a card body that other
-people read. Two consequences drive everything below:
+people read. Two facts drive everything below:
 
-1. `From:` is not an identity. SMTP lets anyone claim any address, and by the
-   time a message reaches IMAP the envelope sender is gone. The allowlist is a
-   *filter*, not authentication.
-2. Anything the server does with a card's text — notify, subscribe, link,
+1. **`From:` is not an identity.** SMTP lets anyone claim any address, and by
+   the time a message reaches IMAP the envelope sender is gone. The allowlist is
+   a *filter*; `requireAuth` is the only thing that authenticates.
+2. **Anything the server does with a card's text** — notify, subscribe, link,
    render — is now reachable by that stranger.
 
-**Status: not shippable yet.** Intake is default-off with no UI to turn it on,
-which is the only reason the P0s below are not live issues. Nothing here should
-be exposed to users until P0 is done.
+## Defences
 
-## Already handled
+Every row has at least one test; the ones marked ▲ were additionally verified by
+mutation (break the code, watch the named test fail).
 
-Each of these has a test unless noted.
+### Content and privilege
 
-| # | Threat | Defence | Where |
-|---|---|---|---|
-| 1 | Credential sniffed in transit | TLS mandatory (no cleartext mode); `verify_peer` + `verify_peer_name`, no self-signed | `StreamImapTransport::open` |
-| 2 | STARTTLS sent after the password | STARTTLS is the only command written before the upgrade | `ImapClient::connect`, test asserts `writesBeforeCrypto === 1` |
-| 3 | Credential readable at rest | `ICrypto`-encrypted (NC's server-secret cipher) | `MailIntakeService::saveConfig` |
-| 4 | Credential leaking outward | Omitted from `jsonSerialize` (`hasPassword` instead); LOGIN failure text replaced wholesale, since servers echo the command back | `MailIntake`, `ImapClient::login` |
-| 5 | IMAP command injection via config fields | CR/LF/NUL rejected at the config boundary *and* in the client; quoted-string escaping | `saveConfig`, `ImapClient::assertArgumentSafe` |
-| 6 | Config changed by a non-manager | MANAGE asserted on every endpoint | `MailIntakeService`, 3 denial tests |
-| 7 | Duplicate cards from re-delivery | UID watermark + UIDVALIDITY pairing; watermark persisted on the failure path | `poll()` |
-| 8 | Duplicate cards from the `n:*` range quirk | Client-side filter (`UID 9:*` returns UID 4 on a mailbox that ends at 4) | `searchUidsAbove` |
-| 9 | Poller marks a human's mail as read | `EXAMINE` (read-only) + `BODY.PEEK[]` | `ImapClient` |
-| 10 | Memory exhaustion from a huge message | 5 MiB ceiling, drained to keep the stream in sync | `ImapClient::fetchMessage` |
-| 11 | Parser DoS via nesting/fan-out | Depth cap 10, part cap 200 | `MimeParser` |
-| 12 | Invalid UTF-8 failing the INSERT | Scrubbed on every body and header | `MimeParser::toUtf8` |
-| 13 | One board's failure stopping all intake | Per-mailbox catch, error recorded on the row | `pollAll` |
-| 14 | Stored XSS via message body | `MarkdownIt({html: false})` + DOMPurify; HTML mail is flattened to text before storage | `src/services/markdown.js`, `MimeParser::htmlToText` |
+| Threat | Defence |
+|---|---|
+| **`@mention` notification spoofing** — a description write re-parses `@name` and sends real notifications + auto-subscriptions attributed to the writer. Intake writes a stranger's text *as the board owner*, so `@alice` in an email would ping Alice with the owner's name on it. | `CardService::update(..., notifyMentions: false)`. The flag exists solely for this caller. ▲ |
+| Card attributed to a forged sender | Cards are always created as the board **owner**, never the NC user whose address `From:` claims. The claimed sender is plain text in the body. |
+| Reader cannot tell a card came from outside | Every intake card opens with a provenance line naming the sender and stating explicitly whether the domain was verified — `linkify` makes URLs in stranger mail clickable, so "who sent this" has to be on the card. |
+| Stored XSS via message body | `MarkdownIt({html: false})` + DOMPurify in the renderer; HTML mail is flattened to text before storage. |
+| Bidi/zero-width spoofing of a card title (`invoice\u{202E}gnp.exe`) | Invisible and bidi-control characters stripped from every header-derived string. |
 
-## P0 — must land before intake can be enabled
+### Network
 
-### 0.1 `@mention` notification spoofing (worst one)
+| Threat | Defence |
+|---|---|
+| **SSRF** — `host`/`port` are free text from any board *manager*, so intake could dial `127.0.0.1`, `169.254.169.254` or any internal host, with `testConnection` reporting the outcome (a working port scanner). | `MailHostGuard` resolves the name and rejects loopback, private, link-local, unique-local, unspecified and IPv4-mapped equivalents. Admin opt-in (`mail_intake_allow_private_hosts`) permits LAN servers but **never** loopback. |
+| DNS rebinding around that check | The guard returns the resolved IP and the socket dials **that**, not the name — closing the window between check and connect. The hostname travels separately as `peer_name` so TLS still validates against it. |
+| Credential sniffed in transit | TLS mandatory (no cleartext mode); `verify_peer` + `verify_peer_name`, no self-signed. |
+| Password sent before the TLS upgrade | STARTTLS is the only command written before `enableCrypto()`; asserted by test. |
+| IMAP command injection via config fields | CR/LF/NUL rejected at the config boundary *and* in the client; quoted-string escaping. ▲ |
 
-`CardService::update` re-parses the description server-side and
-`MentionService::handleMentions` sends real notifications and auto-subscribes
-the named users. Intake writes an unauthenticated stranger's text into that
-description, with `actorUid` = the **board owner**.
+### Credential handling
 
-So `@alice @bob` in an email body produces genuine Nextcloud notifications that
-read as though the board owner mentioned them — unauthenticated notification
-spam with a spoofed actor, and a plausible phishing primitive ("the owner
-mentioned you, click here").
+| Threat | Defence |
+|---|---|
+| Credential readable at rest | `ICrypto`-encrypted (NC's server-secret cipher). |
+| Credential leaking outward | Absent from `jsonSerialize` (`hasPassword` instead); login-failure text replaced wholesale, since servers echo the command back; the configured username is scrubbed out of any stored error. |
+| Credential outliving its mailbox | Deleting the config removes the row and its dedupe keys. |
+| Undecryptable credential after a server-secret change | Reported as "re-enter it" rather than a generic failure. |
 
-*Fix:* intake-created content must not drive mentions. Either write the
-description through a path that skips `handleMentions`, or neutralise `@` in
-intake bodies before storage. The former is better — it keeps the body faithful.
+### Abuse and spam
 
-### 0.2 SSRF via the configured host
+| Threat | Defence |
+|---|---|
+| **Auto-responder / bounce loops** — a card raises a notification email, an out-of-office answers it, that answer becomes a card, forever. | Messages carrying `Auto-Submitted`, `Precedence: bulk/list/junk`, `List-Id`/`List-Unsubscribe`/`List-Post`, `X-Auto-Response-Suppress`, a null `Return-Path`, or a `multipart/report` content type are never carded. |
+| Spam becoming cards | The upstream filter's verdict is honoured (`X-Spam-Flag`, `X-Spam-Status`, `X-Spamd-Result`). Kanso does not re-implement spam detection. |
+| Forged sender passing the allowlist | `requireAuth` demands a DMARC pass from the receiving MTA, cross-checked against the `From` domain (with subdomain alignment). SPF-only or DKIM-only does **not** satisfy it: SPF authenticates the envelope, not the visible `From`. |
+| A forged `Authentication-Results` header | Only the **topmost** occurrence is read — hops prepend, so it is the one our own MTA wrote. Anything below is the sender's to invent. ▲ |
+| Board flooded from an open address | Per-mailbox daily cap (default 200) *and* per-sender daily cap (default 50), both overridable. Hitting the mailbox cap stops the run **without advancing the watermark**, so the excess waits on the server rather than being destroyed. A per-sender cap skips-and-advances instead, so one flooder cannot wedge the mailbox for everyone. |
+| Duplicate cards from re-delivery | `kanso_mail_seen` keyed on the Message-ID hash, with a UNIQUE index doing the work — the failing insert *is* the check, so it is race-free. Messages with no Message-ID fall back to a content hash. |
+| A user cannot tell why nothing happened | A healthy run records what it declined ("Last run skipped 3 messages from senders not on the allowlist") in the field the config screen shows. |
 
-`host`/`port` are free-text from any board **manager**, not just an admin. That
-turns Kanso into a connect-anywhere probe: `127.0.0.1`, link-local metadata
-endpoints, internal-only hosts. `testConnection` returns the error text
-synchronously, which makes it a usable port scanner (open/refused/timeout are
-distinguishable).
+### Resource exhaustion
 
-*Fix:* reject loopback / private / link-local / unique-local destinations by
-default, resolved at connect time (not just on the config string, or DNS
-rebinding walks around it). Add an admin-level allowlist for the legitimate
-"our IMAP server is on the LAN" case.
+| Threat | Defence |
+|---|---|
+| Memory exhaustion from a huge message | 5 MiB ceiling; oversized messages are drained (keeping the stream in sync) and skipped. |
+| Parser DoS via nesting/fan-out | Depth cap 10, part cap 200. |
+| Regex CPU burn on a multi-megabyte header | Header values clamped to 2 KB before parsing. |
+| Cron overrun from many unreachable servers | 30 s per-connection timeout plus a 120 s whole-run budget; deferred mailboxes are logged and picked up next tick. |
+| Duplicate-key table growing forever | 60-day retention, pruned on roughly one run a day. |
+| One board's failure stopping all intake | Per-mailbox catch; the error is recorded on that board's row. ▲ |
 
-### 0.3 Auto-responder and bounce loops
+### Correctness that protects the mailbox
 
-Nothing checks whether a message is itself automated. A card created by intake
-can generate a Nextcloud notification email → an out-of-office replies → a new
-card → and so on. A bounce loop does the same.
+| Threat | Defence |
+|---|---|
+| Poller marking a human's mail as read | `EXAMINE` (read-only) + `BODY.PEEK[]` — no flag writes at all. |
+| Duplicate cards from the `n:*` range quirk (`UID 9:*` returns UID 4 on a mailbox ending at 4) | Client-side filter. ▲ |
+| Replaying the batch after a crash | The watermark advances per message and is persisted on the failure path. ▲ |
+| Re-carding all history after a mailbox is restored | A UIDVALIDITY change resumes from `UIDNEXT` ("card what arrives from now on"). A *first* poll still ingests what is already there, which is what someone setting up a new address expects. |
+| Mail lost while the target column is deleted | The stack is checked before connecting; the watermark does not advance, so the mail waits. |
+| Config changed with no trace | Create/update/delete are logged with actor, board, host, account and mailbox — never the password. |
 
-*Fix:* drop before carding when any of these is present — `Auto-Submitted:`
-anything but `no`, `Precedence: bulk|list|junk`, `X-Auto-Response-Suppress`,
-`List-Id`/`List-Unsubscribe`, or an empty `Return-Path: <>`. Cheap, and it is
-the standard set.
+## Residual risks
 
-### 0.4 Unbounded card creation from an open address
+These are accepted, not solved. They are properties of the feature as specified.
 
-With an empty allowlist (the "public intake address" the issue asks for),
-anyone who learns the address can create cards without limit. The only current
-bound is 50 per poll, i.e. ~600/hour/mailbox — enough to bury a board.
-
-*Fix:* a per-mailbox daily cap and a per-sender rate limit, both with the excess
-left on the server rather than silently dropped, plus `lastError` reporting when
-a cap engages so it is visible rather than mysterious.
-
-## P1 — before it is documented as production-ready
-
-- **Sender authentication.** We cannot check SPF/DKIM ourselves post-delivery,
-  but the receiving MTA already did and recorded it in `Authentication-Results:`.
-  Read that header (trusting only the topmost one, from our own MTA) and offer a
-  "require passing DMARC" toggle. Without it, allowlist entries are trivially
-  forged — which makes the allowlist feel like security while providing none.
-- **Spam-header awareness.** Honour `X-Spam-Flag: YES` / `X-Spam-Status: Yes`
-  from the upstream filter rather than re-implementing spam detection.
-- **Deduplicate by `Message-ID`.** Protects against a mailbox re-delivering
-  after a UIDVALIDITY reset, which currently re-cards the entire history.
-- **UIDVALIDITY reset policy.** Today a renumbered mailbox restarts at UID 0 and
-  re-cards everything it still holds. Starting from `UIDNEXT` instead ("card
-  what arrives from now on") is almost certainly the behaviour people want, and
-  is a one-line change — but it is a product decision, so it needs a call.
-- **Link handling.** `linkify: true` makes every URL in a stranger's email a
-  clickable link in the card. Consider marking intake-created cards visually as
-  externally-sourced so a reader knows the content is untrusted.
-
-## P2 — hardening
-
-- **Header-length cap before regex.** `parseFrom`'s pattern runs over an
-  unbounded header value (a single header can be ~5 MiB under the message cap);
-  backtracking there is superlinear. Clamp header values to ~2 KB before
-  decoding — no legitimate `From` is longer.
-- **Unicode spoofing in titles.** Bidi overrides and confusables let a subject
-  render deceptively in the card list. Strip bidi control characters.
-- **Poll-time budget.** N mailboxes × a 30 s timeout can run one cron tick long.
-  Add a whole-run wall-clock budget and resume next tick.
-- **`lastError` exposure.** It can carry the server's text, which may include
-  the username. Manager-only today, so low, but worth scrubbing.
-- **Config-change audit.** Changing the mailbox is a security-relevant act with
-  no activity entry.
+- **An open intake address is open by design.** With an empty allowlist, anyone
+  who learns the address can create cards up to the daily caps. That is the
+  feature the issue asked for; the caps bound it and the UI says so plainly.
+- **`requireAuth` is only as good as the deployment.** It trusts the topmost
+  `Authentication-Results`, which means it trusts that mail reaches the mailbox
+  through an MTA that actually authenticates. A mailbox fed directly by a third
+  party would have no such header — or a sender-supplied one. Kanso cannot
+  detect this, so the option is off by default and the admin doc states the
+  requirement.
+- **A board manager still chooses the mail server.** The SSRF guard restricts
+  *where*, not *whether*. A manager can still point intake at any public host.
+- **Content is unverified text.** A phishing mail that clears the filters still
+  becomes a card with a clickable link. The provenance line is the mitigation;
+  it is not a content filter.
 
 ## Deliberately out of scope
 
 - **Storing attachments.** Intake names attached files in the body and stores
   none of them. Storing them adds malware distribution, quota exhaustion and
-  content-type confusion to the threat surface, and should be its own piece of
-  work with its own review.
+  content-type confusion to the threat surface, and belongs in its own change
+  with its own review.
 - **Replies as comments.** Threading a reply onto the original card means
   trusting `In-Reply-To`, which is attacker-settable — it would let a stranger
-  append to a chosen existing card. Needs a real design before it is built.
+  append to a card of their choosing. Needs a real design first.

--- a/docs/email-intake-security.md
+++ b/docs/email-intake-security.md
@@ -1,0 +1,144 @@
+<!--
+SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Email intake: threat model and abuse plan
+
+Working document for #117 (create cards by email). It records what the current
+implementation already defends against, what it does **not**, and the order the
+gaps should be closed in.
+
+## The trust change this feature makes
+
+Every other way a card gets created requires a Nextcloud session or a per-board
+HMAC secret. Email intake is the first path where **an unauthenticated stranger
+causes a write**, and the content they supply lands in a card body that other
+people read. Two consequences drive everything below:
+
+1. `From:` is not an identity. SMTP lets anyone claim any address, and by the
+   time a message reaches IMAP the envelope sender is gone. The allowlist is a
+   *filter*, not authentication.
+2. Anything the server does with a card's text — notify, subscribe, link,
+   render — is now reachable by that stranger.
+
+**Status: not shippable yet.** Intake is default-off with no UI to turn it on,
+which is the only reason the P0s below are not live issues. Nothing here should
+be exposed to users until P0 is done.
+
+## Already handled
+
+Each of these has a test unless noted.
+
+| # | Threat | Defence | Where |
+|---|---|---|---|
+| 1 | Credential sniffed in transit | TLS mandatory (no cleartext mode); `verify_peer` + `verify_peer_name`, no self-signed | `StreamImapTransport::open` |
+| 2 | STARTTLS sent after the password | STARTTLS is the only command written before the upgrade | `ImapClient::connect`, test asserts `writesBeforeCrypto === 1` |
+| 3 | Credential readable at rest | `ICrypto`-encrypted (NC's server-secret cipher) | `MailIntakeService::saveConfig` |
+| 4 | Credential leaking outward | Omitted from `jsonSerialize` (`hasPassword` instead); LOGIN failure text replaced wholesale, since servers echo the command back | `MailIntake`, `ImapClient::login` |
+| 5 | IMAP command injection via config fields | CR/LF/NUL rejected at the config boundary *and* in the client; quoted-string escaping | `saveConfig`, `ImapClient::assertArgumentSafe` |
+| 6 | Config changed by a non-manager | MANAGE asserted on every endpoint | `MailIntakeService`, 3 denial tests |
+| 7 | Duplicate cards from re-delivery | UID watermark + UIDVALIDITY pairing; watermark persisted on the failure path | `poll()` |
+| 8 | Duplicate cards from the `n:*` range quirk | Client-side filter (`UID 9:*` returns UID 4 on a mailbox that ends at 4) | `searchUidsAbove` |
+| 9 | Poller marks a human's mail as read | `EXAMINE` (read-only) + `BODY.PEEK[]` | `ImapClient` |
+| 10 | Memory exhaustion from a huge message | 5 MiB ceiling, drained to keep the stream in sync | `ImapClient::fetchMessage` |
+| 11 | Parser DoS via nesting/fan-out | Depth cap 10, part cap 200 | `MimeParser` |
+| 12 | Invalid UTF-8 failing the INSERT | Scrubbed on every body and header | `MimeParser::toUtf8` |
+| 13 | One board's failure stopping all intake | Per-mailbox catch, error recorded on the row | `pollAll` |
+| 14 | Stored XSS via message body | `MarkdownIt({html: false})` + DOMPurify; HTML mail is flattened to text before storage | `src/services/markdown.js`, `MimeParser::htmlToText` |
+
+## P0 — must land before intake can be enabled
+
+### 0.1 `@mention` notification spoofing (worst one)
+
+`CardService::update` re-parses the description server-side and
+`MentionService::handleMentions` sends real notifications and auto-subscribes
+the named users. Intake writes an unauthenticated stranger's text into that
+description, with `actorUid` = the **board owner**.
+
+So `@alice @bob` in an email body produces genuine Nextcloud notifications that
+read as though the board owner mentioned them — unauthenticated notification
+spam with a spoofed actor, and a plausible phishing primitive ("the owner
+mentioned you, click here").
+
+*Fix:* intake-created content must not drive mentions. Either write the
+description through a path that skips `handleMentions`, or neutralise `@` in
+intake bodies before storage. The former is better — it keeps the body faithful.
+
+### 0.2 SSRF via the configured host
+
+`host`/`port` are free-text from any board **manager**, not just an admin. That
+turns Kanso into a connect-anywhere probe: `127.0.0.1`, link-local metadata
+endpoints, internal-only hosts. `testConnection` returns the error text
+synchronously, which makes it a usable port scanner (open/refused/timeout are
+distinguishable).
+
+*Fix:* reject loopback / private / link-local / unique-local destinations by
+default, resolved at connect time (not just on the config string, or DNS
+rebinding walks around it). Add an admin-level allowlist for the legitimate
+"our IMAP server is on the LAN" case.
+
+### 0.3 Auto-responder and bounce loops
+
+Nothing checks whether a message is itself automated. A card created by intake
+can generate a Nextcloud notification email → an out-of-office replies → a new
+card → and so on. A bounce loop does the same.
+
+*Fix:* drop before carding when any of these is present — `Auto-Submitted:`
+anything but `no`, `Precedence: bulk|list|junk`, `X-Auto-Response-Suppress`,
+`List-Id`/`List-Unsubscribe`, or an empty `Return-Path: <>`. Cheap, and it is
+the standard set.
+
+### 0.4 Unbounded card creation from an open address
+
+With an empty allowlist (the "public intake address" the issue asks for),
+anyone who learns the address can create cards without limit. The only current
+bound is 50 per poll, i.e. ~600/hour/mailbox — enough to bury a board.
+
+*Fix:* a per-mailbox daily cap and a per-sender rate limit, both with the excess
+left on the server rather than silently dropped, plus `lastError` reporting when
+a cap engages so it is visible rather than mysterious.
+
+## P1 — before it is documented as production-ready
+
+- **Sender authentication.** We cannot check SPF/DKIM ourselves post-delivery,
+  but the receiving MTA already did and recorded it in `Authentication-Results:`.
+  Read that header (trusting only the topmost one, from our own MTA) and offer a
+  "require passing DMARC" toggle. Without it, allowlist entries are trivially
+  forged — which makes the allowlist feel like security while providing none.
+- **Spam-header awareness.** Honour `X-Spam-Flag: YES` / `X-Spam-Status: Yes`
+  from the upstream filter rather than re-implementing spam detection.
+- **Deduplicate by `Message-ID`.** Protects against a mailbox re-delivering
+  after a UIDVALIDITY reset, which currently re-cards the entire history.
+- **UIDVALIDITY reset policy.** Today a renumbered mailbox restarts at UID 0 and
+  re-cards everything it still holds. Starting from `UIDNEXT` instead ("card
+  what arrives from now on") is almost certainly the behaviour people want, and
+  is a one-line change — but it is a product decision, so it needs a call.
+- **Link handling.** `linkify: true` makes every URL in a stranger's email a
+  clickable link in the card. Consider marking intake-created cards visually as
+  externally-sourced so a reader knows the content is untrusted.
+
+## P2 — hardening
+
+- **Header-length cap before regex.** `parseFrom`'s pattern runs over an
+  unbounded header value (a single header can be ~5 MiB under the message cap);
+  backtracking there is superlinear. Clamp header values to ~2 KB before
+  decoding — no legitimate `From` is longer.
+- **Unicode spoofing in titles.** Bidi overrides and confusables let a subject
+  render deceptively in the card list. Strip bidi control characters.
+- **Poll-time budget.** N mailboxes × a 30 s timeout can run one cron tick long.
+  Add a whole-run wall-clock budget and resume next tick.
+- **`lastError` exposure.** It can carry the server's text, which may include
+  the username. Manager-only today, so low, but worth scrubbing.
+- **Config-change audit.** Changing the mailbox is a security-relevant act with
+  no activity entry.
+
+## Deliberately out of scope
+
+- **Storing attachments.** Intake names attached files in the body and stores
+  none of them. Storing them adds malware distribution, quota exhaustion and
+  content-type confusion to the threat surface, and should be its own piece of
+  work with its own review.
+- **Replies as comments.** Threading a reply onto the original card means
+  trusting `In-Reply-To`, which is attacker-settable — it would let a stranger
+  append to a chosen existing card. Needs a real design before it is built.

--- a/docs/email-intake.md
+++ b/docs/email-intake.md
@@ -116,6 +116,23 @@ the address and nothing happened, look there first.
 - `@name` in an email does **not** notify that person. Only mentions typed by a
   real user in Kanso do.
 
+## Who can see these settings
+
+Only people with **manage** permission on the board. Ordinary members — read or
+edit — cannot see the mail server, the account name, or that intake exists at
+all; the endpoint returns "Access denied" to them.
+
+**Nobody gets the password back, not even a manager.** It is stored encrypted
+and the settings screen only reports that one is saved, which is why the field
+comes up blank when you reopen the form. Leaving it blank keeps the stored
+password; you only have to retype it if you change the mail server or the
+account, because a saved password is never carried across to a different server.
+
+The password is not included in board exports or backups. A Nextcloud server
+administrator can still recover it from the database and `config.php`, the same
+way they can any external-storage credential — another reason to use a mailbox
+that exists only for this.
+
 ## Administration
 
 ### Mail servers on your local network

--- a/docs/email-intake.md
+++ b/docs/email-intake.md
@@ -1,0 +1,166 @@
+<!--
+SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Creating cards by email
+
+Point a board at a mailbox and every message that arrives there becomes a card:
+the subject becomes the title, the body becomes the description.
+
+Kanso does not receive mail itself — Nextcloud has no inbound mail server. It
+**polls a mailbox you already have** over IMAP, every five minutes, using
+Nextcloud's background jobs.
+
+## Before you start
+
+You need a mailbox that exists **only for this board** — `cards@example.com`,
+`support@example.com`, a `+board` alias, whatever your provider gives you. Two
+reasons it should be dedicated:
+
+- Every message in it becomes a card, including ones you did not mean to file.
+- Kanso needs the account's password. Give it a mailbox whose password you are
+  willing to store, not your personal account. If your provider supports app
+  passwords, use one.
+
+Your IMAP server must accept TLS — either implicit TLS (usually port 993) or
+STARTTLS (usually port 143). Kanso will not connect in the clear, because that
+would put the mailbox password on the wire.
+
+## Setting it up
+
+1. Open the board → **Board settings** → **Automation** → **Email intake**.
+   You need *manage* permission on the board.
+2. Fill in the IMAP server, port and encryption.
+3. Enter the mailbox account and its password.
+4. Choose the folder (`INBOX` unless you filter into a subfolder) and the
+   **column** new cards should land in.
+5. Click **Test connection**. This connects and signs in immediately, so a typo
+   shows up now rather than in five minutes.
+6. Tick **Check this mailbox automatically** and **Save**.
+
+The first check picks up whatever is already sitting in the mailbox, then each
+run handles what has arrived since.
+
+### Who is allowed to send
+
+**Leave the allowlist empty and anyone who knows the address can create cards.**
+That is sometimes exactly what you want — a public `support@` address — but it
+is worth deciding deliberately.
+
+To restrict it, put one entry per line:
+
+```
+jacek@example.com
+@example.com
+```
+
+A bare address matches exactly; an `@domain` entry matches anyone at that
+domain.
+
+> **The allowlist is a filter, not proof.** A sender address is trivial to
+> forge. Anyone who knows an allowed address can put it in a `From:` header.
+> To make it mean something, turn on **Require verified senders** below.
+
+### Require verified senders (recommended)
+
+With this on, a message is only carded if your mail server verified that it
+really came from the domain its `From:` claims — a DMARC pass.
+
+This works only if mail reaches the mailbox through a mail server that performs
+that check and records it in an `Authentication-Results:` header. Most hosted
+providers (Google Workspace, Microsoft 365, Fastmail, Mailcow, mailu) and any
+Postfix with OpenDMARC or Rspamd do. If yours does not, every message will be
+rejected — use **Test connection**, send yourself a message, and check the
+status line under the form.
+
+Kanso only trusts the *topmost* such header, the one added by the server that
+delivered the message. Headers below it can be forged by the sender.
+
+### Limits
+
+Two caps stop a board being buried, set per mailbox (`0` uses the default):
+
+| | Default | What happens when it is reached |
+|---|---|---|
+| Cards per day, whole mailbox | 200 | Polling stops for the day. The remaining mail **stays on the server** and is picked up tomorrow — nothing is lost. |
+| Cards per day, one sender | 50 | That sender's further messages are skipped. Everyone else still gets through. |
+
+## What gets skipped
+
+Some mail is never carded, whatever the allowlist says:
+
+- **Automatic mail** — out-of-office replies, bounces, mailing-list posts and
+  anything marked `Auto-Submitted` or `Precedence: bulk`. This is not a
+  nicety: a card can raise a notification email, and if an auto-reply to that
+  became a card you would have an endless loop.
+- **Spam**, when your mail server has already flagged it.
+- **Messages already turned into a card**, even if the server delivers them
+  twice.
+
+When a run skips anything, the Email intake panel says so — "Last run skipped 3
+messages from senders not on the allowlist". If someone reports that they mailed
+the address and nothing happened, look there first.
+
+## What a card looks like
+
+- **Title** — the subject. A message with no subject is titled after its sender.
+- **Description** — a line recording who the mail claimed to be from and whether
+  that was verified, then the message text. HTML mail is converted to plain
+  text; when a message has both, the plain-text version is used.
+- **Attachments are not imported.** Their file names are listed at the end of
+  the description so you know something was left behind. Fetch them from the
+  mailbox if you need them.
+- The card is created as the **board owner**, not as the sender — Kanso will not
+  attribute a card to a Nextcloud user on the strength of an email header.
+- `@name` in an email does **not** notify that person. Only mentions typed by a
+  real user in Kanso do.
+
+## Administration
+
+### Mail servers on your local network
+
+By default Kanso refuses to connect to private, loopback or link-local
+addresses, so that configuring a mailbox cannot be used to probe your internal
+network. If your IMAP server genuinely is on the LAN:
+
+```
+occ config:app:set kanso mail_intake_allow_private_hosts --value yes
+```
+
+This is instance-wide and admin-only, on purpose. Loopback stays blocked even
+with it on.
+
+### Checking it runs
+
+Intake runs from Nextcloud's background jobs, so cron must be working
+(**Administration settings → Basic settings → Background jobs**; AJAX cron is
+too unreliable for this). To poll immediately:
+
+```
+occ background-job:execute --force "OCA\\Kanso\\Cron\\PollMailIntake"
+```
+
+Failures are recorded per board — visible in the Email intake panel and logged
+with the `kanso` app id.
+
+### Turning it off
+
+Untick **Check this mailbox automatically** to pause, or **Remove mailbox** to
+delete the settings and the stored password entirely.
+
+## Security
+
+The threat model, the defences and the residual risks are written up in
+[email-intake-security.md](email-intake-security.md). The short version: the
+password is encrypted at rest and never sent back to the browser, connections
+are TLS-only and cannot be aimed at your internal network, and content arriving
+by mail cannot trigger notifications or run script in a card.
+
+## Limitations
+
+- Polling is every five minutes, so a card can take that long to appear.
+- Replying to an intake card by email creates a **new card**; it does not add a
+  comment.
+- One mailbox per board.
+- Attachments are named, not stored.

--- a/lib/Controller/MailIntakeController.php
+++ b/lib/Controller/MailIntakeController.php
@@ -62,8 +62,11 @@ class MailIntakeController extends Controller {
 		string $mailbox = 'INBOX',
 		string $senderAllowlist = '',
 		bool $enabled = false,
+		bool $requireAuth = false,
+		int $dailyLimit = 0,
+		int $perSenderDailyLimit = 0,
 	): JSONResponse {
-		return $this->respond(function () use ($id, $stackId, $host, $port, $encryption, $username, $password, $mailbox, $senderAllowlist, $enabled): JSONResponse {
+		return $this->respond(function () use ($id, $stackId, $host, $port, $encryption, $username, $password, $mailbox, $senderAllowlist, $enabled, $requireAuth, $dailyLimit, $perSenderDailyLimit): JSONResponse {
 			$config = $this->mailIntakeService->saveConfig(
 				$id,
 				$stackId,
@@ -76,6 +79,9 @@ class MailIntakeController extends Controller {
 				$senderAllowlist,
 				$enabled,
 				$this->currentUserId(),
+				$requireAuth,
+				$dailyLimit,
+				$perSenderDailyLimit,
 			);
 			return new JSONResponse($config->jsonSerialize());
 		});

--- a/lib/Controller/MailIntakeController.php
+++ b/lib/Controller/MailIntakeController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Controller;
+
+use OCA\Kanso\Service\MailIntakeService;
+use OCA\Kanso\Service\NotPermittedException;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Email-intake config for a board (#117). Every endpoint is MANAGE-gated in the
+ * service; there is no public ingest counterpart because intake PULLS from IMAP
+ * on cron rather than being pushed to.
+ *
+ * The mailbox password travels in on {@see save} and never travels back out -
+ * {@see \OCA\Kanso\Db\MailIntake::jsonSerialize} reports only whether one is
+ * stored.
+ */
+class MailIntakeController extends Controller {
+	use ApiErrorTrait;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private MailIntakeService $mailIntakeService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	#[NoAdminRequired]
+	public function show(int $id): JSONResponse {
+		return $this->respond(function () use ($id): JSONResponse {
+			$config = $this->mailIntakeService->getConfig($id, $this->currentUserId());
+			// A board with no mailbox is a normal state, not a 404 - the config UI
+			// renders an empty form from it.
+			return new JSONResponse($config?->jsonSerialize());
+		});
+	}
+
+	/**
+	 * Creates or replaces the config. `$password` null (the field left untouched
+	 * in the UI) keeps the stored credential.
+	 */
+	#[NoAdminRequired]
+	public function save(
+		int $id,
+		int $stackId,
+		string $host,
+		int $port = 993,
+		string $encryption = 'ssl',
+		string $username = '',
+		?string $password = null,
+		string $mailbox = 'INBOX',
+		string $senderAllowlist = '',
+		bool $enabled = false,
+	): JSONResponse {
+		return $this->respond(function () use ($id, $stackId, $host, $port, $encryption, $username, $password, $mailbox, $senderAllowlist, $enabled): JSONResponse {
+			$config = $this->mailIntakeService->saveConfig(
+				$id,
+				$stackId,
+				$host,
+				$port,
+				$encryption,
+				$username,
+				$password,
+				$mailbox,
+				$senderAllowlist,
+				$enabled,
+				$this->currentUserId(),
+			);
+			return new JSONResponse($config->jsonSerialize());
+		});
+	}
+
+	/**
+	 * Connects and authenticates once, right now, so a wrong password is a
+	 * message on screen rather than a five-minute wait for cron.
+	 */
+	#[NoAdminRequired]
+	public function test(int $id): JSONResponse {
+		return $this->respond(function () use ($id): JSONResponse {
+			return new JSONResponse($this->mailIntakeService->testConnection($id, $this->currentUserId()));
+		});
+	}
+
+	#[NoAdminRequired]
+	public function destroy(int $id): JSONResponse {
+		return $this->respond(function () use ($id): JSONResponse {
+			$this->mailIntakeService->deleteConfig($id, $this->currentUserId());
+			return new JSONResponse([]);
+		});
+	}
+
+	/**
+	 * @throws NotPermittedException if there is no user session
+	 */
+	private function currentUserId(): string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No authenticated user');
+		}
+		return $user->getUID();
+	}
+}

--- a/lib/Cron/PollMailIntake.php
+++ b/lib/Cron/PollMailIntake.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Cron;
+
+use OCA\Kanso\Service\MailIntakeService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+
+/**
+ * Five-minute email-intake poller (#117): every board with an enabled mailbox
+ * gets its new mail turned into cards.
+ *
+ * Five minutes is the compromise between "mail should feel prompt" and the cost
+ * of a TLS handshake plus LOGIN per mailbox per tick. Per-mailbox error
+ * handling, the message budget and the UID watermark all live in
+ * {@see MailIntakeService::pollAll} - one unreachable server is recorded on its
+ * own board and stepped over, so it cannot stall the others.
+ *
+ * TIME_INSENSITIVE: intake is not something a user is waiting on in the moment,
+ * so it belongs in the window where NC is happy to run heavier work.
+ */
+class PollMailIntake extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private MailIntakeService $mailIntakeService,
+	) {
+		parent::__construct($time);
+		$this->setInterval(60 * 5);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+	}
+
+	#[\Override]
+	protected function run(mixed $argument): void {
+		$this->mailIntakeService->pollAll();
+	}
+}

--- a/lib/Db/MailIntake.php
+++ b/lib/Db/MailIntake.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * A board's email-intake mailbox (table `kanso_mail_intake`): the IMAP account
+ * {@see \OCA\Kanso\Cron\PollMailIntake} polls, and the stack the cards it
+ * creates land in. At most one per board.
+ *
+ * `password` holds ICrypto CIPHERTEXT, never the secret itself, and
+ * {@see jsonSerialize} does not emit it - not even redacted-but-present, so
+ * there is no field a future UI could accidentally round-trip back as a literal
+ * password. The config endpoint reports `hasPassword` instead.
+ *
+ * @method int getBoardId()
+ * @method void setBoardId(int $boardId)
+ * @method int getStackId()
+ * @method void setStackId(int $stackId)
+ * @method string getHost()
+ * @method void setHost(string $host)
+ * @method int getPort()
+ * @method void setPort(int $port)
+ * @method string getEncryption()
+ * @method void setEncryption(string $encryption)
+ * @method string getUsername()
+ * @method void setUsername(string $username)
+ * @method string getPassword()
+ * @method void setPassword(string $password)
+ * @method string getMailbox()
+ * @method void setMailbox(string $mailbox)
+ * @method string|null getSenderAllowlist()
+ * @method void setSenderAllowlist(?string $senderAllowlist)
+ * @method bool getEnabled()
+ * @method void setEnabled(bool $enabled)
+ * @method int getLastUid()
+ * @method void setLastUid(int $lastUid)
+ * @method int getUidValidity()
+ * @method void setUidValidity(int $uidValidity)
+ * @method int getLastRun()
+ * @method void setLastRun(int $lastRun)
+ * @method string|null getLastError()
+ * @method void setLastError(?string $lastError)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ */
+class MailIntake extends Entity implements \JsonSerializable {
+	/** Implicit TLS from the first byte (the 993 default). */
+	public const ENCRYPTION_SSL = 'ssl';
+	/** Cleartext connect on 143, upgraded with STARTTLS before LOGIN. */
+	public const ENCRYPTION_TLS = 'tls';
+
+	// Properties default to null (not to the column defaults): Entity::setter()
+	// skips values equal to the current one, so a non-null default would keep
+	// explicit sets of that same value out of INSERT statements.
+	protected ?int $boardId = null;
+	protected ?int $stackId = null;
+	protected ?string $host = null;
+	protected ?int $port = null;
+	protected ?string $encryption = null;
+	protected ?string $username = null;
+	protected ?string $password = null;
+	protected ?string $mailbox = null;
+	protected ?string $senderAllowlist = null;
+	protected ?bool $enabled = null;
+	protected ?int $lastUid = null;
+	protected ?int $uidValidity = null;
+	protected ?int $lastRun = null;
+	protected ?string $lastError = null;
+	protected ?int $createdAt = null;
+
+	public function __construct() {
+		$this->addType('boardId', Types::INTEGER);
+		$this->addType('stackId', Types::INTEGER);
+		$this->addType('host', Types::STRING);
+		$this->addType('port', Types::INTEGER);
+		$this->addType('encryption', Types::STRING);
+		$this->addType('username', Types::STRING);
+		$this->addType('password', Types::STRING);
+		$this->addType('mailbox', Types::STRING);
+		$this->addType('senderAllowlist', Types::STRING);
+		$this->addType('enabled', Types::BOOLEAN);
+		$this->addType('lastUid', Types::INTEGER);
+		$this->addType('uidValidity', Types::INTEGER);
+		$this->addType('lastRun', Types::INTEGER);
+		$this->addType('lastError', Types::STRING);
+		$this->addType('createdAt', Types::INTEGER);
+	}
+
+	/**
+	 * The allowlist as trimmed, lowercased addresses. Stored as one blob so the
+	 * config surface stays a single textarea; split here so every consumer reads
+	 * it the same way.
+	 *
+	 * @return string[] empty when the mailbox accepts any sender
+	 */
+	public function allowedSenders(): array {
+		$raw = $this->senderAllowlist ?? '';
+		if (trim($raw) === '') {
+			return [];
+		}
+		// Commas and newlines both separate - people paste either.
+		$parts = preg_split('/[\s,;]+/', $raw) ?: [];
+		$out = [];
+		foreach ($parts as $part) {
+			$part = mb_strtolower(trim($part));
+			if ($part !== '') {
+				$out[] = $part;
+			}
+		}
+		return array_values(array_unique($out));
+	}
+
+	/**
+	 * @return array{id: int, boardId: int, stackId: int, host: string, port: int, encryption: string, username: string, hasPassword: bool, mailbox: string, senderAllowlist: string, enabled: bool, lastRun: int, lastError: string|null}
+	 */
+	#[\Override]
+	public function jsonSerialize(): array {
+		return [
+			'id' => (int)$this->id,
+			'boardId' => (int)$this->boardId,
+			'stackId' => (int)$this->stackId,
+			'host' => (string)$this->host,
+			'port' => (int)$this->port,
+			'encryption' => (string)$this->encryption,
+			'username' => (string)$this->username,
+			// Never the credential, not even a masked stand-in.
+			'hasPassword' => ($this->password ?? '') !== '',
+			'mailbox' => (string)$this->mailbox,
+			'senderAllowlist' => $this->senderAllowlist ?? '',
+			'enabled' => (bool)$this->enabled,
+			'lastRun' => (int)$this->lastRun,
+			'lastError' => $this->lastError,
+		];
+	}
+}

--- a/lib/Db/MailIntake.php
+++ b/lib/Db/MailIntake.php
@@ -50,6 +50,14 @@ use OCP\DB\Types;
  * @method void setLastError(?string $lastError)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
+ * @method bool getRequireAuth()
+ * @method void setRequireAuth(bool $requireAuth)
+ * @method string|null getDailyState()
+ * @method void setDailyState(?string $dailyState)
+ * @method int getDailyLimit()
+ * @method void setDailyLimit(int $dailyLimit)
+ * @method int getPerSenderDailyLimit()
+ * @method void setPerSenderDailyLimit(int $perSenderDailyLimit)
  */
 class MailIntake extends Entity implements \JsonSerializable {
 	/** Implicit TLS from the first byte (the 993 default). */
@@ -75,6 +83,10 @@ class MailIntake extends Entity implements \JsonSerializable {
 	protected ?int $lastRun = null;
 	protected ?string $lastError = null;
 	protected ?int $createdAt = null;
+	protected ?bool $requireAuth = null;
+	protected ?string $dailyState = null;
+	protected ?int $dailyLimit = null;
+	protected ?int $perSenderDailyLimit = null;
 
 	public function __construct() {
 		$this->addType('boardId', Types::INTEGER);
@@ -92,6 +104,10 @@ class MailIntake extends Entity implements \JsonSerializable {
 		$this->addType('lastRun', Types::INTEGER);
 		$this->addType('lastError', Types::STRING);
 		$this->addType('createdAt', Types::INTEGER);
+		$this->addType('requireAuth', Types::BOOLEAN);
+		$this->addType('dailyState', Types::STRING);
+		$this->addType('dailyLimit', Types::INTEGER);
+		$this->addType('perSenderDailyLimit', Types::INTEGER);
 	}
 
 	/**
@@ -119,7 +135,75 @@ class MailIntake extends Entity implements \JsonSerializable {
 	}
 
 	/**
-	 * @return array{id: int, boardId: int, stackId: int, host: string, port: int, encryption: string, username: string, hasPassword: bool, mailbox: string, senderAllowlist: string, enabled: bool, lastRun: int, lastError: string|null}
+	 * How many distinct senders the per-sender counter tracks in a day. When the
+	 * map is full it is pruned to the HIGHEST counts, which keeps precisely the
+	 * senders a per-sender limit exists to catch; a sender that drops out starts
+	 * again from zero but is still bounded by the whole-mailbox daily cap.
+	 */
+	private const MAX_TRACKED_SENDERS = 500;
+
+	/**
+	 * Today's counters, resetting automatically when the day rolls over.
+	 *
+	 * @param int $day the current day as YYYYMMDD
+	 * @return array{day: int, total: int, senders: array<string, int>}
+	 */
+	public function dailyCounters(int $day): array {
+		$empty = ['day' => $day, 'total' => 0, 'senders' => []];
+
+		$raw = $this->dailyState ?? '';
+		if (trim($raw) === '') {
+			return $empty;
+		}
+
+		$decoded = json_decode($raw, true);
+		// Corrupt or hand-edited state must not stall intake - start the day over.
+		if (!is_array($decoded) || (int)($decoded['day'] ?? 0) !== $day) {
+			return $empty;
+		}
+
+		$senders = [];
+		if (isset($decoded['senders']) && is_array($decoded['senders'])) {
+			foreach ($decoded['senders'] as $sender => $count) {
+				if (is_string($sender) && is_int($count)) {
+					$senders[$sender] = $count;
+				}
+			}
+		}
+
+		return [
+			'day' => $day,
+			'total' => max(0, (int)($decoded['total'] ?? 0)),
+			'senders' => $senders,
+		];
+	}
+
+	public function cardedToday(int $day): int {
+		return $this->dailyCounters($day)['total'];
+	}
+
+	public function cardedTodayBy(string $sender, int $day): int {
+		return $this->dailyCounters($day)['senders'][$sender] ?? 0;
+	}
+
+	/** Counts one carded message against today's totals. */
+	public function recordCarded(string $sender, int $day): void {
+		$counters = $this->dailyCounters($day);
+		$counters['total']++;
+		if ($sender !== '') {
+			$counters['senders'][$sender] = ($counters['senders'][$sender] ?? 0) + 1;
+		}
+
+		if (count($counters['senders']) > self::MAX_TRACKED_SENDERS) {
+			arsort($counters['senders']);
+			$counters['senders'] = array_slice($counters['senders'], 0, self::MAX_TRACKED_SENDERS, true);
+		}
+
+		$this->setDailyState((string)json_encode($counters));
+	}
+
+	/**
+	 * @return array{id: int, boardId: int, stackId: int, host: string, port: int, encryption: string, username: string, hasPassword: bool, mailbox: string, senderAllowlist: string, enabled: bool, requireAuth: bool, dailyLimit: int, perSenderDailyLimit: int, lastRun: int, lastError: string|null}
 	 */
 	#[\Override]
 	public function jsonSerialize(): array {
@@ -136,8 +220,12 @@ class MailIntake extends Entity implements \JsonSerializable {
 			'mailbox' => (string)$this->mailbox,
 			'senderAllowlist' => $this->senderAllowlist ?? '',
 			'enabled' => (bool)$this->enabled,
+			'requireAuth' => (bool)$this->requireAuth,
+			'dailyLimit' => (int)$this->dailyLimit,
+			'perSenderDailyLimit' => (int)$this->perSenderDailyLimit,
 			'lastRun' => (int)$this->lastRun,
 			'lastError' => $this->lastError,
+			// dailyState is operational detail, not config - deliberately absent.
 		];
 	}
 }

--- a/lib/Db/MailIntakeMapper.php
+++ b/lib/Db/MailIntakeMapper.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `kanso_mail_intake`.
+ *
+ * @template-extends QBMapper<MailIntake>
+ */
+class MailIntakeMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'kanso_mail_intake', MailIntake::class);
+	}
+
+	/**
+	 * The board's mailbox config.
+	 *
+	 * @throws DoesNotExistException if the board has no mailbox configured
+	 * @throws MultipleObjectsReturnedException
+	 * @throws Exception
+	 */
+	public function findByBoard(int $boardId): MailIntake {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * Every enabled mailbox across all boards - the cron's work list. Ordered by
+	 * id so a run that hits the per-run budget always resumes in the same order
+	 * rather than starving the tail.
+	 *
+	 * @return MailIntake[]
+	 * @throws Exception
+	 */
+	public function findEnabled(): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('enabled', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->orderBy('id', 'ASC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Drops a board's mailbox config. Used when the board itself goes away, so
+	 * credentials do not outlive the thing they fed.
+	 *
+	 * @throws Exception
+	 */
+	public function deleteByBoard(int $boardId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('board_id', $qb->createNamedParameter($boardId, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Db/MailSeenMessage.php
+++ b/lib/Db/MailSeenMessage.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * One already-carded message (table `kanso_mail_seen`), identified by the hash
+ * of its Message-ID - see {@see \OCA\Kanso\Service\Mail\MimeMessage::dedupeKey}.
+ *
+ * Exists so that a mailbox re-delivering a message, or a watermark rewind after
+ * the server renumbers, cannot produce a second card for mail already handled.
+ *
+ * @method int getIntakeId()
+ * @method void setIntakeId(int $intakeId)
+ * @method string getDedupeKey()
+ * @method void setDedupeKey(string $dedupeKey)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ */
+class MailSeenMessage extends Entity {
+	protected ?int $intakeId = null;
+	protected ?string $dedupeKey = null;
+	protected ?int $createdAt = null;
+
+	public function __construct() {
+		$this->addType('intakeId', Types::INTEGER);
+		$this->addType('dedupeKey', Types::STRING);
+		$this->addType('createdAt', Types::INTEGER);
+	}
+}

--- a/lib/Db/MailSeenMessageMapper.php
+++ b/lib/Db/MailSeenMessageMapper.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Mapper for `kanso_mail_seen`.
+ *
+ * @template-extends QBMapper<MailSeenMessage>
+ */
+class MailSeenMessageMapper extends QBMapper {
+	/**
+	 * How long a dedupe key is remembered. Long enough to cover a mailbox
+	 * re-delivering after an outage or a restore, short enough that the table
+	 * does not grow forever. A message older than this that arrives again is
+	 * genuinely new mail as far as anyone is concerned.
+	 */
+	public const RETENTION_SECONDS = 60 * 60 * 24 * 60;
+
+	public function __construct(
+		IDBConnection $db,
+		private ITimeFactory $time,
+	) {
+		parent::__construct($db, 'kanso_mail_seen', MailSeenMessage::class);
+	}
+
+	/**
+	 * Records a message as carded, returning false if it already was.
+	 *
+	 * The UNIQUE index does the work: we INSERT and treat a constraint violation
+	 * as "already seen". A SELECT-then-INSERT would have a window between the
+	 * two in which a concurrent poll of the same mailbox inserts the same key -
+	 * unlikely, but the whole point of this table is to make double-carding
+	 * impossible rather than improbable.
+	 *
+	 * @return bool true when this call claimed the message, false when another
+	 *              already had
+	 */
+	public function claim(int $intakeId, string $dedupeKey): bool {
+		$entity = new MailSeenMessage();
+		$entity->setIntakeId($intakeId);
+		$entity->setDedupeKey($dedupeKey);
+		$entity->setCreatedAt($this->time->getTime());
+
+		try {
+			$this->insert($entity);
+			return true;
+		} catch (Exception $e) {
+			if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				return false;
+			}
+			throw $e;
+		}
+	}
+
+	/**
+	 * Drops keys past the retention window.
+	 *
+	 * @return int rows removed
+	 * @throws Exception
+	 */
+	public function pruneOlderThan(int $cutoff): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->lt('created_at', $qb->createNamedParameter($cutoff, IQueryBuilder::PARAM_INT)));
+
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * Drops every key for one mailbox - used when its config is deleted, so the
+	 * rows do not outlive the thing they belonged to.
+	 *
+	 * @throws Exception
+	 */
+	public function deleteByIntake(int $intakeId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('intake_id', $qb->createNamedParameter($intakeId, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Migration/Version006000Date20260916000000.php
+++ b/lib/Migration/Version006000Date20260916000000.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Email intake (#117): `kanso_mail_intake` - one polled IMAP mailbox per board,
+ * turning inbound mail into cards.
+ *
+ * Modelled on the forge-webhook config, with one structural difference: the
+ * webhook config rides COLUMNS on `kanso_boards` because it is three small
+ * scalars, whereas a mailbox is a dozen fields including a credential. Those
+ * belong in their own row so a board read - the hottest query in the app - does
+ * not carry an encrypted password it never uses.
+ *
+ * A board has at most ONE mailbox: `board_id` is UNIQUE, which makes the config
+ * write an upsert and keeps "which mailbox feeds this board" unambiguous.
+ *
+ * Columns worth explaining:
+ * - `password` is TEXT, not STRING: it holds the ICrypto CIPHERTEXT (base64 with
+ *   an IV and HMAC appended), which is several times longer than the secret and
+ *   grows with NC's cipher choice. It is never stored or logged in the clear.
+ * - `last_uid` is the intake watermark - the highest IMAP UID already turned
+ *   into a card. Polling asks the server for `UID <n+1>:*` rather than tracking
+ *   the \Seen flag, so a human reading the mailbox in a mail client cannot make
+ *   the poller skip messages, and a re-delivered message is never carded twice.
+ *   It is reset to 0 when the mailbox's `uidvalidity` changes (the server
+ *   renumbered; see `uid_validity`).
+ * - `uid_validity` pairs with `last_uid`. IMAP UIDs are only meaningful within
+ *   one UIDVALIDITY generation; without this a renumbered mailbox would either
+ *   replay every message or silently ingest none.
+ * - `last_error` holds the most recent failure text for the config UI. A poll
+ *   failure must be visible - a mailbox that quietly stopped ingesting looks
+ *   exactly like a mailbox nobody wrote to.
+ *
+ * hasTable-guarded so the step is idempotent; index names are globally unique.
+ */
+class Version006000Date20260916000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::createTable()
+	 *  is docblocked as Doctrine\DBAL\Schema\Table, not part of the OCP stubs.
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('kanso_mail_intake')) {
+			$table = $schema->createTable('kanso_mail_intake');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('board_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			// The stack new cards land in. Not a FK (no table in this app uses
+			// them); a stack deleted out from under the config is handled at poll
+			// time, which parks the mailbox with an error rather than dropping mail.
+			$table->addColumn('stack_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('host', Types::STRING, [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->addColumn('port', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 993,
+			]);
+			// 'ssl' (implicit TLS, port 993) or 'tls' (STARTTLS on 143). Plaintext
+			// IMAP is deliberately not an option - see MailIntakeService::ENCRYPTIONS.
+			$table->addColumn('encryption', Types::STRING, [
+				'notnull' => true,
+				'length' => 8,
+				'default' => 'ssl',
+			]);
+			$table->addColumn('username', Types::STRING, [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->addColumn('password', Types::TEXT, [
+				'notnull' => true,
+			]);
+			$table->addColumn('mailbox', Types::STRING, [
+				'notnull' => true,
+				'length' => 255,
+				'default' => 'INBOX',
+			]);
+			// Newline-separated sender addresses permitted to create cards. Empty
+			// = accept any sender, which is only safe for a mailbox nobody else
+			// knows the address of; the config UI says so.
+			$table->addColumn('sender_allowlist', Types::TEXT, [
+				'notnull' => false,
+			]);
+			$table->addColumn('enabled', Types::BOOLEAN, [
+				'notnull' => true,
+				'default' => false,
+			]);
+			$table->addColumn('last_uid', Types::BIGINT, [
+				'notnull' => true,
+				'default' => 0,
+				'length' => 8,
+			]);
+			$table->addColumn('uid_validity', Types::BIGINT, [
+				'notnull' => true,
+				'default' => 0,
+				'length' => 8,
+			]);
+			$table->addColumn('last_run', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+			$table->addColumn('last_error', Types::TEXT, [
+				'notnull' => false,
+			]);
+			$table->addColumn('created_at', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+
+			$table->setPrimaryKey(['id'], 'kanso_mailin_pk');
+			// One mailbox per board - the config write is an upsert on this.
+			$table->addUniqueIndex(['board_id'], 'kanso_mailin_board_uniq');
+			// The cron's work list: every enabled mailbox across all boards.
+			$table->addIndex(['enabled'], 'kanso_mailin_enabled_idx');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version006000Date20260916000000.php
+++ b/lib/Migration/Version006000Date20260916000000.php
@@ -106,8 +106,14 @@ class Version006000Date20260916000000 extends SimpleMigrationStep {
 			$table->addColumn('sender_allowlist', Types::TEXT, [
 				'notnull' => false,
 			]);
+			// Nullable, like every other boolean in this schema. A NOT NULL
+			// boolean defaulting to false is rejected by Nextcloud's migration
+			// validation ("is type Bool and also NotNull, so it can not store
+			// false") because Oracle stores false as an empty string, which it
+			// then treats as NULL. The entity casts on read, so a null reads as
+			// false either way.
 			$table->addColumn('enabled', Types::BOOLEAN, [
-				'notnull' => true,
+				'notnull' => false,
 				'default' => false,
 			]);
 			$table->addColumn('last_uid', Types::BIGINT, [

--- a/lib/Migration/Version006100Date20260917000000.php
+++ b/lib/Migration/Version006100Date20260917000000.php
@@ -51,8 +51,12 @@ class Version006100Date20260917000000 extends SimpleMigrationStep {
 			$table = $schema->getTable('kanso_mail_intake');
 
 			if (!$table->hasColumn('require_auth')) {
+				// Nullable for the same reason as `enabled` in the migration this
+				// builds on: Nextcloud rejects a NOT NULL boolean that defaults to
+				// false, because Oracle stores false as an empty string and reads
+				// that back as NULL.
 				$table->addColumn('require_auth', Types::BOOLEAN, [
-					'notnull' => true,
+					'notnull' => false,
 					'default' => false,
 				]);
 			}

--- a/lib/Migration/Version006100Date20260917000000.php
+++ b/lib/Migration/Version006100Date20260917000000.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Abuse controls for email intake (#117), on top of
+ * {@see Version006000Date20260916000000}.
+ *
+ * Three additions, all driven by the same fact: intake is the only path in the
+ * app where an unauthenticated stranger causes a write.
+ *
+ * - `require_auth` on `kanso_mail_intake`: only card messages the receiving MTA
+ *   authenticated (DMARC). Off by default, because it depends on the deployment
+ *   actually running such an MTA - see docs/email-intake-security.md.
+ * - `daily_state`: today's counters as JSON - `{"day":20260917,"total":12,
+ *   "senders":{"a@b":3}}`. One column rather than a counters table because the
+ *   whole value is rewritten once per poll and never queried across rows; a
+ *   table would buy nothing but joins. Reset by day, so it cannot grow without
+ *   bound.
+ * - `kanso_mail_seen`: dedupe keys of messages already carded, so a mailbox
+ *   that re-delivers (or a UIDVALIDITY reset that rewinds the watermark) cannot
+ *   card the same message twice. The UNIQUE index is the actual guard - the
+ *   insert failing IS the duplicate check, which is race-free in a way a
+ *   read-then-write is not.
+ *
+ * Both tables/columns are guarded so the step is idempotent.
+ */
+class Version006100Date20260917000000 extends SimpleMigrationStep {
+	/**
+	 * @psalm-suppress UndefinedDocblockClass ISchemaWrapper::getTable() and
+	 *  createTable() are docblocked as Doctrine\DBAL\Schema\Table, not part of
+	 *  the OCP stubs.
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('kanso_mail_intake')) {
+			$table = $schema->getTable('kanso_mail_intake');
+
+			if (!$table->hasColumn('require_auth')) {
+				$table->addColumn('require_auth', Types::BOOLEAN, [
+					'notnull' => true,
+					'default' => false,
+				]);
+			}
+			if (!$table->hasColumn('daily_state')) {
+				$table->addColumn('daily_state', Types::TEXT, [
+					'notnull' => false,
+				]);
+			}
+			// Per-mailbox overrides for the abuse caps. 0 = use the service
+			// default; an explicit value lets a busy team raise it (or a public
+			// address lower it) without a code change.
+			if (!$table->hasColumn('daily_limit')) {
+				$table->addColumn('daily_limit', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+				]);
+			}
+			if (!$table->hasColumn('per_sender_daily_limit')) {
+				$table->addColumn('per_sender_daily_limit', Types::INTEGER, [
+					'notnull' => true,
+					'default' => 0,
+				]);
+			}
+		}
+
+		if (!$schema->hasTable('kanso_mail_seen')) {
+			$table = $schema->createTable('kanso_mail_seen');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('intake_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			// A hash, never the Message-ID itself: it is sender-controlled text of
+			// unbounded length, and a fixed-width hash indexes far better. 64 chars
+			// = sha256 hex, prefixed by the key kind (see MimeMessage::dedupeKey).
+			$table->addColumn('dedupe_key', Types::STRING, [
+				'notnull' => true,
+				'length' => 72,
+			]);
+			$table->addColumn('created_at', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+
+			$table->setPrimaryKey(['id'], 'kanso_mailseen_pk');
+			// THE guard: a duplicate insert fails rather than being detected.
+			$table->addUniqueIndex(['intake_id', 'dedupe_key'], 'kanso_mailseen_uniq');
+			// Pruning scans by age.
+			$table->addIndex(['created_at'], 'kanso_mailseen_age_idx');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -975,6 +975,13 @@ class CardService {
 	 * write still advances the revision, so a guarded editor that seeded before
 	 * it is correctly refused afterwards.
 	 *
+	 * $notifyMentions is the ONE switch an untrusted writer must turn off (#117).
+	 * A description write normally re-parses `@name` and sends real notifications
+	 * + auto-subscriptions attributed to $uid. Email intake writes a body that an
+	 * unauthenticated stranger composed, as the board OWNER - so leaving this on
+	 * would let anyone who knows an intake address ping arbitrary members with
+	 * the owner's name on it. Every human-originated caller leaves it true.
+	 *
 	 * @throws DoesNotExistException if the card or its board does not exist or is deleted
 	 * @throws NotPermittedException if the user may not edit the board, or the review gate blocks completion while the card has unapproved reviews
 	 * @throws InvalidInputException on invalid title, duedate, cover colour or type, or a description over MAX_DESCRIPTION_LENGTH
@@ -999,6 +1006,7 @@ class CardService {
 		?string $visibility = null,
 		?int $baseLastModified = null,
 		?int $baseDescriptionRevision = null,
+		bool $notifyMentions = true,
 	): Card {
 		$card = $this->loadCard($id);
 		$board = $this->loadBoard($card->getBoardId());
@@ -1306,8 +1314,9 @@ class CardService {
 		}
 
 		// A new @mention in the description pings + auto-subscribes readable-board
-		// participants (only when the description actually changed).
-		if ($descriptionChanged) {
+		// participants (only when the description actually changed). Suppressed
+		// when the text did not come from $uid - see $notifyMentions above.
+		if ($descriptionChanged && $notifyMentions) {
 			$this->mentionService->handleMentions($card, $board, (string)$description, $uid);
 		}
 

--- a/lib/Service/Mail/AuthenticationResults.php
+++ b/lib/Service/Mail/AuthenticationResults.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * The verdict an `Authentication-Results:` header records (RFC 8601).
+ *
+ * Kanso cannot check SPF or DKIM itself: both need the SMTP envelope and the
+ * message as it arrived, and by the time a message is sitting in an IMAP
+ * mailbox the envelope is long gone. What CAN be done is read the check the
+ * receiving MTA already performed and stamped onto the message.
+ *
+ * That is only trustworthy under one condition, and it is the whole reason this
+ * class is careful: `Authentication-Results` is an ORDINARY header, so a sender
+ * can simply include a forged one claiming `dmarc=pass`. Each hop PREPENDS its
+ * own, so the TOPMOST occurrence is the one written by the last MTA to touch
+ * the message - our own. Anything below it is the sender's to invent.
+ * {@see MimeParser} keeps headers in arrival order for exactly this reason, and
+ * only the first is ever passed here.
+ *
+ * Even the topmost is only as trustworthy as the deployment: it means nothing
+ * if mail reaches the mailbox without passing through an MTA that authenticates
+ * (a mailbox fed directly by a third party, say). That is a deployment property
+ * we cannot detect, so the admin doc states it and the option is off by default.
+ */
+class AuthenticationResults {
+	/**
+	 * @param array<string, string> $methods method => result, lowercased
+	 *                                       (e.g. ['dmarc' => 'pass', 'spf' => 'fail'])
+	 */
+	private function __construct(
+		private readonly array $methods,
+		private readonly string $dmarcFromDomain,
+	) {
+	}
+
+	/**
+	 * Parses the TOPMOST Authentication-Results header. `$raw` empty (no header
+	 * at all) yields an instance whose checks all report "not verified".
+	 */
+	public static function fromHeader(string $raw): self {
+		$methods = [];
+		$dmarcFromDomain = '';
+
+		// 'mx.example.com; dmarc=pass header.from=example.com; spf=pass ...'
+		// Method results are 'method=result', optionally followed by
+		// 'ptype.property=value' pairs that must NOT be read as further methods.
+		if (preg_match_all('/\b(dmarc|spf|dkim)\s*=\s*([a-z]+)/i', $raw, $matches, PREG_SET_ORDER) !== false) {
+			foreach ($matches as $match) {
+				$method = strtolower($match[1]);
+				// First occurrence wins: a message can carry several dkim= results
+				// (one per signature) and any single pass is what senders rely on,
+				// but for our purposes the leading verdict is the summary one.
+				if (!isset($methods[$method])) {
+					$methods[$method] = strtolower($match[2]);
+				}
+			}
+		}
+
+		if (preg_match('/header\.from\s*=\s*"?([^\s;"]+)"?/i', $raw, $m) === 1) {
+			$dmarcFromDomain = strtolower(trim($m[1]));
+		}
+
+		return new self($methods, $dmarcFromDomain);
+	}
+
+	/**
+	 * Whether the message is authenticated as genuinely coming from the domain
+	 * its `From:` claims.
+	 *
+	 * DMARC is the check that matters, because it is the only one that ties the
+	 * authentication to the HEADER From - the address a person reads and the
+	 * address the allowlist matches. SPF alone authenticates the envelope
+	 * sender, which can differ entirely from the visible From, so an
+	 * SPF-pass-only message is NOT accepted as proof of who sent it.
+	 *
+	 * The `header.from` in the header is cross-checked against the address we
+	 * parsed, so a `dmarc=pass` for some other domain cannot vouch for this one.
+	 */
+	public function authenticates(string $fromAddress): bool {
+		if (($this->methods['dmarc'] ?? '') !== 'pass') {
+			return false;
+		}
+
+		$at = strrpos($fromAddress, '@');
+		if ($at === false) {
+			return false;
+		}
+		$fromDomain = strtolower(substr($fromAddress, $at + 1));
+		if ($fromDomain === '') {
+			return false;
+		}
+
+		// A dmarc=pass with no header.from to check it against cannot be tied to
+		// this message's sender.
+		if ($this->dmarcFromDomain === '') {
+			return false;
+		}
+
+		// DMARC alignment allows an organisational-domain match, so a pass for
+		// 'example.com' covers 'mail.example.com'.
+		return $fromDomain === $this->dmarcFromDomain
+			|| str_ends_with($fromDomain, '.' . $this->dmarcFromDomain);
+	}
+
+	/** The raw verdict for one method, '' when the header did not report it. */
+	public function result(string $method): string {
+		return $this->methods[strtolower($method)] ?? '';
+	}
+}

--- a/lib/Service/Mail/ImapClient.php
+++ b/lib/Service/Mail/ImapClient.php
@@ -50,6 +50,7 @@ class ImapClient {
 
 	public function __construct(
 		private ImapTransport $transport,
+		private MailHostGuard $hostGuard,
 	) {
 	}
 
@@ -64,8 +65,13 @@ class ImapClient {
 	public function connect(string $host, int $port, string $encryption): void {
 		$this->assertArgumentSafe($host, 'host');
 
+		// Resolved and vetted BEFORE the socket opens, and the vetted address is
+		// what we dial - see MailHostGuard for why validating the name alone is
+		// not enough.
+		$address = $this->hostGuard->resolve($host);
+
 		$implicitTls = $encryption === MailIntake::ENCRYPTION_SSL;
-		$this->transport->open($host, $port, $implicitTls, self::TIMEOUT_SECONDS);
+		$this->transport->open($address, $host, $port, $implicitTls, self::TIMEOUT_SECONDS);
 		$this->connected = true;
 
 		// The greeting arrives unprompted, before any command. PREAUTH means the

--- a/lib/Service/Mail/ImapClient.php
+++ b/lib/Service/Mail/ImapClient.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+use OCA\Kanso\Db\MailIntake;
+
+/**
+ * The slice of IMAP4rev1 (RFC 3501) email intake actually needs: connect,
+ * authenticate, select a mailbox, list the UIDs that arrived since last time,
+ * and fetch those messages whole.
+ *
+ * Deliberately NOT a general IMAP library. No IDLE, no partial fetch, no server
+ * search beyond a UID range, no flag writes at all - {@see fetchMessage} uses
+ * `BODY.PEEK[]` so polling never marks a human's mail as read.
+ *
+ * Intake position is tracked by a UID WATERMARK ({@see MailIntake} `lastUid`),
+ * not by the \Seen flag. That choice is what makes the poller safe to point at
+ * a mailbox a person also reads: opening a message in a mail client cannot make
+ * the poller skip it, and marking one unread cannot make it card the message
+ * twice.
+ *
+ * All I/O failures surface as {@see ImapException}.
+ */
+class ImapClient {
+	/** Connect/read timeout. A poll runs inside cron; it must not hang a worker. */
+	private const TIMEOUT_SECONDS = 30;
+
+	/**
+	 * Hard ceiling on one fetched message. A mailbox someone mails a DVD image
+	 * to must not OOM the cron worker. An oversized message is drained (so the
+	 * stream stays in sync) and reported as empty - the caller skips it and
+	 * still advances the watermark, so one huge message cannot wedge intake.
+	 */
+	private const MAX_MESSAGE_BYTES = 5 * 1024 * 1024;
+
+	/** Bounds a single response against a server that never sends its tag. */
+	private const MAX_RESPONSE_LINES = 10_000;
+
+	/** How many bytes are pulled per read when draining an oversized literal. */
+	private const DRAIN_CHUNK_BYTES = 65_536;
+
+	private int $tagCounter = 0;
+
+	private bool $connected = false;
+
+	public function __construct(
+		private ImapTransport $transport,
+	) {
+	}
+
+	/**
+	 * Opens the connection and completes TLS. `$encryption` is one of
+	 * {@see MailIntake::ENCRYPTION_SSL} (implicit TLS) or
+	 * {@see MailIntake::ENCRYPTION_TLS} (STARTTLS). There is no cleartext mode:
+	 * a plaintext LOGIN would put the mailbox password on the wire.
+	 *
+	 * @throws ImapException
+	 */
+	public function connect(string $host, int $port, string $encryption): void {
+		$this->assertArgumentSafe($host, 'host');
+
+		$implicitTls = $encryption === MailIntake::ENCRYPTION_SSL;
+		$this->transport->open($host, $port, $implicitTls, self::TIMEOUT_SECONDS);
+		$this->connected = true;
+
+		// The greeting arrives unprompted, before any command. PREAUTH means the
+		// server has already authenticated us (rare, but legal); BYE is a refusal.
+		$greeting = $this->transport->readLine();
+		if (str_starts_with($greeting, '* BYE')) {
+			throw new ImapException('IMAP server refused the connection');
+		}
+		if (!str_starts_with($greeting, '* OK') && !str_starts_with($greeting, '* PREAUTH')) {
+			throw new ImapException('Unexpected IMAP greeting');
+		}
+
+		if (!$implicitTls) {
+			// STARTTLS is a normal tagged command; only after its OK may the
+			// socket be upgraded. Everything before this point was cleartext,
+			// which is why no credential has been sent yet.
+			$this->command('STARTTLS');
+			$this->transport->enableCrypto();
+		}
+	}
+
+	/**
+	 * @throws ImapException if the server rejects the credentials
+	 */
+	public function login(string $username, string $password): void {
+		// A CR or LF here would end the LOGIN line early and let the remainder be
+		// read as a further command - command injection through a config field.
+		// Rejecting is correct rather than escaping: no real credential contains
+		// a line break.
+		$this->assertArgumentSafe($username, 'username');
+		$this->assertArgumentSafe($password, 'password');
+
+		try {
+			$this->command('LOGIN ' . $this->quote($username) . ' ' . $this->quote($password));
+		} catch (ImapException $e) {
+			// The server's NO text is echoed into the board's `lastError`, and on
+			// some servers that text quotes the command back. Replace it with a
+			// fixed string so a password can never reach the config UI or the log.
+			throw new ImapException('IMAP login failed - check the username and password');
+		}
+	}
+
+	/**
+	 * Selects the mailbox READ-ONLY (EXAMINE, not SELECT) - intake never needs
+	 * write access, and read-only makes it structurally impossible for a bug
+	 * here to delete or re-flag a person's mail.
+	 *
+	 * @return array{uidValidity: int, uidNext: int}
+	 * @throws ImapException if the mailbox does not exist
+	 */
+	public function selectMailbox(string $mailbox): array {
+		$this->assertArgumentSafe($mailbox, 'mailbox');
+
+		$response = $this->command('EXAMINE ' . $this->quote($mailbox));
+
+		$uidValidity = 0;
+		$uidNext = 0;
+		foreach ($response['untagged'] as $entry) {
+			if (preg_match('/\[UIDVALIDITY (\d+)\]/i', $entry['line'], $m) === 1) {
+				$uidValidity = (int)$m[1];
+			}
+			if (preg_match('/\[UIDNEXT (\d+)\]/i', $entry['line'], $m) === 1) {
+				$uidNext = (int)$m[1];
+			}
+		}
+
+		if ($uidValidity === 0) {
+			// Every compliant server sends UIDVALIDITY on select. Without it the
+			// watermark cannot be trusted, and guessing would risk replaying the
+			// whole mailbox as cards.
+			throw new ImapException('IMAP server did not report UIDVALIDITY for ' . $mailbox);
+		}
+
+		return ['uidValidity' => $uidValidity, 'uidNext' => $uidNext];
+	}
+
+	/**
+	 * The UIDs strictly greater than `$lastUid`, ascending.
+	 *
+	 * The client-side filter is not redundant. IMAP ranges are inclusive and `*`
+	 * means "the highest UID in the mailbox", and a range is normalised rather
+	 * than treated as empty when its endpoints are reversed - so `UID 9:*` in a
+	 * mailbox whose highest UID is 4 matches `4:9` and returns message 4, one
+	 * already carded. Every real server does this; it is the single most common
+	 * way a home-grown IMAP poller ends up duplicating messages.
+	 *
+	 * @return int[]
+	 * @throws ImapException
+	 */
+	public function searchUidsAbove(int $lastUid): array {
+		$from = max(0, $lastUid) + 1;
+		$response = $this->command('UID SEARCH UID ' . $from . ':*');
+
+		$uids = [];
+		foreach ($response['untagged'] as $entry) {
+			// '* SEARCH 12 15 18', or '* SEARCH' alone when nothing matched.
+			if (preg_match('/^\*\s+SEARCH\b(.*)$/i', $entry['line'], $m) !== 1) {
+				continue;
+			}
+			foreach (preg_split('/\s+/', trim($m[1])) ?: [] as $token) {
+				if ($token !== '' && ctype_digit($token)) {
+					$uid = (int)$token;
+					if ($uid > $lastUid) {
+						$uids[] = $uid;
+					}
+				}
+			}
+		}
+
+		$uids = array_values(array_unique($uids));
+		sort($uids);
+		return $uids;
+	}
+
+	/**
+	 * The complete RFC 822 source of one message, or '' if it exceeds
+	 * {@see MAX_MESSAGE_BYTES} (drained and skipped rather than fetched).
+	 *
+	 * `BODY.PEEK[]` rather than `BODY[]`: the latter sets \Seen as a side effect
+	 * of reading, which would silently mark a shared mailbox's mail as read.
+	 *
+	 * @throws ImapException
+	 */
+	public function fetchMessage(int $uid): string {
+		$response = $this->command('UID FETCH ' . $uid . ' (BODY.PEEK[])');
+
+		foreach ($response['untagged'] as $entry) {
+			if ($entry['literal'] !== null && preg_match('/\bFETCH\b/i', $entry['line']) === 1) {
+				return $entry['literal'];
+			}
+		}
+
+		// A UID that vanished between SEARCH and FETCH (someone deleted the mail
+		// mid-poll) answers with a tagged OK and no FETCH data. Not an error -
+		// the caller skips it and moves the watermark past it.
+		return '';
+	}
+
+	public function disconnect(): void {
+		if ($this->connected) {
+			try {
+				$this->command('LOGOUT');
+			} catch (ImapException) {
+				// A server that hangs up on LOGOUT is not a problem worth raising -
+				// we are closing the socket next anyway.
+			}
+			$this->connected = false;
+		}
+		$this->transport->close();
+	}
+
+	// ---- protocol plumbing -------------------------------------------------
+
+	/**
+	 * Sends one tagged command and reads through to its tagged completion.
+	 *
+	 * @return array{untagged: list<array{line: string, literal: string|null}>, tagged: string}
+	 * @throws ImapException if the server answers NO or BAD
+	 */
+	private function command(string $command): array {
+		$tag = sprintf('K%03d', ++$this->tagCounter);
+		$this->transport->writeLine($tag . ' ' . $command);
+		$response = $this->readUntilTagged($tag);
+
+		// 'TAG OK ...' is success; 'TAG NO ...' is a refusal, 'TAG BAD ...' a
+		// protocol complaint. Both carry server text worth keeping for the UI -
+		// except after LOGIN, where the caller replaces it.
+		if (preg_match('/^' . preg_quote($tag, '/') . '\s+OK\b/i', $response['tagged']) !== 1) {
+			$detail = trim(substr($response['tagged'], strlen($tag)));
+			throw new ImapException($detail === '' ? 'IMAP command failed' : $detail);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Reads untagged responses until the tagged completion line for `$tag`.
+	 *
+	 * Literals are the reason this cannot be a plain line loop: `{123}` at the
+	 * end of a line announces exactly 123 following bytes that are counted, not
+	 * delimited, and may contain CRLF - reading them as lines would desynchronise
+	 * the connection for every later command.
+	 *
+	 * @return array{untagged: list<array{line: string, literal: string|null}>, tagged: string}
+	 * @throws ImapException
+	 */
+	private function readUntilTagged(string $tag): array {
+		$untagged = [];
+		$lineCount = 0;
+
+		while (true) {
+			if (++$lineCount > self::MAX_RESPONSE_LINES) {
+				throw new ImapException('IMAP response exceeded the line limit');
+			}
+
+			$line = $this->transport->readLine();
+
+			if (preg_match('/\{(\d+)\}$/', $line, $m) === 1) {
+				$length = (int)$m[1];
+				if ($length > self::MAX_MESSAGE_BYTES) {
+					// Drain it anyway: the bytes are already committed by the server,
+					// so skipping the read would leave them queued as garbage in front
+					// of every subsequent response.
+					$this->drain($length);
+					$untagged[] = ['line' => $line, 'literal' => null];
+				} else {
+					$untagged[] = ['line' => $line, 'literal' => $this->transport->readBytes($length)];
+				}
+				// The rest of this response continues on the next line read.
+				continue;
+			}
+
+			if (str_starts_with($line, $tag . ' ')) {
+				return ['untagged' => $untagged, 'tagged' => $line];
+			}
+
+			if (str_starts_with($line, '+')) {
+				// A continuation request means the server wants literal data we never
+				// offered to send. Nothing this client sends can prompt one, so it
+				// means the connection is out of sync - keep talking and every later
+				// response is misread.
+				throw new ImapException('Unexpected IMAP continuation request');
+			}
+
+			$untagged[] = ['line' => $line, 'literal' => null];
+		}
+	}
+
+	/**
+	 * Reads and discards `$length` bytes in bounded chunks, so draining an
+	 * oversized literal costs a fixed amount of memory rather than the whole
+	 * message.
+	 *
+	 * @throws ImapException
+	 */
+	private function drain(int $length): void {
+		$remaining = $length;
+		while ($remaining > 0) {
+			$chunk = min($remaining, self::DRAIN_CHUNK_BYTES);
+			$this->transport->readBytes($chunk);
+			$remaining -= $chunk;
+		}
+	}
+
+	/**
+	 * IMAP quoted-string form. Backslash and double-quote are the only
+	 * characters that need escaping inside one; CR/LF are excluded upstream by
+	 * {@see assertArgumentSafe} because no escape for them exists in this form.
+	 */
+	private function quote(string $value): string {
+		return '"' . addcslashes($value, '\\"') . '"';
+	}
+
+	/**
+	 * @throws ImapException if the value could break out of its command line
+	 */
+	private function assertArgumentSafe(string $value, string $what): void {
+		if (preg_match('/[\r\n\x00]/', $value) === 1) {
+			throw new ImapException('Invalid ' . $what . ': line breaks are not allowed');
+		}
+	}
+}

--- a/lib/Service/Mail/ImapClientFactory.php
+++ b/lib/Service/Mail/ImapClientFactory.php
@@ -16,7 +16,12 @@ namespace OCA\Kanso\Service\Mail;
  * tests replace to drive a scripted server without a network.
  */
 class ImapClientFactory {
+	public function __construct(
+		private MailHostGuard $hostGuard,
+	) {
+	}
+
 	public function create(): ImapClient {
-		return new ImapClient(new StreamImapTransport());
+		return new ImapClient(new StreamImapTransport(), $this->hostGuard);
 	}
 }

--- a/lib/Service/Mail/ImapClientFactory.php
+++ b/lib/Service/Mail/ImapClientFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * Hands out a fresh {@see ImapClient} per poll.
+ *
+ * A factory rather than an injected client because a client owns one socket and
+ * one tag sequence: reusing an instance across two mailboxes would talk to the
+ * second server on the first one's connection. It is also the seam the unit
+ * tests replace to drive a scripted server without a network.
+ */
+class ImapClientFactory {
+	public function create(): ImapClient {
+		return new ImapClient(new StreamImapTransport());
+	}
+}

--- a/lib/Service/Mail/ImapException.php
+++ b/lib/Service/Mail/ImapException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * Anything that stops an IMAP poll: a refused connection, a failed TLS upgrade,
+ * bad credentials, a missing mailbox, a protocol answer we cannot act on.
+ *
+ * The message is surfaced to board managers in the intake config (`lastError`),
+ * so it must stay short and free of the credential.
+ */
+class ImapException extends \RuntimeException {
+}

--- a/lib/Service/Mail/ImapTransport.php
+++ b/lib/Service/Mail/ImapTransport.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * The byte pipe {@see ImapClient} speaks over, kept behind an interface for one
+ * reason: the protocol logic is the part worth testing, and a real socket makes
+ * that untestable. {@see StreamImapTransport} is the production implementation;
+ * the unit tests drive a scripted fake.
+ *
+ * Implementations throw {@see ImapException} on any I/O failure - the client
+ * never inspects error codes.
+ */
+interface ImapTransport {
+	/**
+	 * Opens the connection. `$implicitTls` selects TLS from the first byte
+	 * (port 993); a STARTTLS upgrade is a separate {@see enableCrypto} call
+	 * after the greeting.
+	 *
+	 * @throws ImapException if the connection cannot be established
+	 */
+	public function open(string $host, int $port, bool $implicitTls, int $timeoutSeconds): void;
+
+	/**
+	 * Upgrades an already-open cleartext connection to TLS (the STARTTLS half of
+	 * the handshake, called once the server has answered OK).
+	 *
+	 * @throws ImapException if the upgrade fails
+	 */
+	public function enableCrypto(): void;
+
+	/**
+	 * Writes one command line. The CRLF terminator is the implementation's job,
+	 * so no caller can forget it.
+	 *
+	 * @throws ImapException on a short or failed write
+	 */
+	public function writeLine(string $line): void;
+
+	/**
+	 * Reads one CRLF-terminated line, WITHOUT the terminator.
+	 *
+	 * @throws ImapException on timeout or if the peer closed mid-response
+	 */
+	public function readLine(): string;
+
+	/**
+	 * Reads exactly `$length` bytes - an IMAP literal, which is counted, not
+	 * delimited, and may contain CRLF anywhere inside it.
+	 *
+	 * @throws ImapException if the peer closes before `$length` bytes arrive
+	 */
+	public function readBytes(int $length): string;
+
+	/** Closes the connection. Never throws; a close failure is not actionable. */
+	public function close(): void;
+}

--- a/lib/Service/Mail/ImapTransport.php
+++ b/lib/Service/Mail/ImapTransport.php
@@ -22,9 +22,17 @@ interface ImapTransport {
 	 * (port 993); a STARTTLS upgrade is a separate {@see enableCrypto} call
 	 * after the greeting.
 	 *
+	 * `$address` and `$peerName` are separate on purpose. The socket goes to the
+	 * IP {@see MailHostGuard} already resolved and vetted, so the name cannot be
+	 * re-resolved to somewhere else between the check and the connection (DNS
+	 * rebinding); `$peerName` carries the original hostname so SNI and
+	 * certificate validation still happen against the name the user configured.
+	 *
+	 * @param string $address the vetted IP literal to connect to
+	 * @param string $peerName the hostname TLS must validate against
 	 * @throws ImapException if the connection cannot be established
 	 */
-	public function open(string $host, int $port, bool $implicitTls, int $timeoutSeconds): void;
+	public function open(string $address, string $peerName, int $port, bool $implicitTls, int $timeoutSeconds): void;
 
 	/**
 	 * Upgrades an already-open cleartext connection to TLS (the STARTTLS half of

--- a/lib/Service/Mail/MailHostGuard.php
+++ b/lib/Service/Mail/MailHostGuard.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+use OCP\IConfig;
+
+/**
+ * Stops email intake from being an SSRF primitive.
+ *
+ * The mail server host is free text supplied by any board MANAGER - not an
+ * admin. Without this, "configure a mailbox" is really "make the Nextcloud
+ * server open a TCP connection to any address you name, and tell you how it
+ * went": `testConnection` reports connect-refused, timeout and TLS failure
+ * distinguishably, which is a working port scanner for the server's internal
+ * network, cloud metadata endpoints included.
+ *
+ * The guard resolves the name HERE and returns the address to connect to, and
+ * that return value is what makes it sound. Validating the hostname and then
+ * letting the socket resolve it again is the classic DNS-rebinding hole: the
+ * attacker's resolver answers with a public address for our check and
+ * 169.254.169.254 microseconds later for the connection. Resolving once and
+ * connecting to the resolved IP closes that window, and the original hostname
+ * is carried separately so TLS still validates against the certificate's name.
+ *
+ * Admins whose IMAP server genuinely IS on the LAN can allow private ranges
+ * with `occ config:app:set kanso mail_intake_allow_private_hosts --value yes`.
+ * It is deliberately an admin-only, instance-wide switch: the whole point is
+ * that a board manager must not be able to reach the internal network by
+ * filling in a form.
+ */
+class MailHostGuard {
+	public const APP_ID = 'kanso';
+	public const KEY_ALLOW_PRIVATE = 'mail_intake_allow_private_hosts';
+
+	public function __construct(
+		private IConfig $config,
+	) {
+	}
+
+	/**
+	 * Resolves `$host` and returns the single IP literal the connection must be
+	 * made to.
+	 *
+	 * @throws ImapException if the name does not resolve, or resolves anywhere
+	 *                       the server should not be dialling
+	 */
+	public function resolve(string $host): string {
+		$host = trim($host);
+		if ($host === '') {
+			throw new ImapException('Mail server host is empty');
+		}
+
+		$allowPrivate = $this->allowsPrivateHosts();
+
+		// An IP literal needs no resolution - just the same verdict.
+		if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+			$this->assertAddressAllowed($host, $allowPrivate);
+			return $host;
+		}
+
+		$addresses = $this->lookup($host);
+		if ($addresses === []) {
+			throw new ImapException('Cannot resolve mail server host ' . $host);
+		}
+
+		// EVERY answer must be acceptable, not just the one we pick. A name that
+		// resolves to both a public and an internal address would otherwise be a
+		// coin flip the attacker gets to re-toss on every poll.
+		foreach ($addresses as $address) {
+			$this->assertAddressAllowed($address, $allowPrivate);
+		}
+
+		return $addresses[0];
+	}
+
+	/**
+	 * Whether the admin has opted the instance into private-range mail servers.
+	 */
+	public function allowsPrivateHosts(): bool {
+		return $this->config->getAppValue(self::APP_ID, self::KEY_ALLOW_PRIVATE, 'no') === 'yes';
+	}
+
+	/**
+	 * @return string[] every A and AAAA answer for the name
+	 */
+	private function lookup(string $host): array {
+		$addresses = [];
+
+		// gethostbynamel covers IPv4 and is the cheap path; dns_get_record adds
+		// AAAA, which must be checked too or an internal target reachable only
+		// over IPv6 walks straight through.
+		$v4 = @gethostbynamel($host);
+		if (is_array($v4)) {
+			$addresses = $v4;
+		}
+
+		$records = @dns_get_record($host, DNS_AAAA);
+		if (is_array($records)) {
+			foreach ($records as $record) {
+				if (isset($record['ipv6']) && is_string($record['ipv6'])) {
+					$addresses[] = $record['ipv6'];
+				}
+			}
+		}
+
+		return array_values(array_unique($addresses));
+	}
+
+	/**
+	 * @throws ImapException if the address is one the server must not dial
+	 */
+	private function assertAddressAllowed(string $address, bool $allowPrivate): void {
+		if (filter_var($address, FILTER_VALIDATE_IP) === false) {
+			throw new ImapException('Mail server host resolved to an invalid address');
+		}
+
+		if ($allowPrivate) {
+			// Even with the opt-in, loopback stays blocked: there is no legitimate
+			// "my IMAP server is the Nextcloud process itself", and it is the most
+			// useful address to an attacker (admin panels bound to 127.0.0.1).
+			if ($this->isLoopback($address)) {
+				throw new ImapException('Mail server host resolves to a loopback address');
+			}
+			return;
+		}
+
+		// NO_PRIV_RANGE covers RFC 1918 and fc00::/7; NO_RES_RANGE covers
+		// loopback, link-local, 0.0.0.0/8 and the reserved blocks.
+		$public = filter_var(
+			$address,
+			FILTER_VALIDATE_IP,
+			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+		);
+		if ($public === false) {
+			throw new ImapException(
+				'Mail server host resolves to a private or reserved address ('
+				. $address
+				. '). An administrator can allow this with the mail_intake_allow_private_hosts app setting.'
+			);
+		}
+
+		// Belt and braces for the ranges PHP's filter has historically been
+		// inconsistent about across versions, and the ones that matter most:
+		// the cloud metadata address and IPv4-mapped IPv6.
+		if ($this->isLoopback($address) || $this->isLinkLocal($address) || $this->isMappedV4($address)) {
+			throw new ImapException('Mail server host resolves to a restricted address (' . $address . ')');
+		}
+	}
+
+	private function isLoopback(string $address): bool {
+		if (str_starts_with($address, '127.')) {
+			return true;
+		}
+		$packed = @inet_pton($address);
+		return $packed !== false && $packed === @inet_pton('::1');
+	}
+
+	private function isLinkLocal(string $address): bool {
+		// 169.254.0.0/16 - includes 169.254.169.254, the cloud metadata endpoint.
+		if (str_starts_with($address, '169.254.')) {
+			return true;
+		}
+		// fe80::/10
+		$lower = strtolower($address);
+		return str_starts_with($lower, 'fe8')
+			|| str_starts_with($lower, 'fe9')
+			|| str_starts_with($lower, 'fea')
+			|| str_starts_with($lower, 'feb');
+	}
+
+	/**
+	 * ::ffff:127.0.0.1 and friends - an IPv4 address wearing an IPv6 costume,
+	 * which some validators wave through.
+	 */
+	private function isMappedV4(string $address): bool {
+		$lower = strtolower($address);
+		if (!str_contains($lower, ':') || !str_contains($lower, '.')) {
+			return false;
+		}
+		$lastColon = strrpos($lower, ':');
+		if ($lastColon === false) {
+			return false;
+		}
+		$tail = substr($lower, $lastColon + 1);
+		if (filter_var($tail, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+			return false;
+		}
+		// Judge the embedded IPv4 on its own merits.
+		return filter_var(
+			$tail,
+			FILTER_VALIDATE_IP,
+			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+		) === false;
+	}
+}

--- a/lib/Service/Mail/MailHostGuard.php
+++ b/lib/Service/Mail/MailHostGuard.php
@@ -37,6 +37,48 @@ class MailHostGuard {
 	public const APP_ID = 'kanso';
 	public const KEY_ALLOW_PRIVATE = 'mail_intake_allow_private_hosts';
 
+	/**
+	 * Ranges the server must never dial, whatever the admin has opted into.
+	 *
+	 * These are matched EXPLICITLY rather than through `filter_var`'s
+	 * `FILTER_FLAG_NO_RES_RANGE`, because that flag's answer depends on the PHP
+	 * version: PHP 8.2 rejects `2001:db8::1` as reserved and PHP 8.5 accepts it.
+	 * A security control whose verdict changes when the runtime is upgraded is
+	 * not a control, so the list is spelled out here and compared bit by bit.
+	 *
+	 * Covers loopback, the unspecified address, link-local (which is where
+	 * 169.254.169.254, the cloud metadata endpoint, lives), carrier-grade NAT,
+	 * IETF protocol assignments, benchmarking, multicast and the reserved
+	 * top block.
+	 */
+	private const ALWAYS_BLOCKED = [
+		// IPv4
+		'0.0.0.0/8',
+		'127.0.0.0/8',
+		'100.64.0.0/10',
+		'169.254.0.0/16',
+		'192.0.0.0/24',
+		'198.18.0.0/15',
+		'224.0.0.0/4',
+		'240.0.0.0/4',
+		// IPv6
+		'::/128',
+		'::1/128',
+		'fe80::/10',
+		'ff00::/8',
+	];
+
+	/**
+	 * Ranges an admin can opt into with {@see KEY_ALLOW_PRIVATE} - the "our IMAP
+	 * server is on the LAN" case, and nothing beyond it.
+	 */
+	private const PRIVATE_RANGES = [
+		'10.0.0.0/8',
+		'172.16.0.0/12',
+		'192.168.0.0/16',
+		'fc00::/7',
+	];
+
 	public function __construct(
 		private IConfig $config,
 	) {
@@ -115,86 +157,89 @@ class MailHostGuard {
 	 * @throws ImapException if the address is one the server must not dial
 	 */
 	private function assertAddressAllowed(string $address, bool $allowPrivate): void {
-		if (filter_var($address, FILTER_VALIDATE_IP) === false) {
+		$packed = @inet_pton($address);
+		if ($packed === false) {
 			throw new ImapException('Mail server host resolved to an invalid address');
 		}
 
-		if ($allowPrivate) {
-			// Even with the opt-in, loopback stays blocked: there is no legitimate
-			// "my IMAP server is the Nextcloud process itself", and it is the most
-			// useful address to an attacker (admin panels bound to 127.0.0.1).
-			if ($this->isLoopback($address)) {
-				throw new ImapException('Mail server host resolves to a loopback address');
+		// An IPv4-mapped IPv6 address (::ffff:127.0.0.1) is an IPv4 address in a
+		// costume; unwrap it so it is judged by the IPv4 rules rather than
+		// sliding past them as "some IPv6 address".
+		$packed = $this->unwrapMappedV4($packed);
+
+		foreach (self::ALWAYS_BLOCKED as $range) {
+			if ($this->inRange($packed, $range)) {
+				throw new ImapException(
+					'Mail server host resolves to a restricted address (' . $address . ')'
+				);
 			}
+		}
+
+		if ($allowPrivate) {
+			// The opt-in covers RFC 1918 / ULA only. Loopback, link-local and the
+			// rest stayed blocked above: there is no legitimate "my IMAP server is
+			// the Nextcloud process itself", and loopback is where admin panels bind.
 			return;
 		}
 
-		// NO_PRIV_RANGE covers RFC 1918 and fc00::/7; NO_RES_RANGE covers
-		// loopback, link-local, 0.0.0.0/8 and the reserved blocks.
-		$public = filter_var(
-			$address,
-			FILTER_VALIDATE_IP,
-			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
-		);
-		if ($public === false) {
-			throw new ImapException(
-				'Mail server host resolves to a private or reserved address ('
-				. $address
-				. '). An administrator can allow this with the mail_intake_allow_private_hosts app setting.'
-			);
+		foreach (self::PRIVATE_RANGES as $range) {
+			if ($this->inRange($packed, $range)) {
+				throw new ImapException(
+					'Mail server host resolves to a private or reserved address ('
+					. $address
+					. '). An administrator can allow this with the mail_intake_allow_private_hosts app setting.'
+				);
+			}
 		}
-
-		// Belt and braces for the ranges PHP's filter has historically been
-		// inconsistent about across versions, and the ones that matter most:
-		// the cloud metadata address and IPv4-mapped IPv6.
-		if ($this->isLoopback($address) || $this->isLinkLocal($address) || $this->isMappedV4($address)) {
-			throw new ImapException('Mail server host resolves to a restricted address (' . $address . ')');
-		}
-	}
-
-	private function isLoopback(string $address): bool {
-		if (str_starts_with($address, '127.')) {
-			return true;
-		}
-		$packed = @inet_pton($address);
-		return $packed !== false && $packed === @inet_pton('::1');
-	}
-
-	private function isLinkLocal(string $address): bool {
-		// 169.254.0.0/16 - includes 169.254.169.254, the cloud metadata endpoint.
-		if (str_starts_with($address, '169.254.')) {
-			return true;
-		}
-		// fe80::/10
-		$lower = strtolower($address);
-		return str_starts_with($lower, 'fe8')
-			|| str_starts_with($lower, 'fe9')
-			|| str_starts_with($lower, 'fea')
-			|| str_starts_with($lower, 'feb');
 	}
 
 	/**
-	 * ::ffff:127.0.0.1 and friends - an IPv4 address wearing an IPv6 costume,
-	 * which some validators wave through.
+	 * `::ffff:a.b.c.d` -> the packed 4-byte form of `a.b.c.d`. Anything else is
+	 * returned unchanged.
 	 */
-	private function isMappedV4(string $address): bool {
-		$lower = strtolower($address);
-		if (!str_contains($lower, ':') || !str_contains($lower, '.')) {
+	private function unwrapMappedV4(string $packed): string {
+		if (strlen($packed) !== 16) {
+			return $packed;
+		}
+		// 80 zero bits then 16 one bits is the IPv4-mapped prefix.
+		if (substr($packed, 0, 12) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff") {
+			return substr($packed, 12, 4);
+		}
+		return $packed;
+	}
+
+	/**
+	 * Whether a packed address falls inside `<address>/<prefix>`. Compares whole
+	 * bytes then the remaining bits, so it is exact rather than a string prefix
+	 * match on the textual form (which is what makes '169.254.' style checks
+	 * miss things like '::ffff:169.254.169.254').
+	 */
+	private function inRange(string $packed, string $cidr): bool {
+		$parts = explode('/', $cidr, 2);
+		$networkPacked = @inet_pton($parts[0]);
+		if ($networkPacked === false) {
 			return false;
 		}
-		$lastColon = strrpos($lower, ':');
-		if ($lastColon === false) {
+		// An IPv4 address is never inside an IPv6 range, and vice versa.
+		if (strlen($networkPacked) !== strlen($packed)) {
 			return false;
 		}
-		$tail = substr($lower, $lastColon + 1);
-		if (filter_var($tail, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+
+		// A bare address with no prefix means that single host, not "everything":
+		// the entries above all carry a prefix, and defaulting the other way
+		// would turn a typo into a rule that matches the whole internet.
+		$bits = isset($parts[1]) ? (int)$parts[1] : strlen($networkPacked) * 8;
+		$wholeBytes = intdiv($bits, 8);
+		$remainingBits = $bits % 8;
+
+		if ($wholeBytes > 0 && strncmp($packed, $networkPacked, $wholeBytes) !== 0) {
 			return false;
 		}
-		// Judge the embedded IPv4 on its own merits.
-		return filter_var(
-			$tail,
-			FILTER_VALIDATE_IP,
-			FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
-		) === false;
+		if ($remainingBits === 0) {
+			return true;
+		}
+
+		$mask = 0xFF << (8 - $remainingBits) & 0xFF;
+		return (ord($packed[$wholeBytes]) & $mask) === (ord($networkPacked[$wholeBytes]) & $mask);
 	}
 }

--- a/lib/Service/Mail/MimeMessage.php
+++ b/lib/Service/Mail/MimeMessage.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * The handful of things email intake takes from a message, already decoded to
+ * UTF-8 by {@see MimeParser}. Everything else in an email - routing headers,
+ * alternative parts, inline images - is deliberately dropped.
+ *
+ * `attachmentNames` records what was attached WITHOUT storing the bytes.
+ * Intake does not create card attachments (that is a separate, larger piece of
+ * work); naming the files in the card body is the difference between a person
+ * knowing something was left behind and silently losing it.
+ */
+class MimeMessage {
+	/**
+	 * @param string $fromAddress lowercased sender address, '' when unparseable
+	 * @param string $fromName the sender's display name, '' when absent
+	 * @param string $subject decoded Subject, '' when absent
+	 * @param string $body the text body, UTF-8, '' when the message had none
+	 * @param string[] $attachmentNames file names of the attached parts
+	 */
+	public function __construct(
+		public readonly string $fromAddress,
+		public readonly string $fromName,
+		public readonly string $subject,
+		public readonly string $body,
+		public readonly array $attachmentNames = [],
+	) {
+	}
+
+	/** The sender as a person reads it: "Name <addr>", or just the address. */
+	public function fromLabel(): string {
+		if ($this->fromName !== '' && $this->fromAddress !== '') {
+			return $this->fromName . ' <' . $this->fromAddress . '>';
+		}
+		return $this->fromName !== '' ? $this->fromName : $this->fromAddress;
+	}
+}

--- a/lib/Service/Mail/MimeMessage.php
+++ b/lib/Service/Mail/MimeMessage.php
@@ -12,6 +12,19 @@ namespace OCA\Kanso\Service\Mail;
  * UTF-8 by {@see MimeParser}. Everything else in an email - routing headers,
  * alternative parts, inline images - is deliberately dropped.
  *
+ * Beyond the content there are three CLASSIFICATION flags, computed by the
+ * parser because that is what holds the headers, and acted on by
+ * {@see \OCA\Kanso\Service\MailIntakeService} because that is what holds the
+ * policy:
+ *
+ * - `isAutomated` - the message is machine-generated (an out-of-office reply, a
+ *   bounce, a mailing-list post). Carding these is how an intake mailbox and a
+ *   notification mailbox saw each other into an infinite card loop.
+ * - `isSpam` - the upstream filter already judged it. Kanso does not
+ *   re-implement spam detection; it honours the verdict of whatever did.
+ * - `authentication` - the receiving MTA's SPF/DKIM/DMARC verdict, for mailboxes
+ *   configured to require one.
+ *
  * `attachmentNames` records what was attached WITHOUT storing the bytes.
  * Intake does not create card attachments (that is a separate, larger piece of
  * work); naming the files in the card body is the difference between a person
@@ -24,6 +37,9 @@ class MimeMessage {
 	 * @param string $subject decoded Subject, '' when absent
 	 * @param string $body the text body, UTF-8, '' when the message had none
 	 * @param string[] $attachmentNames file names of the attached parts
+	 * @param string $messageId the RFC 5322 Message-ID, '' when absent
+	 * @param bool $isAutomated the message is machine-generated
+	 * @param bool $isSpam an upstream filter flagged it
 	 */
 	public function __construct(
 		public readonly string $fromAddress,
@@ -31,6 +47,10 @@ class MimeMessage {
 		public readonly string $subject,
 		public readonly string $body,
 		public readonly array $attachmentNames = [],
+		public readonly string $messageId = '',
+		public readonly bool $isAutomated = false,
+		public readonly bool $isSpam = false,
+		public readonly ?AuthenticationResults $authentication = null,
 	) {
 	}
 
@@ -40,5 +60,28 @@ class MimeMessage {
 			return $this->fromName . ' <' . $this->fromAddress . '>';
 		}
 		return $this->fromName !== '' ? $this->fromName : $this->fromAddress;
+	}
+
+	/**
+	 * Whether the receiving MTA authenticated this message as really coming from
+	 * the domain its From claims. False when no verdict was recorded at all.
+	 */
+	public function isAuthenticated(): bool {
+		return $this->authentication?->authenticates($this->fromAddress) ?? false;
+	}
+
+	/**
+	 * A stable dedupe key: the Message-ID when the sender supplied one, else a
+	 * hash of the parts of the message that identify it.
+	 *
+	 * The fallback matters because Message-ID is optional in practice - plenty
+	 * of automated senders omit it - and a mailbox that re-delivers such a
+	 * message would otherwise card it twice.
+	 */
+	public function dedupeKey(): string {
+		if ($this->messageId !== '') {
+			return 'mid:' . hash('sha256', $this->messageId);
+		}
+		return 'syn:' . hash('sha256', $this->fromAddress . "\x00" . $this->subject . "\x00" . $this->body);
 	}
 }

--- a/lib/Service/Mail/MimeParser.php
+++ b/lib/Service/Mail/MimeParser.php
@@ -41,6 +41,23 @@ class MimeParser {
 	/** Bounds the attachment list a single card description can carry. */
 	private const MAX_ATTACHMENT_NAMES = 50;
 
+	/**
+	 * Longest header value kept, in bytes. A single header is otherwise bounded
+	 * only by the 5 MiB message ceiling, and the address pattern in
+	 * {@see parseFrom} backtracks superlinearly - a multi-megabyte `From:` is a
+	 * cheap way to burn cron CPU. No legitimate header comes close to 2 KB.
+	 */
+	private const MAX_HEADER_VALUE_BYTES = 2048;
+
+	/**
+	 * Bidi controls and other invisible formatting characters. A subject can use
+	 * these to render as something other than what it contains - the classic
+	 * "invoice\u{202E}fdp.exe" trick - and a card title is read by people
+	 * deciding whether to trust it. Stripped from every header-derived string.
+	 * U+200B..U+200F, U+202A..U+202E, U+2066..U+2069, U+FEFF, plus C0/C1.
+	 */
+	private const INVISIBLE_CHARS = '/[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}\x{FEFF}\x{0000}-\x{0008}\x{000B}\x{000C}\x{000E}-\x{001F}\x{007F}-\x{009F}]/u';
+
 	private int $partsSeen = 0;
 
 	public function parse(string $raw): MimeMessage {
@@ -78,9 +95,113 @@ class MimeParser {
 			$from['address'],
 			$from['name'],
 			$this->normaliseWhitespace($subject),
-			trim($text),
+			$this->stripInvisible(trim($text)),
 			$attachmentNames,
+			$this->parseMessageId($this->headerValue($headers, 'message-id')),
+			$this->looksAutomated($headers),
+			$this->looksLikeSpam($headers),
+			// ONLY the topmost Authentication-Results is read - see the class
+			// docblock on AuthenticationResults for why the rest are the sender's
+			// to forge.
+			AuthenticationResults::fromHeader($this->headerValue($headers, 'authentication-results')),
 		);
+	}
+
+	/**
+	 * Whether the message is machine-generated and must not become a card.
+	 *
+	 * This is the loop breaker. A card created by intake can raise a Nextcloud
+	 * notification email; an out-of-office or a bounce answers it; that answer
+	 * lands back in the intake mailbox as a new card, and the cycle runs until
+	 * someone notices. The header set below is the standard one senders use to
+	 * say "do not reply to this automatically", and honouring it is how every
+	 * other ticket-by-mail system avoids the same loop.
+	 *
+	 * @param array<string, list<string>> $headers
+	 */
+	private function looksAutomated(array $headers): bool {
+		// RFC 3834. Anything but 'no' means automatic; the header exists solely
+		// to mark auto-replies, auto-forwards and system notifications.
+		$autoSubmitted = strtolower(trim($this->headerValue($headers, 'auto-submitted')));
+		if ($autoSubmitted !== '' && !str_starts_with($autoSubmitted, 'no')) {
+			return true;
+		}
+
+		// Bulk/list traffic: newsletters and mailing-list posts.
+		$precedence = strtolower(trim($this->headerValue($headers, 'precedence')));
+		if (in_array($precedence, ['bulk', 'list', 'junk', 'auto_reply'], true)) {
+			return true;
+		}
+
+		// Mailing lists identify themselves with these regardless of Precedence.
+		foreach (['list-id', 'list-unsubscribe', 'list-post'] as $listHeader) {
+			if ($this->headerValue($headers, $listHeader) !== '') {
+				return true;
+			}
+		}
+
+		// Microsoft's equivalent of Auto-Submitted, and the older X-Autoreply /
+		// X-Autorespond pair.
+		foreach (['x-auto-response-suppress', 'x-autoreply', 'x-autorespond', 'x-autoresponder'] as $msHeader) {
+			if ($this->headerValue($headers, $msHeader) !== '') {
+				return true;
+			}
+		}
+
+		// A null return path is the signature of a BOUNCE (RFC 5321 requires
+		// delivery-status notifications to use an empty envelope sender, exactly
+		// so that replying to them cannot loop).
+		$returnPath = trim($this->headerValue($headers, 'return-path'));
+		if ($returnPath === '<>' || $returnPath === '') {
+			// '' only counts when the header is present but empty, not when it is
+			// absent - plenty of ordinary mail has no Return-Path by the time it
+			// reaches IMAP.
+			if (isset($headers['return-path'])) {
+				return true;
+			}
+		}
+
+		// The content type a bounce carries.
+		$contentType = strtolower($this->headerValue($headers, 'content-type'));
+		if (str_contains($contentType, 'multipart/report') || str_contains($contentType, 'delivery-status')) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether an upstream filter already judged this spam. Kanso does not
+	 * re-implement spam detection - it honours the verdict of whatever did,
+	 * which on a normal mail host is SpamAssassin or Rspamd.
+	 *
+	 * @param array<string, list<string>> $headers
+	 */
+	private function looksLikeSpam(array $headers): bool {
+		if (str_starts_with(strtolower(trim($this->headerValue($headers, 'x-spam-flag'))), 'yes')) {
+			return true;
+		}
+		// 'Yes, score=8.1 required=5.0 ...'
+		if (str_starts_with(strtolower(trim($this->headerValue($headers, 'x-spam-status'))), 'yes')) {
+			return true;
+		}
+		// Rspamd's verdict header.
+		$action = strtolower(trim($this->headerValue($headers, 'x-spamd-result')));
+		if (str_contains($action, 'reject') || str_contains($action, 'add header')) {
+			return true;
+		}
+		return false;
+	}
+
+	/** The Message-ID with its angle brackets removed. */
+	private function parseMessageId(string $raw): string {
+		$raw = trim($this->stripInvisible($raw));
+		if (preg_match('/<([^<>]{1,512})>/', $raw, $m) === 1) {
+			return trim($m[1]);
+		}
+		// Some senders omit the brackets. Keep it only if it looks like an id
+		// rather than a sentence.
+		return preg_match('/^\S{1,512}$/', $raw) === 1 ? $raw : '';
 	}
 
 	/**
@@ -141,9 +262,35 @@ class MimeParser {
 		return $headers;
 	}
 
-	/** @param array<string, list<string>> $headers */
+	/**
+	 * The FIRST occurrence of a header, clamped to a sane length.
+	 *
+	 * "First" is load-bearing for `Authentication-Results`: hops prepend, so the
+	 * first is the one our own MTA wrote and every later one is the sender's to
+	 * forge. {@see parseHeaders} preserves arrival order to make this true.
+	 *
+	 * @param array<string, list<string>> $headers
+	 */
 	private function headerValue(array $headers, string $name): string {
-		return $headers[$name][0] ?? '';
+		$value = $headers[$name][0] ?? '';
+		if (strlen($value) > self::MAX_HEADER_VALUE_BYTES) {
+			$value = substr($value, 0, self::MAX_HEADER_VALUE_BYTES);
+		}
+		return $value;
+	}
+
+	/**
+	 * Removes zero-width and bidi-override characters.
+	 *
+	 * A card title is something a person reads to decide whether to trust a
+	 * card, and these characters let a subject display as something other than
+	 * what it says. Applied to headers and to the body.
+	 */
+	private function stripInvisible(string $value): string {
+		$stripped = preg_replace(self::INVISIBLE_CHARS, '', $value);
+		// preg_replace returns null on a UTF-8 failure; the /u pattern above can
+		// hit that on a body that survived scrubbing but is still odd.
+		return $stripped ?? $value;
 	}
 
 	/**
@@ -494,8 +641,12 @@ class MimeParser {
 		return trim($text);
 	}
 
-	/** Collapses all whitespace to single spaces - for one-line values. */
+	/**
+	 * Collapses all whitespace to single spaces and drops invisible characters -
+	 * for one-line values such as the subject and attachment names.
+	 */
 	private function normaliseWhitespace(string $value): string {
+		$value = $this->stripInvisible($value);
 		return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
 	}
 }

--- a/lib/Service/Mail/MimeParser.php
+++ b/lib/Service/Mail/MimeParser.php
@@ -1,0 +1,501 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * Turns raw RFC 822/2045 bytes into the {@see MimeMessage} intake acts on.
+ *
+ * Why hand-rolled: NC's `3rdparty` carries `symfony/mime`, which COMPOSES
+ * messages and cannot parse one (it ships no parser), and Kanso ships no
+ * `vendor/`. What it does give us is enough - the decoding primitives this
+ * needs are all PHP builtins: `iconv_mime_decode` for encoded-word headers,
+ * `quoted_printable_decode` and `base64_decode` for bodies, `mb_convert_encoding`
+ * for charsets.
+ *
+ * Scope: headers, the MIME part tree, and ONE text body - `text/plain` if the
+ * message has one anywhere, else `text/html` flattened to text. Attached parts
+ * are named, not stored. Everything is normalised to UTF-8, because a card
+ * description that renders as mojibake is worse than one that lost an accent.
+ *
+ * Robustness over strictness throughout: real mail is malformed constantly, and
+ * the failure mode that matters is a poll that throws and stalls a mailbox. A
+ * message this cannot make sense of yields empty strings, never an exception.
+ */
+class MimeParser {
+	/**
+	 * How deep the multipart tree is walked. `multipart/mixed` wrapping
+	 * `multipart/alternative` wrapping `multipart/related` is ordinary mail and
+	 * only three deep; beyond this is a malformed or hostile message, and
+	 * unbounded recursion on attacker-shaped input is how a parser becomes a DoS.
+	 */
+	private const MAX_DEPTH = 10;
+
+	/** Bounds the parts walked in one message, for the same reason. */
+	private const MAX_PARTS = 200;
+
+	/** Bounds the attachment list a single card description can carry. */
+	private const MAX_ATTACHMENT_NAMES = 50;
+
+	private int $partsSeen = 0;
+
+	public function parse(string $raw): MimeMessage {
+		$this->partsSeen = 0;
+
+		// Normalise line endings first: the boundary and header-block scans below
+		// both key on "\n", and real mail arrives with CRLF, bare LF, and
+		// occasionally bare CR from older agents.
+		$raw = str_replace(["\r\n", "\r"], "\n", $raw);
+
+		[$headerBlock, $body] = $this->splitHeaders($raw);
+		$headers = $this->parseHeaders($headerBlock);
+
+		$from = $this->parseFrom($this->headerValue($headers, 'from'));
+		$subject = $this->decodeHeader($this->headerValue($headers, 'subject'));
+
+		// Attachments are collected by their OWN complete walk, not as a side
+		// effect of the text search: the search stops at the first part it wants,
+		// so a message whose text part precedes its attachments - the ordinary
+		// shape - would report no attachments at all.
+		$attachmentNames = [];
+		$this->collectAttachments($headers, $body, 0, $attachmentNames);
+
+		// Two exact passes rather than one pass that guesses. Preference must be
+		// by the type of the LEAF that produced the text, and a single walk only
+		// ever sees the type of the subtree it descended into - so a text/plain
+		// nested inside a multipart/related inside a multipart/alternative would
+		// be indistinguishable from HTML that came the same way.
+		$text = $this->findText($headers, $body, 0, 'text/plain');
+		if ($text === '') {
+			$text = $this->findText($headers, $body, 0, 'text/html');
+		}
+
+		return new MimeMessage(
+			$from['address'],
+			$from['name'],
+			$this->normaliseWhitespace($subject),
+			trim($text),
+			$attachmentNames,
+		);
+	}
+
+	/**
+	 * Splits the header block from the body at the first empty line.
+	 *
+	 * @return array{0: string, 1: string}
+	 */
+	private function splitHeaders(string $raw): array {
+		$split = strpos($raw, "\n\n");
+		if ($split === false) {
+			// All headers and no body is legal (and common for a subject-only
+			// message sent from a phone).
+			return [$raw, ''];
+		}
+		return [substr($raw, 0, $split), substr($raw, $split + 2)];
+	}
+
+	/**
+	 * Header name (lowercased) => list of raw values. A list, not a scalar,
+	 * because `Received` and friends repeat - we only read single-valued headers,
+	 * but collapsing duplicates silently would make the first `Content-Type` win
+	 * or lose unpredictably depending on the implementation.
+	 *
+	 * @return array<string, list<string>>
+	 */
+	private function parseHeaders(string $headerBlock): array {
+		$headers = [];
+		$name = null;
+		$value = '';
+
+		foreach (explode("\n", $headerBlock) as $line) {
+			if ($line === '') {
+				continue;
+			}
+			// A leading space or tab continues (folds into) the previous header.
+			if ($name !== null && ($line[0] === ' ' || $line[0] === "\t")) {
+				$value .= ' ' . trim($line);
+				continue;
+			}
+			if ($name !== null) {
+				$headers[$name][] = $value;
+			}
+			$colon = strpos($line, ':');
+			if ($colon === false) {
+				// Garbage between headers - skip it rather than treating the rest of
+				// the block as a continuation of whatever came before.
+				$name = null;
+				$value = '';
+				continue;
+			}
+			$name = strtolower(trim(substr($line, 0, $colon)));
+			$value = trim(substr($line, $colon + 1));
+		}
+		if ($name !== null) {
+			$headers[$name][] = $value;
+		}
+
+		return $headers;
+	}
+
+	/** @param array<string, list<string>> $headers */
+	private function headerValue(array $headers, string $name): string {
+		return $headers[$name][0] ?? '';
+	}
+
+	/**
+	 * Walks the part tree depth-first and returns the first body whose leaf is
+	 * exactly `$wantedType`, decoded to UTF-8 (and flattened, for HTML).
+	 *
+	 * Called once per candidate type, which is what makes `multipart/alternative`
+	 * come out right: senders list the plain alternative first and the HTML one
+	 * last, so "first text part wins" would pick plain by luck here and HTML the
+	 * moment a sender reorders them. Searching the whole tree for plain before
+	 * considering HTML is a preference, not an ordering accident.
+	 *
+	 * @param array<string, list<string>> $headers
+	 * @param string $wantedType 'text/plain' or 'text/html'
+	 */
+	private function findText(array $headers, string $body, int $depth, string $wantedType): string {
+		if ($depth === 0) {
+			// Each pass gets the full part budget; sharing it would let a wide
+			// message exhaust the budget on the plain pass and return nothing at
+			// all rather than falling back to its HTML.
+			$this->partsSeen = 0;
+		}
+		if ($depth > self::MAX_DEPTH || ++$this->partsSeen > self::MAX_PARTS) {
+			return '';
+		}
+
+		$contentType = $this->parseContentType($this->headerValue($headers, 'content-type'));
+
+		if (str_starts_with($contentType['type'], 'multipart/')) {
+			$boundary = $contentType['params']['boundary'] ?? '';
+			if ($boundary === '') {
+				return '';
+			}
+			foreach ($this->splitParts($body, $boundary) as $partRaw) {
+				[$partHeaderBlock, $partBody] = $this->splitHeaders($partRaw);
+				$partHeaders = $this->parseHeaders($partHeaderBlock);
+				$found = $this->findText($partHeaders, $partBody, $depth + 1, $wantedType);
+				if ($found !== '') {
+					return $found;
+				}
+			}
+			return '';
+		}
+
+		// ---- a leaf part -----------------------------------------------------
+
+		if ($this->isAttachment($headers, $contentType) !== '') {
+			// An attached text/plain is a file, not the message body.
+			return '';
+		}
+
+		if ($contentType['type'] !== $wantedType) {
+			return '';
+		}
+
+		$decoded = $this->decodeBody(
+			$body,
+			strtolower(trim($this->headerValue($headers, 'content-transfer-encoding'))),
+		);
+		$decoded = $this->toUtf8($decoded, $contentType['params']['charset'] ?? '');
+
+		if ($wantedType === 'text/html') {
+			$decoded = $this->htmlToText($decoded);
+		}
+
+		// An empty part must not count as a match, or an empty plain alternative
+		// would suppress the HTML fallback that carries the real body.
+		return trim($decoded) === '' ? '' : $decoded;
+	}
+
+	/**
+	 * Walks the WHOLE tree naming every attached part. Unlike {@see findText}
+	 * this never short-circuits - the point is the complete list.
+	 *
+	 * @param array<string, list<string>> $headers
+	 * @param string[] $names collected by reference
+	 */
+	private function collectAttachments(array $headers, string $body, int $depth, array &$names): void {
+		if ($depth === 0) {
+			$this->partsSeen = 0;
+		}
+		if ($depth > self::MAX_DEPTH || ++$this->partsSeen > self::MAX_PARTS || count($names) >= self::MAX_ATTACHMENT_NAMES) {
+			return;
+		}
+
+		$contentType = $this->parseContentType($this->headerValue($headers, 'content-type'));
+
+		if (str_starts_with($contentType['type'], 'multipart/')) {
+			$boundary = $contentType['params']['boundary'] ?? '';
+			if ($boundary === '') {
+				return;
+			}
+			foreach ($this->splitParts($body, $boundary) as $partRaw) {
+				[$partHeaderBlock, $partBody] = $this->splitHeaders($partRaw);
+				$this->collectAttachments($this->parseHeaders($partHeaderBlock), $partBody, $depth + 1, $names);
+			}
+			return;
+		}
+
+		$filename = $this->isAttachment($headers, $contentType);
+		// Deduped: `multipart/related` legitimately references the same inline
+		// file from more than one alternative.
+		if ($filename !== '' && !in_array($filename, $names, true)) {
+			$names[] = $filename;
+		}
+	}
+
+	/**
+	 * The part's file name if it is an attachment, '' if it is body content.
+	 *
+	 * A NAMED part counts as an attachment even when the sender omitted
+	 * Content-Disposition, which older clients do routinely - otherwise its
+	 * bytes are read as the message body.
+	 *
+	 * @param array{type: string, params: array<string, string>} $contentType
+	 * @param array<string, list<string>> $headers
+	 */
+	private function isAttachment(array $headers, array $contentType): string {
+		$disposition = strtolower(trim(explode(';', $this->headerValue($headers, 'content-disposition'))[0]));
+		$filename = $this->partFilename($headers, $contentType);
+
+		if ($disposition === 'attachment') {
+			// An attachment the sender did not name still has to suppress the body
+			// read, so fall back to a placeholder rather than ''.
+			return $filename !== '' ? $filename : 'unnamed attachment';
+		}
+		if ($filename !== '' && $disposition !== 'inline') {
+			return $filename;
+		}
+		return '';
+	}
+
+	/**
+	 * Splits a multipart body on its boundary.
+	 *
+	 * @return string[] the part bodies, preamble and epilogue discarded
+	 */
+	private function splitParts(string $body, string $boundary): array {
+		$delimiter = '--' . $boundary;
+		$chunks = explode($delimiter, $body);
+
+		// The first chunk is the preamble (text before the first boundary, which
+		// mail clients use for "this is a MIME message" notices) - never a part.
+		array_shift($chunks);
+
+		$parts = [];
+		foreach ($chunks as $chunk) {
+			// '--' immediately after the boundary is the terminator; everything
+			// after it is the epilogue.
+			if (str_starts_with($chunk, '--')) {
+				break;
+			}
+			// Drop the CRLF that belongs to the boundary line itself.
+			$parts[] = ltrim($chunk, "\n");
+		}
+		return $parts;
+	}
+
+	/**
+	 * @return array{type: string, params: array<string, string>}
+	 */
+	private function parseContentType(string $value): array {
+		if (trim($value) === '') {
+			// RFC 2045: a part with no Content-Type is text/plain; us-ascii.
+			return ['type' => 'text/plain', 'params' => []];
+		}
+
+		$segments = $this->splitParameters($value);
+		$type = strtolower(trim(array_shift($segments) ?? ''));
+
+		$params = [];
+		foreach ($segments as $segment) {
+			$eq = strpos($segment, '=');
+			if ($eq === false) {
+				continue;
+			}
+			$key = strtolower(trim(substr($segment, 0, $eq)));
+			$raw = trim(substr($segment, $eq + 1));
+			// Quoted parameter values are the norm for boundaries, which routinely
+			// contain '=' and other characters that would otherwise re-split.
+			if (strlen($raw) >= 2 && $raw[0] === '"') {
+				$closing = strrpos($raw, '"');
+				// An unterminated quote (the closing one IS the opening one) still
+				// has to yield the rest of the value rather than an empty string.
+				$raw = ($closing !== false && $closing > 0)
+					? substr($raw, 1, $closing - 1)
+					: substr($raw, 1);
+			}
+			$params[$key] = $raw;
+		}
+
+		return ['type' => $type, 'params' => $params];
+	}
+
+	/**
+	 * Splits a header value on semicolons that are NOT inside a quoted string -
+	 * a plain explode(';') mangles `boundary="a;b"`, which is legal and does
+	 * occur.
+	 *
+	 * @return string[]
+	 */
+	private function splitParameters(string $value): array {
+		$segments = [];
+		$current = '';
+		$inQuotes = false;
+		$length = strlen($value);
+
+		for ($i = 0; $i < $length; $i++) {
+			$char = $value[$i];
+			if ($char === '"') {
+				$inQuotes = !$inQuotes;
+				$current .= $char;
+				continue;
+			}
+			if ($char === ';' && !$inQuotes) {
+				$segments[] = $current;
+				$current = '';
+				continue;
+			}
+			$current .= $char;
+		}
+		$segments[] = $current;
+
+		return $segments;
+	}
+
+	/**
+	 * The part's file name, from Content-Disposition's `filename` or
+	 * Content-Type's `name`.
+	 *
+	 * @param array{type: string, params: array<string, string>} $contentType
+	 * @param array<string, list<string>> $headers
+	 */
+	private function partFilename(array $headers, array $contentType): string {
+		$disposition = $this->parseContentType($this->headerValue($headers, 'content-disposition'));
+		$name = $disposition['params']['filename'] ?? ($contentType['params']['name'] ?? '');
+		$name = $this->decodeHeader($name);
+		// The name is only ever displayed inside a card description, but it comes
+		// from the sender - keep it to one line and a sane length.
+		$name = $this->normaliseWhitespace($name);
+		return mb_substr($name, 0, 120);
+	}
+
+	private function decodeBody(string $body, string $encoding): string {
+		return match ($encoding) {
+			'base64' => (string)base64_decode($body, false),
+			'quoted-printable' => quoted_printable_decode($body),
+			// 7bit / 8bit / binary / absent / anything unrecognised: the bytes are
+			// already the content.
+			default => $body,
+		};
+	}
+
+	/**
+	 * Converts a part body to UTF-8, falling back progressively rather than
+	 * throwing - the caller cannot do anything useful with a charset failure,
+	 * and a lossy body beats a stalled mailbox.
+	 */
+	private function toUtf8(string $text, string $charset): string {
+		$charset = trim($charset);
+		if ($charset === '' || strtolower($charset) === 'utf-8') {
+			// Claimed UTF-8 is often not valid UTF-8. Scrub rather than trust:
+			// invalid bytes reaching the database can fail the INSERT outright on
+			// a strict connection.
+			return $this->scrubUtf8($text);
+		}
+
+		$converted = @mb_convert_encoding($text, 'UTF-8', $charset);
+		if (is_string($converted) && $converted !== '') {
+			return $this->scrubUtf8($converted);
+		}
+
+		// mb doesn't know this charset; iconv knows several it doesn't. //IGNORE
+		// keeps the rest of the body when one sequence is undecodable.
+		$converted = @iconv($charset, 'UTF-8//IGNORE', $text);
+		if (is_string($converted)) {
+			return $this->scrubUtf8($converted);
+		}
+
+		return $this->scrubUtf8($text);
+	}
+
+	/** Drops byte sequences that are not valid UTF-8. */
+	private function scrubUtf8(string $text): string {
+		if (mb_check_encoding($text, 'UTF-8')) {
+			return $text;
+		}
+		return (string)mb_convert_encoding($text, 'UTF-8', 'UTF-8');
+	}
+
+	/**
+	 * Decodes RFC 2047 encoded-words (`=?utf-8?B?...?=`) in a header value.
+	 */
+	private function decodeHeader(string $value): string {
+		if ($value === '') {
+			return '';
+		}
+		// CONTINUE_ON_ERROR: a header mixing a broken encoded-word with good text
+		// should still yield the good text.
+		$decoded = @iconv_mime_decode($value, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
+		return $this->scrubUtf8(is_string($decoded) ? $decoded : $value);
+	}
+
+	/**
+	 * @return array{address: string, name: string}
+	 */
+	private function parseFrom(string $value): array {
+		$value = $this->decodeHeader($value);
+		if (trim($value) === '') {
+			return ['address' => '', 'name' => ''];
+		}
+
+		// 'Display Name <addr@example.com>' is the common form; a bare address is
+		// equally legal. Only the LAST angle-bracket pair is the address, so a
+		// display name containing brackets cannot shadow it.
+		if (preg_match('/^(.*)<([^<>]*)>[^<>]*$/s', $value, $m) === 1) {
+			$name = trim($m[1], " \t\"'");
+			$address = trim($m[2]);
+		} else {
+			$name = '';
+			$address = trim($value);
+		}
+
+		return [
+			'address' => mb_strtolower($this->normaliseWhitespace($address)),
+			'name' => $this->normaliseWhitespace($name),
+		];
+	}
+
+	/**
+	 * Flattens HTML to readable text. Not a renderer - just enough that an
+	 * HTML-only message produces a description a person can read instead of a
+	 * wall of markup.
+	 */
+	private function htmlToText(string $html): string {
+		// Script and style CONTENT would otherwise survive strip_tags as visible
+		// text - their bodies are not markup.
+		$text = preg_replace('#<(script|style)\b[^>]*>.*?</\1>#is', '', $html) ?? $html;
+		// Keep the block structure that carries meaning in a mail body.
+		$text = preg_replace('#<br\s*/?>#i', "\n", $text) ?? $text;
+		$text = preg_replace('#</(p|div|tr|li|h[1-6])\s*>#i', "\n", $text) ?? $text;
+		$text = strip_tags($text);
+		$text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		// HTML mail is full of indentation that means nothing once tags are gone.
+		$text = preg_replace('/[ \t]+/', ' ', $text) ?? $text;
+		$text = preg_replace('/\n[ \t]+/', "\n", $text) ?? $text;
+		$text = preg_replace('/\n{3,}/', "\n\n", $text) ?? $text;
+		return trim($text);
+	}
+
+	/** Collapses all whitespace to single spaces - for one-line values. */
+	private function normaliseWhitespace(string $value): string {
+		return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+	}
+}

--- a/lib/Service/Mail/StreamImapTransport.php
+++ b/lib/Service/Mail/StreamImapTransport.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service\Mail;
+
+/**
+ * {@see ImapTransport} over a PHP stream socket.
+ *
+ * Why a hand-rolled socket at all: the Nextcloud runtime ships neither
+ * `ext-imap` (dropped from core PHP, absent from the official images) nor any
+ * IMAP client library in `3rdparty`, and Kanso ships no `vendor/` of its own -
+ * runtime dependencies must already exist on the server. Streams plus
+ * `ext-openssl` are always there.
+ *
+ * TLS is NOT optional and certificates are NOT trusted blindly: `verify_peer`
+ * and `verify_peer_name` stay on, so a mailbox credential is never handed to an
+ * unauthenticated middlebox. A server with a self-signed certificate fails to
+ * connect, loudly, rather than silently downgrading.
+ */
+class StreamImapTransport implements ImapTransport {
+	/** @var resource|null */
+	private $stream = null;
+
+	private int $timeoutSeconds = 30;
+
+	#[\Override]
+	public function open(string $host, int $port, bool $implicitTls, int $timeoutSeconds): void {
+		$this->timeoutSeconds = $timeoutSeconds;
+
+		$context = stream_context_create([
+			'ssl' => [
+				'verify_peer' => true,
+				'verify_peer_name' => true,
+				'allow_self_signed' => false,
+				'SNI_enabled' => true,
+				'peer_name' => $host,
+			],
+		]);
+
+		// The scheme carries implicit TLS; STARTTLS connects in the clear and is
+		// upgraded by enableCrypto() once the server has agreed.
+		$scheme = $implicitTls ? 'ssl://' : 'tcp://';
+		$errno = 0;
+		$errstr = '';
+		$stream = @stream_socket_client(
+			$scheme . $host . ':' . $port,
+			$errno,
+			$errstr,
+			$timeoutSeconds,
+			STREAM_CLIENT_CONNECT,
+			$context,
+		);
+
+		if ($stream === false) {
+			// $errstr can carry the host but never a credential - safe to surface.
+			throw new ImapException('Cannot connect to ' . $host . ':' . $port . ' (' . trim($errstr) . ')');
+		}
+
+		stream_set_timeout($stream, $timeoutSeconds);
+		$this->stream = $stream;
+	}
+
+	#[\Override]
+	public function enableCrypto(): void {
+		$stream = $this->requireStream();
+		// CLIENT (not CLIENT_TLS_ANY_CLIENT) so the negotiated version follows
+		// PHP's own modern default rather than pinning a version that ages out.
+		$ok = @stream_socket_enable_crypto($stream, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+		if ($ok !== true) {
+			throw new ImapException('STARTTLS upgrade failed');
+		}
+	}
+
+	#[\Override]
+	public function writeLine(string $line): void {
+		$stream = $this->requireStream();
+		$payload = $line . "\r\n";
+		$written = @fwrite($stream, $payload);
+		if ($written === false || $written < strlen($payload)) {
+			throw new ImapException('Write to IMAP server failed');
+		}
+	}
+
+	#[\Override]
+	public function readLine(): string {
+		$stream = $this->requireStream();
+		$line = @fgets($stream);
+		if ($line === false) {
+			// Distinguish the two ways fgets fails - a timeout is a server that
+			// went quiet, EOF is one that hung up. Both stop the poll, but they
+			// point at different problems in the config UI.
+			$meta = stream_get_meta_data($stream);
+			if (!empty($meta['timed_out'])) {
+				throw new ImapException('IMAP server timed out after ' . $this->timeoutSeconds . 's');
+			}
+			throw new ImapException('IMAP server closed the connection');
+		}
+		return rtrim($line, "\r\n");
+	}
+
+	#[\Override]
+	public function readBytes(int $length): string {
+		if ($length <= 0) {
+			return '';
+		}
+		$stream = $this->requireStream();
+		$buffer = '';
+		$remaining = $length;
+		while ($remaining > 0) {
+			$chunk = @fread($stream, $remaining);
+			// '' means EOF or a timed-out read; either way no more bytes are
+			// coming and the literal we were promised is incomplete.
+			if ($chunk === false || $chunk === '') {
+				throw new ImapException('IMAP server closed mid-message');
+			}
+			$buffer .= $chunk;
+			$remaining -= strlen($chunk);
+		}
+		return $buffer;
+	}
+
+	#[\Override]
+	public function close(): void {
+		// Cleared BEFORE the fclose so the property never holds a closed handle -
+		// a second close() (disconnect() is called from a finally, so it happens)
+		// must be a no-op rather than an fclose on dead bytes.
+		$stream = $this->stream;
+		$this->stream = null;
+		if ($stream !== null) {
+			@fclose($stream);
+		}
+	}
+
+	/**
+	 * @return resource
+	 * @throws ImapException if used before open() or after close()
+	 */
+	private function requireStream() {
+		if ($this->stream === null) {
+			throw new ImapException('IMAP connection is not open');
+		}
+		return $this->stream;
+	}
+}

--- a/lib/Service/Mail/StreamImapTransport.php
+++ b/lib/Service/Mail/StreamImapTransport.php
@@ -28,7 +28,7 @@ class StreamImapTransport implements ImapTransport {
 	private int $timeoutSeconds = 30;
 
 	#[\Override]
-	public function open(string $host, int $port, bool $implicitTls, int $timeoutSeconds): void {
+	public function open(string $address, string $peerName, int $port, bool $implicitTls, int $timeoutSeconds): void {
 		$this->timeoutSeconds = $timeoutSeconds;
 
 		$context = stream_context_create([
@@ -37,17 +37,23 @@ class StreamImapTransport implements ImapTransport {
 				'verify_peer_name' => true,
 				'allow_self_signed' => false,
 				'SNI_enabled' => true,
-				'peer_name' => $host,
+				// Validated against the NAME the user configured, even though the
+				// socket dials the vetted IP - otherwise pinning the address would
+				// have cost us certificate validation, trading one hole for another.
+				'peer_name' => $peerName,
+				'SNI_server_name' => $peerName,
 			],
 		]);
 
 		// The scheme carries implicit TLS; STARTTLS connects in the clear and is
 		// upgraded by enableCrypto() once the server has agreed.
 		$scheme = $implicitTls ? 'ssl://' : 'tcp://';
+		// An IPv6 literal has to be bracketed in a host:port string.
+		$hostPart = str_contains($address, ':') ? '[' . $address . ']' : $address;
 		$errno = 0;
 		$errstr = '';
 		$stream = @stream_socket_client(
-			$scheme . $host . ':' . $port,
+			$scheme . $hostPart . ':' . $port,
 			$errno,
 			$errstr,
 			$timeoutSeconds,
@@ -57,7 +63,7 @@ class StreamImapTransport implements ImapTransport {
 
 		if ($stream === false) {
 			// $errstr can carry the host but never a credential - safe to surface.
-			throw new ImapException('Cannot connect to ' . $host . ':' . $port . ' (' . trim($errstr) . ')');
+			throw new ImapException('Cannot connect to ' . $peerName . ':' . $port . ' (' . trim($errstr) . ')');
 		}
 
 		stream_set_timeout($stream, $timeoutSeconds);

--- a/lib/Service/MailIntakeService.php
+++ b/lib/Service/MailIntakeService.php
@@ -215,6 +215,18 @@ class MailIntakeService {
 			if ($existing === null || $existing->getPassword() === '') {
 				throw new InvalidInputException('Mail account password is required');
 			}
+			// A stored password may only be carried over to the SAME server and
+			// account. Otherwise a board manager who never knew the credential
+			// could repoint an existing config at a host they control, leave the
+			// password field blank, and have the next connection hand them the
+			// password - credential theft needing nothing but MANAGE on the board.
+			// Changing only the folder is exempt: same server, same account,
+			// nothing to steal.
+			if ($existing->getHost() !== $host || $existing->getUsername() !== $username) {
+				throw new InvalidInputException(
+					'Enter the mailbox password again when you change the mail server or account'
+				);
+			}
 		}
 
 		$entity = $existing ?? new MailIntake();

--- a/lib/Service/MailIntakeService.php
+++ b/lib/Service/MailIntakeService.php
@@ -1,0 +1,539 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\MailIntake;
+use OCA\Kanso\Db\MailIntakeMapper;
+use OCA\Kanso\Db\Stack;
+use OCA\Kanso\Db\StackMapper;
+use OCA\Kanso\Service\Mail\ImapClient;
+use OCA\Kanso\Service\Mail\ImapClientFactory;
+use OCA\Kanso\Service\Mail\ImapException;
+use OCA\Kanso\Service\Mail\MimeMessage;
+use OCA\Kanso\Service\Mail\MimeParser;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Security\ICrypto;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Email intake (#117): a board can point at an IMAP mailbox, and every message
+ * that arrives there becomes a card.
+ *
+ * Shape follows the forge-webhook config it sits beside - MANAGE-gated config,
+ * an intake stack, cards created as the board OWNER through {@see CardService}
+ * so sort keys, change rows and realtime all fire. What differs is the
+ * direction: a webhook is pushed to us and authenticated by HMAC, whereas a
+ * mailbox is PULLED by cron and authenticated by a stored credential, which
+ * drags in three problems a webhook does not have.
+ *
+ * 1. The credential is at rest. It is stored {@see ICrypto}-encrypted (the same
+ *    server-secret-derived cipher NC uses for external storage passwords) and
+ *    never leaves this class in the clear - not in the config payload, not in
+ *    `lastError`, not in the log.
+ *
+ * 2. `From:` is not authentication. Anyone can send mail claiming to be anyone,
+ *    so the sender allowlist is a FILTER, not an identity, and the card is
+ *    never attributed to the NC user whose address matches. Attributing it
+ *    would turn a forged header into a way to create cards as someone else -
+ *    the card records the claimed sender as TEXT in its description instead,
+ *    where it reads as what it is: something the message said about itself.
+ *    A mailbox with an empty allowlist accepts anyone who knows the address,
+ *    which is the feature working as asked (a public intake address) and is
+ *    called out in the config UI.
+ *
+ * 3. A poll can fail forever. Every failure is caught per mailbox, recorded in
+ *    `lastError` for the config UI, and never allowed to escape into the cron
+ *    worker - one board's expired password must not stop every other board's
+ *    intake.
+ *
+ * Not in scope here: attachments are NAMED in the card body, not stored as card
+ * attachments, and a reply to an intake card is a new card rather than a
+ * comment. Both are follow-on work, and both are stated in the UI rather than
+ * left to be discovered.
+ */
+class MailIntakeService {
+	/** The encryption modes offered. Cleartext IMAP is deliberately absent. */
+	public const ENCRYPTIONS = [MailIntake::ENCRYPTION_SSL, MailIntake::ENCRYPTION_TLS];
+
+	/**
+	 * Messages carded per mailbox per run. A first poll of a mailbox with years
+	 * of history would otherwise create thousands of cards in one cron tick;
+	 * the watermark makes the next run continue where this one stopped.
+	 */
+	private const MAX_MESSAGES_PER_RUN = 50;
+
+	/** Keeps a runaway server's error text out of the database and the UI. */
+	private const MAX_ERROR_LENGTH = 500;
+
+	public function __construct(
+		private MailIntakeMapper $mapper,
+		private BoardMapper $boardMapper,
+		private StackMapper $stackMapper,
+		private CardService $cardService,
+		private PermissionService $permissionService,
+		private MimeParser $mimeParser,
+		private ICrypto $crypto,
+		private ITimeFactory $time,
+		private LoggerInterface $logger,
+		private ImapClientFactory $clientFactory,
+	) {
+	}
+
+	// ---- config (MANAGE) ---------------------------------------------------
+
+	/**
+	 * The board's intake config, or null when none is set up. The password is
+	 * never included - {@see MailIntake::jsonSerialize} reports `hasPassword`.
+	 *
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not manage the board
+	 */
+	public function getConfig(int $boardId, string $actorUid): ?MailIntake {
+		$board = $this->loadBoard($boardId);
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
+
+		try {
+			return $this->mapper->findByBoard($boardId);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+
+	/**
+	 * Creates or replaces the board's mailbox config. Requires MANAGE.
+	 *
+	 * `$password` null means "keep the stored one" - the config UI never receives
+	 * the password back, so it cannot send it back either, and re-saving the form
+	 * to change the stack must not wipe the credential.
+	 *
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not manage the board
+	 * @throws InvalidInputException if any field is unusable
+	 */
+	public function saveConfig(
+		int $boardId,
+		int $stackId,
+		string $host,
+		int $port,
+		string $encryption,
+		string $username,
+		?string $password,
+		string $mailbox,
+		string $senderAllowlist,
+		bool $enabled,
+		string $actorUid,
+	): MailIntake {
+		$board = $this->loadBoard($boardId);
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
+
+		$host = trim($host);
+		$username = trim($username);
+		$mailbox = trim($mailbox);
+		$mailbox = $mailbox === '' ? 'INBOX' : $mailbox;
+
+		if ($host === '') {
+			throw new InvalidInputException('Mail server host is required');
+		}
+		if (mb_strlen($host) > 255 || mb_strlen($username) > 255 || mb_strlen($mailbox) > 255) {
+			throw new InvalidInputException('Mail server settings must not exceed 255 characters');
+		}
+		// The same rejection ImapClient makes, applied at the config boundary so a
+		// bad value is a 400 at save time rather than a mailbox that fails every
+		// poll for a reason nobody can see.
+		foreach (['host' => $host, 'username' => $username, 'mailbox' => $mailbox] as $what => $value) {
+			if (preg_match('/[\r\n\x00]/', $value) === 1) {
+				throw new InvalidInputException('Invalid ' . $what . ': line breaks are not allowed');
+			}
+		}
+		if ($username === '') {
+			throw new InvalidInputException('Mail account username is required');
+		}
+		if ($port < 1 || $port > 65535) {
+			throw new InvalidInputException('Port must be between 1 and 65535');
+		}
+		if (!in_array($encryption, self::ENCRYPTIONS, true)) {
+			throw new InvalidInputException('Encryption must be one of: ' . implode(', ', self::ENCRYPTIONS));
+		}
+		if (mb_strlen($senderAllowlist) > 4000) {
+			throw new InvalidInputException('Sender allowlist is too long');
+		}
+		if ($this->findAliveStack($boardId, $stackId) === null) {
+			throw new InvalidInputException('Stack does not belong to this board');
+		}
+		if ($password !== null && preg_match('/[\r\n\x00]/', $password) === 1) {
+			throw new InvalidInputException('Invalid password: line breaks are not allowed');
+		}
+
+		$existing = null;
+		try {
+			$existing = $this->mapper->findByBoard($boardId);
+		} catch (DoesNotExistException) {
+			// First-time setup.
+		}
+
+		if ($password === null || $password === '') {
+			if ($existing === null || $existing->getPassword() === '') {
+				throw new InvalidInputException('Mail account password is required');
+			}
+		}
+
+		$entity = $existing ?? new MailIntake();
+		$entity->setBoardId($boardId);
+		$entity->setStackId($stackId);
+		// A move to a different account or mailbox invalidates the watermark: UIDs
+		// are only meaningful within one mailbox on one server, so carrying the
+		// old number over would skip everything below it on the new one.
+		$identityChanged = $existing !== null && (
+			$existing->getHost() !== $host
+			|| $existing->getUsername() !== $username
+			|| $existing->getMailbox() !== $mailbox
+		);
+		$entity->setHost($host);
+		$entity->setPort($port);
+		$entity->setEncryption($encryption);
+		$entity->setUsername($username);
+		if ($password !== null && $password !== '') {
+			$entity->setPassword($this->crypto->encrypt($password));
+		}
+		$entity->setMailbox($mailbox);
+		$entity->setSenderAllowlist(trim($senderAllowlist) === '' ? null : $senderAllowlist);
+		$entity->setEnabled($enabled);
+		if ($identityChanged) {
+			$entity->setLastUid(0);
+			$entity->setUidValidity(0);
+		}
+
+		if ($existing === null) {
+			$entity->setLastUid(0);
+			$entity->setUidValidity(0);
+			$entity->setLastRun(0);
+			$entity->setCreatedAt($this->time->getTime());
+			// A config that has never been polled has no error to report, and a
+			// stale one from a previous setup would be misleading.
+			$entity->setLastError(null);
+			return $this->mapper->insert($entity);
+		}
+
+		$entity->setLastError(null);
+		return $this->mapper->update($entity);
+	}
+
+	/**
+	 * Deletes the board's mailbox config, credential included. Requires MANAGE.
+	 * Idempotent.
+	 *
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 * @throws NotPermittedException if the actor may not manage the board
+	 */
+	public function deleteConfig(int $boardId, string $actorUid): void {
+		$board = $this->loadBoard($boardId);
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
+		$this->mapper->deleteByBoard($boardId);
+	}
+
+	/**
+	 * Connects, authenticates and selects the mailbox, then hangs up without
+	 * reading anything. Requires MANAGE.
+	 *
+	 * Worth its own endpoint because the alternative is a person saving a config
+	 * and waiting up to five minutes for cron to tell them the password is
+	 * wrong.
+	 *
+	 * @return array{ok: bool, error: string|null}
+	 * @throws DoesNotExistException if the board or its config does not exist
+	 * @throws NotPermittedException if the actor may not manage the board
+	 */
+	public function testConnection(int $boardId, string $actorUid): array {
+		$board = $this->loadBoard($boardId);
+		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
+
+		$config = $this->mapper->findByBoard($boardId);
+
+		$client = $this->clientFactory->create();
+		try {
+			$this->openMailbox($client, $config);
+			return ['ok' => true, 'error' => null];
+		} catch (ImapException $e) {
+			return ['ok' => false, 'error' => $this->clampError($e->getMessage())];
+		} finally {
+			$client->disconnect();
+		}
+	}
+
+	// ---- polling (cron) ----------------------------------------------------
+
+	/**
+	 * Polls every enabled mailbox. The cron entry point.
+	 *
+	 * One mailbox's failure is recorded and stepped over: a shared cron job that
+	 * dies on the first unreachable server would let one board's expired password
+	 * silently stop intake for every other board.
+	 *
+	 * @return int how many cards were created across all mailboxes
+	 */
+	public function pollAll(): int {
+		$created = 0;
+		foreach ($this->mapper->findEnabled() as $config) {
+			try {
+				$created += $this->poll($config);
+			} catch (\Throwable $e) {
+				// Already recorded on the row by poll(); this is the operator-facing
+				// copy. The message can carry a server hostname but never a
+				// credential - login failures are rewritten in ImapClient.
+				$this->logger->warning('Kanso mail intake failed for board ' . $config->getBoardId(), [
+					'exception' => $e,
+					'app' => 'kanso',
+				]);
+			}
+		}
+		return $created;
+	}
+
+	/**
+	 * Polls one mailbox: fetch everything above the watermark, card it, advance
+	 * the watermark.
+	 *
+	 * The watermark advances per message, immediately after that message's card
+	 * is created, and is persisted even when the run ends in an error. A crash
+	 * halfway through therefore re-fetches at most the one message it was
+	 * working on, rather than replaying the whole batch as duplicate cards.
+	 *
+	 * @return int cards created
+	 */
+	public function poll(MailIntake $config): int {
+		$client = $this->clientFactory->create();
+		$created = 0;
+
+		try {
+			// Board and stack are checked BEFORE the socket opens: a board in the
+			// trash, or a config pointing at a deleted stack, has nowhere to put a
+			// card, and connecting first would hand a credential to a remote server
+			// on every tick to accomplish nothing. Neither advances the watermark,
+			// so the mail is still waiting when the board or stack comes back.
+			$board = $this->loadBoard($config->getBoardId());
+			$stack = $this->findAliveStack($config->getBoardId(), $config->getStackId());
+			if ($stack === null) {
+				throw new ImapException('The stack email intake was pointing at no longer exists');
+			}
+
+			$status = $this->openMailbox($client, $config);
+
+			// UIDs are only comparable within one UIDVALIDITY generation. When the
+			// server renumbers (a restored or recreated mailbox), the old watermark
+			// addresses different messages entirely - start from 0 and treat the
+			// mailbox as new rather than skipping everything below a meaningless
+			// number.
+			if ($status['uidValidity'] !== $config->getUidValidity()) {
+				$config->setUidValidity($status['uidValidity']);
+				$config->setLastUid(0);
+			}
+
+			$uids = $client->searchUidsAbove($config->getLastUid());
+			$allowed = $config->allowedSenders();
+
+			foreach (array_slice($uids, 0, self::MAX_MESSAGES_PER_RUN) as $uid) {
+				$raw = $client->fetchMessage($uid);
+				// '' means the message vanished between SEARCH and FETCH, or was
+				// over the size ceiling. Either way it is skipped, and the watermark
+				// still moves past it so it is not retried forever.
+				if ($raw !== '') {
+					$message = $this->mimeParser->parse($raw);
+					if ($this->senderAllowed($message->fromAddress, $allowed)) {
+						if ($this->createCard($board, $stack, $message)) {
+							$created++;
+						}
+					}
+				}
+
+				$config->setLastUid($uid);
+			}
+
+			$config->setLastError(null);
+			return $created;
+		} catch (\Throwable $e) {
+			$config->setLastError($this->clampError($e->getMessage()));
+			throw $e;
+		} finally {
+			$client->disconnect();
+			// Always persisted, on both paths: the watermark advanced by the loop
+			// above is what stops a failed run from re-carding what it already
+			// carded, so it must survive the exception that interrupted it.
+			$config->setLastRun($this->time->getTime());
+			try {
+				$this->mapper->update($config);
+			} catch (\Throwable $persistError) {
+				$this->logger->error('Kanso mail intake could not save its position for board ' . $config->getBoardId(), [
+					'exception' => $persistError,
+					'app' => 'kanso',
+				]);
+			}
+		}
+	}
+
+	// ---- helpers -----------------------------------------------------------
+
+	/**
+	 * @return array{uidValidity: int, uidNext: int}
+	 * @throws ImapException
+	 */
+	private function openMailbox(ImapClient $client, MailIntake $config): array {
+		try {
+			$password = $this->crypto->decrypt($config->getPassword());
+		} catch (\Throwable) {
+			// Typically a changed server secret, which makes every stored
+			// credential undecryptable. Say what to do about it.
+			throw new ImapException('The stored mail password could not be decrypted - re-enter it');
+		}
+
+		$client->connect($config->getHost(), $config->getPort(), $config->getEncryption());
+		$client->login($config->getUsername(), $password);
+		return $client->selectMailbox($config->getMailbox());
+	}
+
+	/**
+	 * An empty allowlist accepts anything - the "public intake address" case.
+	 * Otherwise the sender must match exactly, or match a `@domain.example`
+	 * entry, which is how people actually want to express "anyone at my company".
+	 *
+	 * @param string[] $allowed already lowercased by {@see MailIntake::allowedSenders}
+	 */
+	private function senderAllowed(string $fromAddress, array $allowed): bool {
+		if ($allowed === []) {
+			return true;
+		}
+		if ($fromAddress === '') {
+			// A message whose From we could not parse cannot satisfy a non-empty
+			// allowlist. Fail closed.
+			return false;
+		}
+		foreach ($allowed as $entry) {
+			if ($entry === $fromAddress) {
+				return true;
+			}
+			if (str_starts_with($entry, '@') && str_ends_with($fromAddress, $entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Creates the card. Returns false when the create was rejected, which is
+	 * logged and skipped rather than aborting the batch.
+	 */
+	private function createCard(Board $board, Stack $stack, MimeMessage $message): bool {
+		$title = $message->subject;
+		if (mb_strlen($title) > CardService::MAX_TITLE_LENGTH) {
+			$title = trim(mb_substr($title, 0, CardService::MAX_TITLE_LENGTH));
+		}
+		// AFTER truncation, so a title of nothing but spaces cannot reach create()
+		// empty and throw.
+		if ($title === '') {
+			$title = 'Email from ' . ($message->fromLabel() !== '' ? $message->fromLabel() : 'unknown sender');
+			$title = trim(mb_substr($title, 0, CardService::MAX_TITLE_LENGTH));
+		}
+
+		try {
+			// As the board OWNER, exactly like forge issue intake - never as the
+			// user whose address the (forgeable) From header claims.
+			$card = $this->cardService->create($stack->getId(), $title, $board->getOwner());
+		} catch (\Throwable $e) {
+			$this->logger->warning('Kanso mail intake could not create a card on board ' . $board->getId(), [
+				'exception' => $e,
+				'app' => 'kanso',
+			]);
+			return false;
+		}
+
+		$description = $this->buildDescription($message);
+		if ($description !== '') {
+			try {
+				$this->cardService->update(
+					$card->getId(),
+					null,
+					$description,
+					null,
+					null,
+					null,
+					$board->getOwner(),
+				);
+			} catch (\Throwable $e) {
+				// The card exists with its subject as the title; losing the body is
+				// bad but recoverable, and failing here would re-card the message on
+				// the next run.
+				$this->logger->warning('Kanso mail intake could not save a card description on board ' . $board->getId(), [
+					'exception' => $e,
+					'app' => 'kanso',
+				]);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * The card body: who the message claimed to be from, the text, and the names
+	 * of anything attached.
+	 *
+	 * The sender line is plain text, not a mention or a link, because `From:` is
+	 * unverified - see the class docblock.
+	 */
+	private function buildDescription(MimeMessage $message): string {
+		$parts = [];
+
+		$from = $message->fromLabel();
+		if ($from !== '') {
+			$parts[] = 'From: ' . $from;
+		}
+		if ($message->body !== '') {
+			$parts[] = $message->body;
+		}
+		if ($message->attachmentNames !== []) {
+			// Named, not stored - intake creates no card attachments yet, and a
+			// silently dropped file is worse than a listed one.
+			$parts[] = 'Attachments (not imported): ' . implode(', ', $message->attachmentNames);
+		}
+
+		$description = implode("\n\n", $parts);
+		if (mb_strlen($description) > CardService::MAX_DESCRIPTION_LENGTH) {
+			$description = mb_substr($description, 0, CardService::MAX_DESCRIPTION_LENGTH);
+		}
+		return $description;
+	}
+
+	private function clampError(string $message): string {
+		$message = trim(preg_replace('/\s+/', ' ', $message) ?? $message);
+		return mb_substr($message, 0, self::MAX_ERROR_LENGTH);
+	}
+
+	/**
+	 * @throws DoesNotExistException if the board does not exist or is deleted
+	 */
+	private function loadBoard(int $boardId): Board {
+		$board = $this->boardMapper->find($boardId);
+		if ($board->getDeletedAt() > 0) {
+			throw new DoesNotExistException('Board ' . $boardId . ' is deleted');
+		}
+		return $board;
+	}
+
+	private function findAliveStack(int $boardId, int $stackId): ?Stack {
+		try {
+			$stack = $this->stackMapper->find($stackId);
+		} catch (\Throwable) {
+			return null;
+		}
+		if ($stack->getBoardId() !== $boardId || $stack->getDeletedAt() > 0) {
+			return null;
+		}
+		return $stack;
+	}
+}

--- a/lib/Service/MailIntakeService.php
+++ b/lib/Service/MailIntakeService.php
@@ -11,6 +11,7 @@ use OCA\Kanso\Db\Board;
 use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\MailIntake;
 use OCA\Kanso\Db\MailIntakeMapper;
+use OCA\Kanso\Db\MailSeenMessageMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCA\Kanso\Service\Mail\ImapClient;
@@ -29,35 +30,43 @@ use Psr\Log\LoggerInterface;
  *
  * Shape follows the forge-webhook config it sits beside - MANAGE-gated config,
  * an intake stack, cards created as the board OWNER through {@see CardService}
- * so sort keys, change rows and realtime all fire. What differs is the
- * direction: a webhook is pushed to us and authenticated by HMAC, whereas a
- * mailbox is PULLED by cron and authenticated by a stored credential, which
- * drags in three problems a webhook does not have.
+ * so sort keys, change rows and realtime all fire. What differs is the trust
+ * level, and it differs completely: this is the ONLY path in the app where an
+ * unauthenticated stranger causes a write, and their text lands in a card body
+ * that colleagues read. Everything unusual in this class follows from that.
  *
- * 1. The credential is at rest. It is stored {@see ICrypto}-encrypted (the same
- *    server-secret-derived cipher NC uses for external storage passwords) and
- *    never leaves this class in the clear - not in the config payload, not in
- *    `lastError`, not in the log.
+ * ## What the sender is not
  *
- * 2. `From:` is not authentication. Anyone can send mail claiming to be anyone,
- *    so the sender allowlist is a FILTER, not an identity, and the card is
- *    never attributed to the NC user whose address matches. Attributing it
- *    would turn a forged header into a way to create cards as someone else -
- *    the card records the claimed sender as TEXT in its description instead,
- *    where it reads as what it is: something the message said about itself.
- *    A mailbox with an empty allowlist accepts anyone who knows the address,
- *    which is the feature working as asked (a public intake address) and is
- *    called out in the config UI.
+ * `From:` is not authentication. SMTP lets anyone claim any address, and the
+ * envelope is long gone by the time a message sits in IMAP. So:
  *
- * 3. A poll can fail forever. Every failure is caught per mailbox, recorded in
- *    `lastError` for the config UI, and never allowed to escape into the cron
- *    worker - one board's expired password must not stop every other board's
- *    intake.
+ * - The card is created as the board owner and NEVER attributed to the NC user
+ *   whose address the header claims - that would turn a forged header into a
+ *   way to act as someone else. The claimed sender is recorded as plain text.
+ * - `$notifyMentions: false` on the description write. A description normally
+ *   re-parses `@name` and sends real notifications; leaving that on would let
+ *   anyone who knows the address ping arbitrary members with the owner's name
+ *   attached.
+ * - The allowlist is a FILTER, not an identity check, and is documented as
+ *   such. `requireAuth` is what actually authenticates: it demands the
+ *   receiving MTA's DMARC pass ({@see \OCA\Kanso\Service\Mail\AuthenticationResults}).
  *
- * Not in scope here: attachments are NAMED in the card body, not stored as card
- * attachments, and a reply to an intake card is a new card rather than a
- * comment. Both are follow-on work, and both are stated in the UI rather than
- * left to be discovered.
+ * ## Why a message gets skipped
+ *
+ * Automated mail, spam-flagged mail, disallowed senders, unauthenticated
+ * senders and already-seen messages are all skipped, and the watermark still
+ * advances past them - a skipped message that stayed unread would be
+ * re-examined on every poll forever.
+ *
+ * The ONE exception is the whole-mailbox daily cap: hitting it stops the run
+ * WITHOUT advancing, so the excess waits on the server instead of being
+ * silently destroyed. A per-sender cap does the opposite and skips-with-advance
+ * on purpose - otherwise one abusive sender wedges the mailbox for everyone.
+ *
+ * ## Not in scope
+ *
+ * Attachments are named in the card body, not stored; a reply is a new card,
+ * not a comment. Both are deliberate - see docs/email-intake-security.md.
  */
 class MailIntakeService {
 	/** The encryption modes offered. Cleartext IMAP is deliberately absent. */
@@ -70,11 +79,28 @@ class MailIntakeService {
 	 */
 	private const MAX_MESSAGES_PER_RUN = 50;
 
+	/** Default whole-mailbox daily cap, overridable per mailbox. */
+	public const DEFAULT_DAILY_LIMIT = 200;
+
+	/** Default per-sender daily cap, overridable per mailbox. */
+	public const DEFAULT_PER_SENDER_DAILY_LIMIT = 50;
+
+	/**
+	 * Wall-clock budget for one cron tick across ALL mailboxes. Each mailbox can
+	 * burn a 30 s connect timeout, so without this a dozen unreachable servers
+	 * turn a 5-minute job into a 6-minute one and cron starts overlapping.
+	 */
+	private const MAX_RUN_SECONDS = 120;
+
 	/** Keeps a runaway server's error text out of the database and the UI. */
 	private const MAX_ERROR_LENGTH = 500;
 
+	/** Roughly daily, given the 5-minute poll interval. */
+	private const PRUNE_PROBABILITY = 288;
+
 	public function __construct(
 		private MailIntakeMapper $mapper,
+		private MailSeenMessageMapper $seenMapper,
 		private BoardMapper $boardMapper,
 		private StackMapper $stackMapper,
 		private CardService $cardService,
@@ -130,6 +156,9 @@ class MailIntakeService {
 		string $senderAllowlist,
 		bool $enabled,
 		string $actorUid,
+		bool $requireAuth = false,
+		int $dailyLimit = 0,
+		int $perSenderDailyLimit = 0,
 	): MailIntake {
 		$board = $this->loadBoard($boardId);
 		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
@@ -164,6 +193,9 @@ class MailIntakeService {
 		}
 		if (mb_strlen($senderAllowlist) > 4000) {
 			throw new InvalidInputException('Sender allowlist is too long');
+		}
+		if ($dailyLimit < 0 || $dailyLimit > 100000 || $perSenderDailyLimit < 0 || $perSenderDailyLimit > 100000) {
+			throw new InvalidInputException('Daily limits must be between 0 and 100000');
 		}
 		if ($this->findAliveStack($boardId, $stackId) === null) {
 			throw new InvalidInputException('Stack does not belong to this board');
@@ -206,6 +238,9 @@ class MailIntakeService {
 		$entity->setMailbox($mailbox);
 		$entity->setSenderAllowlist(trim($senderAllowlist) === '' ? null : $senderAllowlist);
 		$entity->setEnabled($enabled);
+		$entity->setRequireAuth($requireAuth);
+		$entity->setDailyLimit($dailyLimit);
+		$entity->setPerSenderDailyLimit($perSenderDailyLimit);
 		if ($identityChanged) {
 			$entity->setLastUid(0);
 			$entity->setUidValidity(0);
@@ -215,15 +250,20 @@ class MailIntakeService {
 			$entity->setLastUid(0);
 			$entity->setUidValidity(0);
 			$entity->setLastRun(0);
+			$entity->setDailyState(null);
 			$entity->setCreatedAt($this->time->getTime());
 			// A config that has never been polled has no error to report, and a
 			// stale one from a previous setup would be misleading.
 			$entity->setLastError(null);
-			return $this->mapper->insert($entity);
+			$saved = $this->mapper->insert($entity);
+			$this->audit('created', $boardId, $actorUid, $host, $username, $mailbox, $enabled);
+			return $saved;
 		}
 
 		$entity->setLastError(null);
-		return $this->mapper->update($entity);
+		$saved = $this->mapper->update($entity);
+		$this->audit('updated', $boardId, $actorUid, $host, $username, $mailbox, $enabled);
+		return $saved;
 	}
 
 	/**
@@ -236,7 +276,18 @@ class MailIntakeService {
 	public function deleteConfig(int $boardId, string $actorUid): void {
 		$board = $this->loadBoard($boardId);
 		$this->permissionService->assertPermission($board, $actorUid, PermissionService::PERMISSION_MANAGE);
+
+		try {
+			$existing = $this->mapper->findByBoard($boardId);
+			// The dedupe keys belong to this mailbox; they must not outlive it, or
+			// a later mailbox reusing the row id would inherit them.
+			$this->seenMapper->deleteByIntake($existing->getId());
+		} catch (DoesNotExistException) {
+			// Nothing configured - the delete below is still a safe no-op.
+		}
+
 		$this->mapper->deleteByBoard($boardId);
+		$this->audit('deleted', $boardId, $actorUid, '', '', '', false);
 	}
 
 	/**
@@ -262,7 +313,7 @@ class MailIntakeService {
 			$this->openMailbox($client, $config);
 			return ['ok' => true, 'error' => null];
 		} catch (ImapException $e) {
-			return ['ok' => false, 'error' => $this->clampError($e->getMessage())];
+			return ['ok' => false, 'error' => $this->clampError($e->getMessage(), $config)];
 		} finally {
 			$client->disconnect();
 		}
@@ -281,7 +332,18 @@ class MailIntakeService {
 	 */
 	public function pollAll(): int {
 		$created = 0;
+		$deadline = $this->time->getTime() + self::MAX_RUN_SECONDS;
+		$skippedForTime = 0;
+
 		foreach ($this->mapper->findEnabled() as $config) {
+			// Whole-run budget. Mailboxes are ordered by id, so the ones deferred
+			// here are picked up by the next tick rather than starved - and the
+			// count is logged, because a silent partial run reads as a complete one.
+			if ($this->time->getTime() >= $deadline) {
+				$skippedForTime++;
+				continue;
+			}
+
 			try {
 				$created += $this->poll($config);
 			} catch (\Throwable $e) {
@@ -294,23 +356,34 @@ class MailIntakeService {
 				]);
 			}
 		}
+
+		if ($skippedForTime > 0) {
+			$this->logger->info(
+				'Kanso mail intake ran out of time; ' . $skippedForTime . ' mailbox(es) deferred to the next run',
+				['app' => 'kanso'],
+			);
+		}
+
+		$this->pruneSeenOccasionally();
+
 		return $created;
 	}
 
 	/**
-	 * Polls one mailbox: fetch everything above the watermark, card it, advance
-	 * the watermark.
+	 * Polls one mailbox: fetch everything above the watermark, apply the intake
+	 * policy, card what survives, advance the watermark.
 	 *
-	 * The watermark advances per message, immediately after that message's card
-	 * is created, and is persisted even when the run ends in an error. A crash
+	 * The watermark advances per message, immediately after that message is
+	 * handled, and is persisted even when the run ends in an error. A crash
 	 * halfway through therefore re-fetches at most the one message it was
-	 * working on, rather than replaying the whole batch as duplicate cards.
+	 * working on, rather than replaying the batch as duplicate cards.
 	 *
 	 * @return int cards created
 	 */
 	public function poll(MailIntake $config): int {
 		$client = $this->clientFactory->create();
 		$created = 0;
+		$skipped = [];
 
 		try {
 			// Board and stack are checked BEFORE the socket opens: a board in the
@@ -325,41 +398,52 @@ class MailIntakeService {
 			}
 
 			$status = $this->openMailbox($client, $config);
+			$this->applyUidValidity($config, $status);
 
-			// UIDs are only comparable within one UIDVALIDITY generation. When the
-			// server renumbers (a restored or recreated mailbox), the old watermark
-			// addresses different messages entirely - start from 0 and treat the
-			// mailbox as new rather than skipping everything below a meaningless
-			// number.
-			if ($status['uidValidity'] !== $config->getUidValidity()) {
-				$config->setUidValidity($status['uidValidity']);
-				$config->setLastUid(0);
-			}
+			$day = (int)gmdate('Ymd', $this->time->getTime());
+			$dailyLimit = $config->getDailyLimit() > 0 ? $config->getDailyLimit() : self::DEFAULT_DAILY_LIMIT;
+			$perSenderLimit = $config->getPerSenderDailyLimit() > 0
+				? $config->getPerSenderDailyLimit()
+				: self::DEFAULT_PER_SENDER_DAILY_LIMIT;
 
 			$uids = $client->searchUidsAbove($config->getLastUid());
 			$allowed = $config->allowedSenders();
 
 			foreach (array_slice($uids, 0, self::MAX_MESSAGES_PER_RUN) as $uid) {
+				// The whole-mailbox cap STOPS the run without advancing, so the
+				// excess waits on the server. Every other skip advances past the
+				// message - see the class docblock.
+				if ($config->cardedToday($day) >= $dailyLimit) {
+					$skipped['daily_limit'] = ($skipped['daily_limit'] ?? 0) + 1;
+					break;
+				}
+
 				$raw = $client->fetchMessage($uid);
 				// '' means the message vanished between SEARCH and FETCH, or was
 				// over the size ceiling. Either way it is skipped, and the watermark
 				// still moves past it so it is not retried forever.
 				if ($raw !== '') {
 					$message = $this->mimeParser->parse($raw);
-					if ($this->senderAllowed($message->fromAddress, $allowed)) {
-						if ($this->createCard($board, $stack, $message)) {
-							$created++;
-						}
+					$reason = $this->rejectionReason($message, $config, $allowed, $perSenderLimit, $day);
+
+					if ($reason !== null) {
+						$skipped[$reason] = ($skipped[$reason] ?? 0) + 1;
+					} elseif (!$this->seenMapper->claim($config->getId(), $message->dedupeKey())) {
+						// Already carded - a re-delivery, or a watermark rewind.
+						$skipped['duplicate'] = ($skipped['duplicate'] ?? 0) + 1;
+					} elseif ($this->createCard($board, $stack, $message)) {
+						$config->recordCarded($message->fromAddress, $day);
+						$created++;
 					}
 				}
 
 				$config->setLastUid($uid);
 			}
 
-			$config->setLastError(null);
+			$config->setLastError($this->skipSummary($skipped));
 			return $created;
 		} catch (\Throwable $e) {
-			$config->setLastError($this->clampError($e->getMessage()));
+			$config->setLastError($this->clampError($e->getMessage(), $config));
 			throw $e;
 		} finally {
 			$client->disconnect();
@@ -378,24 +462,82 @@ class MailIntakeService {
 		}
 	}
 
-	// ---- helpers -----------------------------------------------------------
+	// ---- policy ------------------------------------------------------------
 
 	/**
-	 * @return array{uidValidity: int, uidNext: int}
-	 * @throws ImapException
+	 * Why this message must not become a card, or null to card it.
+	 *
+	 * @param string[] $allowed
 	 */
-	private function openMailbox(ImapClient $client, MailIntake $config): array {
-		try {
-			$password = $this->crypto->decrypt($config->getPassword());
-		} catch (\Throwable) {
-			// Typically a changed server secret, which makes every stored
-			// credential undecryptable. Say what to do about it.
-			throw new ImapException('The stored mail password could not be decrypted - re-enter it');
+	private function rejectionReason(
+		MimeMessage $message,
+		MailIntake $config,
+		array $allowed,
+		int $perSenderLimit,
+		int $day,
+	): ?string {
+		// Loop breaker, checked FIRST and regardless of the allowlist: a bounce
+		// from an allowed sender is still a bounce, and the notification->
+		// autoreply->card cycle is the failure that runs away fastest.
+		if ($message->isAutomated) {
+			return 'automated';
+		}
+		if ($message->isSpam) {
+			return 'spam';
+		}
+		if (!$this->senderAllowed($message->fromAddress, $allowed)) {
+			return 'sender_not_allowed';
+		}
+		// The only check that actually authenticates the sender; the allowlist
+		// above merely filters a forgeable header.
+		if ($config->getRequireAuth() && !$message->isAuthenticated()) {
+			return 'not_authenticated';
+		}
+		// Per-sender cap skips just this message: making one sender's flood stop
+		// the mailbox would hand them a denial of service against the board.
+		if ($message->fromAddress !== '' && $config->cardedTodayBy($message->fromAddress, $day) >= $perSenderLimit) {
+			return 'sender_daily_limit';
+		}
+		return null;
+	}
+
+	/**
+	 * How the intake position responds to the server's UIDVALIDITY.
+	 *
+	 * A mailbox that has never been polled starts at 0 and ingests what is
+	 * already sitting there - that is what someone setting up a dedicated
+	 * address expects.
+	 *
+	 * A mailbox whose UIDVALIDITY CHANGED was renumbered by the server (restored
+	 * from backup, recreated). The old watermark now addresses different
+	 * messages, and restarting at 0 would re-card the entire history. So intake
+	 * jumps to the server's UIDNEXT: "card what arrives from now on". The dedupe
+	 * table is the safety net either way.
+	 *
+	 * @param array{uidValidity: int, uidNext: int} $status
+	 */
+	private function applyUidValidity(MailIntake $config, array $status): void {
+		if ($status['uidValidity'] === $config->getUidValidity()) {
+			return;
 		}
 
-		$client->connect($config->getHost(), $config->getPort(), $config->getEncryption());
-		$client->login($config->getUsername(), $password);
-		return $client->selectMailbox($config->getMailbox());
+		$firstEverPoll = $config->getUidValidity() === 0;
+		$config->setUidValidity($status['uidValidity']);
+
+		if ($firstEverPoll) {
+			$config->setLastUid(0);
+			return;
+		}
+
+		// UIDNEXT is the id the NEXT message will get, so one less is "everything
+		// currently in the mailbox". A server that did not report it leaves us
+		// with 0, which is the safe-but-noisy fallback of reading from the start.
+		$config->setLastUid(max(0, $status['uidNext'] - 1));
+		$this->logger->info(
+			'Kanso mail intake: mailbox for board ' . $config->getBoardId()
+			. ' was renumbered (UIDVALIDITY changed); resuming from new mail only',
+			['app' => 'kanso'],
+		);
 	}
 
 	/**
@@ -424,6 +566,8 @@ class MailIntakeService {
 		}
 		return false;
 	}
+
+	// ---- card creation -----------------------------------------------------
 
 	/**
 	 * Creates the card. Returns false when the create was rejected, which is
@@ -464,6 +608,12 @@ class MailIntakeService {
 					null,
 					null,
 					$board->getOwner(),
+					// Positional run-up to the one argument that matters here.
+					null, null, null, null, null, null, null, null, null, null, null,
+					// The whole reason this call is spelled out: the body is a
+					// stranger's text being written as the board owner, so it must not
+					// be allowed to fire @mention notifications in the owner's name.
+					notifyMentions: false,
 				);
 			} catch (\Throwable $e) {
 				// The card exists with its subject as the title; losing the body is
@@ -480,19 +630,26 @@ class MailIntakeService {
 	}
 
 	/**
-	 * The card body: who the message claimed to be from, the text, and the names
-	 * of anything attached.
+	 * The card body: where it came from, whether that origin was verified, the
+	 * text, and the names of anything attached.
 	 *
-	 * The sender line is plain text, not a mention or a link, because `From:` is
-	 * unverified - see the class docblock.
+	 * The provenance line is not decoration. A reader seeing a card with a
+	 * plausible sender and a link in it has no other way to know the content
+	 * arrived from outside and that nobody proved who sent it - and `linkify`
+	 * will have made that link clickable.
 	 */
 	private function buildDescription(MimeMessage $message): string {
 		$parts = [];
 
 		$from = $message->fromLabel();
-		if ($from !== '') {
-			$parts[] = 'From: ' . $from;
-		}
+		$provenance = $from !== ''
+			? 'Received by email from ' . $from
+			: 'Received by email from an unknown sender';
+		$provenance .= $message->isAuthenticated()
+			? ' (sender domain verified)'
+			: ' (unverified sender - anyone can put any address here)';
+		$parts[] = $provenance;
+
 		if ($message->body !== '') {
 			$parts[] = $message->body;
 		}
@@ -509,9 +666,127 @@ class MailIntakeService {
 		return $description;
 	}
 
-	private function clampError(string $message): string {
+	// ---- helpers -----------------------------------------------------------
+
+	/**
+	 * @return array{uidValidity: int, uidNext: int}
+	 * @throws ImapException
+	 */
+	private function openMailbox(ImapClient $client, MailIntake $config): array {
+		try {
+			$password = $this->crypto->decrypt($config->getPassword());
+		} catch (\Throwable) {
+			// Typically a changed server secret, which makes every stored
+			// credential undecryptable. Say what to do about it.
+			throw new ImapException('The stored mail password could not be decrypted - re-enter it');
+		}
+
+		$client->connect($config->getHost(), $config->getPort(), $config->getEncryption());
+		$client->login($config->getUsername(), $password);
+		return $client->selectMailbox($config->getMailbox());
+	}
+
+	/**
+	 * A human-readable note about what a healthy run declined to card, or null
+	 * when it carded everything. Written to `lastError` so a mailbox that is
+	 * silently rejecting mail is diagnosable from the config screen - the
+	 * commonest support question this feature can generate is "I sent an email
+	 * and nothing happened".
+	 *
+	 * @param array<string, int> $skipped
+	 */
+	private function skipSummary(array $skipped): ?string {
+		if ($skipped === []) {
+			return null;
+		}
+
+		$labels = [
+			'automated' => 'automated/bounce messages',
+			'spam' => 'messages flagged as spam',
+			'sender_not_allowed' => 'messages from senders not on the allowlist',
+			'not_authenticated' => 'messages that failed sender authentication',
+			'sender_daily_limit' => 'messages over a sender\'s daily limit',
+			'daily_limit' => 'messages held back by the mailbox daily limit',
+			'duplicate' => 'messages already turned into cards',
+		];
+
+		$parts = [];
+		foreach ($skipped as $reason => $count) {
+			$parts[] = $count . ' ' . ($labels[$reason] ?? $reason);
+		}
+
+		return $this->truncate('Last run skipped ' . implode(', ', $parts) . '.');
+	}
+
+	/**
+	 * Clamps an error for storage, and removes the configured username from it -
+	 * some servers echo the account name back in their error text, and
+	 * `lastError` is shown in the UI and kept in the database.
+	 */
+	private function clampError(string $message, ?MailIntake $config = null): string {
 		$message = trim(preg_replace('/\s+/', ' ', $message) ?? $message);
+
+		$username = $config?->getUsername() ?? '';
+		if ($username !== '' && mb_strlen($username) > 2) {
+			$message = str_ireplace($username, '<account>', $message);
+		}
+
+		return $this->truncate($message);
+	}
+
+	private function truncate(string $message): string {
 		return mb_substr($message, 0, self::MAX_ERROR_LENGTH);
+	}
+
+	/**
+	 * Records a config change. Changing which mailbox feeds a board - or who it
+	 * accepts mail from - is a security-relevant act, and it previously left no
+	 * trace at all.
+	 */
+	private function audit(
+		string $action,
+		int $boardId,
+		string $actorUid,
+		string $host,
+		string $username,
+		string $mailbox,
+		bool $enabled,
+	): void {
+		$this->logger->info('Kanso mail intake config ' . $action, [
+			'app' => 'kanso',
+			'action' => $action,
+			'boardId' => $boardId,
+			'actor' => $actorUid,
+			'host' => $host,
+			// The account name, never the credential.
+			'username' => $username,
+			'mailbox' => $mailbox,
+			'enabled' => $enabled,
+		]);
+	}
+
+	/**
+	 * Prunes expired dedupe keys on roughly one run a day. Sampling rather than
+	 * a second cron job: the work is tiny and its exact timing does not matter,
+	 * and a dedicated job would be more moving parts than the task deserves.
+	 */
+	private function pruneSeenOccasionally(): void {
+		try {
+			if (random_int(1, self::PRUNE_PROBABILITY) !== 1) {
+				return;
+			}
+			$cutoff = $this->time->getTime() - MailSeenMessageMapper::RETENTION_SECONDS;
+			$removed = $this->seenMapper->pruneOlderThan($cutoff);
+			if ($removed > 0) {
+				$this->logger->debug('Kanso mail intake pruned ' . $removed . ' dedupe keys', ['app' => 'kanso']);
+			}
+		} catch (\Throwable $e) {
+			// Housekeeping must never break a poll.
+			$this->logger->warning('Kanso mail intake could not prune dedupe keys', [
+				'exception' => $e,
+				'app' => 'kanso',
+			]);
+		}
 	}
 
 	/**

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -1460,6 +1460,167 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					</div>
 				</div>
 
+				<!-- Email intake group (#117): poll an IMAP mailbox into a column -->
+				<div class="automation__group">
+					<button
+						class="automation__group-header"
+						type="button"
+						:aria-expanded="automationGroups.mailIntake ? 'true' : 'false'"
+						aria-controls="bs-automation-mail-intake"
+						@click="toggleAutomationGroup('mailIntake')">
+						<EmailIcon :size="16" class="automation__group-icon" />
+						<span class="automation__group-title">{{ t('kanso', 'Email intake') }}</span>
+						<span v-if="mailIntake.enabled" class="automation__group-badge">{{ t('kanso', 'Active') }}</span>
+						<ChevronUpIcon v-if="automationGroups.mailIntake" :size="16" class="automation__group-chevron" />
+						<ChevronDownIcon v-else :size="16" class="automation__group-chevron" />
+					</button>
+					<div v-show="automationGroups.mailIntake" id="bs-automation-mail-intake" class="automation__group-body">
+						<p v-if="!canManage" class="workflow__readonly-notice">
+							{{ t('kanso', 'You need manage permission to configure email intake.') }}
+						</p>
+						<template v-else>
+							<p class="github-webhook__hint">
+								{{ t('kanso', 'Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board.') }}
+							</p>
+							<p class="github-webhook__hint github-webhook__hint--warning">
+								{{ t('kanso', 'Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on "Require verified senders" if your mail server checks DMARC.') }}
+							</p>
+
+							<label class="github-webhook__label" for="bs-mail-host">{{ t('kanso', 'IMAP server') }}</label>
+							<div class="github-webhook__row">
+								<input
+									id="bs-mail-host"
+									v-model="mailIntakeForm.host"
+									class="github-webhook__input"
+									type="text"
+									placeholder="imap.example.com"
+									:disabled="mailIntakeBusy">
+								<input
+									v-model.number="mailIntakeForm.port"
+									class="github-webhook__input github-webhook__input--narrow"
+									type="number"
+									min="1"
+									max="65535"
+									:aria-label="t('kanso', 'Port')"
+									:disabled="mailIntakeBusy">
+								<select
+									v-model="mailIntakeForm.encryption"
+									class="workflow__select"
+									:aria-label="t('kanso', 'Encryption')"
+									:disabled="mailIntakeBusy"
+									@change="onMailEncryptionChange">
+									<option value="ssl">{{ t('kanso', 'SSL/TLS (993)') }}</option>
+									<option value="tls">{{ t('kanso', 'STARTTLS (143)') }}</option>
+								</select>
+							</div>
+
+							<label class="github-webhook__label" for="bs-mail-username">{{ t('kanso', 'Mailbox account') }}</label>
+							<div class="github-webhook__row">
+								<input
+									id="bs-mail-username"
+									v-model="mailIntakeForm.username"
+									class="github-webhook__input"
+									type="text"
+									autocomplete="off"
+									placeholder="cards@example.com"
+									:disabled="mailIntakeBusy">
+								<input
+									v-model="mailIntakeForm.password"
+									class="github-webhook__input"
+									type="password"
+									autocomplete="new-password"
+									:placeholder="mailIntake.hasPassword ? t('kanso', 'Password stored — leave blank to keep it') : t('kanso', 'Password')"
+									:disabled="mailIntakeBusy">
+							</div>
+
+							<label class="github-webhook__label" for="bs-mail-folder">{{ t('kanso', 'Folder and target column') }}</label>
+							<div class="github-webhook__row">
+								<input
+									id="bs-mail-folder"
+									v-model="mailIntakeForm.mailbox"
+									class="github-webhook__input"
+									type="text"
+									placeholder="INBOX"
+									:disabled="mailIntakeBusy">
+								<select
+									v-model="mailIntakeForm.stackId"
+									class="workflow__select"
+									:aria-label="t('kanso', 'Column new cards land in')"
+									:disabled="mailIntakeBusy">
+									<option value="">{{ t('kanso', 'Choose a column…') }}</option>
+									<option v-for="s in stacks" :key="s.id" :value="String(s.id)">{{ s.title }}</option>
+								</select>
+							</div>
+
+							<label class="github-webhook__label" for="bs-mail-allowlist">{{ t('kanso', 'Accept mail from (one address or @domain per line — leave empty to accept anyone)') }}</label>
+							<textarea
+								id="bs-mail-allowlist"
+								v-model="mailIntakeForm.senderAllowlist"
+								class="github-webhook__input github-webhook__textarea"
+								rows="3"
+								placeholder="jacek@example.com&#10;@example.com"
+								:disabled="mailIntakeBusy" />
+
+							<div class="github-webhook__row github-webhook__row--wrap">
+								<NcCheckboxRadioSwitch
+									:model-value="mailIntakeForm.requireAuth"
+									:disabled="mailIntakeBusy"
+									@update:model-value="mailIntakeForm.requireAuth = $event">
+									{{ t('kanso', 'Require verified senders (DMARC)') }}
+								</NcCheckboxRadioSwitch>
+								<NcCheckboxRadioSwitch
+									:model-value="mailIntakeForm.enabled"
+									:disabled="mailIntakeBusy"
+									@update:model-value="mailIntakeForm.enabled = $event">
+									{{ t('kanso', 'Check this mailbox automatically') }}
+								</NcCheckboxRadioSwitch>
+							</div>
+
+							<label class="github-webhook__label" for="bs-mail-daily-limit">{{ t('kanso', 'Daily card limits (0 uses the default)') }}</label>
+							<div class="github-webhook__row">
+								<input
+									id="bs-mail-daily-limit"
+									v-model.number="mailIntakeForm.dailyLimit"
+									class="github-webhook__input github-webhook__input--narrow"
+									type="number"
+									min="0"
+									:aria-label="t('kanso', 'Cards per day from this mailbox')"
+									:disabled="mailIntakeBusy">
+								<span class="github-webhook__hint">{{ t('kanso', 'per mailbox') }}</span>
+								<input
+									v-model.number="mailIntakeForm.perSenderDailyLimit"
+									class="github-webhook__input github-webhook__input--narrow"
+									type="number"
+									min="0"
+									:aria-label="t('kanso', 'Cards per day from one sender')"
+									:disabled="mailIntakeBusy">
+								<span class="github-webhook__hint">{{ t('kanso', 'per sender') }}</span>
+							</div>
+
+							<div class="github-webhook__actions">
+								<NcButton type="primary" :disabled="mailIntakeBusy || !mailIntakeCanSave" @click="handleSaveMailIntake">
+									{{ t('kanso', 'Save') }}
+								</NcButton>
+								<NcButton :disabled="mailIntakeBusy || !mailIntake.id" @click="handleTestMailIntake">
+									{{ t('kanso', 'Test connection') }}
+								</NcButton>
+								<NcButton v-if="mailIntake.id" :disabled="mailIntakeBusy" @click="handleDeleteMailIntake">
+									{{ t('kanso', 'Remove mailbox') }}
+								</NcButton>
+							</div>
+
+							<p v-if="mailIntakeStatus" class="github-webhook__status">{{ mailIntakeStatus }}</p>
+							<p v-if="mailIntake.lastRun" class="github-webhook__hint">
+								{{ t('kanso', 'Last checked: {when}', { when: formatMailIntakeLastRun }) }}
+							</p>
+							<!-- lastError doubles as the "nothing happened" explainer: it
+							     carries the count of messages a healthy run declined. -->
+							<p v-if="mailIntake.lastError" class="label-settings__error">{{ mailIntake.lastError }}</p>
+							<span v-if="mailIntakeError" class="label-settings__error">{{ mailIntakeError }}</span>
+						</template>
+					</div>
+				</div>
+
 				<!-- Calendar feed group (read-only ICS of card due dates) (#3541) -->
 				<div class="automation__group">
 					<button
@@ -2271,6 +2432,7 @@ import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
+import EmailIcon from 'vue-material-design-icons/Email.vue'
 import ArchiveArrowDownIcon from 'vue-material-design-icons/ArchiveArrowDown.vue'
 import DownloadIcon from 'vue-material-design-icons/Download.vue'
 import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
@@ -2313,6 +2475,10 @@ import { normalizeCardFeatures } from '../services/cardFeatures.js'
 import { getScaleOptions, scaleTokens } from '../services/estimateScales.js'
 import {
 	fetchWebhookConfig,
+	fetchMailIntakeConfig,
+	saveMailIntakeConfig,
+	testMailIntakeConnection,
+	deleteMailIntakeConfig,
 	rotateWebhookSecret as apiRotateWebhookSecret,
 	disableWebhook as apiDisableWebhook,
 	updateWebhookIntake as apiUpdateWebhookIntake,
@@ -2437,6 +2603,157 @@ async function loadWebhookConfig() {
 		}
 	} catch (e) {
 		webhookError.value = t('kanso', 'Failed to load the GitHub webhook config.')
+	}
+}
+
+// ── Email intake (#117) ──────────────────────────────────────────────────────
+// The mailbox password is WRITE-ONLY: the server reports `hasPassword` and never
+// the credential, so the form field starts empty on every load and an empty
+// field means "keep what is stored" rather than "clear it".
+const mailIntake = ref({ id: 0, enabled: false, hasPassword: false, lastRun: 0, lastError: null })
+const mailIntakeForm = ref(emptyMailIntakeForm())
+const mailIntakeBusy = ref(false)
+const mailIntakeError = ref('')
+const mailIntakeStatus = ref('')
+
+function emptyMailIntakeForm() {
+	return {
+		host: '',
+		port: 993,
+		encryption: 'ssl',
+		username: '',
+		password: '',
+		mailbox: 'INBOX',
+		stackId: '',
+		senderAllowlist: '',
+		enabled: false,
+		requireAuth: false,
+		dailyLimit: 0,
+		perSenderDailyLimit: 0,
+	}
+}
+
+const mailIntakeCanSave = computed(() => {
+	const f = mailIntakeForm.value
+	// A first save needs a password; later saves may reuse the stored one.
+	const hasCredential = f.password.trim() !== '' || mailIntake.value.hasPassword
+	return f.host.trim() !== '' && f.username.trim() !== '' && f.stackId !== '' && hasCredential
+})
+
+const formatMailIntakeLastRun = computed(() => {
+	if (!mailIntake.value.lastRun) return ''
+	return new Date(mailIntake.value.lastRun * 1000).toLocaleString()
+})
+
+function syncMailIntakeFromConfig(config) {
+	mailIntake.value = config || { id: 0, enabled: false, hasPassword: false, lastRun: 0, lastError: null }
+	if (!config) {
+		mailIntakeForm.value = emptyMailIntakeForm()
+		return
+	}
+	mailIntakeForm.value = {
+		host: config.host || '',
+		port: config.port || 993,
+		encryption: config.encryption || 'ssl',
+		username: config.username || '',
+		// Never seeded from the server - there is nothing to seed it with.
+		password: '',
+		mailbox: config.mailbox || 'INBOX',
+		stackId: config.stackId ? String(config.stackId) : '',
+		senderAllowlist: config.senderAllowlist || '',
+		enabled: !!config.enabled,
+		requireAuth: !!config.requireAuth,
+		dailyLimit: config.dailyLimit || 0,
+		perSenderDailyLimit: config.perSenderDailyLimit || 0,
+	}
+}
+
+async function loadMailIntakeConfig() {
+	if (!canManage.value) return
+	try {
+		const config = await fetchMailIntakeConfig(props.boardId)
+		syncMailIntakeFromConfig(config)
+		// An active mailbox should be visible without a click.
+		if (mailIntake.value.enabled) {
+			automationGroups.value.mailIntake = true
+		}
+	} catch (e) {
+		mailIntakeError.value = t('kanso', 'Failed to load the email intake settings.')
+	}
+}
+
+// The conventional port follows the encryption choice, but only while the port
+// is still the other mode's default - a deliberately custom port is left alone.
+function onMailEncryptionChange() {
+	const f = mailIntakeForm.value
+	if (f.encryption === 'ssl' && f.port === 143) f.port = 993
+	else if (f.encryption === 'tls' && f.port === 993) f.port = 143
+}
+
+async function handleSaveMailIntake() {
+	mailIntakeError.value = ''
+	mailIntakeStatus.value = ''
+	mailIntakeBusy.value = true
+	try {
+		const f = mailIntakeForm.value
+		const config = await saveMailIntakeConfig(props.boardId, {
+			stackId: Number(f.stackId),
+			host: f.host.trim(),
+			port: Number(f.port) || 993,
+			encryption: f.encryption,
+			username: f.username.trim(),
+			// null, not '', so the server can tell "unchanged" from "cleared".
+			password: f.password.trim() === '' ? null : f.password,
+			mailbox: f.mailbox.trim() || 'INBOX',
+			senderAllowlist: f.senderAllowlist,
+			enabled: f.enabled,
+			requireAuth: f.requireAuth,
+			dailyLimit: Number(f.dailyLimit) || 0,
+			perSenderDailyLimit: Number(f.perSenderDailyLimit) || 0,
+		})
+		syncMailIntakeFromConfig(config)
+		mailIntakeStatus.value = t('kanso', 'Saved.')
+	} catch (e) {
+		mailIntakeError.value = e?.response?.data?.message
+			|| e?.response?.data?.error
+			|| t('kanso', 'Could not save the email intake settings.')
+	} finally {
+		mailIntakeBusy.value = false
+	}
+}
+
+async function handleTestMailIntake() {
+	mailIntakeError.value = ''
+	mailIntakeStatus.value = ''
+	mailIntakeBusy.value = true
+	try {
+		// Worth its own button: the alternative is saving and waiting up to five
+		// minutes for cron to reveal a typo in the password.
+		const res = await testMailIntakeConnection(props.boardId)
+		if (res.ok) {
+			mailIntakeStatus.value = t('kanso', 'Connected to the mailbox successfully.')
+		} else {
+			mailIntakeError.value = res.error || t('kanso', 'Could not connect to the mailbox.')
+		}
+	} catch (e) {
+		mailIntakeError.value = e?.response?.data?.error || t('kanso', 'Could not connect to the mailbox.')
+	} finally {
+		mailIntakeBusy.value = false
+	}
+}
+
+async function handleDeleteMailIntake() {
+	mailIntakeError.value = ''
+	mailIntakeStatus.value = ''
+	mailIntakeBusy.value = true
+	try {
+		await deleteMailIntakeConfig(props.boardId)
+		syncMailIntakeFromConfig(null)
+		mailIntakeStatus.value = t('kanso', 'Mailbox removed.')
+	} catch (e) {
+		mailIntakeError.value = e?.response?.data?.error || t('kanso', 'Could not remove the mailbox.')
+	} finally {
+		mailIntakeBusy.value = false
 	}
 }
 
@@ -2745,6 +3062,7 @@ async function disableCalendarFeed() {
 
 onMounted(loadWebhookConfig)
 onMounted(loadForgejoConfig)
+onMounted(loadMailIntakeConfig)
 onMounted(loadPublicShareConfig)
 onMounted(loadCalendarFeedConfig)
 
@@ -2821,6 +3139,7 @@ const automationGroups = ref({
 	recurring: false,
 	github: false,
 	forgejo: false,
+	mailIntake: false,
 	publicLink: false,
 	calendarFeed: false,
 })
@@ -5593,6 +5912,36 @@ async function doDeleteAutoRule(rule) {
 .github-webhook__status {
 	color: var(--kanso-success-legible);
 	font-weight: 600;
+}
+
+/* Email intake (#117) additions to the shared webhook form styles. */
+
+/* Ports and per-day limits: numeric fields that should not stretch like a
+   hostname does. */
+.github-webhook__input--narrow {
+	flex: 0 0 auto;
+	width: 8ch;
+}
+
+/* The intake form has more controls per row than the webhook panes, so its rows
+   have to be allowed to wrap on a narrow modal instead of overflowing. */
+.github-webhook__row--wrap {
+	flex-wrap: wrap;
+}
+
+.github-webhook__textarea {
+	width: 100%;
+	resize: vertical;
+	margin-bottom: 8px;
+}
+
+/* The "anyone who knows the address can create cards" caveat. It is a standing
+   property of the feature, not an error, so it is warning-coloured rather than
+   red - but it must not read as ordinary muted hint text either. */
+.github-webhook__hint--warning {
+	color: var(--color-warning-text, var(--color-text-maxcontrast));
+	border-inline-start: 3px solid var(--color-warning, var(--color-border));
+	padding-inline-start: 8px;
 }
 
 /* Muted descriptive hint under the share/feed rotate actions — NOT a status

--- a/src/components/BoardSettingsModal.vue
+++ b/src/components/BoardSettingsModal.vue
@@ -1529,7 +1529,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									class="github-webhook__input"
 									type="password"
 									autocomplete="new-password"
-									:placeholder="mailIntake.hasPassword ? t('kanso', 'Password stored — leave blank to keep it') : t('kanso', 'Password')"
+									:placeholder="mailIntakePasswordPlaceholder"
 									:disabled="mailIntakeBusy">
 							</div>
 
@@ -2635,9 +2635,31 @@ function emptyMailIntakeForm() {
 
 const mailIntakeCanSave = computed(() => {
 	const f = mailIntakeForm.value
-	// A first save needs a password; later saves may reuse the stored one.
-	const hasCredential = f.password.trim() !== '' || mailIntake.value.hasPassword
+	// A first save needs a password; later saves may reuse the stored one - but
+	// only for the same server and account (see mailIntakeCredentialTargetChanged).
+	const hasCredential = f.password.trim() !== ''
+		|| (mailIntake.value.hasPassword && !mailIntakeCredentialTargetChanged.value)
 	return f.host.trim() !== '' && f.username.trim() !== '' && f.stackId !== '' && hasCredential
+})
+
+// A stored password is only reusable for the SAME server and account - moving
+// either one means retyping it, so that a manager cannot repoint the mailbox at
+// a host they control and collect the credential. Say so in the field itself
+// rather than letting the save fail with a message.
+const mailIntakeCredentialTargetChanged = computed(() => {
+	if (!mailIntake.value.hasPassword) return false
+	return mailIntakeForm.value.host.trim() !== (mailIntake.value.host || '')
+		|| mailIntakeForm.value.username.trim() !== (mailIntake.value.username || '')
+})
+
+const mailIntakePasswordPlaceholder = computed(() => {
+	if (mailIntakeCredentialTargetChanged.value) {
+		return t('kanso', 'Enter the password again for the new server or account')
+	}
+	if (mailIntake.value.hasPassword) {
+		return t('kanso', 'Password stored — leave blank to keep it')
+	}
+	return t('kanso', 'Password')
 })
 
 const formatMailIntakeLastRun = computed(() => {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -431,6 +431,22 @@ export const disableForgejo = (boardId) =>
 export const updateForgejoIntake = (boardId, stackId, label) =>
 	axios.put(url(`/api/boards/${boardId}/forgejo/intake`), { stackId, label }).then((r) => r.data)
 
+// Email intake (board-level, MANAGE) (#117). Unlike the webhooks above, mail is
+// PULLED from IMAP by cron, so there is no ingest URL to hand out - just the
+// mailbox to poll. The password is write-only: `show` reports `hasPassword`
+// rather than the credential, and `save` with password null keeps the stored one.
+export const fetchMailIntakeConfig = (boardId) =>
+	axios.get(url(`/api/boards/${boardId}/mail-intake`)).then((r) => r.data)
+
+export const saveMailIntakeConfig = (boardId, config) =>
+	axios.put(url(`/api/boards/${boardId}/mail-intake`), config).then((r) => r.data)
+
+export const testMailIntakeConnection = (boardId) =>
+	axios.post(url(`/api/boards/${boardId}/mail-intake/test`)).then((r) => r.data)
+
+export const deleteMailIntakeConfig = (boardId) =>
+	axios.delete(url(`/api/boards/${boardId}/mail-intake`)).then((r) => r.data)
+
 // Public / read-only board share link (board-level, MANAGE)
 export const fetchPublicShareConfig = (boardId) =>
 	axios.get(url(`/api/boards/${boardId}/public-share`)).then((r) => r.data)

--- a/tests/e2e/mail-intake.spec.js
+++ b/tests/e2e/mail-intake.spec.js
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { test, expect, api, ncLogin, BASE } from './helpers.js'
+
+// Email intake (#117). There is no IMAP server in CI, so this deliberately does
+// NOT try to poll a mailbox — the polling logic is covered by unit tests against
+// a scripted server. What only a browser can prove is that the config panel is
+// actually wired: that it renders, that it saves through the API, and above all
+// that the stored password never comes back to the client.
+//
+// That last one is the reason this spec exists rather than an API-level test:
+// the password round-trip is a property of what the *browser* receives.
+test.describe('Email intake configuration', () => {
+	const state = { boardId: 0, stackId: 0 }
+
+	test.beforeAll(async () => {
+		const board = await api.post('/boards', { title: 'Mail intake E2E ' + Math.floor(Date.now() / 1000) })
+		state.boardId = board.id
+		const stack = await api.post('/stacks', { boardId: board.id, title: 'Incoming' })
+		state.stackId = stack.id
+	})
+
+	test.afterAll(async () => {
+		if (state.boardId) await api.delete(`/boards/${state.boardId}`).catch(() => {})
+	})
+
+	async function openIntakePanel(page) {
+		await ncLogin(page)
+		await page.goto(`${BASE}/index.php/apps/kanso#/board/${state.boardId}`)
+		await page.waitForSelector('.board-view__header', { timeout: 15_000 })
+
+		await page.getByRole('button', { name: 'More' }).click()
+		await page.getByRole('menuitem', { name: /board settings/i }).click()
+		await page.getByRole('tab', { name: /automation/i }).click()
+		await expect(page.locator('#bs-pane-automation')).toBeVisible({ timeout: 8_000 })
+
+		await page.getByRole('button', { name: /Email intake/i }).click()
+		const body = page.locator('#bs-automation-mail-intake')
+		await expect(body).toBeVisible()
+		return body
+	}
+
+	test('the panel saves a mailbox and never returns the password', async ({ page }) => {
+		const body = await openIntakePanel(page)
+
+		// The caveat has to be on screen: with an empty allowlist this address is
+		// open to anyone who learns it.
+		await expect(body.getByText(/Anyone who knows the address can create cards/i)).toBeVisible()
+
+		await body.locator('#bs-mail-host').fill('imap.example.com')
+		await body.locator('#bs-mail-username').fill('cards@example.com')
+		await body.locator('input[type="password"]').fill('super-secret-value')
+		await body.locator('#bs-mail-folder').fill('INBOX')
+		await body.locator('select').last().selectOption(String(state.stackId))
+
+		// Capture what the server sends back for the save AND for the reload.
+		const responses = []
+		page.on('response', async (res) => {
+			if (res.url().includes('/mail-intake')) {
+				responses.push(await res.text().catch(() => ''))
+			}
+		})
+
+		await body.getByRole('button', { name: /^Save$/ }).click()
+		await expect(body.getByText(/Saved\./)).toBeVisible({ timeout: 8_000 })
+
+		// The credential must not travel back to the browser in any form.
+		for (const payload of responses) {
+			expect(payload).not.toContain('super-secret-value')
+		}
+		expect(responses.join('')).toContain('hasPassword')
+	})
+
+	test('a saved mailbox reloads without the password and keeps it on re-save', async ({ page }) => {
+		const body = await openIntakePanel(page)
+
+		// Settings come back...
+		await expect(body.locator('#bs-mail-host')).toHaveValue('imap.example.com')
+		await expect(body.locator('#bs-mail-username')).toHaveValue('cards@example.com')
+		// ...but the password field is empty, with the placeholder explaining that
+		// leaving it so keeps the stored one.
+		const password = body.locator('input[type="password"]')
+		await expect(password).toHaveValue('')
+		await expect(password).toHaveAttribute('placeholder', /leave blank to keep it/i)
+
+		// Re-saving without retyping the password must not wipe it - that is the
+		// whole reason an empty field means "unchanged" rather than "clear".
+		await body.locator('#bs-mail-folder').fill('Archive')
+		await body.getByRole('button', { name: /^Save$/ }).click()
+		await expect(body.getByText(/Saved\./)).toBeVisible({ timeout: 8_000 })
+
+		const config = await api.get(`/boards/${state.boardId}/mail-intake`)
+		expect(config.hasPassword).toBe(true)
+		expect(config.mailbox).toBe('Archive')
+		expect(config).not.toHaveProperty('password')
+	})
+
+	test('the server refuses a mailbox pointed at a private address', async () => {
+		// The SSRF guard runs at connect time, so a save is allowed but the test
+		// connection must refuse rather than dial the internal network.
+		await api.put(`/boards/${state.boardId}/mail-intake`, {
+			stackId: state.stackId,
+			host: '127.0.0.1',
+			port: 993,
+			encryption: 'ssl',
+			username: 'cards@example.com',
+			password: 'irrelevant',
+			mailbox: 'INBOX',
+			senderAllowlist: '',
+			enabled: false,
+		})
+
+		const result = await api.post(`/boards/${state.boardId}/mail-intake/test`)
+
+		expect(result.ok).toBe(false)
+		expect(result.error).toMatch(/loopback|private|reserved|restricted/i)
+	})
+
+	test('removing the mailbox clears it', async ({ page }) => {
+		const body = await openIntakePanel(page)
+
+		await body.getByRole('button', { name: /Remove mailbox/i }).click()
+		await expect(body.getByText(/Mailbox removed\./)).toBeVisible({ timeout: 8_000 })
+
+		const config = await api.get(`/boards/${state.boardId}/mail-intake`)
+		// A board with no mailbox reports null rather than 404 - the form renders
+		// empty from it.
+		expect(config === null || config === '').toBeTruthy()
+	})
+})

--- a/tests/e2e/mail-intake.spec.js
+++ b/tests/e2e/mail-intake.spec.js
@@ -11,6 +11,12 @@ import { test, expect, api, ncLogin, BASE } from './helpers.js'
 //
 // That last one is the reason this spec exists rather than an API-level test:
 // the password round-trip is a property of what the *browser* receives.
+// These four are one flow over a single board - save it, read it back, re-save
+// it, remove it - so each depends on the previous one having run. Serial mode
+// keeps them in one worker and in order; without it a run at E2E_WORKERS=2 can
+// start the "reads it back" test before the save has landed.
+test.describe.configure({ mode: 'serial' })
+
 test.describe('Email intake configuration', () => {
 	const state = { boardId: 0, stackId: 0 }
 
@@ -54,22 +60,22 @@ test.describe('Email intake configuration', () => {
 		await body.locator('#bs-mail-folder').fill('INBOX')
 		await body.locator('select').last().selectOption(String(state.stackId))
 
-		// Capture what the server sends back for the save AND for the reload.
-		const responses = []
-		page.on('response', async (res) => {
-			if (res.url().includes('/mail-intake')) {
-				responses.push(await res.text().catch(() => ''))
-			}
-		})
-
-		await body.getByRole('button', { name: /^Save$/ }).click()
+		// waitForResponse rather than a page.on('response') collector: the handler
+		// form has to await res.text(), so the assertion can run before the body
+		// has been read and see an empty array. This ties the capture to the click.
+		const [saveResponse] = await Promise.all([
+			page.waitForResponse(
+				(r) => r.url().includes('/mail-intake') && r.request().method() === 'PUT',
+				{ timeout: 15_000 },
+			),
+			body.getByRole('button', { name: /^Save$/ }).click(),
+		])
 		await expect(body.getByText(/Saved\./)).toBeVisible({ timeout: 8_000 })
 
 		// The credential must not travel back to the browser in any form.
-		for (const payload of responses) {
-			expect(payload).not.toContain('super-secret-value')
-		}
-		expect(responses.join('')).toContain('hasPassword')
+		const payload = await saveResponse.text()
+		expect(payload).not.toContain('super-secret-value')
+		expect(payload).toContain('hasPassword')
 	})
 
 	test('a saved mailbox reloads without the password and keeps it on re-save', async ({ page }) => {

--- a/tests/unit/Service/Mail/AuthenticationResultsTest.php
+++ b/tests/unit/Service/Mail/AuthenticationResultsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service\Mail;
+
+use OCA\Kanso\Service\Mail\AuthenticationResults;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationResultsTest extends TestCase {
+	public function testDmarcPassForTheMatchingDomainAuthenticates(): void {
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=pass header.from=example.com');
+
+		self::assertTrue($results->authenticates('jacek@example.com'));
+	}
+
+	public function testDmarcPassIsCaseInsensitive(): void {
+		$results = AuthenticationResults::fromHeader('mx.ours.test; DMARC=PASS header.from=Example.COM');
+
+		self::assertTrue($results->authenticates('Jacek@Example.com'));
+	}
+
+	public function testDmarcPassForAnotherDomainDoesNotVouchForThisSender(): void {
+		// Without the header.from cross-check, any message carrying a pass for
+		// any domain would authenticate every sender.
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=pass header.from=attacker.test');
+
+		self::assertFalse($results->authenticates('jacek@example.com'));
+	}
+
+	public function testSubdomainOfThePassingDomainIsAligned(): void {
+		// DMARC alignment allows the organisational domain to cover subdomains.
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=pass header.from=example.com');
+
+		self::assertTrue($results->authenticates('bot@mail.example.com'));
+	}
+
+	public function testALookalikeSuffixIsNotAligned(): void {
+		// 'notexample.com' ends with 'example.com' as a STRING but is a different
+		// domain; alignment requires a label boundary.
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=pass header.from=example.com');
+
+		self::assertFalse($results->authenticates('sneaky@notexample.com'));
+	}
+
+	public function testSpfPassAloneDoesNotAuthenticate(): void {
+		// SPF authenticates the ENVELOPE sender, which can differ entirely from
+		// the visible From that a person reads and the allowlist matches.
+		$results = AuthenticationResults::fromHeader('mx.ours.test; spf=pass smtp.mailfrom=bounce.example.com');
+
+		self::assertFalse($results->authenticates('jacek@example.com'));
+	}
+
+	public function testDkimPassAloneDoesNotAuthenticate(): void {
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dkim=pass header.d=example.com');
+
+		self::assertFalse($results->authenticates('jacek@example.com'));
+	}
+
+	public function testDmarcFailDoesNotAuthenticate(): void {
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=fail header.from=example.com');
+
+		self::assertFalse($results->authenticates('jacek@example.com'));
+	}
+
+	public function testAbsentHeaderDoesNotAuthenticate(): void {
+		// No verdict is not a pass - a deployment with no authenticating MTA must
+		// not silently accept everything.
+		$results = AuthenticationResults::fromHeader('');
+
+		self::assertFalse($results->authenticates('jacek@example.com'));
+	}
+
+	public function testDmarcPassWithNoHeaderFromCannotBeTiedToTheSender(): void {
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=pass');
+
+		self::assertFalse($results->authenticates('jacek@example.com'));
+	}
+
+	public function testAddressWithoutADomainDoesNotAuthenticate(): void {
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dmarc=pass header.from=example.com');
+
+		self::assertFalse($results->authenticates('not-an-address'));
+	}
+
+	public function testReadsAMixedResultHeader(): void {
+		$raw = 'mx.ours.test; spf=fail smtp.mailfrom=x.test; dkim=pass header.d=example.com; dmarc=pass header.from=example.com';
+		$results = AuthenticationResults::fromHeader($raw);
+
+		self::assertSame('fail', $results->result('spf'));
+		self::assertSame('pass', $results->result('dkim'));
+		self::assertSame('pass', $results->result('dmarc'));
+		self::assertTrue($results->authenticates('a@example.com'));
+	}
+
+	public function testPropertyNamesAreNotMistakenForMethodResults(): void {
+		// 'header.d=example.com' and friends must not be read as further verdicts.
+		$results = AuthenticationResults::fromHeader('mx.ours.test; dkim=fail header.d=dmarc.example.com');
+
+		self::assertSame('', $results->result('dmarc'));
+		self::assertFalse($results->authenticates('a@dmarc.example.com'));
+	}
+
+	public function testGarbageHeaderIsInert(): void {
+		$results = AuthenticationResults::fromHeader('!!! not a header at all ???');
+
+		self::assertFalse($results->authenticates('a@example.com'));
+		self::assertSame('', $results->result('dmarc'));
+	}
+}

--- a/tests/unit/Service/Mail/ImapClientTest.php
+++ b/tests/unit/Service/Mail/ImapClientTest.php
@@ -11,16 +11,22 @@ use OCA\Kanso\Db\MailIntake;
 use OCA\Kanso\Service\Mail\ImapClient;
 use OCA\Kanso\Service\Mail\ImapException;
 use OCA\Kanso\Service\Mail\ImapTransport;
+use OCA\Kanso\Service\Mail\MailHostGuard;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ImapClientTest extends TestCase {
 	private FakeImapTransport $transport;
+	private MailHostGuard&MockObject $hostGuard;
 	private ImapClient $client;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->transport = new FakeImapTransport();
-		$this->client = new ImapClient($this->transport);
+		$this->hostGuard = $this->createMock(MailHostGuard::class);
+		// Stands in for a public A record.
+		$this->hostGuard->method('resolve')->willReturn('198.51.100.7');
+		$this->client = new ImapClient($this->transport, $this->hostGuard);
 	}
 
 	/** Queues the greeting plus whatever the scripted server answers next. */
@@ -36,11 +42,41 @@ class ImapClientTest extends TestCase {
 	public function testConnectReadsTheGreeting(): void {
 		$this->connect();
 
-		self::assertSame('mail.example.com', $this->transport->host);
 		self::assertSame(993, $this->transport->port);
 		self::assertTrue($this->transport->implicitTls);
 		// Implicit TLS needs no in-band upgrade.
 		self::assertFalse($this->transport->cryptoEnabled);
+	}
+
+	public function testConnectDialsTheVettedAddressButValidatesTheCertificateAgainstTheHostname(): void {
+		$this->connect();
+
+		// Dialling the already-resolved IP is what closes the DNS-rebinding
+		// window: the name cannot resolve somewhere else between the guard's
+		// check and the connection.
+		self::assertSame('198.51.100.7', $this->transport->address);
+		// ...and the hostname still has to travel separately, or pinning the
+		// address would have silently cost us TLS certificate validation.
+		self::assertSame('mail.example.com', $this->transport->peerName);
+	}
+
+	public function testConnectIsRefusedWhenTheHostGuardRejectsTheTarget(): void {
+		$transport = new FakeImapTransport();
+		$guard = $this->createMock(MailHostGuard::class);
+		$guard->method('resolve')
+			->willThrowException(new ImapException('Mail server host resolves to a private or reserved address'));
+		$client = new ImapClient($transport, $guard);
+
+		try {
+			$client->connect('internal.corp', 993, MailIntake::ENCRYPTION_SSL);
+			self::fail('Expected an ImapException');
+		} catch (ImapException $e) {
+			self::assertStringContainsString('private or reserved', $e->getMessage());
+		}
+
+		// No socket may be opened at all - the point is that the server never
+		// makes the connection, not that it hangs up afterwards.
+		self::assertSame('', $transport->address);
 	}
 
 	public function testStartTlsUpgradesTheConnectionBeforeAnyCredentialIsSent(): void {
@@ -255,7 +291,8 @@ class ImapClientTest extends TestCase {
  * be tested without a network.
  */
 class FakeImapTransport implements ImapTransport {
-	public string $host = '';
+	public string $address = '';
+	public string $peerName = '';
 	public int $port = 0;
 	public bool $implicitTls = false;
 	public bool $cryptoEnabled = false;
@@ -272,8 +309,9 @@ class FakeImapTransport implements ImapTransport {
 	}
 
 	#[\Override]
-	public function open(string $host, int $port, bool $implicitTls, int $timeoutSeconds): void {
-		$this->host = $host;
+	public function open(string $address, string $peerName, int $port, bool $implicitTls, int $timeoutSeconds): void {
+		$this->address = $address;
+		$this->peerName = $peerName;
 		$this->port = $port;
 		$this->implicitTls = $implicitTls;
 	}

--- a/tests/unit/Service/Mail/ImapClientTest.php
+++ b/tests/unit/Service/Mail/ImapClientTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service\Mail;
+
+use OCA\Kanso\Db\MailIntake;
+use OCA\Kanso\Service\Mail\ImapClient;
+use OCA\Kanso\Service\Mail\ImapException;
+use OCA\Kanso\Service\Mail\ImapTransport;
+use PHPUnit\Framework\TestCase;
+
+class ImapClientTest extends TestCase {
+	private FakeImapTransport $transport;
+	private ImapClient $client;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->transport = new FakeImapTransport();
+		$this->client = new ImapClient($this->transport);
+	}
+
+	/** Queues the greeting plus whatever the scripted server answers next. */
+	private function script(string ...$lines): void {
+		$this->transport->queue(implode("\r\n", $lines) . "\r\n");
+	}
+
+	private function connect(): void {
+		$this->script('* OK [CAPABILITY IMAP4rev1] Dovecot ready');
+		$this->client->connect('mail.example.com', 993, MailIntake::ENCRYPTION_SSL);
+	}
+
+	public function testConnectReadsTheGreeting(): void {
+		$this->connect();
+
+		self::assertSame('mail.example.com', $this->transport->host);
+		self::assertSame(993, $this->transport->port);
+		self::assertTrue($this->transport->implicitTls);
+		// Implicit TLS needs no in-band upgrade.
+		self::assertFalse($this->transport->cryptoEnabled);
+	}
+
+	public function testStartTlsUpgradesTheConnectionBeforeAnyCredentialIsSent(): void {
+		$this->script('* OK ready', 'K001 OK STARTTLS completed');
+
+		$this->client->connect('mail.example.com', 143, MailIntake::ENCRYPTION_TLS);
+
+		self::assertFalse($this->transport->implicitTls);
+		self::assertSame(['K001 STARTTLS'], $this->transport->written);
+		self::assertTrue($this->transport->cryptoEnabled);
+		// Nothing but STARTTLS may precede the upgrade - a LOGIN sent first would
+		// have gone out in the clear.
+		self::assertSame(1, $this->transport->writesBeforeCrypto);
+	}
+
+	public function testConnectRejectsAByeGreeting(): void {
+		$this->script('* BYE Too many connections');
+
+		$this->expectException(ImapException::class);
+		$this->client->connect('mail.example.com', 993, MailIntake::ENCRYPTION_SSL);
+	}
+
+	public function testLoginQuotesAndEscapesTheCredentials(): void {
+		$this->connect();
+		$this->script('K001 OK Logged in');
+
+		$this->client->login('bo"b', 'pa\\ss');
+
+		// Backslash and double quote are the only characters an IMAP quoted
+		// string escapes; getting this wrong ends the string early.
+		self::assertSame(['K001 LOGIN "bo\\"b" "pa\\\\ss"'], $this->transport->written);
+	}
+
+	public function testLoginRejectsALineBreakInTheCredentials(): void {
+		$this->connect();
+
+		// A CR here would terminate the LOGIN line and let the rest be read as a
+		// further command - injection straight through a config field.
+		$this->expectException(ImapException::class);
+		$this->client->login("user\r\nK999 DELETE INBOX", 'pw');
+	}
+
+	public function testLoginFailureNeverEchoesThePassword(): void {
+		$this->connect();
+		// Some servers quote the offending command back in their NO text.
+		$this->script('K001 NO [AUTHENTICATIONFAILED] LOGIN "bob" "hunter2" failed');
+
+		try {
+			$this->client->login('bob', 'hunter2');
+			self::fail('Expected an ImapException');
+		} catch (ImapException $e) {
+			self::assertStringNotContainsString('hunter2', $e->getMessage());
+			self::assertStringContainsString('login failed', $e->getMessage());
+		}
+	}
+
+	public function testSelectMailboxParsesUidValidityAndUidNext(): void {
+		$this->connect();
+		$this->script(
+			'* 42 EXISTS',
+			'* OK [UIDVALIDITY 1234567890] UIDs valid',
+			'* OK [UIDNEXT 987] Predicted next UID',
+			'K001 OK [READ-ONLY] EXAMINE completed',
+		);
+
+		$status = $this->client->selectMailbox('INBOX');
+
+		self::assertSame(1234567890, $status['uidValidity']);
+		self::assertSame(987, $status['uidNext']);
+		// EXAMINE, not SELECT: intake never needs write access to a person's mail.
+		self::assertSame(['K001 EXAMINE "INBOX"'], $this->transport->written);
+	}
+
+	public function testSelectMailboxFailsWhenTheServerOmitsUidValidity(): void {
+		$this->connect();
+		$this->script('* 42 EXISTS', 'K001 OK EXAMINE completed');
+
+		// Without it the watermark is meaningless, and guessing risks replaying
+		// the whole mailbox as cards.
+		$this->expectException(ImapException::class);
+		$this->client->selectMailbox('INBOX');
+	}
+
+	public function testSelectMailboxFailsOnAMissingMailbox(): void {
+		$this->connect();
+		$this->script('K001 NO Mailbox does not exist');
+
+		$this->expectException(ImapException::class);
+		$this->client->selectMailbox('Archive/Nope');
+	}
+
+	public function testSearchReturnsUidsAboveTheWatermark(): void {
+		$this->connect();
+		$this->script('* SEARCH 12 15 18', 'K001 OK SEARCH completed');
+
+		self::assertSame([12, 15, 18], $this->client->searchUidsAbove(11));
+		self::assertSame(['K001 UID SEARCH UID 12:*'], $this->transport->written);
+	}
+
+	public function testSearchDiscardsTheTrailingMessageAServerReturnsForAnOutOfRangeQuery(): void {
+		// The IMAP trap this exists for: ranges are inclusive and normalised, and
+		// '*' is the highest UID present. So 'UID 9:*' against a mailbox whose
+		// highest UID is 4 is read as '4:9' and returns message 4 - already
+		// carded. Every real server does this; without the client-side filter,
+		// every idle poll re-cards the newest message.
+		$this->connect();
+		$this->script('* SEARCH 4', 'K001 OK SEARCH completed');
+
+		self::assertSame([], $this->client->searchUidsAbove(8));
+	}
+
+	public function testSearchHandlesAnEmptyResult(): void {
+		$this->connect();
+		$this->script('* SEARCH', 'K001 OK SEARCH completed');
+
+		self::assertSame([], $this->client->searchUidsAbove(5));
+	}
+
+	public function testSearchSortsAndDedupesUids(): void {
+		$this->connect();
+		$this->script('* SEARCH 18 12 12 15', 'K001 OK SEARCH completed');
+
+		self::assertSame([12, 15, 18], $this->client->searchUidsAbove(1));
+	}
+
+	public function testFetchReadsALiteralExactly(): void {
+		$this->connect();
+		// The literal contains CRLF and a ')' - a line-based reader would stop
+		// early and desynchronise every later command.
+		$body = "Subject: hi\r\n\r\nLine one\r\nLine two (with a paren)\r\n";
+		$this->transport->queue(
+			'* 7 FETCH (UID 42 BODY[] {' . strlen($body) . "}\r\n"
+			. $body
+			. ")\r\n"
+			. "K001 OK FETCH completed\r\n"
+		);
+
+		self::assertSame($body, $this->client->fetchMessage(42));
+		self::assertSame(['K001 UID FETCH 42 (BODY.PEEK[])'], $this->transport->written);
+	}
+
+	public function testFetchUsesPeekSoPollingNeverMarksMailAsRead(): void {
+		$this->connect();
+		$this->script('K001 OK FETCH completed');
+
+		$this->client->fetchMessage(42);
+
+		// BODY[] (without PEEK) sets \Seen as a side effect of reading.
+		self::assertStringContainsString('BODY.PEEK[]', $this->transport->written[0]);
+		self::assertStringNotContainsString('(BODY[])', $this->transport->written[0]);
+	}
+
+	public function testFetchReturnsEmptyWhenTheMessageVanished(): void {
+		// Deleted between SEARCH and FETCH: a tagged OK with no FETCH data.
+		$this->connect();
+		$this->script('K001 OK FETCH completed');
+
+		self::assertSame('', $this->client->fetchMessage(42));
+	}
+
+	public function testOversizedMessageIsDrainedAndSkippedRatherThanRead(): void {
+		$this->connect();
+		// One byte over the 5 MiB ceiling.
+		$huge = str_repeat('x', 5 * 1024 * 1024 + 1);
+		$this->transport->queue(
+			'* 7 FETCH (UID 42 BODY[] {' . strlen($huge) . "}\r\n"
+			. $huge
+			. ")\r\n"
+			. "K001 OK FETCH completed\r\n"
+			. "K002 OK LOGOUT\r\n"
+		);
+
+		self::assertSame('', $this->client->fetchMessage(42));
+		// Drained, not skipped: the bytes are already on the wire, so leaving them
+		// queued would corrupt every later response. Proof is that the next
+		// command still parses.
+		$this->client->disconnect();
+		self::assertSame('K002 LOGOUT', $this->transport->written[1]);
+	}
+
+	public function testNoResponseBecomesAnException(): void {
+		$this->connect();
+		$this->script('K001 NO Server said no');
+
+		$this->expectException(ImapException::class);
+		$this->expectExceptionMessage('NO Server said no');
+		$this->client->searchUidsAbove(0);
+	}
+
+	public function testUnexpectedContinuationRequestIsAnException(): void {
+		$this->connect();
+		// Nothing this client sends can prompt one, so it means the connection is
+		// out of sync and every later response would be misread.
+		$this->script('+ go ahead');
+
+		$this->expectException(ImapException::class);
+		$this->client->searchUidsAbove(0);
+	}
+
+	public function testDisconnectSurvivesAServerThatHangsUpOnLogout(): void {
+		$this->connect();
+		// Nothing queued: LOGOUT's read hits EOF.
+		$this->client->disconnect();
+
+		self::assertTrue($this->transport->closed);
+	}
+}
+
+/**
+ * A scripted IMAP server: byte-for-byte what the peer would send, consumed the
+ * way a socket consumes it. Lets the protocol logic - literals, tags, ranges -
+ * be tested without a network.
+ */
+class FakeImapTransport implements ImapTransport {
+	public string $host = '';
+	public int $port = 0;
+	public bool $implicitTls = false;
+	public bool $cryptoEnabled = false;
+	public bool $closed = false;
+	public int $writesBeforeCrypto = 0;
+
+	/** @var string[] every command line the client sent, in order */
+	public array $written = [];
+
+	private string $buffer = '';
+
+	public function queue(string $bytes): void {
+		$this->buffer .= $bytes;
+	}
+
+	#[\Override]
+	public function open(string $host, int $port, bool $implicitTls, int $timeoutSeconds): void {
+		$this->host = $host;
+		$this->port = $port;
+		$this->implicitTls = $implicitTls;
+	}
+
+	#[\Override]
+	public function enableCrypto(): void {
+		$this->cryptoEnabled = true;
+		$this->writesBeforeCrypto = count($this->written);
+	}
+
+	#[\Override]
+	public function writeLine(string $line): void {
+		$this->written[] = $line;
+	}
+
+	#[\Override]
+	public function readLine(): string {
+		$end = strpos($this->buffer, "\r\n");
+		if ($end === false) {
+			throw new ImapException('IMAP server closed the connection');
+		}
+		$line = substr($this->buffer, 0, $end);
+		$this->buffer = substr($this->buffer, $end + 2);
+		return $line;
+	}
+
+	#[\Override]
+	public function readBytes(int $length): string {
+		if (strlen($this->buffer) < $length) {
+			throw new ImapException('IMAP server closed mid-message');
+		}
+		$bytes = substr($this->buffer, 0, $length);
+		$this->buffer = substr($this->buffer, $length);
+		return $bytes;
+	}
+
+	#[\Override]
+	public function close(): void {
+		$this->closed = true;
+	}
+}

--- a/tests/unit/Service/Mail/MailHostGuardTest.php
+++ b/tests/unit/Service/Mail/MailHostGuardTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service\Mail;
+
+use OCA\Kanso\Service\Mail\ImapException;
+use OCA\Kanso\Service\Mail\MailHostGuard;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The guard that stops "configure a mailbox" from meaning "make the server
+ * open a connection to any address you name and tell you how it went".
+ *
+ * Uses IP literals throughout: the point under test is the verdict, and going
+ * through real DNS would make the suite depend on a resolver.
+ */
+class MailHostGuardTest extends TestCase {
+	private IConfig&MockObject $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+	}
+
+	private function guard(bool $allowPrivate = false): MailHostGuard {
+		$this->config->method('getAppValue')->willReturn($allowPrivate ? 'yes' : 'no');
+		return new MailHostGuard($this->config);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public static function blockedAddresses(): array {
+		return [
+			'loopback v4' => ['127.0.0.1'],
+			'loopback v4, other octet' => ['127.99.1.5'],
+			'loopback v6' => ['::1'],
+			'private 10/8' => ['10.0.0.51'],
+			'private 172.16/12' => ['172.16.4.9'],
+			'private 192.168/16' => ['192.168.2.170'],
+			// The cloud metadata endpoint - the single most valuable SSRF target.
+			'cloud metadata' => ['169.254.169.254'],
+			'link-local v6' => ['fe80::1'],
+			'unique local v6' => ['fd00::1'],
+			'unspecified' => ['0.0.0.0'],
+			// An IPv4 address wearing an IPv6 costume, which some validators wave
+			// through.
+			'ipv4-mapped loopback' => ['::ffff:127.0.0.1'],
+			'ipv4-mapped private' => ['::ffff:10.0.0.51'],
+		];
+	}
+
+	/**
+	 * @dataProvider blockedAddresses
+	 */
+	public function testRejectsAddressesTheServerMustNotDial(string $address): void {
+		$this->expectException(ImapException::class);
+		$this->guard()->resolve($address);
+	}
+
+	public function testAllowsAPublicAddress(): void {
+		self::assertSame('198.51.100.7', $this->guard()->resolve('198.51.100.7'));
+	}
+
+	public function testAllowsAPublicIpv6Address(): void {
+		self::assertSame('2001:db8::1', $this->guard()->resolve('2001:db8::1'));
+	}
+
+	public function testAdminOptInAllowsPrivateRanges(): void {
+		// "Our IMAP server is on the LAN" is legitimate - but it takes an
+		// instance-wide admin setting, not a board manager filling in a form.
+		self::assertSame('192.168.2.170', $this->guard(allowPrivate: true)->resolve('192.168.2.170'));
+	}
+
+	public function testAdminOptInStillRefusesLoopback(): void {
+		// There is no legitimate "my IMAP server is this very process", and
+		// loopback is where admin panels bind.
+		$this->expectException(ImapException::class);
+		$this->guard(allowPrivate: true)->resolve('127.0.0.1');
+	}
+
+	public function testAdminOptInStillRefusesIpv6Loopback(): void {
+		$this->expectException(ImapException::class);
+		$this->guard(allowPrivate: true)->resolve('::1');
+	}
+
+	public function testRejectsAnEmptyHost(): void {
+		$this->expectException(ImapException::class);
+		$this->guard()->resolve('   ');
+	}
+
+	public function testRejectsAHostThatDoesNotResolve(): void {
+		// .invalid is reserved by RFC 2606 precisely so it can never resolve.
+		$this->expectException(ImapException::class);
+		$this->guard()->resolve('nonexistent-host.invalid');
+	}
+
+	public function testTheErrorNamesTheOptInSoAnAdminKnowsWhatToDo(): void {
+		try {
+			$this->guard()->resolve('10.0.0.51');
+			self::fail('Expected an ImapException');
+		} catch (ImapException $e) {
+			self::assertStringContainsString('mail_intake_allow_private_hosts', $e->getMessage());
+		}
+	}
+}

--- a/tests/unit/Service/Mail/MailHostGuardTest.php
+++ b/tests/unit/Service/Mail/MailHostGuardTest.php
@@ -49,10 +49,17 @@ class MailHostGuardTest extends TestCase {
 			'link-local v6' => ['fe80::1'],
 			'unique local v6' => ['fd00::1'],
 			'unspecified' => ['0.0.0.0'],
+			'unspecified v6' => ['::'],
+			'multicast v4' => ['224.0.0.1'],
+			'multicast v6' => ['ff02::1'],
+			'carrier-grade NAT' => ['100.64.0.1'],
+			'benchmarking' => ['198.18.0.1'],
+			'reserved top block' => ['240.0.0.1'],
 			// An IPv4 address wearing an IPv6 costume, which some validators wave
 			// through.
 			'ipv4-mapped loopback' => ['::ffff:127.0.0.1'],
 			'ipv4-mapped private' => ['::ffff:10.0.0.51'],
+			'ipv4-mapped metadata' => ['::ffff:169.254.169.254'],
 		];
 	}
 
@@ -69,7 +76,36 @@ class MailHostGuardTest extends TestCase {
 	}
 
 	public function testAllowsAPublicIpv6Address(): void {
-		self::assertSame('2001:db8::1', $this->guard()->resolve('2001:db8::1'));
+		// A genuinely routable address. NOT 2001:db8::1 - that is the RFC 3849
+		// documentation prefix, and whether filter_var calls it "reserved"
+		// changes between PHP 8.2 and 8.5, which is exactly the version-dependent
+		// behaviour the guard now avoids by matching ranges itself.
+		self::assertSame('2606:4700:4700::1111', $this->guard()->resolve('2606:4700:4700::1111'));
+	}
+
+	public function testBoundariesOfBlockedRangesAreExact(): void {
+		$guard = $this->guard();
+
+		// 172.16/12 ends at 172.31.255.255, so its neighbours are public. A
+		// string-prefix check ('172.16.') would get these wrong in both
+		// directions.
+		self::assertSame('172.15.0.1', $guard->resolve('172.15.0.1'));
+		self::assertSame('172.32.0.1', $guard->resolve('172.32.0.1'));
+		// 100.64/10 ends at 100.127.255.255.
+		self::assertSame('100.128.0.1', $guard->resolve('100.128.0.1'));
+	}
+
+	public function testJustInsideABlockedRangeIsStillBlocked(): void {
+		$guard = $this->guard();
+		$refused = 0;
+		foreach (['172.16.0.0', '172.31.255.255', '100.64.0.0', '100.127.255.255'] as $address) {
+			try {
+				$guard->resolve($address);
+			} catch (ImapException) {
+				$refused++;
+			}
+		}
+		self::assertSame(4, $refused, 'every edge of a blocked range must be refused');
 	}
 
 	public function testAdminOptInAllowsPrivateRanges(): void {

--- a/tests/unit/Service/Mail/MimeParserTest.php
+++ b/tests/unit/Service/Mail/MimeParserTest.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service\Mail;
+
+use OCA\Kanso\Service\Mail\MimeParser;
+use PHPUnit\Framework\TestCase;
+
+class MimeParserTest extends TestCase {
+	private MimeParser $parser;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->parser = new MimeParser();
+	}
+
+	/** Builds a message with CRLF endings, the way one actually arrives. */
+	private function message(string $body): string {
+		return str_replace("\n", "\r\n", $body);
+	}
+
+	public function testParsesASimplePlainTextMessage(): void {
+		$raw = $this->message(<<<EOM
+			From: Jacek <jacek@example.com>
+			To: inbox@example.com
+			Subject: Buy more milk
+			Content-Type: text/plain; charset=utf-8
+
+			Two litres, semi-skimmed.
+			EOM);
+
+		$message = $this->parser->parse($raw);
+
+		self::assertSame('jacek@example.com', $message->fromAddress);
+		self::assertSame('Jacek', $message->fromName);
+		self::assertSame('Buy more milk', $message->subject);
+		self::assertSame('Two litres, semi-skimmed.', $message->body);
+		self::assertSame('Jacek <jacek@example.com>', $message->fromLabel());
+	}
+
+	public function testMessageWithNoBodyIsNotAnError(): void {
+		// Subject-only mail is how a phone sends a one-line note.
+		$raw = $this->message("From: a@example.com\nSubject: Just the subject");
+
+		$message = $this->parser->parse($raw);
+
+		self::assertSame('Just the subject', $message->subject);
+		self::assertSame('', $message->body);
+	}
+
+	public function testDecodesEncodedWordSubject(): void {
+		// =?UTF-8?B?...?= is RFC 2047; the payload is 'Überraschung ✓'.
+		$encoded = '=?UTF-8?B?' . base64_encode('Überraschung ✓') . '?=';
+		$raw = $this->message("From: a@example.com\nSubject: {$encoded}\n\nbody");
+
+		self::assertSame('Überraschung ✓', $this->parser->parse($raw)->subject);
+	}
+
+	public function testFoldedHeaderIsUnfolded(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: A subject that was
+			 folded across two lines
+
+			body
+			EOM);
+
+		self::assertSame('A subject that was folded across two lines', $this->parser->parse($raw)->subject);
+	}
+
+	public function testDecodesBase64Body(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: b64
+			Content-Type: text/plain; charset=utf-8
+			Content-Transfer-Encoding: base64
+
+			EOM) . "\r\n" . base64_encode('Decoded body text');
+
+		self::assertSame('Decoded body text', $this->parser->parse($raw)->body);
+	}
+
+	public function testDecodesQuotedPrintableBody(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: qp
+			Content-Type: text/plain; charset=utf-8
+			Content-Transfer-Encoding: quoted-printable
+
+			Caf=C3=A9 =E2=80=94 open till 6
+			EOM);
+
+		self::assertSame('Café — open till 6', $this->parser->parse($raw)->body);
+	}
+
+	public function testConvertsNonUtf8CharsetToUtf8(): void {
+		$body = mb_convert_encoding('Grüße aus Köln', 'ISO-8859-1', 'UTF-8');
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: latin
+			Content-Type: text/plain; charset=iso-8859-1
+
+			EOM) . "\r\n" . $body;
+
+		self::assertSame('Grüße aus Köln', $this->parser->parse($raw)->body);
+	}
+
+	public function testPrefersPlainTextOverHtmlRegardlessOfPartOrder(): void {
+		// The HTML alternative is listed FIRST here. A parser that takes the first
+		// text part it meets would return the HTML.
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: alternative
+			Content-Type: multipart/alternative; boundary="bnd-alt"
+
+			--bnd-alt
+			Content-Type: text/html; charset=utf-8
+
+			<p>The HTML one</p>
+			--bnd-alt
+			Content-Type: text/plain; charset=utf-8
+
+			The plain one
+			--bnd-alt--
+			EOM);
+
+		self::assertSame('The plain one', $this->parser->parse($raw)->body);
+	}
+
+	public function testPrefersPlainTextEvenWhenItIsNestedDeeperThanTheHtml(): void {
+		// The regression this guards: preference must be decided by the type of
+		// the LEAF that produced the text, not by the type of the subtree that was
+		// descended into. The plain part is two levels down, the HTML one level.
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: nested
+			Content-Type: multipart/mixed; boundary="bnd-outer"
+
+			--bnd-outer
+			Content-Type: text/html; charset=utf-8
+
+			<p>Shallow HTML</p>
+			--bnd-outer
+			Content-Type: multipart/related; boundary="bnd-inner"
+
+			--bnd-inner
+			Content-Type: text/plain; charset=utf-8
+
+			Deep plain text
+			--bnd-inner--
+			--bnd-outer--
+			EOM);
+
+		self::assertSame('Deep plain text', $this->parser->parse($raw)->body);
+	}
+
+	public function testFallsBackToHtmlWhenThePlainAlternativeIsEmpty(): void {
+		// Senders do emit an empty text/plain alongside real HTML. Treating the
+		// empty part as a match would produce a blank card.
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: empty plain
+			Content-Type: multipart/alternative; boundary="bnd-e"
+
+			--bnd-e
+			Content-Type: text/plain; charset=utf-8
+
+
+			--bnd-e
+			Content-Type: text/html; charset=utf-8
+
+			<p>The real body</p>
+			--bnd-e--
+			EOM);
+
+		self::assertSame('The real body', $this->parser->parse($raw)->body);
+	}
+
+	public function testFlattensHtmlAndDropsScriptAndStyleContent(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: html only
+			Content-Type: text/html; charset=utf-8
+
+			<html><head><style>p { color: red }</style></head>
+			<body><p>First line</p><p>Second<br>third</p>
+			<script>alert('nope')</script></body></html>
+			EOM);
+
+		$body = $this->parser->parse($raw)->body;
+
+		self::assertStringContainsString('First line', $body);
+		self::assertStringContainsString('Second', $body);
+		self::assertStringContainsString('third', $body);
+		// Stylesheet and script BODIES are not markup, so strip_tags alone leaves
+		// them behind as visible text.
+		self::assertStringNotContainsString('color: red', $body);
+		self::assertStringNotContainsString('alert', $body);
+	}
+
+	public function testDecodesHtmlEntities(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: entities
+			Content-Type: text/html; charset=utf-8
+
+			<p>Tom &amp; Jerry &lt;3</p>
+			EOM);
+
+		self::assertSame('Tom & Jerry <3', $this->parser->parse($raw)->body);
+	}
+
+	public function testNamesAttachmentsWithoutPuttingThemInTheBody(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: with attachment
+			Content-Type: multipart/mixed; boundary="bnd-att"
+
+			--bnd-att
+			Content-Type: text/plain; charset=utf-8
+
+			See attached.
+			--bnd-att
+			Content-Type: application/pdf; name="invoice.pdf"
+			Content-Disposition: attachment; filename="invoice.pdf"
+			Content-Transfer-Encoding: base64
+
+			JVBERi0xLjQKJSVFT0Y=
+			--bnd-att--
+			EOM);
+
+		$message = $this->parser->parse($raw);
+
+		self::assertSame('See attached.', $message->body);
+		self::assertSame(['invoice.pdf'], $message->attachmentNames);
+		// The encoded bytes must not leak into the description.
+		self::assertStringNotContainsString('JVBERi', $message->body);
+	}
+
+	public function testTreatsANamedPartWithoutDispositionAsAnAttachment(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: legacy client
+			Content-Type: multipart/mixed; boundary="bnd-legacy"
+
+			--bnd-legacy
+			Content-Type: text/plain; charset=utf-8
+
+			Body here.
+			--bnd-legacy
+			Content-Type: image/png; name="screenshot.png"
+
+			binary-ish
+			--bnd-legacy--
+			EOM);
+
+		self::assertSame(['screenshot.png'], $this->parser->parse($raw)->attachmentNames);
+	}
+
+	public function testHandlesBoundaryParameterContainingASemicolon(): void {
+		// Legal, and a plain explode(';') on the header mangles it.
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: tricky boundary
+			Content-Type: multipart/mixed; boundary="ab;cd"
+
+			--ab;cd
+			Content-Type: text/plain; charset=utf-8
+
+			Survived the split.
+			--ab;cd--
+			EOM);
+
+		self::assertSame('Survived the split.', $this->parser->parse($raw)->body);
+	}
+
+	public function testParsesBareAddressWithoutDisplayName(): void {
+		$raw = $this->message("From: plain@example.com\nSubject: s\n\nb");
+
+		$message = $this->parser->parse($raw);
+
+		self::assertSame('plain@example.com', $message->fromAddress);
+		self::assertSame('', $message->fromName);
+		self::assertSame('plain@example.com', $message->fromLabel());
+	}
+
+	public function testLowercasesTheSenderAddress(): void {
+		// The allowlist comparison is case-sensitive by the time it runs, so
+		// normalisation has to happen here.
+		$raw = $this->message("From: Loud <SHOUTING@Example.COM>\nSubject: s\n\nb");
+
+		self::assertSame('shouting@example.com', $this->parser->parse($raw)->fromAddress);
+	}
+
+	public function testDisplayNameContainingAngleBracketsDoesNotShadowTheAddress(): void {
+		$raw = $this->message("From: \"<evil@attacker.test>\" <real@example.com>\nSubject: s\n\nb");
+
+		self::assertSame('real@example.com', $this->parser->parse($raw)->fromAddress);
+	}
+
+	public function testMalformedMessageYieldsEmptyFieldsRatherThanThrowing(): void {
+		// A poll must not die on junk - a stalled mailbox is the failure that
+		// matters.
+		$message = $this->parser->parse("not a message at all\x00\xff\xfe");
+
+		self::assertSame('', $message->fromAddress);
+		self::assertSame('', $message->subject);
+	}
+
+	public function testMultipartWithoutABoundaryYieldsNoBody(): void {
+		$raw = $this->message(<<<EOM
+			From: a@example.com
+			Subject: broken multipart
+			Content-Type: multipart/mixed
+
+			--something
+			Content-Type: text/plain
+
+			unreachable
+			--something--
+			EOM);
+
+		self::assertSame('', $this->parser->parse($raw)->body);
+	}
+
+	public function testInvalidUtf8InABodyClaimingUtf8IsScrubbed(): void {
+		// Invalid bytes reaching the database can fail the INSERT outright.
+		$raw = $this->message("From: a@example.com\nSubject: s\nContent-Type: text/plain; charset=utf-8\n\n")
+			. "valid \xC3\x28 tail";
+
+		$body = $this->parser->parse($raw)->body;
+
+		self::assertTrue(mb_check_encoding($body, 'UTF-8'));
+		self::assertStringContainsString('valid', $body);
+	}
+
+	public function testHandlesBareLineFeedMessages(): void {
+		// Some agents (and some IMAP servers' literals) use bare LF.
+		$raw = "From: a@example.com\nSubject: LF only\n\nBody with LF";
+
+		$message = $this->parser->parse($raw);
+
+		self::assertSame('LF only', $message->subject);
+		self::assertSame('Body with LF', $message->body);
+	}
+
+	public function testPartWithNoContentTypeIsTreatedAsPlainText(): void {
+		// RFC 2045: an absent Content-Type means text/plain.
+		$raw = $this->message("From: a@example.com\nSubject: s\n\nImplicitly plain");
+
+		self::assertSame('Implicitly plain', $this->parser->parse($raw)->body);
+	}
+}

--- a/tests/unit/Service/Mail/MimeParserTest.php
+++ b/tests/unit/Service/Mail/MimeParserTest.php
@@ -348,6 +348,176 @@ class MimeParserTest extends TestCase {
 		self::assertSame('Body with LF', $message->body);
 	}
 
+	// ---- classification ----------------------------------------------------
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public static function automatedHeaders(): array {
+		return [
+			'auto-replied' => ['Auto-Submitted: auto-replied'],
+			'auto-generated' => ['Auto-Submitted: auto-generated'],
+			'precedence bulk' => ['Precedence: bulk'],
+			'precedence list' => ['Precedence: list'],
+			'precedence junk' => ['Precedence: junk'],
+			'list-id' => ['List-Id: <announce.example.com>'],
+			'list-unsubscribe' => ['List-Unsubscribe: <mailto:x@example.com>'],
+			'ms suppress' => ['X-Auto-Response-Suppress: OOF'],
+			'x-autoreply' => ['X-Autoreply: yes'],
+			'null return path' => ['Return-Path: <>'],
+		];
+	}
+
+	/**
+	 * @dataProvider automatedHeaders
+	 */
+	public function testDetectsAutomatedMail(string $header): void {
+		$raw = $this->message("From: a@example.com\nSubject: s\n{$header}\n\nbody");
+
+		self::assertTrue($this->parser->parse($raw)->isAutomated);
+	}
+
+	public function testOrdinaryMailIsNotFlaggedAsAutomated(): void {
+		// The loop breaker must not swallow real mail.
+		$raw = $this->message("From: a@example.com\nSubject: s\nReturn-Path: <a@example.com>\n\nbody");
+
+		self::assertFalse($this->parser->parse($raw)->isAutomated);
+	}
+
+	public function testAutoSubmittedNoIsNotAutomated(): void {
+		// RFC 3834: 'no' is the explicit "this is a human" value.
+		$raw = $this->message("From: a@example.com\nSubject: s\nAuto-Submitted: no\n\nbody");
+
+		self::assertFalse($this->parser->parse($raw)->isAutomated);
+	}
+
+	public function testAbsentReturnPathIsNotABounce(): void {
+		// Plenty of ordinary mail has no Return-Path by the time it reaches IMAP;
+		// only a PRESENT-but-empty one is the bounce signature.
+		$raw = $this->message("From: a@example.com\nSubject: s\n\nbody");
+
+		self::assertFalse($this->parser->parse($raw)->isAutomated);
+	}
+
+	public function testDetectsADeliveryReport(): void {
+		$raw = $this->message("From: mailer@example.com\nSubject: Undelivered\nContent-Type: multipart/report; boundary=\"b\"\n\n--b--");
+
+		self::assertTrue($this->parser->parse($raw)->isAutomated);
+	}
+
+	public function testDetectsSpamFlags(): void {
+		$flag = $this->message("From: a@example.com\nSubject: s\nX-Spam-Flag: YES\n\nbody");
+		$status = $this->message("From: a@example.com\nSubject: s\nX-Spam-Status: Yes, score=9.4 required=5.0\n\nbody");
+		$clean = $this->message("From: a@example.com\nSubject: s\nX-Spam-Status: No, score=-1.2\n\nbody");
+
+		self::assertTrue($this->parser->parse($flag)->isSpam);
+		self::assertTrue($this->parser->parse($status)->isSpam);
+		self::assertFalse($this->parser->parse($clean)->isSpam);
+	}
+
+	public function testReadsOnlyTheTopmostAuthenticationResults(): void {
+		// Hops PREPEND, so the first is our own MTA's and everything below it is
+		// the sender's to forge.
+		$raw = $this->message(<<<EOM
+			From: liar@example.com
+			Subject: s
+			Authentication-Results: mx.ours.test; dmarc=fail header.from=example.com
+			Authentication-Results: attacker-supplied; dmarc=pass header.from=example.com
+
+			body
+			EOM);
+
+		self::assertFalse($this->parser->parse($raw)->isAuthenticated());
+	}
+
+	public function testHonoursAGenuineTopmostPass(): void {
+		$raw = $this->message(<<<EOM
+			From: real@example.com
+			Subject: s
+			Authentication-Results: mx.ours.test; dmarc=pass header.from=example.com
+
+			body
+			EOM);
+
+		self::assertTrue($this->parser->parse($raw)->isAuthenticated());
+	}
+
+	// ---- dedupe key --------------------------------------------------------
+
+	public function testExtractsTheMessageId(): void {
+		$raw = $this->message("From: a@example.com\nSubject: s\nMessage-ID: <abc123@example.com>\n\nbody");
+
+		self::assertSame('abc123@example.com', $this->parser->parse($raw)->messageId);
+	}
+
+	public function testTheSameMessageIdYieldsTheSameDedupeKey(): void {
+		$one = $this->message("From: a@example.com\nSubject: First\nMessage-ID: <same@example.com>\n\nbody");
+		// Same id, different everything else - a re-delivery of one message.
+		$two = $this->message("From: b@example.com\nSubject: Second\nMessage-ID: <same@example.com>\n\nother");
+
+		self::assertSame(
+			$this->parser->parse($one)->dedupeKey(),
+			$this->parser->parse($two)->dedupeKey(),
+		);
+	}
+
+	public function testMessagesWithoutAnIdStillDedupeOnTheirContent(): void {
+		// Message-ID is optional in practice, and a mailbox re-delivering such a
+		// message would otherwise card it twice.
+		$raw = "From: a@example.com\r\nSubject: s\r\n\r\nidentical body";
+
+		self::assertSame(
+			$this->parser->parse($raw)->dedupeKey(),
+			$this->parser->parse($raw)->dedupeKey(),
+		);
+	}
+
+	public function testDifferentMessagesGetDifferentDedupeKeys(): void {
+		$one = $this->message("From: a@example.com\nSubject: One\n\nbody one");
+		$two = $this->message("From: a@example.com\nSubject: Two\n\nbody two");
+
+		self::assertNotSame(
+			$this->parser->parse($one)->dedupeKey(),
+			$this->parser->parse($two)->dedupeKey(),
+		);
+	}
+
+	// ---- hardening ---------------------------------------------------------
+
+	public function testStripsBidiOverridesFromTheSubject(): void {
+		// The "invoice<RLO>fdp.exe" trick: the title renders as something other
+		// than what it contains, and a card title is what a person judges.
+		$raw = $this->message("From: a@example.com\nSubject: invoice\u{202E}gnp.exe\n\nbody");
+
+		$subject = $this->parser->parse($raw)->subject;
+
+		self::assertStringNotContainsString("\u{202E}", $subject);
+		self::assertStringContainsString('invoice', $subject);
+	}
+
+	public function testStripsZeroWidthCharacters(): void {
+		// Zero-width joiners let two visually identical subjects differ, which
+		// defeats a reader comparing a card against what they expected.
+		$raw = $this->message("From: a@example.com\nSubject: pay\u{200B}ment\n\nbody");
+
+		self::assertSame('payment', $this->parser->parse($raw)->subject);
+	}
+
+	public function testAnAbsurdlyLongHeaderIsClampedRatherThanParsedWhole(): void {
+		// A single header is otherwise bounded only by the 5 MiB message ceiling,
+		// and the address pattern backtracks superlinearly - a cheap way to burn
+		// cron CPU. Should be fast and must not hang.
+		$long = str_repeat('<', 200000);
+		$raw = "From: {$long}\r\nSubject: s\r\n\r\nbody";
+
+		$start = microtime(true);
+		$message = $this->parser->parse($raw);
+		$elapsed = microtime(true) - $start;
+
+		self::assertLessThan(2.0, $elapsed, 'header parsing should not blow up on a pathological value');
+		self::assertSame('s', $message->subject);
+	}
+
 	public function testPartWithNoContentTypeIsTreatedAsPlainText(): void {
 		// RFC 2045: an absent Content-Type means text/plain.
 		$raw = $this->message("From: a@example.com\nSubject: s\n\nImplicitly plain");

--- a/tests/unit/Service/MailIntakeServiceTest.php
+++ b/tests/unit/Service/MailIntakeServiceTest.php
@@ -1,0 +1,622 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 Fatih AKTAS <akfatih2@gmail.com>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\Kanso\Tests\Unit\Service;
+
+use OCA\Kanso\Db\Board;
+use OCA\Kanso\Db\BoardMapper;
+use OCA\Kanso\Db\Card;
+use OCA\Kanso\Db\MailIntake;
+use OCA\Kanso\Db\MailIntakeMapper;
+use OCA\Kanso\Db\Stack;
+use OCA\Kanso\Db\StackMapper;
+use OCA\Kanso\Service\CardService;
+use OCA\Kanso\Service\InvalidInputException;
+use OCA\Kanso\Service\Mail\ImapClient;
+use OCA\Kanso\Service\Mail\ImapClientFactory;
+use OCA\Kanso\Service\Mail\ImapException;
+use OCA\Kanso\Service\Mail\MimeParser;
+use OCA\Kanso\Service\MailIntakeService;
+use OCA\Kanso\Service\NotPermittedException;
+use OCA\Kanso\Service\PermissionService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class MailIntakeServiceTest extends TestCase {
+	private const NOW = 1_800_000_000;
+	private const BOARD_ID = 7;
+	private const STACK_ID = 22;
+	private const OWNER = 'alice';
+
+	private MailIntakeMapper&MockObject $mapper;
+	private BoardMapper&MockObject $boardMapper;
+	private StackMapper&MockObject $stackMapper;
+	private CardService&MockObject $cardService;
+	private PermissionService&MockObject $permissionService;
+	private ICrypto&MockObject $crypto;
+	private ITimeFactory&MockObject $time;
+	private LoggerInterface&MockObject $logger;
+	private ImapClientFactory&MockObject $clientFactory;
+	private ImapClient&MockObject $client;
+	private MailIntakeService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mapper = $this->createMock(MailIntakeMapper::class);
+		$this->boardMapper = $this->createMock(BoardMapper::class);
+		$this->stackMapper = $this->createMock(StackMapper::class);
+		$this->cardService = $this->createMock(CardService::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->time = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->clientFactory = $this->createMock(ImapClientFactory::class);
+		$this->client = $this->createMock(ImapClient::class);
+
+		$this->time->method('getTime')->willReturn(self::NOW);
+		$this->clientFactory->method('create')->willReturn($this->client);
+		// The cipher is NC's business; round-trip through a marker so the tests
+		// can tell encrypted from plaintext.
+		$this->crypto->method('encrypt')->willReturnCallback(static fn (string $v): string => 'enc:' . $v);
+		$this->crypto->method('decrypt')->willReturnCallback(static function (string $v): string {
+			if (!str_starts_with($v, 'enc:')) {
+				throw new \Exception('bad ciphertext');
+			}
+			return substr($v, 4);
+		});
+
+		$this->service = new MailIntakeService(
+			$this->mapper,
+			$this->boardMapper,
+			$this->stackMapper,
+			$this->cardService,
+			$this->permissionService,
+			// The parser is pure and its own tests cover it - a mock here would
+			// only assert that this class calls something.
+			new MimeParser(),
+			$this->crypto,
+			$this->time,
+			$this->logger,
+			$this->clientFactory,
+		);
+	}
+
+	private function board(bool $deleted = false): Board {
+		$board = new Board();
+		$board->setId(self::BOARD_ID);
+		$board->setOwner(self::OWNER);
+		$board->setDeletedAt($deleted ? self::NOW : 0);
+		return $board;
+	}
+
+	private function stack(int $boardId = self::BOARD_ID, bool $deleted = false): Stack {
+		$stack = new Stack();
+		$stack->setId(self::STACK_ID);
+		$stack->setBoardId($boardId);
+		$stack->setDeletedAt($deleted ? self::NOW : 0);
+		return $stack;
+	}
+
+	private function config(string $allowlist = '', int $lastUid = 10, int $uidValidity = 99): MailIntake {
+		$config = new MailIntake();
+		$config->setId(1);
+		$config->setBoardId(self::BOARD_ID);
+		$config->setStackId(self::STACK_ID);
+		$config->setHost('mail.example.com');
+		$config->setPort(993);
+		$config->setEncryption(MailIntake::ENCRYPTION_SSL);
+		$config->setUsername('inbox@example.com');
+		$config->setPassword('enc:secret');
+		$config->setMailbox('INBOX');
+		$config->setSenderAllowlist($allowlist === '' ? null : $allowlist);
+		$config->setEnabled(true);
+		$config->setLastUid($lastUid);
+		$config->setUidValidity($uidValidity);
+		$config->setLastRun(0);
+		return $config;
+	}
+
+	private function rawMessage(string $from, string $subject, string $body = 'Body text'): string {
+		return "From: {$from}\r\nSubject: {$subject}\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n{$body}";
+	}
+
+	private function card(int $id = 500): Card {
+		$card = new Card();
+		$card->setId($id);
+		return $card;
+	}
+
+	private function expectBoardAndStackResolve(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->stackMapper->method('find')->willReturn($this->stack());
+	}
+
+	// ---- permissions -------------------------------------------------------
+
+	public function testGetConfigRequiresManage(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->permissionService->method('assertPermission')
+			->willThrowException(new NotPermittedException('nope'));
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->getConfig(self::BOARD_ID, 'mallory');
+	}
+
+	public function testSaveConfigRequiresManage(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->permissionService->method('assertPermission')
+			->willThrowException(new NotPermittedException('nope'));
+		$this->mapper->expects(self::never())->method('insert');
+
+		$this->expectException(NotPermittedException::class);
+		$this->save(password: 'pw', actorUid: 'mallory');
+	}
+
+	public function testDeleteConfigRequiresManage(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->permissionService->method('assertPermission')
+			->willThrowException(new NotPermittedException('nope'));
+		$this->mapper->expects(self::never())->method('deleteByBoard');
+
+		$this->expectException(NotPermittedException::class);
+		$this->service->deleteConfig(self::BOARD_ID, 'mallory');
+	}
+
+	// ---- config validation -------------------------------------------------
+
+	/** Saves with sensible defaults, overridable per test. */
+	private function save(
+		?string $password = 'pw',
+		string $host = 'mail.example.com',
+		int $port = 993,
+		string $encryption = MailIntake::ENCRYPTION_SSL,
+		string $username = 'inbox@example.com',
+		string $mailbox = 'INBOX',
+		string $allowlist = '',
+		bool $enabled = true,
+		string $actorUid = self::OWNER,
+		int $stackId = self::STACK_ID,
+	): MailIntake {
+		return $this->service->saveConfig(
+			self::BOARD_ID,
+			$stackId,
+			$host,
+			$port,
+			$encryption,
+			$username,
+			$password,
+			$mailbox,
+			$allowlist,
+			$enabled,
+			$actorUid,
+		);
+	}
+
+	public function testSaveConfigStoresThePasswordEncrypted(): void {
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')
+			->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('none'));
+		$this->mapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(static fn (MailIntake $c): MailIntake => $c);
+
+		$saved = $this->save(password: 'hunter2');
+
+		// The credential must never be at rest in the clear.
+		self::assertSame('enc:hunter2', $saved->getPassword());
+		self::assertStringNotContainsString('hunter2', json_encode($saved->jsonSerialize()) ?: '');
+	}
+
+	public function testJsonNeverCarriesThePassword(): void {
+		$json = $this->config()->jsonSerialize();
+
+		self::assertArrayNotHasKey('password', $json);
+		self::assertTrue($json['hasPassword']);
+	}
+
+	public function testSaveConfigKeepsTheStoredPasswordWhenNoneIsSupplied(): void {
+		$existing = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+		$this->mapper->method('update')->willReturnCallback(static fn (MailIntake $c): MailIntake => $c);
+
+		// The UI never receives the password, so re-saving to change the stack
+		// must not blank it.
+		$saved = $this->save(password: null);
+
+		self::assertSame('enc:secret', $saved->getPassword());
+	}
+
+	public function testSaveConfigRejectsAFirstSaveWithNoPassword(): void {
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')
+			->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('none'));
+
+		$this->expectException(InvalidInputException::class);
+		$this->save(password: null);
+	}
+
+	public function testSaveConfigRejectsAnOutOfRangePort(): void {
+		$this->expectBoardAndStackResolve();
+
+		$this->expectException(InvalidInputException::class);
+		$this->save(port: 99999);
+	}
+
+	public function testSaveConfigRejectsCleartextImap(): void {
+		$this->expectBoardAndStackResolve();
+
+		// A plaintext LOGIN would put the mailbox password on the wire.
+		$this->expectException(InvalidInputException::class);
+		$this->save(encryption: 'none');
+	}
+
+	public function testSaveConfigRejectsLineBreaksInTheHost(): void {
+		$this->expectBoardAndStackResolve();
+
+		// Rejected at the config boundary so it is a 400 now, not a mailbox that
+		// silently fails every poll.
+		$this->expectException(InvalidInputException::class);
+		$this->save(host: "mail.example.com\r\nK999 DELETE INBOX");
+	}
+
+	public function testSaveConfigRejectsAStackFromAnotherBoard(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->stackMapper->method('find')->willReturn($this->stack(boardId: 999));
+
+		$this->expectException(InvalidInputException::class);
+		$this->save();
+	}
+
+	public function testSaveConfigResetsTheWatermarkWhenTheMailboxIdentityChanges(): void {
+		$existing = $this->config(lastUid: 500, uidValidity: 99);
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+		$this->mapper->method('update')->willReturnCallback(static fn (MailIntake $c): MailIntake => $c);
+
+		// UIDs mean nothing across accounts - carrying 500 over would skip
+		// everything below it on the new mailbox.
+		$saved = $this->save(username: 'other@example.com');
+
+		self::assertSame(0, $saved->getLastUid());
+		self::assertSame(0, $saved->getUidValidity());
+	}
+
+	public function testSaveConfigKeepsTheWatermarkWhenOnlyTheStackChanges(): void {
+		$existing = $this->config(lastUid: 500);
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+		$this->mapper->method('update')->willReturnCallback(static fn (MailIntake $c): MailIntake => $c);
+
+		$saved = $this->save();
+
+		// Same mailbox: re-reading it from the start would duplicate every card.
+		self::assertSame(500, $saved->getLastUid());
+	}
+
+	// ---- polling -----------------------------------------------------------
+
+	public function testPollCreatesACardPerMessageAsTheBoardOwner(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11, 12]);
+		$this->client->method('fetchMessage')->willReturnMap([
+			[11, $this->rawMessage('jacek@example.com', 'First subject')],
+			[12, $this->rawMessage('jacek@example.com', 'Second subject')],
+		]);
+
+		$titles = [];
+		$this->cardService->expects(self::exactly(2))
+			->method('create')
+			->willReturnCallback(function (int $stackId, string $title, string $uid) use (&$titles): Card {
+				self::assertSame(self::STACK_ID, $stackId);
+				// Never the user whose address the forgeable From claims.
+				self::assertSame(self::OWNER, $uid);
+				$titles[] = $title;
+				return $this->card();
+			});
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		self::assertSame(2, $this->service->poll($config));
+		self::assertSame(['First subject', 'Second subject'], $titles);
+		self::assertSame(12, $config->getLastUid());
+	}
+
+	public function testPollPutsTheSenderAndBodyInTheDescription(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')
+			->willReturn($this->rawMessage('Jacek <jacek@example.com>', 'Subj', 'The body'));
+		$this->cardService->method('create')->willReturn($this->card());
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$description = null;
+		$this->cardService->expects(self::once())
+			->method('update')
+			->willReturnCallback(function (int $id, ?string $title, ?string $desc) use (&$description): Card {
+				$description = $desc;
+				return $this->card();
+			});
+
+		$this->service->poll($config);
+
+		self::assertStringContainsString('Jacek <jacek@example.com>', (string)$description);
+		self::assertStringContainsString('The body', (string)$description);
+	}
+
+	public function testPollSkipsSendersOutsideTheAllowlist(): void {
+		$config = $this->config(allowlist: "jacek@example.com\n@trusted.example");
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11, 12, 13, 14]);
+		$this->client->method('fetchMessage')->willReturnMap([
+			[11, $this->rawMessage('jacek@example.com', 'Allowed exactly')],
+			[12, $this->rawMessage('anyone@trusted.example', 'Allowed by domain')],
+			[13, $this->rawMessage('spammer@evil.test', 'Blocked')],
+			[14, $this->rawMessage('', 'Unparseable sender')],
+		]);
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$titles = [];
+		$this->cardService->method('create')
+			->willReturnCallback(function (int $stackId, string $title, string $uid) use (&$titles): Card {
+				$titles[] = $title;
+				return $this->card();
+			});
+
+		self::assertSame(2, $this->service->poll($config));
+		self::assertSame(['Allowed exactly', 'Allowed by domain'], $titles);
+		// A message that fails the filter still advances the watermark, or every
+		// poll would re-examine it forever.
+		self::assertSame(14, $config->getLastUid());
+	}
+
+	public function testPollAcceptsAnySenderWhenTheAllowlistIsEmpty(): void {
+		$config = $this->config(allowlist: '');
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')->willReturn($this->rawMessage('anyone@anywhere.test', 'Open intake'));
+		$this->cardService->method('create')->willReturn($this->card());
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		self::assertSame(1, $this->service->poll($config));
+	}
+
+	public function testPollResetsTheWatermarkWhenUidValidityChanges(): void {
+		$config = $this->config(lastUid: 500, uidValidity: 99);
+		$this->expectBoardAndStackResolve();
+		// The server renumbered: the old UIDs address different messages now.
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 100, 'uidNext' => 5]);
+		$this->client->expects(self::once())
+			->method('searchUidsAbove')
+			->with(0)
+			->willReturn([]);
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$this->service->poll($config);
+
+		self::assertSame(100, $config->getUidValidity());
+	}
+
+	public function testPollPersistsTheWatermarkEvenWhenItFailsMidBatch(): void {
+		$config = $this->config(lastUid: 10);
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11, 12, 13]);
+		$this->client->method('fetchMessage')->willReturnCallback(function (int $uid): string {
+			if ($uid === 13) {
+				throw new ImapException('connection lost');
+			}
+			return $this->rawMessage('a@example.com', 'Subject ' . $uid);
+		});
+		$this->cardService->method('create')->willReturn($this->card());
+
+		$persisted = null;
+		$this->mapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(static function (MailIntake $c) use (&$persisted): MailIntake {
+				$persisted = $c->getLastUid();
+				return $c;
+			});
+
+		try {
+			$this->service->poll($config);
+			self::fail('Expected the ImapException to propagate');
+		} catch (ImapException) {
+			// Expected - pollAll() records and steps over it.
+		}
+
+		// The two messages already carded must not be carded again on the next
+		// run. Without persisting on the failure path they would be.
+		self::assertSame(12, $persisted);
+		self::assertNotNull($config->getLastError());
+	}
+
+	public function testPollCapsHowManyMessagesOneRunCards(): void {
+		$config = $this->config(lastUid: 0);
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 500]);
+		// A mailbox with years of history.
+		$this->client->method('searchUidsAbove')->willReturn(range(1, 400));
+		$this->client->method('fetchMessage')
+			->willReturnCallback(fn (int $uid): string => $this->rawMessage('a@example.com', 'Subject ' . $uid));
+		$this->cardService->method('create')->willReturn($this->card());
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		// Bounded per run; the watermark makes the next run continue.
+		self::assertSame(50, $this->service->poll($config));
+		self::assertSame(50, $config->getLastUid());
+	}
+
+	public function testPollDoesNotConnectWhenTheTargetStackIsGone(): void {
+		$config = $this->config();
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->stackMapper->method('find')->willReturn($this->stack(deleted: true));
+		// Handing a credential to a remote server to accomplish nothing is the
+		// thing to avoid here.
+		$this->client->expects(self::never())->method('connect');
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$this->expectException(ImapException::class);
+		$this->service->poll($config);
+	}
+
+	public function testPollLeavesTheWatermarkAloneWhenTheStackIsGone(): void {
+		$config = $this->config(lastUid: 10);
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->stackMapper->method('find')->willReturn($this->stack(deleted: true));
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		try {
+			$this->service->poll($config);
+		} catch (ImapException) {
+			// Expected.
+		}
+
+		// The mail is still on the server, waiting for a live stack.
+		self::assertSame(10, $config->getLastUid());
+	}
+
+	public function testPollReportsAnUndecryptableCredentialAsSomethingActionable(): void {
+		$config = $this->config();
+		$config->setPassword('not-encrypted-by-this-secret');
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$this->expectException(ImapException::class);
+		$this->expectExceptionMessage('re-enter it');
+		$this->service->poll($config);
+	}
+
+	public function testPollUsesTheSenderWhenTheSubjectIsEmpty(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')->willReturn($this->rawMessage('jacek@example.com', '   '));
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$title = null;
+		$this->cardService->method('create')
+			->willReturnCallback(function (int $stackId, string $t) use (&$title): Card {
+				$title = $t;
+				return $this->card();
+			});
+
+		$this->service->poll($config);
+
+		// create() throws on an empty title, so a blank subject must never reach it.
+		self::assertNotSame('', trim((string)$title));
+		self::assertStringContainsString('jacek@example.com', (string)$title);
+	}
+
+	public function testPollTruncatesAnOverlongSubject(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')
+			->willReturn($this->rawMessage('a@example.com', str_repeat('x', 300)));
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$title = null;
+		$this->cardService->method('create')
+			->willReturnCallback(function (int $stackId, string $t) use (&$title): Card {
+				$title = $t;
+				return $this->card();
+			});
+
+		$this->service->poll($config);
+
+		self::assertLessThanOrEqual(CardService::MAX_TITLE_LENGTH, mb_strlen((string)$title));
+	}
+
+	public function testPollSkipsAMessageThatVanishedBetweenSearchAndFetch(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 30]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		// '' is what fetch returns for a message deleted mid-poll.
+		$this->client->method('fetchMessage')->willReturn('');
+		$this->cardService->expects(self::never())->method('create');
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		self::assertSame(0, $this->service->poll($config));
+		// Still advanced, so it is not retried forever.
+		self::assertSame(11, $config->getLastUid());
+	}
+
+	public function testPollAlwaysDisconnects(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willThrowException(new ImapException('boom'));
+		$this->mapper->method('update')->willReturnArgument(0);
+		$this->client->expects(self::once())->method('disconnect');
+
+		try {
+			$this->service->poll($config);
+		} catch (ImapException) {
+			// Expected.
+		}
+	}
+
+	public function testPollAllStepsOverAFailingMailbox(): void {
+		$broken = $this->config();
+		$broken->setId(1);
+		$working = $this->config();
+		$working->setId(2);
+
+		$this->mapper->method('findEnabled')->willReturn([$broken, $working]);
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$call = 0;
+		$this->client->method('selectMailbox')->willReturnCallback(function () use (&$call): array {
+			$call++;
+			if ($call === 1) {
+				throw new ImapException('server unreachable');
+			}
+			return ['uidValidity' => 99, 'uidNext' => 30];
+		});
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')->willReturn($this->rawMessage('a@example.com', 'Subject'));
+		$this->cardService->method('create')->willReturn($this->card());
+
+		// One board's expired password must not stop every other board's intake.
+		self::assertSame(1, $this->service->pollAll());
+	}
+
+	public function testTestConnectionReportsAFailureInsteadOfThrowing(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->mapper->method('findByBoard')->willReturn($this->config());
+		$this->client->method('connect')->willThrowException(new ImapException('Cannot connect to mail.example.com:993'));
+
+		$result = $this->service->testConnection(self::BOARD_ID, self::OWNER);
+
+		self::assertFalse($result['ok']);
+		self::assertStringContainsString('Cannot connect', (string)$result['error']);
+	}
+
+	public function testTestConnectionSucceeds(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->mapper->method('findByBoard')->willReturn($this->config());
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 1]);
+
+		$result = $this->service->testConnection(self::BOARD_ID, self::OWNER);
+
+		self::assertTrue($result['ok']);
+		self::assertNull($result['error']);
+	}
+}

--- a/tests/unit/Service/MailIntakeServiceTest.php
+++ b/tests/unit/Service/MailIntakeServiceTest.php
@@ -251,6 +251,54 @@ class MailIntakeServiceTest extends TestCase {
 		$this->save(password: null);
 	}
 
+	public function testStoredPasswordCannotBeCarriedOverToADifferentServer(): void {
+		$existing = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+		$this->mapper->expects(self::never())->method('update');
+
+		// Otherwise a manager who never knew the credential repoints the mailbox
+		// at a host they control, leaves the password blank, and the next
+		// connection hands them the password.
+		$this->expectException(InvalidInputException::class);
+		$this->save(password: null, host: 'evil.attacker.test');
+	}
+
+	public function testStoredPasswordCannotBeCarriedOverToADifferentAccount(): void {
+		$existing = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+
+		$this->expectException(InvalidInputException::class);
+		$this->save(password: null, username: 'someone-else@example.com');
+	}
+
+	public function testChangingTheServerIsAllowedWhenThePasswordIsSuppliedAgain(): void {
+		$existing = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+		$this->mapper->method('update')->willReturnCallback(static fn (MailIntake $c): MailIntake => $c);
+
+		$saved = $this->save(password: 'new-password', host: 'imap.newhost.example');
+
+		self::assertSame('imap.newhost.example', $saved->getHost());
+		self::assertSame('enc:new-password', $saved->getPassword());
+	}
+
+	public function testChangingOnlyTheFolderStillKeepsTheStoredPassword(): void {
+		$existing = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->mapper->method('findByBoard')->willReturn($existing);
+		$this->mapper->method('update')->willReturnCallback(static fn (MailIntake $c): MailIntake => $c);
+
+		// Same server, same account - nothing to steal, so forcing a re-type here
+		// would be friction with no security benefit.
+		$saved = $this->save(password: null, mailbox: 'Archive');
+
+		self::assertSame('Archive', $saved->getMailbox());
+		self::assertSame('enc:secret', $saved->getPassword());
+	}
+
 	public function testSaveConfigRejectsAnOutOfRangePort(): void {
 		$this->expectBoardAndStackResolve();
 

--- a/tests/unit/Service/MailIntakeServiceTest.php
+++ b/tests/unit/Service/MailIntakeServiceTest.php
@@ -12,6 +12,7 @@ use OCA\Kanso\Db\BoardMapper;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\MailIntake;
 use OCA\Kanso\Db\MailIntakeMapper;
+use OCA\Kanso\Db\MailSeenMessageMapper;
 use OCA\Kanso\Db\Stack;
 use OCA\Kanso\Db\StackMapper;
 use OCA\Kanso\Service\CardService;
@@ -36,6 +37,7 @@ class MailIntakeServiceTest extends TestCase {
 	private const OWNER = 'alice';
 
 	private MailIntakeMapper&MockObject $mapper;
+	private MailSeenMessageMapper&MockObject $seenMapper;
 	private BoardMapper&MockObject $boardMapper;
 	private StackMapper&MockObject $stackMapper;
 	private CardService&MockObject $cardService;
@@ -51,6 +53,10 @@ class MailIntakeServiceTest extends TestCase {
 		parent::setUp();
 
 		$this->mapper = $this->createMock(MailIntakeMapper::class);
+		$this->seenMapper = $this->createMock(MailSeenMessageMapper::class);
+		// Default: nothing has been carded before, so every message is new. Tests
+		// about duplicate suppression override this.
+		$this->seenMapper->method('claim')->willReturn(true);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->stackMapper = $this->createMock(StackMapper::class);
 		$this->cardService = $this->createMock(CardService::class);
@@ -75,6 +81,7 @@ class MailIntakeServiceTest extends TestCase {
 
 		$this->service = new MailIntakeService(
 			$this->mapper,
+			$this->seenMapper,
 			$this->boardMapper,
 			$this->stackMapper,
 			$this->cardService,
@@ -394,11 +401,32 @@ class MailIntakeServiceTest extends TestCase {
 		self::assertSame(1, $this->service->poll($config));
 	}
 
-	public function testPollResetsTheWatermarkWhenUidValidityChanges(): void {
+	public function testRenumberedMailboxResumesFromNewMailOnly(): void {
 		$config = $this->config(lastUid: 500, uidValidity: 99);
 		$this->expectBoardAndStackResolve();
-		// The server renumbered: the old UIDs address different messages now.
-		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 100, 'uidNext' => 5]);
+		// The server renumbered (restore from backup, mailbox recreated): the old
+		// UIDs address different messages now.
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 100, 'uidNext' => 900]);
+		// Restarting at 0 would re-card the mailbox's entire history. UIDNEXT-1
+		// means "everything already there is history; card what arrives next".
+		$this->client->expects(self::once())
+			->method('searchUidsAbove')
+			->with(899)
+			->willReturn([]);
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$this->service->poll($config);
+
+		self::assertSame(100, $config->getUidValidity());
+		self::assertSame(899, $config->getLastUid());
+	}
+
+	public function testFirstEverPollIngestsWhatIsAlreadyInTheMailbox(): void {
+		// uidValidity 0 = never polled. Someone who just pointed a board at a
+		// dedicated address expects the mail sitting in it to arrive.
+		$config = $this->config(lastUid: 0, uidValidity: 0);
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 100, 'uidNext' => 900]);
 		$this->client->expects(self::once())
 			->method('searchUidsAbove')
 			->with(0)
@@ -407,7 +435,7 @@ class MailIntakeServiceTest extends TestCase {
 
 		$this->service->poll($config);
 
-		self::assertSame(100, $config->getUidValidity());
+		self::assertSame(0, $config->getLastUid());
 	}
 
 	public function testPollPersistsTheWatermarkEvenWhenItFailsMidBatch(): void {
@@ -607,6 +635,311 @@ class MailIntakeServiceTest extends TestCase {
 
 		self::assertFalse($result['ok']);
 		self::assertStringContainsString('Cannot connect', (string)$result['error']);
+	}
+
+	// ---- abuse controls ----------------------------------------------------
+
+	/**
+	 * Drives one poll over a set of raw messages and returns the card titles
+	 * that resulted.
+	 *
+	 * @param array<int, string> $rawByUid
+	 * @return string[]
+	 */
+	private function pollWith(MailIntake $config, array $rawByUid): array {
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 999]);
+		$this->client->method('searchUidsAbove')->willReturn(array_keys($rawByUid));
+		$this->client->method('fetchMessage')
+			->willReturnCallback(static fn (int $uid): string => $rawByUid[$uid] ?? '');
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$titles = [];
+		$this->cardService->method('create')
+			->willReturnCallback(function (int $stackId, string $title) use (&$titles): Card {
+				$titles[] = $title;
+				return $this->card();
+			});
+
+		$this->service->poll($config);
+		return $titles;
+	}
+
+	/**
+	 * The loop breaker. A card raises a notification email; an out-of-office
+	 * answers it; that answer must not become another card.
+	 */
+	public function testAutomatedMessagesAreNeverCarded(): void {
+		$auto = "From: ooo@example.com\r\nSubject: Out of office\r\nAuto-Submitted: auto-replied\r\n\r\nAway until Monday";
+		$bounce = "From: postmaster@example.com\r\nSubject: Undelivered\r\nReturn-Path: <>\r\n\r\nFailed";
+		$list = "From: list@example.com\r\nSubject: Newsletter\r\nList-Id: <news.example.com>\r\n\r\nHello";
+		$bulk = "From: bulk@example.com\r\nSubject: Promo\r\nPrecedence: bulk\r\n\r\nBuy";
+		$report = "From: mailer@example.com\r\nSubject: Delivery report\r\nContent-Type: multipart/report; boundary=\"x\"\r\n\r\n--x--";
+		$real = $this->rawMessage('human@example.com', 'A real request');
+
+		$titles = $this->pollWith($this->config(), [
+			11 => $auto,
+			12 => $bounce,
+			13 => $list,
+			14 => $bulk,
+			15 => $report,
+			16 => $real,
+		]);
+
+		self::assertSame(['A real request'], $titles);
+	}
+
+	public function testSpamFlaggedMessagesAreNeverCarded(): void {
+		// Kanso does not re-implement spam detection; it honours the upstream
+		// filter's verdict.
+		$spamFlag = "From: spam@example.com\r\nSubject: Cheap pills\r\nX-Spam-Flag: YES\r\n\r\nBuy";
+		$spamStatus = "From: spam2@example.com\r\nSubject: Also spam\r\nX-Spam-Status: Yes, score=9.1\r\n\r\nBuy";
+		$real = $this->rawMessage('human@example.com', 'Legitimate');
+
+		$titles = $this->pollWith($this->config(), [11 => $spamFlag, 12 => $spamStatus, 13 => $real]);
+
+		self::assertSame(['Legitimate'], $titles);
+	}
+
+	public function testRequireAuthRejectsMessagesTheMtaDidNotAuthenticate(): void {
+		$config = $this->config();
+		$config->setRequireAuth(true);
+
+		$passing = "From: real@example.com\r\nSubject: Authenticated\r\n"
+			. "Authentication-Results: mx.ours.test; dmarc=pass header.from=example.com\r\n\r\nBody";
+		// A pass for a DIFFERENT domain must not vouch for this sender.
+		$mismatched = "From: real@example.com\r\nSubject: Mismatched\r\n"
+			. "Authentication-Results: mx.ours.test; dmarc=pass header.from=attacker.test\r\n\r\nBody";
+		$unauthenticated = $this->rawMessage('spoofed@example.com', 'No verdict at all');
+		$spfOnly = "From: real@example.com\r\nSubject: SPF only\r\n"
+			. "Authentication-Results: mx.ours.test; spf=pass\r\n\r\nBody";
+
+		$titles = $this->pollWith($config, [
+			11 => $passing,
+			12 => $mismatched,
+			13 => $unauthenticated,
+			14 => $spfOnly,
+		]);
+
+		// SPF alone authenticates the ENVELOPE sender, not the visible From, so
+		// it is not accepted as proof of who sent this.
+		self::assertSame(['Authenticated'], $titles);
+	}
+
+	public function testForgedLowerAuthenticationResultsHeaderIsIgnored(): void {
+		$config = $this->config();
+		$config->setRequireAuth(true);
+
+		// Hops PREPEND their own header, so the topmost is our MTA's and anything
+		// below it is the sender's to invent. Here our MTA said fail and the
+		// sender pre-inserted a pass underneath it.
+		$raw = "From: liar@example.com\r\nSubject: Forged\r\n"
+			. "Authentication-Results: mx.ours.test; dmarc=fail header.from=example.com\r\n"
+			. "Authentication-Results: attacker-supplied; dmarc=pass header.from=example.com\r\n\r\nBody";
+
+		self::assertSame([], $this->pollWith($config, [11 => $raw]));
+	}
+
+	public function testAlreadySeenMessageIsNotCardedTwice(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 999]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')->willReturn($this->rawMessage('a@example.com', 'Redelivered'));
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		// A fresh mock so the permissive default from setUp does not apply.
+		$seen = $this->createMock(MailSeenMessageMapper::class);
+		$seen->method('claim')->willReturn(false);
+		$service = new MailIntakeService(
+			$this->mapper,
+			$seen,
+			$this->boardMapper,
+			$this->stackMapper,
+			$this->cardService,
+			$this->permissionService,
+			new MimeParser(),
+			$this->crypto,
+			$this->time,
+			$this->logger,
+			$this->clientFactory,
+		);
+
+		$this->cardService->expects(self::never())->method('create');
+
+		self::assertSame(0, $service->poll($config));
+		// Still advanced past it, or it would be re-examined every poll forever.
+		self::assertSame(11, $config->getLastUid());
+	}
+
+	public function testMailboxDailyLimitHoldsTheExcessOnTheServer(): void {
+		$config = $this->config(lastUid: 10);
+		$config->setDailyLimit(2);
+
+		$titles = $this->pollWith($config, [
+			11 => $this->rawMessage('a@example.com', 'One'),
+			12 => $this->rawMessage('b@example.com', 'Two'),
+			13 => $this->rawMessage('c@example.com', 'Three'),
+		]);
+
+		self::assertSame(['One', 'Two'], $titles);
+		// The watermark stops at the last CARDED message, so the excess is still
+		// waiting on the server rather than silently destroyed.
+		self::assertSame(12, $config->getLastUid());
+	}
+
+	public function testPerSenderLimitDoesNotLetOneSenderBlockTheMailbox(): void {
+		$config = $this->config(lastUid: 10);
+		$config->setPerSenderDailyLimit(1);
+
+		$titles = $this->pollWith($config, [
+			11 => $this->rawMessage('flooder@example.com', 'Flood one'),
+			12 => $this->rawMessage('flooder@example.com', 'Flood two'),
+			13 => $this->rawMessage('flooder@example.com', 'Flood three'),
+			14 => $this->rawMessage('someone@example.com', 'Innocent bystander'),
+		]);
+
+		// The flooder is cut off after their first, but everyone else still gets
+		// through - stopping the run instead would hand the flooder a denial of
+		// service against the whole board.
+		self::assertSame(['Flood one', 'Innocent bystander'], $titles);
+		self::assertSame(14, $config->getLastUid());
+	}
+
+	public function testDailyCountersResetOnANewDay(): void {
+		$config = $this->config();
+		$config->setDailyLimit(1);
+		// Yesterday's state must not consume today's budget.
+		$config->setDailyState((string)json_encode(['day' => 20200101, 'total' => 99, 'senders' => []]));
+
+		$titles = $this->pollWith($config, [11 => $this->rawMessage('a@example.com', 'Today')]);
+
+		self::assertSame(['Today'], $titles);
+	}
+
+	public function testCorruptDailyStateDoesNotStallIntake(): void {
+		$config = $this->config();
+		$config->setDailyState('{not json at all');
+
+		$titles = $this->pollWith($config, [11 => $this->rawMessage('a@example.com', 'Still works')]);
+
+		self::assertSame(['Still works'], $titles);
+	}
+
+	/**
+	 * The worst finding in the review: a description write normally re-parses
+	 * `@name` and sends real notifications attributed to the writer. Intake
+	 * writes a stranger's text as the board OWNER.
+	 */
+	public function testIntakeNeverFiresMentionNotifications(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 999]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')
+			->willReturn($this->rawMessage('attacker@evil.test', 'Hi', 'Hey @alice @bob look at this'));
+		$this->cardService->method('create')->willReturn($this->card());
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$notifyMentions = null;
+		$this->cardService->expects(self::once())
+			->method('update')
+			->willReturnCallback(function (...$args) use (&$notifyMentions): Card {
+				// The flag is the last parameter of update().
+				$notifyMentions = $args[18] ?? null;
+				return $this->card();
+			});
+
+		$this->service->poll($config);
+
+		self::assertFalse($notifyMentions, 'intake must suppress @mention notifications');
+	}
+
+	public function testDescriptionMarksTheSenderAsUnverified(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')->willReturn(['uidValidity' => 99, 'uidNext' => 999]);
+		$this->client->method('searchUidsAbove')->willReturn([11]);
+		$this->client->method('fetchMessage')
+			->willReturn($this->rawMessage('boss@example.com', 'Urgent: wire the money'));
+		$this->cardService->method('create')->willReturn($this->card());
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		$description = null;
+		$this->cardService->method('update')
+			->willReturnCallback(function (int $id, ?string $title, ?string $desc) use (&$description): Card {
+				$description = $desc;
+				return $this->card();
+			});
+
+		$this->service->poll($config);
+
+		// A reader has no other way to know this arrived from outside and that
+		// nobody proved who sent it.
+		self::assertStringContainsString('unverified sender', (string)$description);
+	}
+
+	public function testSkippedMessagesAreReportedSoSilentRejectionIsDiagnosable(): void {
+		$config = $this->config(allowlist: 'only@example.com');
+
+		$this->pollWith($config, [
+			11 => $this->rawMessage('stranger@example.com', 'Blocked'),
+		]);
+
+		// "I sent an email and nothing happened" is the support question this
+		// feature generates; the config screen has to be able to answer it.
+		self::assertStringContainsString('allowlist', (string)$config->getLastError());
+	}
+
+	public function testErrorTextNeverEchoesTheAccountName(): void {
+		$config = $this->config();
+		$this->expectBoardAndStackResolve();
+		$this->client->method('selectMailbox')
+			->willThrowException(new ImapException('NO mailbox for inbox@example.com is locked'));
+		$this->mapper->method('update')->willReturnArgument(0);
+
+		try {
+			$this->service->poll($config);
+		} catch (ImapException) {
+			// Expected.
+		}
+
+		self::assertStringNotContainsString('inbox@example.com', (string)$config->getLastError());
+		self::assertStringContainsString('<account>', (string)$config->getLastError());
+	}
+
+	public function testDeleteConfigAlsoDropsTheDedupeKeys(): void {
+		$this->boardMapper->method('find')->willReturn($this->board());
+		$this->mapper->method('findByBoard')->willReturn($this->config());
+
+		// Credentials and dedupe state must not outlive the mailbox they belong
+		// to, or a later config reusing the row id inherits them.
+		$this->seenMapper->expects(self::once())->method('deleteByIntake')->with(1);
+		$this->mapper->expects(self::once())->method('deleteByBoard')->with(self::BOARD_ID);
+
+		$this->service->deleteConfig(self::BOARD_ID, self::OWNER);
+	}
+
+	public function testSaveConfigRejectsAbsurdDailyLimits(): void {
+		$this->expectBoardAndStackResolve();
+
+		$this->expectException(InvalidInputException::class);
+		$this->service->saveConfig(
+			self::BOARD_ID,
+			self::STACK_ID,
+			'mail.example.com',
+			993,
+			MailIntake::ENCRYPTION_SSL,
+			'inbox@example.com',
+			'pw',
+			'INBOX',
+			'',
+			true,
+			self::OWNER,
+			false,
+			-5,
+			0,
+		);
 	}
 
 	public function testTestConnectionSucceeds(): void {

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— keine —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n-mal"
@@ -2055,6 +2055,10 @@ msgstr "Dauer eingeben, z. B. 1h 30m."
 msgid "Enter a name."
 msgstr "Namen eingeben."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Eingabe zum Öffnen · Esc zum Schließen"
@@ -2100,25 +2104,25 @@ msgstr "alle"
 msgid "Every"
 msgstr "Alle"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Täglich"
 msgstr[1] "Alle %n Tage"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Monatlich"
 msgstr[1] "Alle %n Monate"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Wöchentlich"
 msgstr[1] "Alle %n Wochen"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Jährlich"

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— keine —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n-mal"
@@ -338,6 +338,11 @@ msgstr "Eine Karte wurde erstellt, verschoben oder abgeschlossen, oder ein Board
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Jedes Mal wird eine neue Kopie erstellt; diese Karte bleibt die Quelle"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Aktiv"
@@ -514,6 +519,10 @@ msgstr "Beliebig"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Jede Karte kann über ihr ⋯-Menü als Vorlage gespeichert werden (\"Als Vorlage markieren\"). Vorlagen werden auf dem Board ausgeblendet und über das Menü \"＋ Aus Vorlage\" einer Spalte wiederverwendet."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Gemessene Karten"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Karten mit Fälligkeitsdatum werden als Aufgaben mit deinem Kalender und Telefon synchronisiert (via CalDAV/DAVx5). Schalte dies aus, um dieses Board aus deinem eigenen Kalender herauszuhalten. Betrifft nur dich."
 
@@ -1091,6 +1108,10 @@ msgstr "hat den Status auf {value} geändert"
 msgid "Changes requested"
 msgstr "Änderungen angefordert"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Checklistenfortschritt"
 msgid "Choose a board…"
 msgstr "Board auswählen…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Spalte auswählen…"
@@ -1249,6 +1271,10 @@ msgstr "Spalte gelöscht"
 msgid "Column name"
 msgstr "Spaltenname"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Komfortabel"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Bedingung"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Kontakte"
 
@@ -1345,6 +1375,10 @@ msgstr "Datei konnte nicht angehängt werden."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Kartensichtbarkeit konnte nicht geändert werden"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "Deine Boards konnten nicht geladen werden."
 msgid "Could not load your Deck boards."
 msgstr "Deine Deck-Boards konnten nicht geladen werden."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Backup-Einstellungen konnten nicht gespeichert werden"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Täglich"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
@@ -1564,7 +1610,7 @@ msgstr "Gefahrenbereich"
 msgid "Date"
 msgstr "Datum"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Aktivieren & Secret generieren"
 
@@ -1988,6 +2038,10 @@ msgstr "Geplante Backups aktivieren"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Aktiviert"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "alle"
 msgid "Every"
 msgstr "Alle"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Täglich"
 msgstr[1] "Alle %n Tage"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Monatlich"
 msgstr[1] "Alle %n Monate"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Wöchentlich"
 msgstr[1] "Alle %n Wochen"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Jährlich"
@@ -2329,6 +2383,10 @@ msgstr "Vorlagen konnten nicht geladen werden."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Kalender-Feed-Konfiguration konnte nicht geladen werden."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Ordneraktionen"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Für immer"
 
@@ -2849,6 +2911,10 @@ msgstr "Stunden"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importieren"
@@ -2961,6 +3027,10 @@ msgstr "Kanso-Hintergrundaufgaben & E-Mail-Links"
 msgid "Kanso board backups"
 msgstr "Kanso-Board-Backups"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Kanso-Export (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Labels (kommagetrennt)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Labels sind Board-spezifisch: Es werden nur Labels übernommen, die auf dem Ziel-Board ebenfalls vorhanden sind (gleicher Name und gleiche Farbe)."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Wird geladen…"
 msgid "Low"
 msgstr "Niedrig"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Als Unterkarte von … festlegen"
@@ -3194,7 +3276,7 @@ msgstr "Modus"
 msgid "Mon"
 msgstr "Mo"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Eigentümer"
 msgid "Parent card"
 msgstr "Übergeordnete Karte"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "Payload URL"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "Ausstehend"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Angeheftet"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Punkte / Woche (Ø)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Label entfernen…"
 msgid "Remove link"
 msgstr "Link entfernen"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Verknüpfung entfernen"
@@ -4222,6 +4328,10 @@ msgstr "hat ein Review angefordert"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "bat um ein Review für"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Regel speichern"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Als Vorlage gespeichert. Eine Karte daraus kannst du mit der Schaltfläche „+ Aus Vorlage\" in einer beliebigen Spalte hinzufügen."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Sortieren"
 msgid "Sort by"
 msgstr "Sortieren nach"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Spalte {id}"
@@ -4655,6 +4773,10 @@ msgstr "Gestartet"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Beginnt später"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Vorlagenkarte"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Vorlage wurde wieder in eine normale Karte umgewandelt."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook aktiv"
 msgid "Wed"
 msgstr "Mi"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Antwort schreiben…"
 msgid "wrote"
 msgstr "schrieb"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "Du benötigst Bearbeitungsrechte, um Workflows zu konfigurieren."
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Du benötigst Verwaltungsrechte, um Automatisierungsregeln zu konfigurieren."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— ninguno —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -338,6 +338,11 @@ msgstr "Se ha creado, movido o terminado una tarjeta, o se ha compartido un tabl
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Cada vez se crea una copia nueva; esta tarjeta se mantiene como origen"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Activos"
@@ -514,6 +519,10 @@ msgstr "Cualquiera"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Cualquier tarjeta se puede guardar como plantilla desde su menú ⋯ («Marcar como plantilla»). Las plantillas se ocultan del tablero y se reutilizan desde el menú «＋ Desde plantilla» de una columna."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Tarjetas medidas"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Las tarjetas con fecha de vencimiento se sincronizan como tareas con tu calendario y tu teléfono (mediante CalDAV/DAVx5). Desactiva esta opción para mantener este tablero fuera de tu propio calendario. Solo te afecta a ti."
 
@@ -1091,6 +1108,10 @@ msgstr "ha cambiado el estado a {value}"
 msgid "Changes requested"
 msgstr "Cambios solicitados"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Progreso de la lista de tareas"
 msgid "Choose a board…"
 msgstr "Elige un tablero…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Elige una columna…"
@@ -1249,6 +1271,10 @@ msgstr "Columna eliminada"
 msgid "Column name"
 msgstr "Nombre de la columna"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Cómoda"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Condición"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Contactos"
 
@@ -1345,6 +1375,10 @@ msgstr "No se ha podido adjuntar el archivo."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "No se ha podido cambiar la visibilidad de la tarjeta"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "No se han podido cargar tus tableros."
 msgid "Could not load your Deck boards."
 msgstr "No se han podido cargar tus tableros de Deck."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "No se han podido guardar los ajustes de copia de seguridad"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Diaria"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Zona de peligro"
 
@@ -1564,7 +1610,7 @@ msgstr "Zona de peligro"
 msgid "Date"
 msgstr "Fecha"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Activar y generar el secreto"
 
@@ -1988,6 +2038,10 @@ msgstr "Activar las copias de seguridad programadas"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Activada"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "cada"
 msgid "Every"
 msgstr "Cada"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Cada día"
 msgstr[1] "Cada %n días"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Cada mes"
 msgstr[1] "Cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Cada semana"
 msgstr[1] "Cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Cada año"
@@ -2329,6 +2383,10 @@ msgstr "Error al cargar las plantillas."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Error al cargar la configuración de la fuente de calendario."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Acciones de la carpeta"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Sin fin"
 
@@ -2849,6 +2911,10 @@ msgstr "Horas"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importar"
@@ -2961,6 +3027,10 @@ msgstr "Tareas en segundo plano y enlaces de correo de Kanso"
 msgid "Kanso board backups"
 msgstr "Copias de seguridad de los tableros de Kanso"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Exportación de Kanso (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Etiquetas (separadas por comas)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Las etiquetas son propias de cada tablero: solo se conservan las que también existen (con el mismo nombre y color) en el tablero de destino."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Cargando…"
 msgid "Low"
 msgstr "Baja"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Convertir en subtarjeta de…"
@@ -3194,7 +3276,7 @@ msgstr "Modo"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Propietario"
 msgid "Parent card"
 msgstr "Tarjeta principal"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "URL de destino"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "Pendiente"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Fijados"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Puntos / semana (media)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Quitar etiqueta…"
 msgid "Remove link"
 msgstr "Quitar el enlace"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Quitar la relación"
@@ -4222,6 +4328,10 @@ msgstr "ha solicitado una revisión"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "ha solicitado una revisión en"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Guardar la regla"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Guardada como plantilla. Crea una tarjeta a partir de ella con el botón «+ Desde plantilla» de cualquier columna."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Orden"
 msgid "Sort by"
 msgstr "Ordenar por"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Columna {id}"
@@ -4655,6 +4773,10 @@ msgstr "Empezadas"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Empieza más tarde"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Tarjeta de plantilla"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "La plantilla ha vuelto a ser una tarjeta normal."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook activo"
 msgid "Wed"
 msgstr "Mié"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Escribe una respuesta…"
 msgid "wrote"
 msgstr "escribió"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "Necesitas permiso de edición para configurar los flujos de trabajo."
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Necesitas permiso de gestión para configurar las reglas de automatización."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— ninguno —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -2055,6 +2055,10 @@ msgstr "Escribe una duración, p. ej. 1h 30m."
 msgid "Enter a name."
 msgstr "Escribe un nombre."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Intro para abrir · Esc para cerrar"
@@ -2100,25 +2104,25 @@ msgstr "cada"
 msgid "Every"
 msgstr "Cada"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Cada día"
 msgstr[1] "Cada %n días"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Cada mes"
 msgstr[1] "Cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Cada semana"
 msgstr[1] "Cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Cada año"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— aucun —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n fois"
@@ -338,6 +338,11 @@ msgstr "Une carte a été créée, déplacée ou terminée, ou un tableau a ét�
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Une nouvelle copie est créée à chaque fois ; cette carte reste la source"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Actifs"
@@ -514,6 +519,10 @@ msgstr "Tous"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Toute carte peut être enregistrée comme modèle depuis son menu ⋯ (« Marquer comme modèle »). Les modèles sont masqués sur le tableau et réutilisables depuis le menu « ＋ Depuis un modèle » d'une colonne."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Cartes mesurées"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Les cartes ayant une date d'échéance se synchronisent avec votre calendrier et votre téléphone (via CalDAV/DAVx5) sous forme de tâches. Désactivez cette option pour garder ce tableau hors de votre propre calendrier. N'affecte que vous."
 
@@ -1091,6 +1108,10 @@ msgstr "a changé le statut en {value}"
 msgid "Changes requested"
 msgstr "Modifications demandées"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Progression de la liste de contrôle"
 msgid "Choose a board…"
 msgstr "Choisir un tableau…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Choisir une colonne…"
@@ -1249,6 +1271,10 @@ msgstr "Colonne supprimée"
 msgid "Column name"
 msgstr "Nom de la colonne"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Confortable"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Condition"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Contacts"
 
@@ -1345,6 +1375,10 @@ msgstr "Impossible de joindre le fichier."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Impossible de changer la visibilité de la carte"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "Impossible de charger vos tableaux."
 msgid "Could not load your Deck boards."
 msgstr "Impossible de charger vos tableaux Deck."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Impossible d'enregistrer les paramètres de sauvegarde"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Tous les jours"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Zone de danger"
 
@@ -1564,7 +1610,7 @@ msgstr "Zone de danger"
 msgid "Date"
 msgstr "Date"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Éditeur"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Activer et générer le secret"
 
@@ -1988,6 +2038,10 @@ msgstr "Activer les sauvegardes planifiées"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Activée"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "tous les"
 msgid "Every"
 msgstr "Tous les"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Tous les jours"
 msgstr[1] "Tous les %n jours"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Tous les mois"
 msgstr[1] "Tous les %n mois"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toutes les semaines"
 msgstr[1] "Toutes les %n semaines"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Tous les ans"
@@ -2329,6 +2383,10 @@ msgstr "Échec du chargement des modèles."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Échec du chargement de la configuration du flux de calendrier."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Actions du dossier"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Sans fin"
 
@@ -2849,6 +2911,10 @@ msgstr "Heures"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importer"
@@ -2961,6 +3027,10 @@ msgstr "Tâches de fond et liens e-mail de Kanso"
 msgid "Kanso board backups"
 msgstr "Sauvegardes des tableaux Kanso"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Export Kanso (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Étiquettes (séparées par des virgules)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Les étiquettes sont propres à chaque tableau : seules les étiquettes qui existent aussi (même nom et même couleur) sur le tableau cible sont conservées."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Chargement…"
 msgid "Low"
 msgstr "Basse"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Faire de cette carte une sous-carte de…"
@@ -3194,7 +3276,7 @@ msgstr "Mode"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Propriétaire"
 msgid "Parent card"
 msgstr "Carte parente"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "URL de charge utile"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "En attente"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Épinglés"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Points / semaine (moy.)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Retirer une étiquette…"
 msgid "Remove link"
 msgstr "Supprimer le lien"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Supprimer la relation"
@@ -4222,6 +4328,10 @@ msgstr "a demandé une revue"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "a demandé une revue sur"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Enregistrer la règle"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Enregistrée comme modèle. Créez-en une carte avec le bouton « + Depuis un modèle » de n'importe quelle colonne."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Tri"
 msgid "Sort by"
 msgstr "Trier par"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Colonne {id}"
@@ -4655,6 +4773,10 @@ msgstr "Démarrée"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Commence plus tard"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Carte modèle"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Modèle reconverti en carte normale."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook actif"
 msgid "Wed"
 msgstr "Mer"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Écrivez une réponse…"
 msgid "wrote"
 msgstr "a écrit"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "Vous devez avoir l'autorisation de modification pour configurer les flux
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Vous devez avoir l'autorisation de gestion pour configurer les règles d'automatisation."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— aucun —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n fois"
@@ -2055,6 +2055,10 @@ msgstr "Saisissez une durée, par ex. 1h 30m."
 msgid "Enter a name."
 msgstr "Saisissez un nom."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Entrée pour ouvrir · Échap pour fermer"
@@ -2100,25 +2104,25 @@ msgstr "tous les"
 msgid "Every"
 msgstr "Tous les"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Tous les jours"
 msgstr[1] "Tous les %n jours"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Tous les mois"
 msgstr[1] "Tous les %n mois"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toutes les semaines"
 msgstr[1] "Toutes les %n semaines"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Tous les ans"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nessuno —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n volta"
@@ -2055,6 +2055,10 @@ msgstr "Inserisci una durata, es. 1h 30m."
 msgid "Enter a name."
 msgstr "Inserisci un nome."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Invio per aprire · Esc per chiudere"
@@ -2100,25 +2104,25 @@ msgstr "ogni"
 msgid "Every"
 msgstr "Ogni"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Ogni giorno"
 msgstr[1] "Ogni %n giorni"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Ogni mese"
 msgstr[1] "Ogni %n mesi"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Ogni settimana"
 msgstr[1] "Ogni %n settimane"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Ogni anno"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nessuno —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n volta"
@@ -338,6 +338,11 @@ msgstr "Una scheda è stata creata, spostata o completata, oppure una bacheca è
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Ogni volta viene creata una nuova copia; questa scheda resta l'originale"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Attive"
@@ -514,6 +519,10 @@ msgstr "Qualsiasi"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Qualsiasi scheda può essere salvata come modello dal suo menu ⋯ (voce «Segna come modello»). I modelli restano nascosti sulla bacheca e si riutilizzano dal menu «＋ Da modello» di una colonna."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Schede considerate"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Le schede con una scadenza vengono sincronizzate come attività sul calendario e sul telefono (tramite CalDAV/DAVx5). Disattivare questa opzione per tenere la bacheca fuori dal proprio calendario. Riguarda solo l'utente corrente."
 
@@ -1091,6 +1108,10 @@ msgstr "ha cambiato lo stato in {value}"
 msgid "Changes requested"
 msgstr "Modifiche richieste"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Avanzamento della lista di controllo"
 msgid "Choose a board…"
 msgstr "Scegli una bacheca…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Scegli una colonna…"
@@ -1249,6 +1271,10 @@ msgstr "Colonna eliminata"
 msgid "Column name"
 msgstr "Nome della colonna"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Comoda"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Condizione"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Contatti"
 
@@ -1345,6 +1375,10 @@ msgstr "Impossibile allegare il file."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Impossibile cambiare la visibilità della scheda"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "Impossibile caricare le bacheche."
 msgid "Could not load your Deck boards."
 msgstr "Impossibile caricare le bacheche di Deck."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Impossibile salvare le impostazioni di backup"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Giornaliera"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Zona pericolosa"
 
@@ -1564,7 +1610,7 @@ msgstr "Zona pericolosa"
 msgid "Date"
 msgstr "Data"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Attiva e genera il segreto"
 
@@ -1988,6 +2038,10 @@ msgstr "Attiva i backup pianificati"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Attivata"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "ogni"
 msgid "Every"
 msgstr "Ogni"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Ogni giorno"
 msgstr[1] "Ogni %n giorni"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Ogni mese"
 msgstr[1] "Ogni %n mesi"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Ogni settimana"
 msgstr[1] "Ogni %n settimane"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Ogni anno"
@@ -2329,6 +2383,10 @@ msgstr "Impossibile caricare i modelli."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Impossibile caricare la configurazione del feed del calendario."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Azioni della cartella"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Per sempre"
 
@@ -2849,6 +2911,10 @@ msgstr "Ore"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importa"
@@ -2961,6 +3027,10 @@ msgstr "Processi in background e collegamenti email di Kanso"
 msgid "Kanso board backups"
 msgstr "Backup delle bacheche di Kanso"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Esportazione Kanso (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Etichette (separate da virgola)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Le etichette sono legate alla bacheca: vengono mantenute solo quelle che esistono anche sulla bacheca di destinazione (stesso nome e stesso colore)."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Caricamento…"
 msgid "Low"
 msgstr "Bassa"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Rendila una sotto-scheda di…"
@@ -3194,7 +3276,7 @@ msgstr "Modalità"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Proprietario"
 msgid "Parent card"
 msgstr "Scheda principale"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "URL del payload"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "In sospeso"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Fissate"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Punti / settimana (media)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Rimuovi etichetta…"
 msgid "Remove link"
 msgstr "Rimuovi il collegamento"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Rimuovi la relazione"
@@ -4222,6 +4328,10 @@ msgstr "ha richiesto una revisione"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "ha richiesto una revisione su"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Salva la regola"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Salvata come modello. Crea una scheda a partire da esso con il pulsante «+ Da modello» presente su ogni colonna."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Ordina"
 msgid "Sort by"
 msgstr "Ordina per"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Colonna {id}"
@@ -4655,6 +4773,10 @@ msgstr "Iniziata"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Inizia più avanti"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Scheda modello"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Il modello è tornato a essere una scheda normale."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook attivo"
 msgid "Wed"
 msgstr "Mer"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Scrivi una risposta…"
 msgid "wrote"
 msgstr "ha scritto"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "Per configurare i flussi di lavoro servono i permessi di modifica."
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Per configurare le regole di automazione servono i permessi di gestione."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— geen —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n keer"
@@ -338,6 +338,11 @@ msgstr "Er is een kaart aangemaakt, verplaatst of afgerond, of er is een bord me
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Er wordt elke keer een verse kopie gemaakt; deze kaart blijft de bron"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Actief"
@@ -514,6 +519,10 @@ msgstr "Alle"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Elke kaart kun je via het ⋯-menu als sjabloon opslaan (\"Markeren als sjabloon\"). Sjablonen zijn verborgen op het bord en gebruik je opnieuw via het menu \"＋ Van sjabloon\" van een kolom."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Gemeten kaarten"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Kaarten met een einddatum worden als taken gesynchroniseerd met je agenda en je telefoon (via CalDAV/DAVx5). Zet dit uit om dit bord buiten je eigen agenda te houden. Dit geldt alleen voor jou."
 
@@ -1091,6 +1108,10 @@ msgstr "heeft de status gewijzigd in {value}"
 msgid "Changes requested"
 msgstr "Wijzigingen gevraagd"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Voortgang van de checklist"
 msgid "Choose a board…"
 msgstr "Kies een bord…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Kies een kolom…"
@@ -1249,6 +1271,10 @@ msgstr "Kolom verwijderd"
 msgid "Column name"
 msgstr "Kolomnaam"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Ruim"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Voorwaarde"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Contacten"
 
@@ -1345,6 +1375,10 @@ msgstr "Kan het bestand niet bijvoegen."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Kan de zichtbaarheid van de kaart niet wijzigen"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "Kan je borden niet laden."
 msgid "Could not load your Deck boards."
 msgstr "Kan je Deck-borden niet laden."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Kan de back-upinstellingen niet opslaan"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Dagelijks"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Gevarenzone"
 
@@ -1564,7 +1610,7 @@ msgstr "Gevarenzone"
 msgid "Date"
 msgstr "Datum"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Inschakelen en geheim genereren"
 
@@ -1988,6 +2038,10 @@ msgstr "Geplande back-ups inschakelen"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Ingeschakeld"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "elke"
 msgid "Every"
 msgstr "Elke"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Elke dag"
 msgstr[1] "Elke %n dagen"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Elke maand"
 msgstr[1] "Elke %n maanden"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Elke week"
 msgstr[1] "Elke %n weken"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Elk jaar"
@@ -2329,6 +2383,10 @@ msgstr "Kan de sjablonen niet laden."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Kan de configuratie van de agendafeed niet laden."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Mapacties"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Voor altijd"
 
@@ -2849,6 +2911,10 @@ msgstr "Uren"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importeren"
@@ -2961,6 +3027,10 @@ msgstr "Achtergrondtaken en e-maillinks van Kanso"
 msgid "Kanso board backups"
 msgstr "Back-ups van Kanso-borden"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Kanso-export (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Labels (komma-gescheiden)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Labels horen bij één bord: alleen labels die ook op het doelbord bestaan (zelfde naam en kleur) blijven behouden."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Laden…"
 msgid "Low"
 msgstr "Laag"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Hier een subkaart van maken…"
@@ -3194,7 +3276,7 @@ msgstr "Modus"
 msgid "Mon"
 msgstr "ma"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Eigenaar"
 msgid "Parent card"
 msgstr "Hoofdkaart"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "Payload-URL"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "In afwachting"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Vastgezet"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Punten / week (gem.)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Label verwijderen…"
 msgid "Remove link"
 msgstr "Link verwijderen"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Relatie verwijderen"
@@ -4222,6 +4328,10 @@ msgstr "heeft een review aangevraagd"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "vroeg een review aan op"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Regel opslaan"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Opgeslagen als sjabloon. Voeg er een kaart mee toe via de knop \"+ Van sjabloon\" op elke kolom."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Sorteren"
 msgid "Sort by"
 msgstr "Sorteren op"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Kolom {id}"
@@ -4655,6 +4773,10 @@ msgstr "Gestart"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Start later"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Sjabloonkaart"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Sjabloon weer omgezet naar een gewone kaart."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook actief"
 msgid "Wed"
 msgstr "wo"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Schrijf een antwoord…"
 msgid "wrote"
 msgstr "schreef"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "Je hebt bewerkrechten nodig om workflows in te stellen."
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Je hebt beheerrechten nodig om automatiseringsregels in te stellen."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— geen —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n keer"
@@ -2055,6 +2055,10 @@ msgstr "Voer een tijdsduur in, bijv. 1u 30m."
 msgid "Enter a name."
 msgstr "Voer een naam in."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Enter om te openen · Esc om te sluiten"
@@ -2100,25 +2104,25 @@ msgstr "elke"
 msgid "Every"
 msgstr "Elke"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Elke dag"
 msgstr[1] "Elke %n dagen"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Elke maand"
 msgstr[1] "Elke %n maanden"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Elke week"
 msgstr[1] "Elke %n weken"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Elk jaar"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— brak —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n raz"
@@ -351,6 +351,11 @@ msgstr "Utworzono, przeniesiono lub ukończono kartę albo udostępniono Ci tabl
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Za każdym razem powstaje nowa kopia; ta karta pozostaje źródłem"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Aktywne"
@@ -527,6 +532,10 @@ msgstr "Dowolne"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Każdą kartę można zapisać jako szablon z jej menu ⋯ („Oznacz jako szablon”). Szablony są ukryte na tablicy i używa się ich ponownie z menu „＋ Z szablonu” w kolumnie."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -1006,6 +1015,14 @@ msgid "Cards measured"
 msgstr "Zmierzone karty"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Karty z terminem synchronizują się z Twoim kalendarzem i telefonem (przez CalDAV/DAVx5) jako zadania. Wyłącz to, aby ta tablica nie trafiała do Twojego kalendarza. Dotyczy tylko Ciebie."
 
@@ -1104,6 +1121,10 @@ msgstr "zmienił status na {value}"
 msgid "Changes requested"
 msgstr "Poproszono o zmiany"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1130,6 +1151,7 @@ msgstr "Postęp listy kontrolnej"
 msgid "Choose a board…"
 msgstr "Wybierz tablicę…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Wybierz kolumnę…"
@@ -1262,6 +1284,10 @@ msgstr "Kolumna usunięta"
 msgid "Column name"
 msgstr "Nazwa kolumny"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Komfortowa"
@@ -1311,6 +1337,10 @@ msgid "Condition"
 msgstr "Warunek"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Kontakty"
 
@@ -1358,6 +1388,10 @@ msgstr "Nie udało się załączyć pliku."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Nie udało się zmienić widoczności karty"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1428,9 +1462,17 @@ msgstr "Nie udało się wczytać Twoich tablic."
 msgid "Could not load your Deck boards."
 msgstr "Nie udało się wczytać Twoich tablic z Deck."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Nie udało się zapisać ustawień kopii zapasowych"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1570,6 +1612,10 @@ msgid "Daily"
 msgstr "Codziennie"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Strefa niebezpieczna"
 
@@ -1577,7 +1623,7 @@ msgstr "Strefa niebezpieczna"
 msgid "Date"
 msgstr "Data"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1980,6 +2026,10 @@ msgid "Editor"
 msgstr "Edytor"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Włącz i wygeneruj sekret"
 
@@ -2002,6 +2052,10 @@ msgstr "Włącz zaplanowane kopie zapasowe"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Włączone"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2060,28 +2114,28 @@ msgstr "co"
 msgid "Every"
 msgstr "Co"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Codziennie"
 msgstr[1] "Co %n dni"
 msgstr[2] "Co %n dni"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Co miesiąc"
 msgstr[1] "Co %n miesiące"
 msgstr[2] "Co %n miesięcy"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Co tydzień"
 msgstr[1] "Co %n tygodnie"
 msgstr[2] "Co %n tygodni"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Co rok"
@@ -2347,6 +2401,10 @@ msgstr "Nie udało się wczytać szablonów."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Nie udało się wczytać konfiguracji kanału kalendarza."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2736,6 +2794,10 @@ msgid "Folder actions"
 msgstr "Działania na folderze"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Bez końca"
 
@@ -2867,6 +2929,10 @@ msgstr "Godziny"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importuj"
@@ -2979,6 +3045,10 @@ msgstr "Zadania w tle i odnośniki e-mail w Kanso"
 msgid "Kanso board backups"
 msgstr "Kopie zapasowe tablic Kanso"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Eksport Kanso (.zip)"
@@ -3043,6 +3113,10 @@ msgstr "Etykiety (rozdzielone przecinkami)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Etykiety są przypisane do tablicy: zachowywane są tylko te, które istnieją także na tablicy docelowej (ta sama nazwa i kolor)."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3154,6 +3228,14 @@ msgstr "Wczytywanie…"
 msgid "Low"
 msgstr "Niski"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Ustaw jako podkartę…"
@@ -3212,7 +3294,7 @@ msgstr "Tryb"
 msgid "Mon"
 msgstr "Pn"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3834,6 +3916,14 @@ msgstr "Właściciel"
 msgid "Parent card"
 msgstr "Karta nadrzędna"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3845,6 +3935,14 @@ msgstr "Payload URL"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "Oczekuje"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3900,6 +3998,10 @@ msgstr "Przypięte"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Punkty / tydzień (śr.)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4121,6 +4223,10 @@ msgstr "Usuń etykietę…"
 msgid "Remove link"
 msgstr "Usuń odnośnik"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Usuń powiązanie"
@@ -4241,6 +4347,10 @@ msgstr "poprosił o recenzję"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "poprosił o recenzję"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4367,6 +4477,10 @@ msgstr "Zapisz regułę"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Zapisano jako szablon. Dodaj z niego kartę przyciskiem „+ Z szablonu” w dowolnej kolumnie."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4615,6 +4729,10 @@ msgstr "Sortowanie"
 msgid "Sort by"
 msgstr "Sortuj wg"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Kolumna {id}"
@@ -4675,6 +4793,10 @@ msgstr "Rozpoczęte"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Zaczyna się później"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4760,6 +4882,10 @@ msgstr "Karta szablonu"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Szablon zamieniono z powrotem w zwykłą kartę."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5180,7 +5306,7 @@ msgstr "Webhook aktywny"
 msgid "Wed"
 msgstr "Śr"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5262,7 +5388,7 @@ msgstr "Napisz odpowiedź…"
 msgid "wrote"
 msgstr "napisał"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5310,6 +5436,10 @@ msgstr "Do konfigurowania przepływów pracy potrzebne jest uprawnienie do edycj
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Do konfigurowania reguł automatyzacji potrzebne jest uprawnienie do zarządzania."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— brak —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n raz"
@@ -2069,6 +2069,10 @@ msgstr "Podaj czas trwania, np. 1h 30m."
 msgid "Enter a name."
 msgstr "Podaj nazwę."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Enter otwiera · Esc zamyka"
@@ -2114,28 +2118,28 @@ msgstr "co"
 msgid "Every"
 msgstr "Co"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Codziennie"
 msgstr[1] "Co %n dni"
 msgstr[2] "Co %n dni"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Co miesiąc"
 msgstr[1] "Co %n miesiące"
 msgstr[2] "Co %n miesięcy"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Co tydzień"
 msgstr[1] "Co %n tygodnie"
 msgstr[2] "Co %n tygodni"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Co rok"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nenhum —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -338,6 +338,11 @@ msgstr "Um cartão foi criado, movido ou concluído, ou um quadro foi compartilh
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Uma nova cópia é criada a cada vez; este cartão continua sendo a origem"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Ativos"
@@ -514,6 +519,10 @@ msgstr "Qualquer"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Qualquer cartão pode ser salvo como modelo pelo menu ⋯ dele (\"Marcar como modelo\"). Os modelos ficam ocultos no quadro e são reutilizados pelo menu \"＋ A partir de modelo\" de uma coluna."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Cartões medidos"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Cartões com data de vencimento são sincronizados com seu calendário e seu celular (via CalDAV/DAVx5) como tarefas. Desative isto para manter este quadro fora do seu calendário. Afeta apenas você."
 
@@ -1091,6 +1108,10 @@ msgstr "alterou o status para {value}"
 msgid "Changes requested"
 msgstr "Alterações solicitadas"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Progresso do checklist"
 msgid "Choose a board…"
 msgstr "Escolha um quadro…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Escolha uma coluna…"
@@ -1249,6 +1271,10 @@ msgstr "Coluna excluída"
 msgid "Column name"
 msgstr "Nome da coluna"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Confortável"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Condição"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Contatos"
 
@@ -1345,6 +1375,10 @@ msgstr "Não foi possível anexar o arquivo."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Não foi possível alterar a visibilidade do cartão"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "Não foi possível carregar seus quadros."
 msgid "Could not load your Deck boards."
 msgstr "Não foi possível carregar seus quadros do Deck."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Não foi possível salvar as configurações de backup"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Diariamente"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Zona de perigo"
 
@@ -1564,7 +1610,7 @@ msgstr "Zona de perigo"
 msgid "Date"
 msgstr "Data"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Editor"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Ativar e gerar segredo"
 
@@ -1988,6 +2038,10 @@ msgstr "Ativar backups agendados"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Ativado"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "a cada"
 msgid "Every"
 msgstr "A cada"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Todo dia"
 msgstr[1] "A cada %n dias"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Todo mês"
 msgstr[1] "A cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toda semana"
 msgstr[1] "A cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Todo ano"
@@ -2329,6 +2383,10 @@ msgstr "Não foi possível carregar os modelos."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Não foi possível carregar a configuração do feed de calendário."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Ações da pasta"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Para sempre"
 
@@ -2849,6 +2911,10 @@ msgstr "Horas"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.exemplo.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Importar"
@@ -2961,6 +3027,10 @@ msgstr "Tarefas em segundo plano e links de e-mail do Kanso"
 msgid "Kanso board backups"
 msgstr "Backups dos quadros do Kanso"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Exportação do Kanso (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Etiquetas (separadas por vírgula)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "As etiquetas são específicas de cada quadro: só são mantidas as etiquetas que também existem (mesmo nome e cor) no quadro de destino."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Carregando…"
 msgid "Low"
 msgstr "Baixa"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Tornar este um subcartão de…"
@@ -3194,7 +3276,7 @@ msgstr "Modo"
 msgid "Mon"
 msgstr "Seg"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Dono"
 msgid "Parent card"
 msgstr "Cartão pai"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "URL do payload"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "Pendente"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Fixados"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Pontos / semana (méd.)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Remover etiqueta…"
 msgid "Remove link"
 msgstr "Remover link"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Remover relação"
@@ -4222,6 +4328,10 @@ msgstr "solicitou uma revisão"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "solicitou uma revisão em"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Salvar regra"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Salvo como modelo. Adicione um cartão a partir dele com o botão \"+ A partir de modelo\" em qualquer coluna."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Ordenar"
 msgid "Sort by"
 msgstr "Ordenar por"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Coluna {id}"
@@ -4655,6 +4773,10 @@ msgstr "Iniciado"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Começa depois"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Cartão modelo"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "O modelo voltou a ser um cartão normal."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook ativo"
 msgid "Wed"
 msgstr "Qua"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Escreva uma resposta…"
 msgid "wrote"
 msgstr "escreveu"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "Você precisa de permissão de edição para configurar fluxos de trabal
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Você precisa de permissão de gerenciamento para configurar regras de automação."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— nenhum —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n vez"
@@ -2055,6 +2055,10 @@ msgstr "Informe uma duração, ex.: 1h 30m."
 msgid "Enter a name."
 msgstr "Informe um nome."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Enter para abrir · Esc para fechar"
@@ -2100,25 +2104,25 @@ msgstr "a cada"
 msgid "Every"
 msgstr "A cada"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Todo dia"
 msgstr[1] "A cada %n dias"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Todo mês"
 msgstr[1] "A cada %n meses"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Toda semana"
 msgstr[1] "A cada %n semanas"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Todo ano"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— нет —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· повторов: %n"
@@ -2069,6 +2069,10 @@ msgstr "Введите длительность, например 1h 30m."
 msgid "Enter a name."
 msgstr "Введите название."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Enter — открыть · Esc — закрыть"
@@ -2114,28 +2118,28 @@ msgstr "каждые"
 msgid "Every"
 msgstr "Каждые"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Каждый %n день"
 msgstr[1] "Каждые %n дня"
 msgstr[2] "Каждые %n дней"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Каждый %n месяц"
 msgstr[1] "Каждые %n месяца"
 msgstr[2] "Каждые %n месяцев"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Каждую %n неделю"
 msgstr[1] "Каждые %n недели"
 msgstr[2] "Каждые %n недель"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Каждый %n год"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— нет —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· повторов: %n"
@@ -351,6 +351,11 @@ msgstr "Карточка создана, перемещена или завер�
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Каждый раз создается новая копия; эта карточка остается источником"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Активные"
@@ -527,6 +532,10 @@ msgstr "Любые"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Любую карточку можно сохранить как шаблон через ее меню ⋯ («Сделать шаблоном»). Шаблоны скрыты с доски и используются повторно через меню колонки «＋ Из шаблона»."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -1006,6 +1015,14 @@ msgid "Cards measured"
 msgstr "Учтено карточек"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Карточки со сроком выполнения синхронизируются с вашим календарем и телефоном (через CalDAV/DAVx5) как задачи. Отключите, чтобы эта доска не попадала в ваш календарь. Влияет только на вас."
 
@@ -1104,6 +1121,10 @@ msgstr "изменил статус на {value}"
 msgid "Changes requested"
 msgstr "Запрошены изменения"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1130,6 +1151,7 @@ msgstr "Прогресс чек-листа"
 msgid "Choose a board…"
 msgstr "Выберите доску…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Выберите колонку…"
@@ -1262,6 +1284,10 @@ msgstr "Колонка удалена"
 msgid "Column name"
 msgstr "Название колонки"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Свободная"
@@ -1311,6 +1337,10 @@ msgid "Condition"
 msgstr "Условие"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Контакты"
 
@@ -1358,6 +1388,10 @@ msgstr "Не удалось прикрепить файл."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Не удалось изменить видимость карточки"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1428,9 +1462,17 @@ msgstr "Не удалось загрузить ваши доски."
 msgid "Could not load your Deck boards."
 msgstr "Не удалось загрузить ваши доски Deck."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Не удалось сохранить настройки резервного копирования"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1570,6 +1612,10 @@ msgid "Daily"
 msgstr "Ежедневно"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Опасная зона"
 
@@ -1577,7 +1623,7 @@ msgstr "Опасная зона"
 msgid "Date"
 msgstr "Дата"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1980,6 +2026,10 @@ msgid "Editor"
 msgstr "Редактор"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Включить и сгенерировать секрет"
 
@@ -2002,6 +2052,10 @@ msgstr "Включить резервное копирование по расп
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Включено"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2060,28 +2114,28 @@ msgstr "каждые"
 msgid "Every"
 msgstr "Каждые"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Каждый %n день"
 msgstr[1] "Каждые %n дня"
 msgstr[2] "Каждые %n дней"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Каждый %n месяц"
 msgstr[1] "Каждые %n месяца"
 msgstr[2] "Каждые %n месяцев"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Каждую %n неделю"
 msgstr[1] "Каждые %n недели"
 msgstr[2] "Каждые %n недель"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Каждый %n год"
@@ -2347,6 +2401,10 @@ msgstr "Не удалось загрузить шаблоны."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Не удалось загрузить настройки календарной ленты."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2736,6 +2794,10 @@ msgid "Folder actions"
 msgstr "Действия с папкой"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Бессрочно"
 
@@ -2867,6 +2929,10 @@ msgstr "Часы"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "Импорт"
@@ -2979,6 +3045,10 @@ msgstr "Фоновые задачи Kanso и ссылки в письмах"
 msgid "Kanso board backups"
 msgstr "Резервные копии досок Kanso"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Экспорт Kanso (.zip)"
@@ -3043,6 +3113,10 @@ msgstr "Метки (через запятую)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Метки привязаны к доске: сохраняются только те метки, которые есть и на целевой доске (с тем же названием и цветом)."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3154,6 +3228,14 @@ msgstr "Загрузка…"
 msgid "Low"
 msgstr "Низкий"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Сделать подкарточкой…"
@@ -3212,7 +3294,7 @@ msgstr "Режим"
 msgid "Mon"
 msgstr "Пн"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3834,6 +3916,14 @@ msgstr "Владелец"
 msgid "Parent card"
 msgstr "Родительская карточка"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3845,6 +3935,14 @@ msgstr "Payload URL"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "Ожидает"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3900,6 +3998,10 @@ msgstr "Закрепленные"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Баллов в неделю (сред.)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4121,6 +4223,10 @@ msgstr "Убрать метку…"
 msgid "Remove link"
 msgstr "Удалить ссылку"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "Удалить связь"
@@ -4241,6 +4347,10 @@ msgstr "запросил проверку"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "запросил проверку"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4367,6 +4477,10 @@ msgstr "Сохранить правило"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Сохранено как шаблон. Создайте из него карточку кнопкой «+ Из шаблона» в любой колонке."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4615,6 +4729,10 @@ msgstr "Сортировка"
 msgid "Sort by"
 msgstr "Сортировать по"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Колонка {id}"
@@ -4675,6 +4793,10 @@ msgstr "Начатые"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Начнутся позже"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4760,6 +4882,10 @@ msgstr "Карточка-шаблон"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Шаблон снова стал обычной карточкой."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5180,7 +5306,7 @@ msgstr "Webhook активен"
 msgid "Wed"
 msgstr "Ср"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5262,7 +5388,7 @@ msgstr "Напишите ответ…"
 msgid "wrote"
 msgstr "написал"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5310,6 +5436,10 @@ msgstr "Для настройки рабочих процессов нужны �
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Для настройки правил автоматизации нужны права управления."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "— none —"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] ""
@@ -337,6 +337,11 @@ msgstr ""
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr ""
@@ -512,6 +517,10 @@ msgstr ""
 
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -992,6 +1001,14 @@ msgid "Cards measured"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr ""
 
@@ -1090,6 +1107,10 @@ msgstr ""
 msgid "Changes requested"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1116,6 +1137,7 @@ msgstr ""
 msgid "Choose a board…"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr ""
@@ -1248,6 +1270,10 @@ msgstr ""
 msgid "Column name"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr ""
@@ -1297,6 +1323,10 @@ msgid "Condition"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr ""
 
@@ -1343,6 +1373,10 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
 msgstr ""
 
 #: src/components/CardDetail.vue
@@ -1414,8 +1448,16 @@ msgstr ""
 msgid "Could not load your Deck boards."
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -1556,6 +1598,10 @@ msgid "Daily"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr ""
 
@@ -1563,7 +1609,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1965,6 +2011,10 @@ msgid "Editor"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr ""
 
@@ -1986,6 +2036,10 @@ msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -2045,25 +2099,25 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] ""
@@ -2327,6 +2381,10 @@ msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -2717,6 +2775,10 @@ msgid "Folder actions"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr ""
 
@@ -2848,6 +2910,10 @@ msgstr ""
 msgid "https://cloud.example.com/call/abc123"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr ""
@@ -2960,6 +3026,10 @@ msgstr ""
 msgid "Kanso board backups"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr ""
@@ -3023,6 +3093,10 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
 msgstr ""
 
 #: src/views/ViewPage.vue
@@ -3135,6 +3209,14 @@ msgstr ""
 msgid "Low"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr ""
@@ -3193,7 +3275,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3814,6 +3896,14 @@ msgstr ""
 msgid "Parent card"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3824,6 +3914,14 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Pending"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -3879,6 +3977,10 @@ msgstr ""
 
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
 msgstr ""
 
 #: src/components/CardDetail.vue
@@ -4101,6 +4203,10 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr ""
@@ -4220,6 +4326,10 @@ msgstr ""
 
 #: src/views/InboxView.vue
 msgid "requested a review on"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -4346,6 +4456,10 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -4594,6 +4708,10 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr ""
@@ -4653,6 +4771,10 @@ msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
 msgstr ""
 
 #: src/components/BoardFilterBar.vue
@@ -4738,6 +4860,10 @@ msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue
@@ -5159,7 +5285,7 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5240,7 +5366,7 @@ msgstr ""
 msgid "wrote"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5286,6 +5412,10 @@ msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "— none —"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] ""
@@ -2054,6 +2054,10 @@ msgstr ""
 msgid "Enter a name."
 msgstr ""
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr ""
@@ -2099,25 +2103,25 @@ msgstr ""
 msgid "Every"
 msgstr ""
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] ""

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— yok —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n kez"
@@ -338,6 +338,11 @@ msgstr "Bir kart oluşturuldu, taşındı ya da tamamlandı veya seninle bir pan
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "Her seferinde yeni bir kopya oluşturulur; bu kart kaynak olarak kalır"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "Aktif"
@@ -514,6 +519,10 @@ msgstr "Herhangi"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "Her kart, ⋯ menüsünden şablon olarak kaydedilebilir (\"Şablon olarak işaretle\"). Şablonlar panoda görünmez ve bir sütunun \"＋ Şablondan\" menüsünden yeniden kullanılır."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -993,6 +1002,14 @@ msgid "Cards measured"
 msgstr "Ölçülen kartlar"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "Bitiş tarihi olan kartlar takvimine ve telefonuna (CalDAV/DAVx5 ile) görev olarak eşitlenir. Bu panoyu kendi takviminin dışında tutmak için bunu kapat. Yalnızca seni etkiler."
 
@@ -1091,6 +1108,10 @@ msgstr "durumu {value} yaptı"
 msgid "Changes requested"
 msgstr "Değişiklik istendi"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1117,6 +1138,7 @@ msgstr "Kontrol listesi ilerlemesi"
 msgid "Choose a board…"
 msgstr "Bir pano seç…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "Bir sütun seç…"
@@ -1249,6 +1271,10 @@ msgstr "Sütun silindi"
 msgid "Column name"
 msgstr "Sütun adı"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "Rahat"
@@ -1298,6 +1324,10 @@ msgid "Condition"
 msgstr "Koşul"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "Kişiler"
 
@@ -1345,6 +1375,10 @@ msgstr "Dosya iliştirilemedi."
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "Kart görünürlüğü değiştirilemedi"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1415,9 +1449,17 @@ msgstr "Panoların yüklenemedi."
 msgid "Could not load your Deck boards."
 msgstr "Deck panoların yüklenemedi."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "Yedekleme ayarları kaydedilemedi"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1557,6 +1599,10 @@ msgid "Daily"
 msgstr "Günlük"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "Tehlikeli bölge"
 
@@ -1564,7 +1610,7 @@ msgstr "Tehlikeli bölge"
 msgid "Date"
 msgstr "Tarih"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1966,6 +2012,10 @@ msgid "Editor"
 msgstr "Düzenleyici"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "Etkinleştir ve gizli anahtar oluştur"
 
@@ -1988,6 +2038,10 @@ msgstr "Zamanlanmış yedeklemeleri etkinleştir"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "Etkin"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2046,25 +2100,25 @@ msgstr "her"
 msgid "Every"
 msgstr "Her"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Her gün"
 msgstr[1] "Her %n günde bir"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Her ay"
 msgstr[1] "Her %n ayda bir"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Her hafta"
 msgstr[1] "Her %n haftada bir"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Her yıl"
@@ -2329,6 +2383,10 @@ msgstr "Şablonlar yüklenemedi."
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "Takvim akışı yapılandırması yüklenemedi."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2718,6 +2776,10 @@ msgid "Folder actions"
 msgstr "Klasör işlemleri"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "Süresiz"
 
@@ -2849,6 +2911,10 @@ msgstr "Saat"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "İçe aktar"
@@ -2961,6 +3027,10 @@ msgstr "Kanso arka plan görevleri ve e-posta bağlantıları"
 msgid "Kanso board backups"
 msgstr "Kanso pano yedekleri"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Kanso dışa aktarımı (.zip)"
@@ -3025,6 +3095,10 @@ msgstr "Etiketler (virgülle ayrılmış)"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "Etiketler panoya özeldir: yalnızca hedef panoda da bulunan (aynı ad ve renkte) etiketler korunur."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3136,6 +3210,14 @@ msgstr "Yükleniyor…"
 msgid "Low"
 msgstr "Düşük"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "Şunun alt kartı yap…"
@@ -3194,7 +3276,7 @@ msgstr "Mod"
 msgid "Mon"
 msgstr "Pzt"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3815,6 +3897,14 @@ msgstr "Sahip"
 msgid "Parent card"
 msgstr "Üst kart"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3826,6 +3916,14 @@ msgstr "Payload URL'si"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "Bekliyor"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3881,6 +3979,10 @@ msgstr "Sabitlendi"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "Puan / hafta (ort.)"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4102,6 +4204,10 @@ msgstr "Etiketi kaldır…"
 msgid "Remove link"
 msgstr "Bağlantıyı kaldır"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "İlişkiyi kaldır"
@@ -4222,6 +4328,10 @@ msgstr "bir inceleme istedi"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "inceleme istedi:"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4348,6 +4458,10 @@ msgstr "Kuralı kaydet"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "Şablon olarak kaydedildi. Herhangi bir sütundaki \"+ Şablondan\" düğmesiyle ondan kart ekle."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4595,6 +4709,10 @@ msgstr "Sırala"
 msgid "Sort by"
 msgstr "Sıralama ölçütü"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "Sütun {id}"
@@ -4655,6 +4773,10 @@ msgstr "Başladı"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "Sonra başlıyor"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4740,6 +4862,10 @@ msgstr "Şablon kartı"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "Şablon yeniden normal karta dönüştürüldü."
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5160,7 +5286,7 @@ msgstr "Webhook etkin"
 msgid "Wed"
 msgstr "Çar"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5241,7 +5367,7 @@ msgstr "Bir yanıt yaz…"
 msgid "wrote"
 msgstr "yazdı"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5288,6 +5414,10 @@ msgstr "İş akışlarını yapılandırmak için düzenleme iznine ihtiyacın v
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "Otomasyon kurallarını yapılandırmak için yönetme iznine ihtiyacın var."
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— yok —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n kez"
@@ -2055,6 +2055,10 @@ msgstr "Bir süre gir, örn. 1h 30m."
 msgid "Enter a name."
 msgstr "Bir ad gir."
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Açmak için Enter · Kapatmak için Esc"
@@ -2100,25 +2104,25 @@ msgstr "her"
 msgid "Every"
 msgstr "Her"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "Her gün"
 msgstr[1] "Her %n günde bir"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "Her ay"
 msgstr[1] "Her %n ayda bir"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "Her hafta"
 msgstr[1] "Her %n haftada bir"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "Her yıl"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— 无 —"
 
-#: src/components/BoardSettingsModal.vue:4367
+#: src/components/BoardSettingsModal.vue:4389
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n 次"
@@ -2041,6 +2041,10 @@ msgstr "请输入时长，例如 1h 30m。"
 msgid "Enter a name."
 msgstr "请输入名称。"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Enter the password again for the new server or account"
+msgstr ""
+
 #: src/components/CardPreview.vue
 msgid "Enter to open · Esc to close"
 msgstr "Enter 打开 · Esc 关闭"
@@ -2086,22 +2090,22 @@ msgstr "每"
 msgid "Every"
 msgstr "每"
 
-#: src/components/BoardSettingsModal.vue:4347
+#: src/components/BoardSettingsModal.vue:4369
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "每 %n 天"
 
-#: src/components/BoardSettingsModal.vue:4357
+#: src/components/BoardSettingsModal.vue:4379
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "每 %n 个月"
 
-#: src/components/BoardSettingsModal.vue:4349
+#: src/components/BoardSettingsModal.vue:4371
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "每 %n 周"
 
-#: src/components/BoardSettingsModal.vue:4359
+#: src/components/BoardSettingsModal.vue:4381
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "每 %n 年"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "— none —"
 msgstr "— 无 —"
 
-#: src/components/BoardSettingsModal.vue:4048
+#: src/components/BoardSettingsModal.vue:4367
 msgid "· %n time"
 msgid_plural "· %n times"
 msgstr[0] "· %n 次"
@@ -325,6 +325,11 @@ msgstr "有卡片被创建、移动或完成，或有看板与你共享"
 msgid "A fresh copy is created each time; this card stays as the source"
 msgstr "每次都会创建一份新副本；本卡片保留为源卡片"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Accept mail from (one address or @domain per line — leave empty to accept anyone)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 #: src/views/BoardList.vue
 msgid "Active"
 msgstr "活动"
@@ -501,6 +506,10 @@ msgstr "任意"
 #: src/components/ManageTemplatesModal.vue
 msgid "Any card can be saved as a template from its ⋯ menu (\"Mark as template\"). Templates are hidden from the board and reused from a column's \"＋ From template\" menu."
 msgstr "任何卡片都可以从它的 ⋯ 菜单保存为模板（“标记为模板”）。模板不会显示在看板上，可从列的“＋ 从模板创建”菜单中重复使用。"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Anyone who knows the address can create cards. A sender address is easy to forge, so treat the allowlist as a filter rather than proof of who sent something — turn on \"Require verified senders\" if your mail server checks DMARC."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Anyone with the link can subscribe to this board's due dates."
@@ -980,6 +989,14 @@ msgid "Cards measured"
 msgstr "统计的卡片数"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Cards per day from one sender"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Cards per day from this mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Cards with a due date sync to your calendar and phone (via CalDAV/DAVx5) as tasks. Turn this off to keep this board out of your own calendar. Only affects you."
 msgstr "带截止日期的卡片会作为任务同步到你的日历和手机（通过 CalDAV/DAVx5）。关闭后可让此看板不出现在你自己的日历中。仅影响你自己。"
 
@@ -1078,6 +1095,10 @@ msgstr "把状态改为 {value}"
 msgid "Changes requested"
 msgstr "已请求修改"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Check this mailbox automatically"
+msgstr ""
+
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
 msgid "Checklist"
@@ -1104,6 +1125,7 @@ msgstr "清单进度"
 msgid "Choose a board…"
 msgstr "选择看板…"
 
+#: src/components/BoardSettingsModal.vue
 #: src/components/CsvImportModal.vue
 msgid "Choose a column…"
 msgstr "选择列…"
@@ -1236,6 +1258,10 @@ msgstr "列已删除"
 msgid "Column name"
 msgstr "列名称"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Column new cards land in"
+msgstr ""
+
 #: src/views/BoardView.vue
 msgid "Comfortable"
 msgstr "宽松"
@@ -1285,6 +1311,10 @@ msgid "Condition"
 msgstr "条件"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Connected to the mailbox successfully."
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Contacts"
 msgstr "联系人"
 
@@ -1332,6 +1362,10 @@ msgstr "无法附加该文件。"
 #: src/components/CardDetail.vue
 msgid "Could not change the card visibility"
 msgstr "无法更改卡片可见性"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not connect to the mailbox."
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Could not copy to clipboard"
@@ -1402,9 +1436,17 @@ msgstr "无法加载你的看板。"
 msgid "Could not load your Deck boards."
 msgstr "无法加载你的 Deck 看板。"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Could not remove the mailbox."
+msgstr ""
+
 #: src/admin-backup.js
 msgid "Could not save backup settings"
 msgstr "无法保存备份设置"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Could not save the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Could not save the issue-intake settings."
@@ -1544,6 +1586,10 @@ msgid "Daily"
 msgstr "每天"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Daily card limits (0 uses the default)"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Danger zone"
 msgstr "危险区域"
 
@@ -1551,7 +1597,7 @@ msgstr "危险区域"
 msgid "Date"
 msgstr "日期"
 
-#: src/components/BoardSettingsModal.vue:1949
+#: src/components/BoardSettingsModal.vue:2110
 #: src/components/CardDetail.vue:4435
 msgid "day"
 msgid_plural "days"
@@ -1952,6 +1998,10 @@ msgid "Editor"
 msgstr "编辑器"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Email intake"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Enable & generate secret"
 msgstr "启用并生成密钥"
 
@@ -1974,6 +2024,10 @@ msgstr "启用定时备份"
 #: src/components/BoardSettingsModal.vue
 msgid "Enabled"
 msgstr "已启用"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Encryption"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Ends"
@@ -2032,22 +2086,22 @@ msgstr "每"
 msgid "Every"
 msgstr "每"
 
-#: src/components/BoardSettingsModal.vue:4028
+#: src/components/BoardSettingsModal.vue:4347
 msgid "Every day"
 msgid_plural "Every %n days"
 msgstr[0] "每 %n 天"
 
-#: src/components/BoardSettingsModal.vue:4038
+#: src/components/BoardSettingsModal.vue:4357
 msgid "Every month"
 msgid_plural "Every %n months"
 msgstr[0] "每 %n 个月"
 
-#: src/components/BoardSettingsModal.vue:4030
+#: src/components/BoardSettingsModal.vue:4349
 msgid "Every week"
 msgid_plural "Every %n weeks"
 msgstr[0] "每 %n 周"
 
-#: src/components/BoardSettingsModal.vue:4040
+#: src/components/BoardSettingsModal.vue:4359
 msgid "Every year"
 msgid_plural "Every %n years"
 msgstr[0] "每 %n 年"
@@ -2311,6 +2365,10 @@ msgstr "加载模板失败。"
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the calendar feed config."
 msgstr "加载日历订阅配置失败。"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Failed to load the email intake settings."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Failed to load the Forgejo webhook config."
@@ -2700,6 +2758,10 @@ msgid "Folder actions"
 msgstr "文件夹操作"
 
 #: src/components/BoardSettingsModal.vue
+msgid "Folder and target column"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
 msgid "Forever"
 msgstr "永不结束"
 
@@ -2831,6 +2893,10 @@ msgstr "小时"
 msgid "https://cloud.example.com/call/abc123"
 msgstr "https://cloud.example.com/call/abc123"
 
+#: src/components/BoardSettingsModal.vue
+msgid "IMAP server"
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Import"
 msgstr "导入"
@@ -2943,6 +3009,10 @@ msgstr "Kanso 后台任务与邮件链接"
 msgid "Kanso board backups"
 msgstr "Kanso 看板备份"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Kanso checks a dedicated mailbox every five minutes and turns each new message into a card — the subject becomes the title and the body becomes the description. Use a mailbox that exists only for this board."
+msgstr ""
+
 #: src/views/BoardList.vue
 msgid "Kanso export (.zip)"
 msgstr "Kanso 导出文件（.zip）"
@@ -3007,6 +3077,10 @@ msgstr "标签（用逗号分隔）"
 #: src/components/CardDetail.vue
 msgid "Labels are board-specific: only labels that also exist (same name and color) on the target board are kept."
 msgstr "标签是看板专属的：只有在目标看板上同样存在（名称和颜色相同）的标签才会保留。"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Last checked: {when}"
+msgstr ""
 
 #: src/views/ViewPage.vue
 msgid "Last modified"
@@ -3118,6 +3192,14 @@ msgstr "加载中…"
 msgid "Low"
 msgstr "低"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox account"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Mailbox removed."
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Make this a sub-card of…"
 msgstr "设为以下卡片的子卡片…"
@@ -3176,7 +3258,7 @@ msgstr "模式"
 msgid "Mon"
 msgstr "周一"
 
-#: src/components/BoardSettingsModal.vue:1951
+#: src/components/BoardSettingsModal.vue:2112
 #: src/components/CardDetail.vue:4437
 msgid "month"
 msgid_plural "months"
@@ -3796,6 +3878,14 @@ msgstr "所有者"
 msgid "Parent card"
 msgstr "父卡片"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Password"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "Password stored — leave blank to keep it"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Paste a pull request or issue URL…"
 msgstr ""
@@ -3807,6 +3897,14 @@ msgstr "Payload URL"
 #: src/components/CardDetail.vue
 msgid "Pending"
 msgstr "待处理"
+
+#: src/components/BoardSettingsModal.vue
+msgid "per mailbox"
+msgstr ""
+
+#: src/components/BoardSettingsModal.vue
+msgid "per sender"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Permanently remove this board and all of its cards for everyone. This cannot be undone."
@@ -3862,6 +3960,10 @@ msgstr "已置顶"
 #: src/views/BoardStats.vue
 msgid "Points / week (avg)"
 msgstr "点数/周（平均）"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Port"
+msgstr ""
 
 #: src/components/CardDetail.vue
 msgid "Position"
@@ -4083,6 +4185,10 @@ msgstr "移除标签…"
 msgid "Remove link"
 msgstr "移除链接"
 
+#: src/components/BoardSettingsModal.vue
+msgid "Remove mailbox"
+msgstr ""
+
 #: src/components/CardDetail.vue
 msgid "Remove relation"
 msgstr "移除关联"
@@ -4203,6 +4309,10 @@ msgstr "请求了评审"
 #: src/views/InboxView.vue
 msgid "requested a review on"
 msgstr "请求评审"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Require verified senders (DMARC)"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Reset"
@@ -4329,6 +4439,10 @@ msgstr "保存规则"
 #: src/components/CardDetail.vue
 msgid "Saved as a template. Add a card from it with the \"+ From template\" button on any column."
 msgstr "已保存为模板。在任意列上用“+ 从模板创建”按钮即可据此添加卡片。"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Saved."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Saving…"
@@ -4575,6 +4689,10 @@ msgstr "排序"
 msgid "Sort by"
 msgstr "排序依据"
 
+#: src/components/BoardSettingsModal.vue
+msgid "SSL/TLS (993)"
+msgstr ""
+
 #: src/views/BoardStats.vue
 msgid "Stack {id}"
 msgstr "列 {id}"
@@ -4635,6 +4753,10 @@ msgstr "已开始"
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
 msgstr "稍后开始"
+
+#: src/components/BoardSettingsModal.vue
+msgid "STARTTLS (143)"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/CardDetail.vue
@@ -4720,6 +4842,10 @@ msgstr "模板卡片"
 #: src/components/CardDetail.vue
 msgid "Template turned back into a normal card."
 msgstr "模板已变回普通卡片。"
+
+#: src/components/BoardSettingsModal.vue
+msgid "Test connection"
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "Text"
@@ -5140,7 +5266,7 @@ msgstr "Webhook 已启用"
 msgid "Wed"
 msgstr "周三"
 
-#: src/components/BoardSettingsModal.vue:1950
+#: src/components/BoardSettingsModal.vue:2111
 #: src/components/CardDetail.vue:4436
 msgid "week"
 msgid_plural "weeks"
@@ -5220,7 +5346,7 @@ msgstr "写下回复…"
 msgid "wrote"
 msgstr "写道"
 
-#: src/components/BoardSettingsModal.vue:1952
+#: src/components/BoardSettingsModal.vue:2113
 #: src/components/CardDetail.vue:4438
 msgid "year"
 msgid_plural "years"
@@ -5266,6 +5392,10 @@ msgstr "配置工作流需要编辑权限。"
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure automation rules."
 msgstr "配置自动化规则需要管理权限。"
+
+#: src/components/BoardSettingsModal.vue
+msgid "You need manage permission to configure email intake."
+msgstr ""
 
 #: src/components/BoardSettingsModal.vue
 msgid "You need manage permission to configure the calendar feed."


### PR DESCRIPTION
Closes #117.

A board can point at an IMAP mailbox; every message that arrives becomes a card,
subject as the title and body as the description. Configured per board under
**Board settings → Automation → Email intake**, manage-only, polled every five
minutes.

## Why it looks the way it does

Nextcloud receives no mail, and the runtime ships neither `ext-imap` nor any IMAP
client or MIME parser in `3rdparty` — and Kanso ships no `vendor/`. So both are
hand-rolled on builtins: `ImapClient` speaks the slice of IMAP4rev1 this needs
over an `ImapTransport` interface (so the protocol is testable without a
network), and `MimeParser` decodes headers and walks the part tree using
`iconv_mime_decode`, `quoted_printable_decode` and `mb_convert_encoding`.

`EXAMINE` + `BODY.PEEK[]` throughout, so polling never writes flags on a mailbox
a person also reads. Intake position is a **UID watermark paired with
UIDVALIDITY**, not the `\Seen` flag — someone reading the mailbox in a mail
client cannot make the poller skip or repeat messages.

## This is the first path where a stranger causes a write

Every other way a card is created needs a session or an HMAC secret. Email intake
does not, and the text lands in a card body colleagues read. Most of this change
is that fact rather than the IMAP plumbing. The full threat model is in
`docs/email-intake-security.md`; the load-bearing ones:

- **`@mention` notification spoofing.** A description write re-parses `@name` and
  sends real notifications attributed to the writer. Intake writes a stranger's
  text *as the board owner*, so `@alice` in an email would have pinged Alice with
  the owner's name on it. Descriptions now write with `notifyMentions: false`.
- **SSRF.** `host`/`port` are free text from any board *manager*. `MailHostGuard`
  refuses loopback, private, link-local, CGNAT, multicast and IPv4-mapped
  equivalents; it resolves the name and the socket dials *that address*, closing
  the DNS-rebinding window, while the hostname travels separately so TLS still
  validates.
- **Auto-responder loops.** A card raises a notification email; an out-of-office
  answers it; that answer would have become the next card, forever.
  `Auto-Submitted`, `Precedence`, `List-*`, null `Return-Path` and delivery
  reports are never carded.
- **Credential theft by repointing.** A blank password field means "keep the
  stored one" — which let a manager who never knew the credential aim an existing
  mailbox at a host they control and collect it. A stored password is now only
  reusable for the same host and account.
- **Flooding.** Per-mailbox and per-sender daily caps. The mailbox cap stops
  without advancing the watermark, so excess waits on the server; the per-sender
  cap skips-and-advances so one flooder cannot wedge the board.

Optional DMARC enforcement reads **only** the topmost `Authentication-Results`
(hops prepend, so anything below is the sender's to forge) and cross-checks it
against the `From` domain. SPF alone does not satisfy it — SPF authenticates the
envelope, not the visible `From`.

## Verification

- **2021 unit tests**, 162 of them new, identical on PHP 8.2, 8.3 and 8.5.
- The load-bearing behaviours were proven by **mutation** — break the code, watch
  the named test fail: the UID range filter, watermark persistence on failure,
  the plain-over-HTML preference, and the e2e password-leak assertion.
- **Live check against a real Dovecot 2.3** with a CA-signed certificate, since
  the unit tests only drive a scripted fake. TLS, `LOGIN`, `EXAMINE`,
  `UID SEARCH` and a literal `UID FETCH` all behaved; an encoded-word subject and
  quoted-printable UTF-8 body survived intact. Of three seeded messages only the
  genuine one became a card — the auto-reply and the spam-flagged one were
  declined and reported. Four polls, plus one with the watermark forced to zero,
  still produced exactly one card.
- Access control checked with a real second user: a board member with edit
  permission gets `Access denied` on the whole endpoint, and the password appears
  in no response, export or backup — not even for a manager.

## Known boundaries, documented not hidden

Attachments are **named in the card body, not stored**. A reply is a **new card,
not a comment** — so this is "turn emails into cards", not helpdesk ticketing;
two-way threading needs a signed reply-address token and belongs in its own
change. A Nextcloud server admin can still recover the password from the database
plus `config.php`, the same guarantee Nextcloud gives external-storage
credentials.

Setup guide: `docs/email-intake.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
