### PR TITLE
feat: sub-card dates in the parent list, and the column on every search hit

### DIFF
--- a/lib/Db/CommentMapper.php
+++ b/lib/Db/CommentMapper.php
@@ -222,8 +222,8 @@ class CommentMapper extends QBMapper {
 				'cardId' => (int)$row['card_id'],
 				'boardId' => (int)$row['board_id'],
 				// The card's column, so a search hit can name the stage it is at
-				// (#122). Carried as an id; SearchService resolves the titles for
-				// the whole result set in one query.
+				// (#122). Carried as an id; SearchService batch-resolves the titles
+				// for the page it returns.
 				'stackId' => (int)$row['stack_id'],
 				'cardTitle' => (string)$row['title'],
 				'body' => (string)$row['body'],

--- a/lib/Db/CommentMapper.php
+++ b/lib/Db/CommentMapper.php
@@ -192,17 +192,18 @@ class CommentMapper extends QBMapper {
 	 * Non-deleted comments whose body matches a LIKE pattern, restricted to the
 	 * given readable boards (joined through non-deleted cards). Portable
 	 * case-insensitive LIKE; the pattern is pre-escaped/wrapped by the caller.
-	 * Each row carries the parent card's id, board and title so a hit can be
-	 * shown and deep-linked without a second query. $boardIds must be non-empty.
+	 * Each row carries the parent card's id, board, stack and title so a hit can
+	 * be shown and deep-linked without a second query. $boardIds must be
+	 * non-empty.
 	 *
 	 * @param int[] $boardIds
 	 * @param array<int, string> $rolesByBoard the viewer's role per board id
-	 * @return array<int, array{id: int, cardId: int, boardId: int, cardTitle: string, body: string}>
+	 * @return array<int, array{id: int, cardId: int, boardId: int, stackId: int, cardTitle: string, body: string}>
 	 * @throws Exception
 	 */
 	public function searchInBoards(array $boardIds, string $likePattern, int $limit, string $uid, array $rolesByBoard): array {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('cm.id', 'cm.card_id', 'cm.body', 'c.board_id', 'c.title')
+		$qb->select('cm.id', 'cm.card_id', 'cm.body', 'c.board_id', 'c.stack_id', 'c.title')
 			->from($this->getTableName(), 'cm')
 			->innerJoin('cm', 'kanso_cards', 'c', $qb->expr()->eq('cm.card_id', 'c.id'))
 			->where($qb->expr()->in('c.board_id', $qb->createNamedParameter($boardIds, IQueryBuilder::PARAM_INT_ARRAY)))
@@ -220,6 +221,10 @@ class CommentMapper extends QBMapper {
 				'id' => (int)$row['id'],
 				'cardId' => (int)$row['card_id'],
 				'boardId' => (int)$row['board_id'],
+				// The card's column, so a search hit can name the stage it is at
+				// (#122). Carried as an id; SearchService resolves the titles for
+				// the whole result set in one query.
+				'stackId' => (int)$row['stack_id'],
 				'cardTitle' => (string)$row['title'],
 				'body' => (string)$row['body'],
 			];

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -91,6 +91,48 @@ class StackMapper extends QBMapper {
 	}
 
 	/**
+	 * Stack titles by id, ACROSS boards, in ONE query - for a result set that
+	 * already spans every board the viewer can read, where the board-scoped
+	 * {@see self::findByIds()} would mean a query per board (search, #122).
+	 *
+	 * Returns titles only, not entities: the caller wants a label, and a search
+	 * page can reference up to a couple of hundred distinct stacks. Ids the
+	 * query does not resolve - a deleted stack - are simply absent, so the
+	 * caller renders no column rather than an empty one.
+	 *
+	 * NOT filtered on archived: archiving a column does not archive its cards,
+	 * so an archived stack still holds live, searchable cards that must still
+	 * be able to name where they are.
+	 *
+	 * This is a READ of labels the caller has already gated (the rows come from
+	 * boards it resolved as readable), so it carries no ACL of its own.
+	 *
+	 * @param int[] $ids
+	 * @return array<int, string> stack id => title
+	 * @throws Exception
+	 */
+	public function titlesByIds(array $ids): array {
+		if ($ids === []) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'title')
+			->from($this->getTableName())
+			->where($qb->expr()->in('id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->eq('deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+
+		$titles = [];
+		$result = $qb->executeQuery();
+		while (($row = $result->fetch()) !== false) {
+			$titles[(int)$row['id']] = (string)$row['title'];
+		}
+		$result->closeCursor();
+
+		return $titles;
+	}
+
+	/**
 	 * The first non-deleted stack of a board carrying the given workflow role
 	 * (in display order), or null. Used to resolve auto-move targets (e.g. the
 	 * "In review" or "Done" column) without a separate config surface. Ordered

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -11,6 +11,7 @@ use OCA\Kanso\Access\BoardAccess;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CommentMapper;
+use OCA\Kanso\Db\StackMapper;
 use OCP\IDBConnection;
 
 /**
@@ -24,6 +25,10 @@ use OCP\IDBConnection;
  * Ranking (highest first): a card whose TITLE matches, then a card matching only
  * on DESCRIPTION, then a COMMENT body match. Each source is capped before the
  * merge so one noisy source cannot crowd out the others.
+ *
+ * Every hit also names the card's COLUMN (#122) - boards routinely hold several
+ * cards with near-identical titles that are told apart only by the stage they
+ * are at. The titles are batch-resolved for the returned page only.
  */
 class SearchService {
 	/** Per-source row cap before merge/rank - bounds the LIKE scan. */
@@ -41,6 +46,7 @@ class SearchService {
 		private CommentMapper $commentMapper,
 		private IDBConnection $db,
 		private BoardAccess $boardAccess,
+		private StackMapper $stackMapper,
 	) {
 	}
 
@@ -82,6 +88,7 @@ class SearchService {
 				'type' => 'comment',
 				'cardId' => $row['cardId'],
 				'boardId' => $row['boardId'],
+				'stackId' => $row['stackId'],
 				'commentId' => $row['id'],
 				'title' => $row['cardTitle'],
 				'snippet' => $this->snippet($row['body']),
@@ -96,7 +103,7 @@ class SearchService {
 		$total = count($results);
 		$page = array_slice($results, $offset, $limit);
 
-		return ['query' => $term, 'total' => $total, 'results' => $page];
+		return ['query' => $term, 'total' => $total, 'results' => $this->withStackTitles($page)];
 	}
 
 	/**
@@ -108,10 +115,40 @@ class SearchService {
 			'type' => 'card',
 			'cardId' => $card->getId(),
 			'boardId' => $card->getBoardId(),
+			'stackId' => $card->getStackId(),
 			'title' => $card->getTitle(),
 			'snippet' => $this->snippet((string)$card->getDescription()),
 			'rank' => $titleMatches ? self::RANK_CARD_TITLE : self::RANK_CARD_DESCRIPTION,
 		];
+	}
+
+	/**
+	 * Names each hit's column (#122). Two cards can carry near-identical titles
+	 * and be told apart only by the stage they sit at, so a result list without
+	 * the column forces the reader to open rows one by one.
+	 *
+	 * Resolved for the PAGE, not the whole result set - the caller has already
+	 * sliced, so this is at most `$limit` rows however many matched - and in ONE
+	 * batched query over the distinct ids. A stack that does not resolve (it was
+	 * deleted between the match and now) yields a null title, which the client
+	 * renders as no column rather than an empty one.
+	 *
+	 * @param list<array<string, mixed>> $page
+	 * @return list<array<string, mixed>>
+	 */
+	private function withStackTitles(array $page): array {
+		$stackIds = array_values(array_unique(array_filter(
+			array_map(static fn (array $row): ?int => $row['stackId'] ?? null, $page),
+			static fn (?int $id): bool => $id !== null,
+		)));
+		$titles = $this->stackMapper->titlesByIds($stackIds);
+
+		foreach ($page as $index => $row) {
+			$stackId = $row['stackId'] ?? null;
+			$page[$index]['stackTitle'] = $stackId !== null ? ($titles[$stackId] ?? null) : null;
+		}
+
+		return array_values($page);
 	}
 
 	/**

--- a/src/components/CardDetail.vue
+++ b/src/components/CardDetail.vue
@@ -1461,7 +1461,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									:disabled="addChildMutation.isPending.value"
 									@keydown.enter.prevent="handleAddChild">
 							</div>
-							<div v-if="children.length > 0" class="card-modal__children-grid">
+							<div v-if="children.length > 0" class="card-modal__children-list">
 								<div
 									v-for="child in children"
 									:key="child.id"
@@ -1476,6 +1476,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 										@click="openCard(child.id)">
 										{{ child.title }}
 									</button>
+									<!-- #122 — a sub-card's dates, so reading a case's steps no longer
+									     means opening each one. Display-only: children[] comes from
+									     jsonSerializeSummary(), which already carries both dates. -->
+									<span v-if="child.startDate || child.duedate" class="card-modal__child-dates">
+										<span
+											v-if="child.startDate"
+											class="card-modal__child-date card-modal__child-date--start"
+											:title="t('kanso', 'Starts {date}', { date: childDateFull(child, child.startDate) })">
+											<CalendarStartIcon :size="12" />
+											{{ childDate(child, child.startDate) }}
+										</span>
+										<span
+											v-if="child.duedate"
+											class="card-modal__child-date"
+											:class="childDueClass(child)"
+											:title="t('kanso', 'Due {date}', { date: childDateFull(child, child.duedate) })">
+											<CalendarIcon :size="12" />
+											{{ childDate(child, child.duedate) }}
+										</span>
+									</span>
 									<button
 										class="card-modal__child-remove"
 										:title="t('kanso', 'Detach sub-card')"
@@ -2418,6 +2438,7 @@ import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import EmoticonHappyOutlineIcon from 'vue-material-design-icons/EmoticonHappyOutline.vue'
 import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
+import CalendarStartIcon from 'vue-material-design-icons/CalendarStart.vue'
 import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
 import InformationOutlineIcon from 'vue-material-design-icons/InformationOutline.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
@@ -5436,6 +5457,34 @@ const childrenDone = computed(() =>
 	children.value.filter((c) => Number(c.doneAt) > 0).length,
 )
 
+// ── Sub-card date chips (#122) ───────────────────────────────────────────────
+// Display-only: `children[]` rides the card payload from jsonSerializeSummary(),
+// which already carries duedate, startDate and allDay.
+//
+// allDay is load-bearing, not decoration: an all-day date is stored at UTC
+// midnight, so formatting it in local time renders the PREVIOUS day for anyone
+// west of UTC. formatCardDate() handles that when it is told — so tell it.
+function childDate(child, iso) {
+	return formatCardDate(iso, child.allDay === true, { month: 'short', day: 'numeric' })
+}
+
+/** The unabbreviated date, for the chip's title attribute (the year is the point). */
+function childDateFull(child, iso) {
+	return formatCardDate(iso, child.allDay === true, { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+// Overdue / due-soon colouring, mirroring the board tile and the checklist-step
+// chip - including their rule that a DONE sub-card shows its due date neutrally
+// rather than shouting red about work that is already finished.
+function childDueClass(child) {
+	if (!child.duedate || Number(child.doneAt) > 0) return ''
+	const due = new Date(child.duedate)
+	const now = new Date()
+	if (due < now) return 'card-modal__child-date--overdue'
+	if ((due - now) / (1000 * 60 * 60) <= 24) return 'card-modal__child-date--soon'
+	return ''
+}
+
 // Parent title: look up the parent's title from the board cache (fast path),
 // falling back to a generic label so we never render an undefined value.
 const parentTitle = computed(() => {
@@ -7832,13 +7881,24 @@ body.theme--dark .card-modal,
 .card-modal__step-due[role='button'] {
 	cursor: pointer;
 }
+/* Legibility (#122): `--color-error` / `--color-warning` are pale TINT
+ * backgrounds in NC 34 (#FFE7E7 / #FFEEC5), NOT saturated fills - so the
+ * `color: #fff` these carried put white on near-white at roughly 1.1:1, which
+ * is how an overdue chip ended up unreadable.
+ *
+ * Both halves are now derived from the SAME theme-aware `--color-*-text` token
+ * (the legible foreground NC pairs with those tints): the text as-is, the
+ * background as a 12% tint of it. Deriving both from one token is what keeps
+ * this correct across NC 32-34 and both themes - a version where the base
+ * token is a saturated fill instead of a tint would otherwise flip the pairing
+ * from unreadable-light to unreadable-dark. */
 .card-modal__step-due--overdue {
-	background: var(--color-error);
-	color: #fff;
+	background: color-mix(in srgb, var(--color-error-text, #8a0000) 12%, transparent);
+	color: var(--color-error-text, #8a0000);
 }
 .card-modal__step-due--soon {
-	background: var(--color-warning, #d89b00);
-	color: #fff;
+	background: color-mix(in srgb, var(--color-warning-text, #664700) 14%, transparent);
+	color: var(--color-warning-text, #664700);
 }
 .card-modal__step-assignee {
 	display: inline-flex;
@@ -7950,13 +8010,21 @@ body.theme--dark .card-modal,
 .card-modal__parent-link:hover {
 	border-color: var(--color-primary-element);
 }
-.card-modal__children-grid {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 8px;
-}
-.card-modal__child {
+/* #122 — sub-cards are a single-column LIST, not a 2-up grid. Two cards side by
+   side read as a matrix rather than an ordered set of steps, each cell was too
+   narrow to carry anything but the title, and an odd count left a ragged hole.
+   The full row width is also what makes room for the date chips. */
+.card-modal__children-list {
 	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+/* A grid, not a flex row, so the mobile rule below can re-flow the same four
+   parts onto two lines by redeclaring the areas - no duplicated markup. */
+.card-modal__child {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto auto;
+	grid-template-areas: "dot title dates remove";
 	align-items: center;
 	gap: 10px;
 	padding: 10px 12px;
@@ -7964,6 +8032,47 @@ body.theme--dark .card-modal,
 	border-radius: 3px;
 	background: var(--color-main-background);
 	min-width: 0;
+}
+.card-modal__child > .card-modal__child-dot { grid-area: dot; }
+.card-modal__child > .card-modal__child-link { grid-area: title; }
+.card-modal__child > .card-modal__child-dates { grid-area: dates; }
+.card-modal__child > .card-modal__child-remove { grid-area: remove; }
+.card-modal__child-dates {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	min-width: 0;
+}
+/* Same shape as the checklist-step due chip above, so the two read as one
+   family rather than two inventions. */
+.card-modal__child-date {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	flex-shrink: 0;
+	padding: 1px 7px;
+	border-radius: 10px;
+	font-size: 12px;
+	white-space: nowrap;
+	background: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+/* The START chip is deliberately quieter - no pill, just icon + date. Two
+ * identical pills side by side read as one ambiguous pair; the due date is the
+ * one people act on, so it keeps the filled shape and the urgency colour. */
+.card-modal__child-date--start {
+	background: transparent;
+	padding-inline: 0 2px;
+}
+/* Same derived-from-one-token pairing as the checklist step chip above - see
+ * the legibility note there. */
+.card-modal__child-date--overdue {
+	background: color-mix(in srgb, var(--color-error-text, #8a0000) 12%, transparent);
+	color: var(--color-error-text, #8a0000);
+}
+.card-modal__child-date--soon {
+	background: color-mix(in srgb, var(--color-warning-text, #664700) 14%, transparent);
+	color: var(--color-warning-text, #664700);
 }
 .card-modal__child:hover {
 	border-color: var(--color-primary-element);
@@ -9061,7 +9170,19 @@ body.theme--dark .card-modal,
 	.card-modal__content,
 	.card-modal__discussion { max-height: none; }
 	.card-modal__discussion { border-left: none; border-top: 1px solid var(--color-border); }
-	.card-modal__children-grid { grid-template-columns: 1fr; }
+	/* #122 — on a phone the title and two date chips cannot share one line
+	   without crushing the title to an ellipsis, so the dates drop to a second
+	   line, indented under the title and clear of the detach button. Same four
+	   elements, re-flowed by the grid areas alone. */
+	.card-modal__child {
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		grid-template-areas:
+			"dot title remove"
+			"dot dates dates";
+		row-gap: 4px;
+	}
+	.card-modal__child > .card-modal__child-dot { align-self: start; margin-top: 5px; }
+	.card-modal__child-dates { flex-wrap: wrap; }
 	.card-modal__tabbar {
 		display: flex;
 		position: sticky;

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -100,7 +100,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<!-- eslint-disable-next-line vue/no-v-html -->
 							<span class="command-palette__result-title" v-html="item.highlightedTitle" />
 							<span v-if="item.snippet" class="command-palette__result-snippet">{{ item.snippet }}</span>
-							<span v-if="item.badge" class="command-palette__result-badge">{{ item.badge }}</span>
+							<span v-if="item.column || item.badge" class="command-palette__result-meta">
+								<span v-if="item.column" class="command-palette__result-column">{{ item.column }}</span>
+								<span v-if="item.badge" class="command-palette__result-badge">{{ item.badge }}</span>
+							</span>
 						</div>
 					</li>
 				</template>
@@ -239,6 +242,10 @@ const sections = computed(() => {
 				highlightedTitle: highlightMatch(r.title, debouncedTerm.value),
 				snippet: r.snippet ? truncate(r.snippet, 80) : null,
 				badge: r.type === 'comment' ? t('kanso', 'comment') : null,
+				// The column the card sits in (#122) - the palette lists hits from
+				// every board, so near-identical titles need it even more than the
+				// board-scoped search box does. Null when it no longer resolves.
+				column: r.stackTitle || null,
 				// navigation payload
 				type: 'card',
 				boardId: r.boardId,
@@ -463,6 +470,29 @@ function selectItem(item) {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+/* #122 — the column chip sits on one line with the comment badge, under the
+   snippet, rather than adding a third stacked row to every hit. */
+.command-palette__result-meta {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	min-width: 0;
+	align-self: flex-start;
+	max-width: 100%;
+}
+.command-palette__result-column {
+	font-size: 0.7rem;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	border-radius: 8px;
+	padding: 0 6px;
+	line-height: 1.5;
+	max-width: 14em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .command-palette__result-badge {

--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -101,7 +101,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							<span class="command-palette__result-title" v-html="item.highlightedTitle" />
 							<span v-if="item.snippet" class="command-palette__result-snippet">{{ item.snippet }}</span>
 							<span v-if="item.column || item.badge" class="command-palette__result-meta">
-								<span v-if="item.column" class="command-palette__result-column">{{ item.column }}</span>
+								<span v-if="item.column" class="command-palette__result-column" :title="item.column">{{ item.column }}</span>
 								<span v-if="item.badge" class="command-palette__result-badge">{{ item.badge }}</span>
 							</span>
 						</div>

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -90,9 +90,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<span v-if="result.snippet" class="search-box__result-snippet">
 						{{ truncate(result.snippet, 80) }}
 					</span>
-					<!-- Label for comment hits to distinguish from card hits -->
-					<span v-if="result.type === 'comment'" class="search-box__result-badge">
-						{{ t('kanso', 'comment') }}
+					<!-- #122 — the column a hit sits in. Boards routinely hold several
+					     cards with near-identical titles whose only difference is the
+					     stage they are at, which left the list unreadable without
+					     opening each row. Absent when the column no longer resolves. -->
+					<span class="search-box__result-meta">
+						<span v-if="result.stackTitle" class="search-box__result-column">
+							{{ result.stackTitle }}
+						</span>
+						<!-- Label for comment hits to distinguish from card hits -->
+						<span v-if="result.type === 'comment'" class="search-box__result-badge">
+							{{ t('kanso', 'comment') }}
+						</span>
 					</span>
 				</div>
 			</li>
@@ -432,6 +441,27 @@ defineExpose({ focus: () => inputRef.value?.focus() })
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+/* #122 — the column chip and the comment badge share one line under the
+   snippet, so a comment hit shows both without stacking a third row. */
+.search-box__result-meta {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	min-width: 0;
+}
+.search-box__result-column {
+	font-size: 0.7rem;
+	color: var(--color-text-maxcontrast);
+	background: var(--color-background-dark);
+	border-radius: 8px;
+	padding: 0 6px;
+	line-height: 1.5;
+	max-width: 14em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .search-box__result-badge {

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -94,8 +94,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					     cards with near-identical titles whose only difference is the
 					     stage they are at, which left the list unreadable without
 					     opening each row. Absent when the column no longer resolves. -->
-					<span class="search-box__result-meta">
-						<span v-if="result.stackTitle" class="search-box__result-column">
+					<span v-if="result.stackTitle || result.type === 'comment'" class="search-box__result-meta">
+						<span v-if="result.stackTitle" class="search-box__result-column" :title="result.stackTitle">
 							{{ result.stackTitle }}
 						</span>
 						<!-- Label for comment hits to distinguish from card hits -->

--- a/tests/e2e/search.spec.js
+++ b/tests/e2e/search.spec.js
@@ -11,6 +11,7 @@ import { test, expect, api, ncLogin, BASE } from './helpers.js'
 test.describe('Search', () => {
 	const state = {
 		boardId: 0,
+		stackId: 0,
 		cardAlphaId: 0,
 		cardBetaId: 0,
 		cardGammaId: 0,
@@ -30,6 +31,7 @@ test.describe('Search', () => {
 		const board = await api.post('/boards', { title: 'Search Test Board E2E' })
 		state.boardId = board.id
 		const stack = await api.post('/stacks', { boardId: board.id, title: 'Backlog' })
+		state.stackId = stack.id
 
 		// Card 1 - unique title term "Alpha widget"
 		const cardAlpha = await api.post('/cards', {
@@ -179,6 +181,40 @@ test.describe('Search', () => {
 		const emptyState = dropdown.locator('.search-box__status--empty')
 		await expect(emptyState).toBeVisible({ timeout: 5000 })
 		await expect(emptyState).toContainText('No matches')
+	})
+
+	// #122 — a board routinely holds several cards whose titles are near-identical
+	// and whose only distinguishing feature is the stage they are at, which made
+	// the result list unreadable: every row looked the same and had to be opened
+	// to tell them apart. Each hit now names its column.
+	test('results name the column, which is what tells identically-titled cards apart', async ({ page }) => {
+		// Two cards with the SAME title in DIFFERENT columns - the reporter's case.
+		const twinA = await api.post('/cards', { stackId: state.stackId, title: 'Wheelchair repair Kaya' })
+		const secondStack = await api.post('/stacks', { boardId: state.boardId, title: 'Awaiting parts' })
+		const twinB = await api.post('/cards', { stackId: secondStack.id, title: 'Wheelchair repair Kaya' })
+
+		await goToBoard(page)
+		const searchInput = page.locator('.search-box__input')
+		await searchInput.fill('Wheelchair')
+
+		const dropdown = page.locator('.search-box__dropdown')
+		await expect(dropdown).toBeVisible({ timeout: 5000 })
+		const rows = dropdown.locator('.search-box__result').filter({ hasText: 'Wheelchair repair Kaya' })
+		await expect(rows).toHaveCount(2, { timeout: 5000 })
+
+		// Identical titles, so the column is the ONLY thing separating the rows.
+		const columns = await rows.locator('.search-box__result-column').allTextContents()
+		expect(columns.map((c) => c.trim()).sort()).toEqual(['Awaiting parts', 'Backlog'])
+
+		// A comment hit carries it too - it is a card hit by another route.
+		await searchInput.fill('xylorimba')
+		const commentRow = dropdown.locator('.search-box__result').filter({ hasText: 'Gamma fixture' })
+		await expect(commentRow).toBeVisible({ timeout: 5000 })
+		await expect(commentRow.locator('.search-box__result-column')).toHaveText('Backlog')
+
+		await api.delete(`/cards/${twinA.id}`)
+		await api.delete(`/cards/${twinB.id}`)
+		await api.delete(`/stacks/${secondStack.id}`)
 	})
 
 	test('pressing Escape closes the dropdown and clears the input', async ({ page }) => {

--- a/tests/unit/Service/SearchServiceTest.php
+++ b/tests/unit/Service/SearchServiceTest.php
@@ -13,6 +13,7 @@ use OCA\Kanso\Db\Board;
 use OCA\Kanso\Db\Card;
 use OCA\Kanso\Db\CardMapper;
 use OCA\Kanso\Db\CommentMapper;
+use OCA\Kanso\Db\StackMapper;
 use OCA\Kanso\Service\BoardService;
 use OCA\Kanso\Service\SearchService;
 use OCP\IDBConnection;
@@ -25,6 +26,7 @@ class SearchServiceTest extends TestCase {
 	private CommentMapper&MockObject $commentMapper;
 	private IDBConnection&MockObject $db;
 	private BoardAccess&MockObject $boardAccess;
+	private StackMapper&MockObject $stackMapper;
 	private SearchService $service;
 
 	protected function setUp(): void {
@@ -38,12 +40,18 @@ class SearchServiceTest extends TestCase {
 			static fn (string $s): string => str_replace(['\\', '_', '%'], ['\\\\', '\\_', '\\%'], $s),
 		);
 		$this->boardAccess = $this->createMock(BoardAccess::class);
+		// Deliberately NOT given a default stub: PHPUnit takes the return value
+		// from the FIRST matching matcher, so a convenience default configured
+		// here would silently beat every per-test willReturn() and make the
+		// column assertions below untestable.
+		$this->stackMapper = $this->createMock(StackMapper::class);
 		$this->service = new SearchService(
 			$this->boardService,
 			$this->cardMapper,
 			$this->commentMapper,
 			$this->db,
 			$this->boardAccess,
+			$this->stackMapper,
 		);
 	}
 
@@ -59,6 +67,13 @@ class SearchServiceTest extends TestCase {
 		$card->setBoardId($boardId);
 		$card->setTitle($title);
 		$card->setDescription($description);
+		return $card;
+	}
+
+	/** A card pinned to a specific column, for the #122 column assertions. */
+	private function cardInStack(int $id, int $boardId, int $stackId, string $title): Card {
+		$card = $this->card($id, $boardId, $title);
+		$card->setStackId($stackId);
 		return $card;
 	}
 
@@ -94,7 +109,7 @@ class SearchServiceTest extends TestCase {
 			$this->card(21, 1, 'Widget master', 'nope'), // title → rank 3
 		]);
 		$this->commentMapper->method('searchInBoards')->willReturn([
-			['id' => 5, 'cardId' => 22, 'boardId' => 1, 'cardTitle' => 'Card with comment', 'body' => 'a widget mention'],
+			['id' => 5, 'cardId' => 22, 'boardId' => 1, 'stackId' => 3, 'cardTitle' => 'Card with comment', 'body' => 'a widget mention'],
 		]);
 
 		$result = $this->service->search('widget', 'alice', null, 25, 0);
@@ -106,6 +121,84 @@ class SearchServiceTest extends TestCase {
 		self::assertSame('comment', $result['results'][2]['type']); // comment last
 		self::assertSame(22, $result['results'][2]['cardId']);
 		self::assertSame(5, $result['results'][2]['commentId']);
+	}
+
+	/**
+	 * #122: two cards can carry near-identical titles and be told apart only by
+	 * the column they sit in, so every hit - card AND comment - names its
+	 * column.
+	 */
+	public function testEveryResultNamesItsColumn(): void {
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
+		$this->cardMapper->method('searchInBoards')->willReturn([
+			$this->cardInStack(20, 1, 11, 'Wheelchair repair - Yilmaz'),
+			$this->cardInStack(21, 1, 12, 'Wheelchair repair - Yilmaz'),
+		]);
+		$this->commentMapper->method('searchInBoards')->willReturn([
+			['id' => 5, 'cardId' => 22, 'boardId' => 1, 'stackId' => 12, 'cardTitle' => 'Other case', 'body' => 'a wheelchair mention'],
+		]);
+		$this->stackMapper->expects(self::once())
+			->method('titlesByIds')
+			// One batched call over the DISTINCT ids, never one query per row.
+			->with(self::callback(static function (array $ids): bool {
+				sort($ids);
+				return $ids === [11, 12];
+			}))
+			->willReturn([11 => 'Open cases', 12 => 'Awaiting parts']);
+
+		$results = $this->service->search('wheelchair', 'alice', null, 25, 0)['results'];
+
+		self::assertSame('Open cases', $results[0]['stackTitle']);
+		self::assertSame(11, $results[0]['stackId']);
+		// The identically-titled sibling is distinguishable by its column alone.
+		self::assertSame('Awaiting parts', $results[1]['stackTitle']);
+		self::assertSame($results[0]['title'], $results[1]['title']);
+		// Comment hits carry it too - they are card hits by another route.
+		self::assertSame('comment', $results[2]['type']);
+		self::assertSame('Awaiting parts', $results[2]['stackTitle']);
+	}
+
+	/**
+	 * A stack deleted between the match and the read resolves to nothing. The
+	 * key must still be present and null so the client renders no column rather
+	 * than an empty chip.
+	 */
+	public function testAnUnresolvedColumnYieldsANullTitleRatherThanBreaking(): void {
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
+		$this->cardMapper->method('searchInBoards')->willReturn([
+			$this->cardInStack(20, 1, 99, 'Widget master'),
+		]);
+		$this->commentMapper->method('searchInBoards')->willReturn([]);
+		$this->stackMapper->method('titlesByIds')->willReturn([]);
+
+		$results = $this->service->search('widget', 'alice', null, 25, 0)['results'];
+
+		self::assertArrayHasKey('stackTitle', $results[0]);
+		self::assertNull($results[0]['stackTitle']);
+	}
+
+	/**
+	 * The titles are resolved for the PAGE, not the whole match set: a wide
+	 * search can match hundreds of rows across as many columns, and all but one
+	 * page of them is about to be thrown away.
+	 */
+	public function testColumnTitlesAreResolvedForThePageOnly(): void {
+		$this->boardService->method('findAllActive')->with('alice')->willReturn([$this->board(1)]);
+		$cards = [];
+		for ($i = 0; $i < 30; $i++) {
+			$cards[] = $this->cardInStack(100 + $i, 1, 200 + $i, 'Widget ' . $i);
+		}
+		$this->cardMapper->method('searchInBoards')->willReturn($cards);
+		$this->commentMapper->method('searchInBoards')->willReturn([]);
+		$this->stackMapper->expects(self::once())
+			->method('titlesByIds')
+			->with(self::callback(static fn (array $ids): bool => count($ids) === 5))
+			->willReturn([]);
+
+		$result = $this->service->search('widget', 'alice', null, 5, 0);
+
+		self::assertSame(30, $result['total']);
+		self::assertCount(5, $result['results']);
 	}
 
 	public function testSearchSkipsBoardsTheUserHasArchived(): void {

--- a/translationfiles/de/kanso.po
+++ b/translationfiles/de/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n Datenzeile erkannt"
 msgstr[1] "%n Datenzeilen erkannt"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "vor %n Tag"
 msgstr[1] "vor %n Tagen"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "vor %n Stunde"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "vor %n Minute"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n Projekt"
 msgstr[1] "%n Projekte"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "Tag"
@@ -1984,6 +1984,10 @@ msgstr "Ablegen, um von der übergeordneten Karte zu lösen"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Fällig"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "Mo"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "Monat"
@@ -4737,7 +4741,7 @@ msgstr "Formatierungsleiste anzeigen"
 msgid "Show the discussion panel"
 msgstr "Diskussionsbereich anzeigen"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Diskussionsbereich anzeigen (%n Kommentar)"
@@ -4873,6 +4877,10 @@ msgstr "Mit einer Vorlage beginnen"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Gestartet"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "Mi"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "Woche"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "schrieb"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "Jahr"

--- a/translationfiles/es/kanso.po
+++ b/translationfiles/es/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n fila de datos detectada"
 msgstr[1] "%n filas de datos detectadas"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "hace %n día"
 msgstr[1] "hace %n días"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "hace %n hora"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "hace %n minuto"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proyecto"
 msgstr[1] "%n proyectos"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Fecha"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "día"
@@ -1984,6 +1984,10 @@ msgstr "Suelta aquí para separar de la tarjeta principal"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Vencimiento"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mes"
@@ -4737,7 +4741,7 @@ msgstr "Mostrar la barra de formato"
 msgid "Show the discussion panel"
 msgstr "Mostrar el panel de conversación"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar el panel de conversación (%n comentario)"
@@ -4873,6 +4877,10 @@ msgstr "Partir de una plantilla"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Empezadas"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "Mié"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "escribió"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "año"

--- a/translationfiles/fr/kanso.po
+++ b/translationfiles/fr/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n ligne de données détectée"
 msgstr[1] "%n lignes de données détectées"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "il y a %n jour"
 msgstr[1] "il y a %n jours"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "il y a %n heure"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "il y a %n minute"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projet"
 msgstr[1] "%n projets"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "jour"
@@ -1984,6 +1984,10 @@ msgstr "Déposer pour détacher de la carte parente"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Échéance"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mois"
@@ -4737,7 +4741,7 @@ msgstr "Afficher la barre de mise en forme"
 msgid "Show the discussion panel"
 msgstr "Afficher le panneau de discussion"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Afficher le panneau de discussion (%n commentaire)"
@@ -4873,6 +4877,10 @@ msgstr "Partir d'un modèle"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Démarrée"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semaine"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "a écrit"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "an"

--- a/translationfiles/it/kanso.po
+++ b/translationfiles/it/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n riga di dati rilevata"
 msgstr[1] "%n righe di dati rilevate"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n giorno fa"
 msgstr[1] "%n giorni fa"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n ora fa"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuto fa"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n progetto"
 msgstr[1] "%n progetti"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "giorno"
@@ -1984,6 +1984,10 @@ msgstr "Rilascia per staccare dalla scheda principale"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Scadenza"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "Lun"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mese"
@@ -4737,7 +4741,7 @@ msgstr "Mostra la barra di formattazione"
 msgid "Show the discussion panel"
 msgstr "Mostra il pannello della discussione"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostra il pannello della discussione (%n commento)"
@@ -4873,6 +4877,10 @@ msgstr "Parti da un modello"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Iniziata"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "Mer"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "settimana"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "ha scritto"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "anno"

--- a/translationfiles/nl/kanso.po
+++ b/translationfiles/nl/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n gegevensrij gevonden"
 msgstr[1] "%n gegevensrijen gevonden"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dag geleden"
 msgstr[1] "%n dagen geleden"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n uur geleden"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minuut geleden"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n project"
 msgstr[1] "%n projecten"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Datum"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dag"
@@ -1984,6 +1984,10 @@ msgstr "Loslaten om los te maken van de hoofdkaart"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Einde"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "ma"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "maand"
@@ -4737,7 +4741,7 @@ msgstr "Opmaakbalk tonen"
 msgid "Show the discussion panel"
 msgstr "Het discussiepaneel tonen"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Het discussiepaneel tonen (%n reactie)"
@@ -4873,6 +4877,10 @@ msgstr "Begin met een sjabloon"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Gestart"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "wo"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "week"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "schreef"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "jaar"

--- a/translationfiles/pl/kanso.po
+++ b/translationfiles/pl/kanso.po
@@ -301,14 +301,14 @@ msgstr[0] "Wykryto %n wiersz danych"
 msgstr[1] "Wykryto %n wiersze danych"
 msgstr[2] "Wykryto %n wierszy danych"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n dzień temu"
 msgstr[1] "%n dni temu"
 msgstr[2] "%n dni temu"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n godzinę temu"
@@ -336,7 +336,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n minutę temu"
@@ -371,7 +371,7 @@ msgstr[0] "%n projekt"
 msgstr[1] "%n projekty"
 msgstr[2] "%n projektów"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1708,7 +1708,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dzień"
@@ -2007,6 +2007,10 @@ msgstr "Upuść, aby odłączyć od karty nadrzędnej"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Termin"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3383,7 +3387,7 @@ msgid "Mon"
 msgstr "Pn"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "miesiąc"
@@ -4765,7 +4769,7 @@ msgstr "Pokaż pasek formatowania"
 msgid "Show the discussion panel"
 msgstr "Pokaż panel dyskusji"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Pokaż panel dyskusji (%n komentarz)"
@@ -4902,6 +4906,10 @@ msgstr "Zacznij od szablonu"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Rozpoczęte"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5428,7 +5436,7 @@ msgid "Wed"
 msgstr "Śr"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "tydzień"
@@ -5510,7 +5518,7 @@ msgid "wrote"
 msgstr "napisał"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "rok"

--- a/translationfiles/pt_BR/kanso.po
+++ b/translationfiles/pt_BR/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n linha de dados detectada"
 msgstr[1] "%n linhas de dados detectadas"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "há %n dia"
 msgstr[1] "há %n dias"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "há %n hora"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "há %n minuto"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n projeto"
 msgstr[1] "%n projetos"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Data"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "dia"
@@ -1984,6 +1984,10 @@ msgstr "Solte para remover do cartão pai"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Vencimento"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "Seg"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "mês"
@@ -4737,7 +4741,7 @@ msgstr "Mostrar a barra de formatação"
 msgid "Show the discussion panel"
 msgstr "Mostrar o painel de discussão"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Mostrar o painel de discussão (%n comentário)"
@@ -4873,6 +4877,10 @@ msgstr "Comece com um modelo"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Iniciado"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "Qua"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "semana"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "escreveu"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "ano"

--- a/translationfiles/ru/kanso.po
+++ b/translationfiles/ru/kanso.po
@@ -301,14 +301,14 @@ msgstr[0] "Обнаружена %n строка данных"
 msgstr[1] "Обнаружено %n строки данных"
 msgstr[2] "Обнаружено %n строк данных"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n день назад"
 msgstr[1] "%n дня назад"
 msgstr[2] "%n дней назад"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n час назад"
@@ -336,7 +336,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n минуту назад"
@@ -371,7 +371,7 @@ msgstr[0] "%n проект"
 msgstr[1] "%n проекта"
 msgstr[2] "%n проектов"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1708,7 +1708,7 @@ msgid "Date"
 msgstr "Дата"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "день"
@@ -2007,6 +2007,10 @@ msgstr "Отпустите, чтобы открепить от родитель�
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Срок"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3383,7 +3387,7 @@ msgid "Mon"
 msgstr "Пн"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "месяц"
@@ -4765,7 +4769,7 @@ msgstr "Показывать панель форматирования"
 msgid "Show the discussion panel"
 msgstr "Показать панель обсуждения"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Показать панель обсуждения (%n комментарий)"
@@ -4902,6 +4906,10 @@ msgstr "Начать с шаблона"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Начатые"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5428,7 +5436,7 @@ msgid "Wed"
 msgstr "Ср"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "неделя"
@@ -5510,7 +5518,7 @@ msgid "wrote"
 msgstr "написал"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "год"

--- a/translationfiles/templates/kanso.pot
+++ b/translationfiles/templates/kanso.pot
@@ -292,13 +292,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] ""
@@ -322,7 +322,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] ""
@@ -352,7 +352,7 @@ msgid_plural "%n projects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1685,7 +1685,7 @@ msgid "Date"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] ""
@@ -1982,6 +1982,10 @@ msgstr ""
 
 #: src/views/PublicBoard.vue
 msgid "Due"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
 msgstr ""
 
 #: src/components/BoardFilterBar.vue
@@ -3355,7 +3359,7 @@ msgid "Mon"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] ""
@@ -4736,7 +4740,7 @@ msgstr ""
 msgid "Show the discussion panel"
 msgstr ""
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] ""
@@ -4871,6 +4875,10 @@ msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Started"
+msgstr ""
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
 msgstr ""
 
 #: src/composables/useBoardFilters.js
@@ -5398,7 +5406,7 @@ msgid "Wed"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] ""
@@ -5479,7 +5487,7 @@ msgid "wrote"
 msgstr ""
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] ""

--- a/translationfiles/tr/kanso.po
+++ b/translationfiles/tr/kanso.po
@@ -293,13 +293,13 @@ msgid_plural "%n data rows detected"
 msgstr[0] "%n veri satırı bulundu"
 msgstr[1] "%n veri satırı bulundu"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n gün önce"
 msgstr[1] "%n gün önce"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n saat önce"
@@ -323,7 +323,7 @@ msgid_plural "%n labels were not created and are missing from the imported cards
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n dakika önce"
@@ -353,7 +353,7 @@ msgid_plural "%n projects"
 msgstr[0] "%n proje"
 msgstr[1] "%n proje"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1686,7 +1686,7 @@ msgid "Date"
 msgstr "Tarih"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "gün"
@@ -1984,6 +1984,10 @@ msgstr "Üst karttan çıkarmak için bırak"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "Bitiş"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3356,7 +3360,7 @@ msgid "Mon"
 msgstr "Pzt"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "ay"
@@ -4737,7 +4741,7 @@ msgstr "Biçimlendirme araç çubuğunu göster"
 msgid "Show the discussion panel"
 msgstr "Tartışma panelini göster"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "Tartışma panelini göster (%n yorum)"
@@ -4873,6 +4877,10 @@ msgstr "Bir şablonla başla"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "Başladı"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5399,7 +5407,7 @@ msgid "Wed"
 msgstr "Çar"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "hafta"
@@ -5480,7 +5488,7 @@ msgid "wrote"
 msgstr "yazdı"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "yıl"

--- a/translationfiles/zh_CN/kanso.po
+++ b/translationfiles/zh_CN/kanso.po
@@ -285,12 +285,12 @@ msgid "%n data row detected"
 msgid_plural "%n data rows detected"
 msgstr[0] "检测到 %n 行数据"
 
-#: src/components/CardDetail.vue:4323
+#: src/components/CardDetail.vue:4344
 msgid "%n day ago"
 msgid_plural "%n days ago"
 msgstr[0] "%n 天前"
 
-#: src/components/CardDetail.vue:4321
+#: src/components/CardDetail.vue:4342
 msgid "%n hour ago"
 msgid_plural "%n hours ago"
 msgstr[0] "%n 小时前"
@@ -310,7 +310,7 @@ msgid "%n label was not created and is missing from the imported cards: only boa
 msgid_plural "%n labels were not created and are missing from the imported cards: only board managers can add new labels. Ask a manager to add them, then set them on the cards."
 msgstr[0] ""
 
-#: src/components/CardDetail.vue:4319
+#: src/components/CardDetail.vue:4340
 msgid "%n minute ago"
 msgid_plural "%n minutes ago"
 msgstr[0] "%n 分钟前"
@@ -335,7 +335,7 @@ msgid "%n project"
 msgid_plural "%n projects"
 msgstr[0] "%n 个项目"
 
-#: src/components/CardDetail.vue:1995
+#: src/components/CardDetail.vue:2015
 msgid "%n reply"
 msgid_plural "%n replies"
 msgstr[0] ""
@@ -1664,7 +1664,7 @@ msgid "Date"
 msgstr "日期"
 
 #: src/components/BoardSettingsModal.vue:2110
-#: src/components/CardDetail.vue:4512
+#: src/components/CardDetail.vue:4533
 msgid "day"
 msgid_plural "days"
 msgstr[0] "天"
@@ -1961,6 +1961,10 @@ msgstr "放开以从父卡片中移出"
 #: src/views/PublicBoard.vue
 msgid "Due"
 msgstr "截止"
+
+#: src/components/CardDetail.vue
+msgid "Due {date}"
+msgstr ""
 
 #: src/components/BoardFilterBar.vue
 #: src/components/BoardSettingsModal.vue
@@ -3329,7 +3333,7 @@ msgid "Mon"
 msgstr "周一"
 
 #: src/components/BoardSettingsModal.vue:2112
-#: src/components/CardDetail.vue:4514
+#: src/components/CardDetail.vue:4535
 msgid "month"
 msgid_plural "months"
 msgstr[0] "个月"
@@ -4709,7 +4713,7 @@ msgstr "显示格式工具栏"
 msgid "Show the discussion panel"
 msgstr "显示讨论面板"
 
-#: src/components/CardDetail.vue:6189
+#: src/components/CardDetail.vue:6238
 msgid "Show the discussion panel (%n comment)"
 msgid_plural "Show the discussion panel (%n comments)"
 msgstr[0] "显示讨论面板（%n 条评论）"
@@ -4844,6 +4848,10 @@ msgstr "从模板开始"
 #: src/composables/useBoardFilters.js
 msgid "Started"
 msgstr "已开始"
+
+#: src/components/CardDetail.vue
+msgid "Starts {date}"
+msgstr ""
 
 #: src/composables/useBoardFilters.js
 msgid "Starts later"
@@ -5370,7 +5378,7 @@ msgid "Wed"
 msgstr "周三"
 
 #: src/components/BoardSettingsModal.vue:2111
-#: src/components/CardDetail.vue:4513
+#: src/components/CardDetail.vue:4534
 msgid "week"
 msgid_plural "weeks"
 msgstr[0] "周"
@@ -5450,7 +5458,7 @@ msgid "wrote"
 msgstr "写道"
 
 #: src/components/BoardSettingsModal.vue:2113
-#: src/components/CardDetail.vue:4515
+#: src/components/CardDetail.vue:4536
 msgid "year"
 msgid_plural "years"
 msgstr[0] "年"


### PR DESCRIPTION
Closes #122 — both asks, one commit each so the changelog gets both entries.

## 1. Sub-card dates, and a sub-card list that reads like a list

`children[]` already carried `duedate`, `startDate` and `allDay` from `jsonSerializeSummary()`; the UI rendered none of it, so seeing when a step starts or is due meant opening it.

Three changes:

- **One sub-card per row.** It was a two-column grid, which read as a matrix rather than an ordered set of steps, left a ragged hole on an odd count, and gave each cell too little width to carry more than a title.
- **Dates on each row** — a quiet start chip and a filled due chip, with the board tile's overdue / due-soon colouring, including its rule that a *done* sub-card shows its due date neutrally instead of shouting red about finished work. No dates → no chips. `allDay` is honoured, so an all-day date no longer renders as the previous day west of UTC.
- **Mobile**: the dates drop to a second line, indented under the title and clear of the detach button, rather than crushing the title to an ellipsis. Same four elements re-flowed by grid areas — no duplicated markup.

### Legibility fix this surfaced

NC 34's `--color-error` / `--color-warning` are pale **tint backgrounds** (`#FFE7E7` / `#FFEEC5`), not saturated fills — so the `color: #fff` the overdue and due-soon chips carried put white on near-white. Measured:

| chip | before | after |
|---|---|---|
| overdue | **1.18:1** | **7.92:1** |
| due soon | **1.15:1** | **6.78:1** |

Both now derive text and background from the same theme-aware `--color-*-text` token, so dark mode is handled upstream rather than by a hardcoded override. This also fixes the **existing** checklist-step due chips, which had the identical bug.

## 2. The column on every search hit

`SearchService` emitted `type, cardId, boardId, title, snippet, rank` — no column. The reporter's boards hold several open cases per customer with near-identical titles where the column *is* the distinguishing detail, so result rows looked alike and had to be opened one at a time.

- Card hits already carried `stackId`; `CommentMapper::searchInBoards()` now selects `c.stack_id` too.
- New `StackMapper::titlesByIds()` resolves titles **across boards in one query** — the existing `findByIds()` is board-scoped and search spans every readable board. Deliberately not filtered on archived: archiving a column doesn't archive its cards, so an archived column still holds live, searchable cards.
- Resolved for the returned **page**, after slicing — a wide search can match hundreds of rows, and all but one page is about to be discarded. An unresolvable stack yields a null title and the client renders no chip.
- Shown in the search box and the command palette, sharing a line with the comment badge so no hit grows a third row.

## Verification

Against a local NC 34 stack running this branch:

- **phpunit** — 2056 tests, 919346 assertions, **OK** (5 new: every-hit-names-its-column, unresolvable stack → null, page-only resolution, plus a stale comment fixture corrected to the mapper's real shape).
- **psalm** exit 0 · **php-cs-fixer** 0 of 417 · **npm run test:unit** 126 pass · **build** clean · **l10n:check** regenerated and committed.
- **e2e** — `search.spec.js`, `command-palette.spec.js`, `parent-child.spec.js`: **20/20 green**, including a new spec that seeds two identically-titled cards in different columns and asserts the column is what separates them. Proven non-vacuous: nulling `stackTitle` server-side fails it deterministically (3/3 retries), reverting restores green.
- Sub-card layout checked at **1400px and 390px**; no row overflows its container on mobile, and chip variants were asserted per row (overdue / soon / start-only / done-neutral / no-dates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)