### PR TITLE
feat(attachments): show when a file was attached and record attachment changes in Activity

### DIFF
--- a/lib/Controller/CardAttachmentController.php
+++ b/lib/Controller/CardAttachmentController.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace OCA\Kanso\Controller;
 
+use OCA\Kanso\Db\CardAttachment;
 use OCA\Kanso\Service\CardAttachmentService;
 use OCA\Kanso\Service\NotPermittedException;
 use OCP\AppFramework\Controller;
@@ -17,6 +18,7 @@ use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\IUserSession;
 
 /**
@@ -32,6 +34,7 @@ class CardAttachmentController extends Controller {
 		IRequest $request,
 		private IUserSession $userSession,
 		private CardAttachmentService $attachmentService,
+		private IUserManager $userManager,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -39,9 +42,14 @@ class CardAttachmentController extends Controller {
 	#[NoAdminRequired]
 	public function index(int $cardId): JSONResponse {
 		return $this->respond(function () use ($cardId): JSONResponse {
-			return new JSONResponse(
-				$this->attachmentService->listForCard($cardId, $this->currentUserId())
-			);
+			// One display-name cache across the list: a card's attachments are
+			// usually all from the same one or two people.
+			$nameCache = [];
+			$out = [];
+			foreach ($this->attachmentService->listForCard($cardId, $this->currentUserId()) as $attachment) {
+				$out[] = $this->serialize($attachment, $nameCache);
+			}
+			return new JSONResponse($out);
 		});
 	}
 
@@ -61,9 +69,9 @@ class CardAttachmentController extends Controller {
 	public function create(int $cardId): JSONResponse {
 		return $this->respond(function () use ($cardId): JSONResponse {
 			$upload = $this->request->getUploadedFile('file');
-			return new JSONResponse(
+			return new JSONResponse($this->serialize(
 				$this->attachmentService->upload($cardId, $upload, $this->currentUserId())
-			);
+			));
 		});
 	}
 
@@ -81,9 +89,9 @@ class CardAttachmentController extends Controller {
 	#[UserRateLimit(limit: 120, period: 3600)]
 	public function createFromFile(int $cardId, int $fileId = 0): JSONResponse {
 		return $this->respond(function () use ($cardId, $fileId): JSONResponse {
-			return new JSONResponse(
+			return new JSONResponse($this->serialize(
 				$this->attachmentService->attachFromFileNode($cardId, $fileId, $this->currentUserId())
-			);
+			));
 		});
 	}
 
@@ -164,6 +172,31 @@ class CardAttachmentController extends Controller {
 			$this->attachmentService->delete($cardId, $attachmentId, $this->currentUserId());
 			return new JSONResponse([]);
 		});
+	}
+
+	/**
+	 * The wire shape of one attachment: the entity's own metadata plus the
+	 * uploader's display name (#119), so the card can credit a person rather than
+	 * print a raw uid. The uid itself stays in the payload - the avatar endpoint
+	 * is keyed on it.
+	 *
+	 * @param array<string, string> $nameCache uid => display name, reused across a list
+	 * @return array<string, mixed>
+	 */
+	private function serialize(CardAttachment $attachment, array &$nameCache = []): array {
+		return $attachment->jsonSerialize()
+			+ ['uploadedByName' => $this->displayName((string)$attachment->getUploadedBy(), $nameCache)];
+	}
+
+	/**
+	 * @param array<string, string> $nameCache uid => display name, reused across a list
+	 */
+	private function displayName(string $uid, array &$nameCache): string {
+		if (!isset($nameCache[$uid])) {
+			$user = $this->userManager->get($uid);
+			$nameCache[$uid] = $user !== null ? $user->getDisplayName() : $uid;
+		}
+		return $nameCache[$uid];
 	}
 
 	/**

--- a/lib/Db/Change.php
+++ b/lib/Db/Change.php
@@ -80,6 +80,15 @@ class Change extends Entity {
 	public const VERB_THREAD_RESOLVED = 23;
 	public const VERB_THREAD_REOPENED = 24;
 
+	// File attachments (#119). Attachment add/remove previously reused the bare
+	// ENTITY_CARD / ACTION_UPDATE row with no verb, so it rendered as a generic
+	// "updated this card" - and a removal left no readable trace at all. These
+	// verbs carry the filename in `kanso_change_details` (`to` on add, `from` on
+	// remove), so the Activity feed can name the file and, crucially, timestamp
+	// the deletion of one.
+	public const VERB_ATTACHMENT_ADDED = 25;
+	public const VERB_ATTACHMENT_REMOVED = 26;
+
 	// Properties default to null (not to 0 / a constant): Entity::setter()
 	// skips values equal to the current one, so e.g. a default of
 	// ACTION_CREATE would silently drop `action` from INSERTs of create

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -43,9 +43,9 @@ class ActivityService {
 	 * Any item whose change has a `kanso_change_details` side-table row carries
 	 * `detail: {from, to}` (the before/after values) so the client can render the
 	 * specifics of the change: the description diff, the source/target column of a
-	 * move, the label title added/removed, the assignee name, the priority/status/
-	 * type/estimate/date values. Verbs with no detail row (and legacy edits recorded
-	 * before this feature) carry null.
+	 * move, the label title added/removed, the assignee name, the attachment
+	 * filename added/removed, the priority/status/type/estimate/date values. Verbs
+	 * with no detail row (and legacy edits recorded before this feature) carry null.
 	 *
 	 * @return list<array{id: int, actor: ?string, actorName: ?string, verb: ?int, action: int, timestamp: int, detail: array{from: ?string, to: ?string}|null}>
 	 * @throws DoesNotExistException if the card or its board does not exist or is deleted

--- a/lib/Service/CardAttachmentService.php
+++ b/lib/Service/CardAttachmentService.php
@@ -14,6 +14,7 @@ use OCA\Kanso\Db\CardAttachment;
 use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\Change;
+use OCA\Kanso\Db\ChangeDetailMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\File;
 use OCP\Files\IAppData;
@@ -41,8 +42,11 @@ use OCP\Security\ISecureRandom;
  *    rejected before anything is written.
  *
  * Add/delete reuse the card's ENTITY_CARD / ACTION_UPDATE change row so the
- * existing realtime/delta-sync + ETag path reflects the new attachment count
- * with no new Change type.
+ * existing realtime/delta-sync + ETag path reflects the new attachment count.
+ * Since #119 that row also carries a verb (VERB_ATTACHMENT_ADDED /
+ * VERB_ATTACHMENT_REMOVED) plus the filename in `kanso_change_details`, so the
+ * per-card Activity feed can say WHO attached or removed WHICH file and WHEN -
+ * a removal has no other trace, the row and the bytes are both gone.
  */
 class CardAttachmentService {
 	/** Hard cap on a single upload. Oversized uploads are rejected. */
@@ -50,6 +54,12 @@ class CardAttachmentService {
 
 	/** Per-card app-data subfolder holding that card's attachment objects. */
 	private const FOLDER_PREFIX = 'card-';
+
+	/**
+	 * Cap on a change-detail string, matching the other services that write the
+	 * side table (LabelService, AssigneeService, CardService).
+	 */
+	private const MAX_DETAIL_LENGTH = 10000;
 
 	public function __construct(
 		private CardAttachmentMapper $attachmentMapper,
@@ -61,6 +71,7 @@ class CardAttachmentService {
 		private ISecureRandom $secureRandom,
 		private IRootFolder $rootFolder,
 		private CardVisibilityGuard $visibilityGuard,
+		private ChangeDetailMapper $changeDetailMapper,
 	) {
 	}
 
@@ -176,13 +187,7 @@ class CardAttachmentService {
 			throw $e;
 		}
 
-		$this->changeNotifier->notify(
-			$card->getBoardId(),
-			Change::ENTITY_CARD,
-			$cardId,
-			Change::ACTION_UPDATE,
-			$actorUid
-		);
+		$this->recordAttachmentChange($card, $attachment->getFilename(), $actorUid, Change::VERB_ATTACHMENT_ADDED);
 
 		return $attachment;
 	}
@@ -277,13 +282,7 @@ class CardAttachmentService {
 			throw $e;
 		}
 
-		$this->changeNotifier->notify(
-			$card->getBoardId(),
-			Change::ENTITY_CARD,
-			$cardId,
-			Change::ACTION_UPDATE,
-			$actorUid
-		);
+		$this->recordAttachmentChange($card, $attachment->getFilename(), $actorUid, Change::VERB_ATTACHMENT_ADDED);
 
 		return $attachment;
 	}
@@ -408,19 +407,17 @@ class CardAttachmentService {
 		$this->visibilityGuard->assertVisible($board, $card, $actorUid);
 
 		$attachment = $this->loadAttachmentOnCard($attachmentId, $cardId);
+		// Read the label BEFORE the row goes: after the delete it is the only
+		// surviving record of which file this was. (The column is NOT NULL, so the
+		// cast is for the entity's nullable property, never a real row.)
+		$filename = (string)$attachment->getFilename();
 
 		// Drop the row first (the source of truth for what's listed); then
 		// best-effort remove the bytes.
 		$this->attachmentMapper->delete($attachment);
 		$this->deleteObjectQuietly($cardId, $attachment->getStorageKey());
 
-		$this->changeNotifier->notify(
-			$card->getBoardId(),
-			Change::ENTITY_CARD,
-			$cardId,
-			Change::ACTION_UPDATE,
-			$actorUid
-		);
+		$this->recordAttachmentChange($card, $filename, $actorUid, Change::VERB_ATTACHMENT_REMOVED);
 	}
 
 	/**
@@ -456,6 +453,43 @@ class CardAttachmentService {
 		}
 
 		$this->attachmentMapper->deleteByCard($cardId);
+	}
+
+	/**
+	 * Appends the card's change row for an attachment add/remove (#119) and
+	 * records the filename in the `kanso_change_details` side table, so the
+	 * Activity feed can name the file rather than render a bare "updated this
+	 * card". The filename rides the same side as the equivalent label change:
+	 * `to` when something appeared, `from` when something went away.
+	 *
+	 * Still an ENTITY_CARD / ACTION_UPDATE row - delta sync and the ETag key on
+	 * (entity_type, action), never on the verb, so the realtime path is unchanged.
+	 */
+	private function recordAttachmentChange(Card $card, string $filename, string $actorUid, int $verb): void {
+		$change = $this->changeNotifier->notify(
+			$card->getBoardId(),
+			Change::ENTITY_CARD,
+			(int)$card->getId(),
+			Change::ACTION_UPDATE,
+			$actorUid,
+			verb: $verb,
+		);
+
+		$label = $this->capDetail($filename);
+		$added = $verb === Change::VERB_ATTACHMENT_ADDED;
+		$this->changeDetailMapper->insertDetail(
+			$change->getId(),
+			$added ? null : $label,
+			$added ? $label : null,
+		);
+	}
+
+	/**
+	 * Caps a detail string to {@see self::MAX_DETAIL_LENGTH} chars (multibyte-safe),
+	 * consistent with the other services that write the side table.
+	 */
+	private function capDetail(string $value): string {
+		return mb_substr($value, 0, self::MAX_DETAIL_LENGTH);
 	}
 
 	/**

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1598,11 +1598,31 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							</div>
 							<ul v-if="cardAttachments.length > 0" class="card-modal__links-list">
 								<li v-for="att in cardAttachments" :key="att.id" class="card-modal__link-row">
-									<a :href="attachmentHref(att.id)" class="card-modal__link" download>
-										<PaperclipIcon :size="14" class="card-modal__eyebrow-icon" />
-										<span class="card-modal__link-text">{{ att.filename }}</span>
-										<span class="card-modal__attachment-size">{{ formatBytes(att.size) }}</span>
-									</a>
+									<div class="card-modal__attachment">
+										<a :href="attachmentHref(att.id)" class="card-modal__link" download>
+											<PaperclipIcon :size="14" class="card-modal__eyebrow-icon" />
+											<span class="card-modal__link-text">{{ att.filename }}</span>
+											<span class="card-modal__attachment-size">{{ formatBytes(att.size) }}</span>
+										</a>
+										<!-- #119 — "when did this file reach this card?" had no answer
+										     anywhere in the UI, though createdAt was already on the wire.
+										     Same relative + exact pair the activity feed uses, always
+										     rendered rather than hover-only (a tooltip is unreachable on
+										     touch). -->
+										<span v-if="att.createdAt" class="card-modal__attachment-meta">
+											<NcAvatar
+												:user="att.uploadedBy || ''"
+												:display-name="attachmentUploader(att)"
+												:size="16"
+												:disable-menu="true" />
+											<span class="card-modal__attachment-uploader">{{ attachmentUploader(att) }}</span>
+											<span class="card-modal__activity-time"><template v-if="activityRelativeTime(att.createdAt)">{{ activityRelativeTime(att.createdAt) }}<span v-if="exactTimeLabel(att.createdAt)" class="card-modal__activity-sep"> · </span></template><time
+												v-if="exactTimeLabel(att.createdAt)"
+												class="card-modal__activity-exact"
+												:datetime="isoTimestamp(att.createdAt)"
+												:title="exactTimeTitle(att.createdAt)">{{ exactTimeLabel(att.createdAt) }}</time></span>
+										</span>
+									</div>
 									<button
 										v-if="canEdit"
 										class="card-modal__child-remove"
@@ -4107,6 +4127,8 @@ const ACTIVITY_VERBS = {
 	22: () => t('kanso', 'changed the card type'),
 	23: () => t('kanso', 'resolved a thread'),
 	24: () => t('kanso', 'reopened a thread'),
+	25: () => t('kanso', 'attached a file'),
+	26: () => t('kanso', 'removed an attachment'),
 }
 function activityVerbText(item) {
 	const fn = ACTIVITY_VERBS[item.verb]
@@ -4203,6 +4225,12 @@ function activitySegments(item) {
 		if (d) {
 			return d.to ? withOne(t('kanso', 'changed the card type to {value}'), d.to) : plain(t('kanso', 'cleared the card type'))
 		}
+		break
+	case 25: // attachment added
+		if (d && d.to) return withOne(t('kanso', 'attached {value}'), d.to)
+		break
+	case 26: // attachment removed
+		if (d && d.from) return withOne(t('kanso', 'removed the attachment {value}'), d.from)
 		break
 	}
 	// Description (16) keeps the collapsible diff below; every other case falls
@@ -5654,6 +5682,13 @@ const attachmentError = ref('')
 
 function attachmentHref(attachmentId) {
 	return cardAttachmentUrl(props.cardId, attachmentId)
+}
+
+// Who uploaded it (#119). The API sends the resolved display name alongside the
+// uid; fall back to the uid (and then to nothing) so a row from an older cached
+// payload, or an account that has since gone, still renders.
+function attachmentUploader(att) {
+	return att.uploadedByName || att.uploadedBy || ''
 }
 
 function formatBytes(bytes) {
@@ -8081,6 +8116,33 @@ body.theme--dark .card-modal,
 	padding-left: 8px;
 	color: var(--color-text-maxcontrast);
 	font-size: 0.8125rem;
+	white-space: nowrap;
+}
+/* #119 — the attachment row carries a second line (uploader + upload time), so
+ * the link and its meta stack in a column while the remove button stays beside
+ * them. The link's own `flex: 1` is reset: with a `0%` basis in a column it
+ * would contribute no height and collapse the filename line. */
+.card-modal__attachment {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+.card-modal__attachment > .card-modal__link {
+	flex: 0 0 auto;
+}
+.card-modal__attachment-meta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+	padding: 0 10px 6px 10px;
+	color: var(--color-text-maxcontrast);
+	font-size: 0.72rem;
+}
+.card-modal__attachment-uploader {
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 .card-modal__link-add {

--- a/tests/e2e/card-attachments.spec.js
+++ b/tests/e2e/card-attachments.spec.js
@@ -264,6 +264,54 @@ test.describe('Card file attachments', () => {
 			.toHaveCount(0, { timeout: 8000 })
 	})
 
+	// #119 — "when did this file reach this card?" had no answer anywhere: the
+	// row printed only name + size, and the change log had no attachment verb, so
+	// an upload rendered as a bare "updated this card" and a REMOVAL left no trace
+	// at all. Both halves are asserted here, add and remove.
+	test('an attachment shows its upload time, and add/remove are recorded in Activity', async ({ page }) => {
+		await ncLogin(page)
+		const cardUrl = `${BASE}/index.php/apps/kanso#/board/${boardId}/card/${cardId}`
+		await page.goto(cardUrl)
+		await page.waitForSelector('.card-modal', { timeout: 10_000 })
+
+		await page.setInputFiles('.card-modal__file-input', {
+			name: 'dated.txt',
+			mimeType: 'text/plain',
+			buffer: Buffer.from('when did this arrive?'),
+		})
+
+		const row = page.locator('.card-modal__link-row', { hasText: 'dated.txt' })
+		await expect(row).toHaveCount(1, { timeout: 8000 })
+
+		// (a) The row itself now answers "when": a machine-readable <time> stamp
+		// beside a human relative label, and the uploader's name.
+		const meta = row.locator('.card-modal__attachment-meta')
+		await expect(meta).toHaveCount(1)
+		await expect(meta).toContainText('just now')
+		const datetime = await meta.locator('time').getAttribute('datetime')
+		expect(datetime).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+		// The uploader is credited by display name, not a bare uid.
+		await expect(meta.locator('.card-modal__attachment-uploader')).not.toBeEmpty()
+
+		// (b) The upload lands in Activity, naming the file.
+		const activityTab = page.locator('.card-modal__discussion-tab', { hasText: 'Activity' })
+		const discussionTab = page.locator('.card-modal__discussion-tab', { hasText: 'Discussion' })
+		await activityTab.click()
+		await expect(page.locator('.card-modal__activity-row', { hasText: 'attached dated.txt' }))
+			.toHaveCount(1, { timeout: 8000 })
+
+		// ...and so does the removal - the case with no other trace, since the row
+		// and the bytes are both gone.
+		await row.locator('.card-modal__child-remove').click()
+		await expect(page.locator('.card-modal__link-row', { hasText: 'dated.txt' }))
+			.toHaveCount(0, { timeout: 8000 })
+		// The feed is fetched when the tab opens, so reopen it to refetch.
+		await discussionTab.click()
+		await activityTab.click()
+		await expect(page.locator('.card-modal__activity-row', { hasText: 'removed the attachment dated.txt' }))
+			.toHaveCount(1, { timeout: 8000 })
+	})
+
 	// Paste an image into the description editor (#3525): it uploads via the
 	// attachment endpoint and the saved description renders an <img> pointing at
 	// the inline endpoint.

--- a/tests/unit/Controller/CardAttachmentControllerTest.php
+++ b/tests/unit/Controller/CardAttachmentControllerTest.php
@@ -7,10 +7,18 @@ declare(strict_types=1);
 
 namespace OCA\Kanso\Controller;
 
+use OCA\Kanso\Db\CardAttachment;
+use OCA\Kanso\Service\CardAttachmentService;
 use OCP\AppFramework\Http\Attribute\UserRateLimit;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Rate limiting, and the wire shape of an attachment row.
+ *
  * Both attachment WRITE paths land bytes in the app's own app-data, so both carry
  * the same per-user rate limit - limiting only the multipart upload would leave
  * the "attach from Files" copy as the open door beside the closed one. Asserted on
@@ -62,5 +70,90 @@ class CardAttachmentControllerTest extends TestCase {
 			'download' => ['download'],
 			'inline render' => ['inline'],
 		];
+	}
+
+	/**
+	 * #119: the card shows WHO attached a file, so the listing carries the
+	 * uploader's resolved display name beside the uid - the uid stays, the avatar
+	 * endpoint is keyed on it.
+	 */
+	public function testIndexCarriesTheUploaderDisplayName(): void {
+		$service = $this->createMock(CardAttachmentService::class);
+		$service->method('listForCard')->with(9, 'bob')->willReturn([
+			$this->attachment(1, 'report.pdf', 'alice'),
+			$this->attachment(2, 'notes.txt', 'alice'),
+			$this->attachment(3, 'photo.png', 'ghost'),
+		]);
+
+		$response = $this->controller($service, $this->userManager(['alice' => 'Alice Adams']))->index(9);
+		$body = $response->getData();
+
+		self::assertCount(3, $body);
+		self::assertSame('alice', $body[0]['uploadedBy']);
+		self::assertSame('Alice Adams', $body[0]['uploadedByName']);
+		self::assertSame('Alice Adams', $body[1]['uploadedByName']);
+		// An account that no longer resolves falls back to its uid rather than
+		// rendering an empty byline.
+		self::assertSame('ghost', $body[2]['uploadedByName']);
+		// The timestamp the whole issue is about must survive serialization.
+		self::assertSame(1700000000, $body[0]['createdAt']);
+	}
+
+	/**
+	 * The upload response feeds the same row the listing renders, so it must carry
+	 * the display name too - otherwise a just-uploaded file shows a raw uid until
+	 * the list refetches.
+	 */
+	public function testCreateCarriesTheUploaderDisplayName(): void {
+		$service = $this->createMock(CardAttachmentService::class);
+		$service->method('upload')->willReturn($this->attachment(1, 'report.pdf', 'alice'));
+
+		$body = $this->controller($service, $this->userManager(['alice' => 'Alice Adams']))->create(9)->getData();
+
+		self::assertSame('Alice Adams', $body['uploadedByName']);
+	}
+
+	private function attachment(int $id, string $filename, string $uploadedBy): CardAttachment {
+		$a = new CardAttachment();
+		$a->setId($id);
+		$a->setCardId(9);
+		$a->setFilename($filename);
+		$a->setMime('application/octet-stream');
+		$a->setSize(11);
+		$a->setUploadedBy($uploadedBy);
+		$a->setCreatedAt(1700000000);
+		return $a;
+	}
+
+	/**
+	 * @param array<string, string> $names uid => display name; a uid absent here
+	 *                                     resolves to no user at all
+	 */
+	private function userManager(array $names): IUserManager {
+		$manager = $this->createMock(IUserManager::class);
+		$manager->method('get')->willReturnCallback(function (string $uid) use ($names): ?IUser {
+			if (!isset($names[$uid])) {
+				return null;
+			}
+			$user = $this->createMock(IUser::class);
+			$user->method('getDisplayName')->willReturn($names[$uid]);
+			return $user;
+		});
+		return $manager;
+	}
+
+	private function controller(CardAttachmentService $service, IUserManager $userManager): CardAttachmentController {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('bob');
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		return new CardAttachmentController(
+			'kanso',
+			$this->createMock(IRequest::class),
+			$session,
+			$service,
+			$userManager,
+		);
 	}
 }

--- a/tests/unit/Service/CardAttachmentServiceTest.php
+++ b/tests/unit/Service/CardAttachmentServiceTest.php
@@ -13,6 +13,8 @@ use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardAttachment;
 use OCA\Kanso\Db\CardAttachmentMapper;
 use OCA\Kanso\Db\CardMapper;
+use OCA\Kanso\Db\Change;
+use OCA\Kanso\Db\ChangeDetailMapper;
 use OCA\Kanso\Service\CardAttachmentService;
 use OCA\Kanso\Service\CardVisibilityGuard;
 use OCA\Kanso\Service\ChangeNotifier;
@@ -42,6 +44,7 @@ class CardAttachmentServiceTest extends TestCase {
 	private IRootFolder&MockObject $rootFolder;
 	private ISimpleFolder&MockObject $folder;
 	private CardVisibilityGuard&MockObject $visibilityGuard;
+	private ChangeDetailMapper&MockObject $changeDetailMapper;
 	private CardAttachmentService $service;
 
 	/** @var string[] Temp files created for upload tests, cleaned up in tearDown. */
@@ -66,6 +69,12 @@ class CardAttachmentServiceTest extends TestCase {
 
 		$this->visibilityGuard = $this->createMock(CardVisibilityGuard::class);
 		$this->visibilityGuard->method('isVisible')->willReturn(true);
+		$this->changeDetailMapper = $this->createMock(ChangeDetailMapper::class);
+		// Every attachment add/remove records a change row whose id the filename
+		// detail hangs off (#119); hand back a real Change so that id is a real one.
+		$change = new Change();
+		$change->setId(77);
+		$this->changeNotifier->method('notify')->willReturn($change);
 		$this->service = new CardAttachmentService(
 			$this->attachmentMapper,
 			$this->cardMapper,
@@ -76,6 +85,7 @@ class CardAttachmentServiceTest extends TestCase {
 			$this->secureRandom,
 			$this->rootFolder,
 			$this->visibilityGuard,
+			$this->changeDetailMapper,
 		);
 	}
 
@@ -223,6 +233,41 @@ class CardAttachmentServiceTest extends TestCase {
 		self::assertSame(9, $captured->getCardId());
 		self::assertSame(1, $captured->getBoardId());
 		self::assertSame('bob', $captured->getUploadedBy());
+	}
+
+	/**
+	 * #119: the change row an upload writes carries VERB_ATTACHMENT_ADDED and the
+	 * filename as the detail's `to` side, so the Activity feed can name the file
+	 * instead of rendering a bare "updated this card".
+	 */
+	public function testUploadRecordsAnAttachmentAddedChangeNamingTheFile(): void {
+		$this->expectCardLoaded();
+		$this->folder->method('newFile')->willReturn($this->createMock(ISimpleFile::class));
+		$this->attachmentMapper->method('insert')->willReturnCallback(
+			static function (CardAttachment $a): CardAttachment {
+				$a->setId(7);
+				return $a;
+			}
+		);
+
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(
+				1,
+				Change::ENTITY_CARD,
+				9,
+				Change::ACTION_UPDATE,
+				'bob',
+				// Pinned: an upload is not inside a caller-managed transaction, so
+				// the realtime push must fire right away.
+				true,
+				Change::VERB_ATTACHMENT_ADDED,
+			);
+		$this->changeDetailMapper->expects(self::once())
+			->method('insertDetail')
+			->with(77, null, 'report.pdf');
+
+		$this->service->upload(9, $this->upload(['name' => 'report.pdf']), 'bob');
 	}
 
 	public function testUploadIgnoresClientFilenameForStoragePath(): void {
@@ -550,6 +595,39 @@ class CardAttachmentServiceTest extends TestCase {
 		$this->service->delete(9, 5, 'bob');
 	}
 
+	/**
+	 * #119: a removal is the case with NO other trace - the row and the bytes are
+	 * both gone - so the change row must carry VERB_ATTACHMENT_REMOVED and the
+	 * filename on the detail's `from` side, read BEFORE the row is dropped.
+	 */
+	public function testDeleteRecordsAnAttachmentRemovedChangeNamingTheFile(): void {
+		$this->expectCardLoaded();
+		$a = new CardAttachment();
+		$a->setId(5);
+		$a->setCardId(9);
+		$a->setFilename('invoice-2026.pdf');
+		$a->setStorageKey('deadbeefdeadbeefdeadbeefdeadbeef');
+		$this->attachmentMapper->method('find')->with(5)->willReturn($a);
+		$this->folder->method('getFile')->willReturn($this->createMock(ISimpleFile::class));
+
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(
+				1,
+				Change::ENTITY_CARD,
+				9,
+				Change::ACTION_UPDATE,
+				'bob',
+				true,
+				Change::VERB_ATTACHMENT_REMOVED,
+			);
+		$this->changeDetailMapper->expects(self::once())
+			->method('insertDetail')
+			->with(77, 'invoice-2026.pdf', null);
+
+		$this->service->delete(9, 5, 'bob');
+	}
+
 	// ---- deleteAllForCard (cascade on card purge) -------------------------
 
 	private function attachment(int $id, string $key): CardAttachment {
@@ -579,9 +657,12 @@ class CardAttachmentServiceTest extends TestCase {
 		$this->folder->expects(self::once())->method('delete');
 		// ...and every row is dropped in one shot.
 		$this->attachmentMapper->expects(self::once())->method('deleteByCard')->with(9);
-		// No permission check and no realtime notification on an internal cascade.
+		// No permission check and no realtime notification on an internal cascade -
+		// and no per-file "removed" activity either (#119): the card itself is being
+		// purged and emits its own DELETE row.
 		$this->permissionService->expects(self::never())->method('assertPermission');
 		$this->changeNotifier->expects(self::never())->method('notify');
+		$this->changeDetailMapper->expects(self::never())->method('insertDetail');
 
 		$this->service->deleteAllForCard(9);
 	}
@@ -634,6 +715,7 @@ class CardAttachmentServiceTest extends TestCase {
 			$this->secureRandom,
 			$this->rootFolder,
 			$this->visibilityGuard,
+			$this->changeDetailMapper,
 		);
 		$this->attachmentMapper->expects(self::once())->method('deleteByCard')->with(9);
 
@@ -688,6 +770,32 @@ class CardAttachmentServiceTest extends TestCase {
 		self::assertSame(9, $captured->getCardId());
 		self::assertSame(1, $captured->getBoardId());
 		self::assertSame('bob', $captured->getUploadedBy());
+	}
+
+	/**
+	 * A file copied from Files is an ordinary attachment, so it must log the same
+	 * "attached {file}" activity as a multipart upload (#119) - otherwise the two
+	 * doors into the same store leave different traces.
+	 */
+	public function testAttachFromFileRecordsAnAttachmentAddedChangeNamingTheFile(): void {
+		$this->expectCardLoaded();
+		$this->expectUserFolderById(42, [$this->fileNode(42, 11, 'notes.txt', 'text/plain')]);
+		$this->folder->method('newFile')->willReturn($this->createMock(ISimpleFile::class));
+		$this->attachmentMapper->method('insert')->willReturnCallback(
+			static function (CardAttachment $a): CardAttachment {
+				$a->setId(12);
+				return $a;
+			}
+		);
+
+		$this->changeNotifier->expects(self::once())
+			->method('notify')
+			->with(1, Change::ENTITY_CARD, 9, Change::ACTION_UPDATE, 'bob', true, Change::VERB_ATTACHMENT_ADDED);
+		$this->changeDetailMapper->expects(self::once())
+			->method('insertDetail')
+			->with(77, null, 'notes.txt');
+
+		$this->service->attachFromFileNode(9, 42, 'bob');
 	}
 
 	public function testAttachFromFileRejectsUnreadableFileId(): void {

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
 msgstr[1] "%n Projekte"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "Anhängen"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "„{file}\" an eine Karte anhängen. Eine Kopie wird auf der Karte gespeichert."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "hat eine zugewiesene Person entfernt"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "hat das Label {value} entfernt"
 
@@ -4712,7 +4728,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
 msgstr[1] "%n proyectos"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "Adjuntar"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Adjuntar «{file}» a una tarjeta. Se guarda una copia en la tarjeta."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "ha quitado a un asignado"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "ha quitado la etiqueta {value}"
 
@@ -4712,7 +4728,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projet"
 msgstr[1] "%n projets"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "Joindre"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Joindre « {file} » à une carte. Une copie est stockée sur la carte."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "a retiré un assigné"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "a retiré l'étiquette {value}"
 
@@ -4712,7 +4728,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n progetto"
 msgstr[1] "%n progetti"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "Allega"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Allega «{file}» a una scheda. Sulla scheda viene salvata una copia."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "ha rimosso un assegnatario"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "ha rimosso l'etichetta {value}"
 
@@ -4712,7 +4728,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n project"
 msgstr[1] "%n projecten"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "Bijvoegen"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Voeg “{file}” toe aan een kaart. Er wordt een kopie op de kaart bewaard."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "heeft een toegewezen persoon verwijderd"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "heeft het label {value} verwijderd"
 
@@ -4712,7 +4728,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -301,14 +301,14 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
@@ -336,7 +336,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -371,7 +371,7 @@ msgstr[0] "%n projekt"
 msgstr[1] "%n projekty"
 msgstr[2] "%n projektów"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -725,6 +725,14 @@ msgstr "Załącz"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Załącz „{file}” do karty. Kopia zostanie zapisana na karcie."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1695,7 +1703,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -3374,7 +3382,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4340,6 +4348,14 @@ msgid "removed an assignee"
 msgstr "usunął osobę przypisaną"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "usunął etykietę {value}"
 
@@ -4740,7 +4756,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -5395,7 +5411,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5477,7 +5493,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projeto"
 msgstr[1] "%n projetos"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "Anexar"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Anexe “{file}” a um cartão. Uma cópia é armazenada no cartão."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "removeu um responsável"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "removeu a etiqueta {value}"
 
@@ -4712,7 +4728,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -301,14 +301,14 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
@@ -336,7 +336,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -371,7 +371,7 @@ msgstr[0] "%n проект"
 msgstr[1] "%n проекта"
 msgstr[2] "%n проектов"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -725,6 +725,14 @@ msgstr "Прикрепить"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "Прикрепить «{file}» к карточке. На карточке сохраняется копия."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1695,7 +1703,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -3374,7 +3382,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4340,6 +4348,14 @@ msgid "removed an assignee"
 msgstr "убрал исполнителя"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "убрал метку {value}"
 
@@ -4740,7 +4756,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -5395,7 +5411,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5477,7 +5493,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -292,13 +292,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
@@ -322,7 +322,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -352,7 +352,7 @@ msgid_plural "%n projects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -701,6 +701,14 @@ msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
 msgstr ""
 
 #: src/components/AddToKansoDialog.vue
@@ -1672,7 +1680,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -3346,7 +3354,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4311,6 +4319,14 @@ msgid "removed an assignee"
 msgstr ""
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr ""
 
@@ -4711,7 +4727,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -5365,7 +5381,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5446,7 +5462,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proje"
 msgstr[1] "%n proje"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -703,6 +703,14 @@ msgstr "İliştir"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "“{file}” dosyasını bir karta iliştir. Kartta bir kopyası saklanır."
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1673,7 +1681,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -3347,7 +3355,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4312,6 +4320,14 @@ msgid "removed an assignee"
 msgstr "bir atananı kaldırdı"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "{value} etiketini kaldırdı"
 
@@ -4712,7 +4728,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -5366,7 +5382,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5447,7 +5463,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -285,12 +285,12 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4295
+#: src/components/CardDetail.vue:4323
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4293
+#: src/components/CardDetail.vue:4321
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
@@ -310,7 +310,7 @@ msgid "%n label was not created and is missing from the imported cards: only boa
 msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
 msgstr[0] ""
 
-#: src/components/CardDetail.vue:4291
+#: src/components/CardDetail.vue:4319
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -335,7 +335,7 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
 
-#: src/components/CardDetail.vue:1975
+#: src/components/CardDetail.vue:1995
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -681,6 +681,14 @@ msgstr "附加"
 #: src/components/AddToKansoDialog.vue
 msgid "Attach “{file}” to a card. A copy is stored on the card."
 msgstr "把“{file}”附加到卡片。卡片上会保存一份副本。"
+
+#: src/components/CardDetail.vue
+msgid "attached {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "attached a file"
+msgstr ""
 
 #: src/components/AddToKansoDialog.vue
 msgid "Attaching…"
@@ -1651,7 +1659,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4484
+#: src/components/CardDetail.vue:4512
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -3320,7 +3328,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4486
+#: src/components/CardDetail.vue:4514
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4284,6 +4292,14 @@ msgid "removed an assignee"
 msgstr "移除了一位负责人"
 
 #: src/components/CardDetail.vue
+msgid "removed an attachment"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "removed the attachment {value}"
+msgstr ""
+
+#: src/components/CardDetail.vue
 msgid "removed the label {value}"
 msgstr "移除了标签 {value}"
 
@@ -4684,7 +4700,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:6154
+#: src/components/CardDetail.vue:6189
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -5337,7 +5353,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4485
+#: src/components/CardDetail.vue:4513
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5417,7 +5433,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4487
+#: src/components/CardDetail.vue:4515
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"


### PR DESCRIPTION
Closes #119.

An attachment carried no visible timestamp anywhere in the UI. Two separate gaps combined into that, and both are closed here.

## (a) The attachment row now answers "when?"

`CardAttachment::jsonSerialize()` already exposed `createdAt` and `uploadedBy`, but the card rendered only filename and size. The row now carries a second line: the uploader (avatar + display name) and the upload time — the same relative label + exact `<time datetime>` stamp the Activity feed uses, always rendered rather than hover-only (a tooltip is unreachable on touch, and this app is installed on phones).

The list endpoint and both upload responses now carry `uploadedByName` beside the uid, so the card credits a person instead of printing a raw uid. The uid stays in the payload — the avatar endpoint is keyed on it.

## (b) Attachment add/remove are recorded in the change log

Both paths wrote a bare `ENTITY_CARD` / `ACTION_UPDATE` row with no verb, so an upload rendered as a generic "updated this card" and a **removal left no trace at all**. Both now carry a verb (`VERB_ATTACHMENT_ADDED` = 25, `VERB_ATTACHMENT_REMOVED` = 26) plus the filename in the `kanso_change_details` side table, so the feed reads **"attached report.pdf"** / **"removed the attachment report.pdf"** with actor and timestamp, like every other card mutation.

The row stays `ENTITY_CARD` / `ACTION_UPDATE` — delta sync and the ETag key on `(entity_type, action)`, never on the verb — so realtime and polling are unchanged. No migration: the verb column and the details table both already exist.

Notes:
- "Attach from Files" records the same activity as a multipart upload; two doors into the same store must leave the same trace.
- The purge cascade (`deleteAllForCard`) deliberately writes **no** per-file "removed" activity — the card itself is being torn down and emits its own DELETE row.
- The delete path reads the filename *before* dropping the row: afterwards it is the only surviving record of which file it was.

## Verification

Run locally in a throwaway `php:8.3-cli` container (with `zip` installed) against this worktree:

- `phpunit` — **2053 tests, 919334 assertions, OK**, including 4 new cases: upload / attach-from-Files / delete each assert the verb *and* the filename detail, and the purge cascade asserts no detail row.
- `psalm` — **exit 0**, no errors.
- `php-cs-fixer --dry-run` — **0 of 417 files** need fixing.
- `npm run test:unit` — 126 pass. `npm run build` — clean. `npm run l10n:check` — extract/sync/compile re-run and the regenerated catalogues committed.

The new Playwright spec (`card-attachments.spec.js` — asserts the row's `<time datetime>` stamp, and that both the add and the remove show up in Activity naming the file) was **not** run locally: `kanso-dev` is currently mounted to a different worktree, so a local run would have silently tested other code. It runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)